### PR TITLE
avocado-vt: Fail to load plugins on uninitialized virt-test

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -95,6 +95,18 @@ from virttest.standalone_test import LIBVIRT_INSTALL
 from virttest.standalone_test import LIBVIRT_REMOVE
 
 
+class SetupError(Exception):
+    pass
+
+providers_download_dir = os.path.join(data_dir.get_root_dir(),
+                                      'test-providers.d', 'downloads')
+providers_dir_empty = len(os.listdir(providers_download_dir)) == 0
+
+if providers_dir_empty:
+    raise SetupError("virt-test bootstrap missing. "
+                     "Execute './run -t [test-type] --bootstrap' in virt-test")
+
+
 class VirtTestResult(result.HumanTestResult):
 
     """

--- a/avocado/core/plugins/virt_test_list.py
+++ b/avocado/core/plugins/virt_test_list.py
@@ -55,6 +55,19 @@ if VIRT_TEST_PATH is not None:
 
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
 from virttest.defaults import DEFAULT_GUEST_OS
+from virttest import data_dir
+
+
+class SetupError(Exception):
+    pass
+
+providers_download_dir = os.path.join(data_dir.get_root_dir(),
+                                      'test-providers.d', 'downloads')
+providers_dir_empty = len(os.listdir(providers_download_dir)) == 0
+
+if providers_dir_empty:
+    raise SetupError("virt-test bootstrap missing. "
+                     "Execute './run -t [test-type] --bootstrap' in virt-test")
 
 
 class VirtTestListerPlugin(plugin.Plugin):


### PR DESCRIPTION
Solves #7

Disable the vt plugins when virt-test is not initialized.
This avoids the error:

Cannot access 'vt_list_all': File not found

When virt-test was not bootstrapped and you are trying to
list available virt-tests.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>