### PR TITLE
[V3] avocado-vt: Fail to load plugins on uninitialized virt-test

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -95,6 +95,15 @@ from virttest.standalone_test import LIBVIRT_INSTALL
 from virttest.standalone_test import LIBVIRT_REMOVE
 
 
+_PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_root_dir(),
+                                       'test-providers.d', 'downloads')
+
+if len(os.listdir(_PROVIDERS_DOWNLOAD_DIR)) == 0:
+    raise EnvironmentError("virt-test bootstrap missing. "
+                           "Execute './run -t [test-type] --bootstrap' "
+                           "in virt-test")
+
+
 class VirtTestResult(result.HumanTestResult):
 
     """

--- a/avocado/core/plugins/virt_test_list.py
+++ b/avocado/core/plugins/virt_test_list.py
@@ -55,6 +55,16 @@ if VIRT_TEST_PATH is not None:
 
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
 from virttest.defaults import DEFAULT_GUEST_OS
+from virttest import data_dir
+
+
+_PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_root_dir(),
+                                       'test-providers.d', 'downloads')
+
+if len(os.listdir(_PROVIDERS_DOWNLOAD_DIR)) == 0:
+    raise EnvironmentError("virt-test bootstrap missing. "
+                           "Execute './run -t [test-type] --bootstrap' "
+                           "in virt-test")
 
 
 class VirtTestListerPlugin(plugin.Plugin):


### PR DESCRIPTION
Disable the vt plugins when virt-test is not initialized.
This avoids the error:

Cannot access 'vt_list_all': File not found

When virt-test was not bootstrapped and you are trying to
list available virt-tests.

Changes from v3:
 * Removed the changelog from the commit message, per adereis's suggestion.

Changes from v2:

* Removed custom SetupError exception for builtin EnvironmentError, per ldoktor's suggestion
* Do not store elements of downloads dir in the module, per ldoktor's suggestion