### PR TITLE
avocado.core.plugins.virt_test: Return empty test list on LexerError

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -368,7 +368,15 @@ class VirtTestLoader(loader.TestLoader):
     def discover_url(self, url):
         cartesian_parser = self._get_parser()
         if url != 'vt_list_all':
-            cartesian_parser.only_filter(url)
+            try:
+                cartesian_parser.only_filter(url)
+            # If we have a LexerError, this means
+            # the url passed is invalid in the cartesian
+            # config parser, hence it should be ignored.
+            # just return an empty params list and let
+            # the other test plugins to handle the URL.
+            except cartesian_config.LexerError:
+                return []
         params_list = [t for t in cartesian_parser.get_dicts()]
         return params_list
 


### PR DESCRIPTION
The way the virt plugin selects its tests is by passing
the user provided URL to the cartesian parser. Some of
the identifiers the user might pass are illegal in this
context (example, examples/tests/sleeptest.py contains
slashes, that are illegal for the cartesian parser).

The fact the identifier is illegal for the cartesian
parser already means it's invalid, no need to propagate
exceptions. Just return an empty list and let other
test loader plugins to try to identify it.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>