### PR TITLE
virt-test.conf: Fix old env variable name on comment

### DIFF
--- a/etc/avocado/conf.d/virt-test.conf
+++ b/etc/avocado/conf.d/virt-test.conf
@@ -2,7 +2,7 @@
 # Path to virt-test, required for the compatibility plugin to locate
 # virt-test libs. You should set this locally for avocado users.
 # For people working on the compatibility layer itself, you can export the
-# environment variable VIRT_TEST_DIR with that location instead of using
+# environment variable VIRT_TEST_PATH with that location instead of using
 # the config system.
 virt_test_path=
 [virt_test.setup]


### PR DESCRIPTION
I forgot to update that reference, let's fix it.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>