### PR TITLE
plugins.virt_test: Remove unnecessary logging

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -991,13 +991,9 @@ class VirtTestOptionsProcess(object):
         try:
             tcpdump_path = utils_misc.find_command('tcpdump')
         except ValueError:
-            logging.info('Command tcpdump not found')
             tcpdump_path = None
 
         non_root = os.getuid() != 0
-        if non_root and tcpdump_path is not None:
-            logging.info(
-                'Running as a non-root user, disabling tcpdump thread')
 
         if tcpdump_path is None or non_root:
             self.cartesian_parser.assign("run_tcpdump", "no")


### PR DESCRIPTION
Turns out it's unnecessary and a bad idea, since this
will get logged in the avocado job log even if users
are not directly using the vt plugin.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>