### PR TITLE
avocado-vt: Fix bug - Individual test log files come up empty

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -27,11 +27,11 @@ from avocado.core import result
 from avocado.core import loader
 from avocado.core import output
 from avocado.core import exceptions
-from avocado.core.plugins import plugin
-from avocado.core.test import Test as AvocadoTest
-from avocado.core.settings import settings
-from avocado.utils import path
 from avocado.core import multiplexer
+from avocado.core.settings import settings
+from avocado.core.plugins import plugin
+from avocado.utils import path
+from avocado import test
 
 # virt-test supports using autotest from a git checkout, so we'll have to
 # support that as well. The code below will pick up the environment variable
@@ -382,7 +382,7 @@ class VirtTestLoader(loader.TestLoader):
         return params_list
 
 
-class VirtTest(AvocadoTest):
+class VirtTest(test.Test):
 
     """
     Mininal test class used to run a virt test.


### PR DESCRIPTION
Introduced with commit 802ccb7d96c158566828b6fc9906815133a59a45,
this bug is caused by the fact that importing from the core
avocado test class causes the logging configuration stage
to be skipped, causing the individual test logs to come up
empty.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>