### PR TITLE
avocado.core.plugins.virt_test: Remove debugging statement

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -812,7 +812,6 @@ class VirtTestOptionsProcess(object):
 
     def _process_arch(self):
         arch_setting = "option --vt-arch or config virt_test.common.arch"
-        print self.options.vt_arch
         if self.options.vt_arch is None:
             pass
         elif not self.options.vt_config:


### PR DESCRIPTION
Introduced with commit ef1411bb, the print statement
is a leftover that shouldn't be there. Let's remove it.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>