### PR TITLE
API: Relative modules usage and boundary check

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -23,15 +23,15 @@ import Queue
 import time
 import imp
 
-from avocado.core import result
-from avocado.core import loader
-from avocado.core import output
-from avocado.core import exceptions
-from avocado.core import multiplexer
-from avocado.core import test
-from avocado.core.settings import settings
-from avocado.core.plugins import plugin
-from avocado.utils import path
+from . import plugin
+from .. import result
+from .. import loader
+from .. import output
+from .. import exceptions
+from .. import multiplexer
+from .. import test
+from ..settings import settings
+from ...utils import path
 
 # virt-test supports using autotest from a git checkout, so we'll have to
 # support that as well. The code below will pick up the environment variable

--- a/avocado/core/plugins/virt_test_list.py
+++ b/avocado/core/plugins/virt_test_list.py
@@ -19,8 +19,8 @@ Avocado plugin that augments 'avocado list' with virt-test related options.
 import os
 import sys
 
-from avocado.core.settings import settings
-from avocado.core.plugins import plugin
+from . import plugin
+from ..settings import settings
 
 # virt-test supports using autotest from a git checkout, so we'll have to
 # support that as well. The code below will pick up the environment variable

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -11,5 +11,7 @@ rc2=$?
 echo ""
 run_rc 'inspekt style'
 rc3=$?
-exit $rc1 || $rc2 || $rc3
-
+echo ""
+run_rc 'selftests/modules_boundaries'
+rc4=$?
+exit $rc1 || $rc2 || $rc3 || $rc4

--- a/selftests/modules_boundaries
+++ b/selftests/modules_boundaries
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# number of infringements found
+RESULT=0
+
+echo -n "* Checking for non-relative avocado imports from avocado/core: "
+LIST=`git grep -E '^(import avocado\..*|from avocado(.*)import)' avocado/core`
+COUNT=`git grep -E '^(import avocado\..*|from avocado(.*)import)' avocado/core | wc -l`
+(( RESULT = RESULT + COUNT ))
+echo "$COUNT"
+if [ -n "$LIST" ]; then
+   echo "$LIST"
+fi
+unset LIST
+unset COUNT
+
+if [ "$RESULT" -ne 0 ]; then
+    echo "ERROR: $RESULT module boundary infringements found"
+else
+    echo "PASS: no module boundary infringement(s) found"
+fi
+exit $RESULT


### PR DESCRIPTION
This PR replaces imports from `avocado.core` to relative imports. Because the plugins will live, and only work under `avocado.core.plugins`, this is actually OK.

Also, it's been added an adapted version of the `modules_boundaries` check script, and added to `selftests/checkall`, which in turn, adds it to travis and `make check`.