### PR TITLE
requirements: Update inspektor requirement to 0.1.16

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,3 +1,3 @@
 pep8==1.6.2
-inspektor==0.1.15
+inspektor==0.1.16
 autotest==0.16.2


### PR DESCRIPTION
Inspektor 0.1.15 has a bug (it doesn't require pep8,
so people trying to use it without pep8 are in for a
treat).

With the 0.1.16 release, that bug is fixed, so, let's update.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>