### PR TITLE
requirements: Add aexpect and generic requirements

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,3 +1,4 @@
 pep8==1.6.2
 inspektor==0.1.16
 autotest==0.16.2
+aexpect==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+autotest>=0.16.2
+aexpect>=1.0.0


### PR DESCRIPTION
aexpect is required by virt-test. Also add generic requirements.txt for
users.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>