### PR TITLE
virttest.qemu_vm: Use shell=True getting help_info

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2132,7 +2132,8 @@ class VM(virt_vm.BaseVM):
                 continue
 
             help_cmd = '%s -device %s,\? 2>&1' % (self.qemu_binary, vga_type)
-            help_info = process.system_output(help_cmd, verbose=False)
+            help_info = process.system_output(help_cmd, shell=True,
+                                              verbose=False)
             for pro in re.findall(r'%s.(\w+)=' % vga_type, help_info):
                 key = [vga_type.lower(), pro]
                 if migrate:


### PR DESCRIPTION
That particular command must be executed with shell=True,
as it uses shell features. In some supported platforms,
such as RHEL6, we noticed problems, so let's send this
fix.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>