### PR TITLE
Ensure bootstrap always updates the local backend directory

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -8,7 +8,7 @@ URL: http://avocado-framework.readthedocs.org/
 Source: avocado-plugins-vt-%{version}.tar.gz
 BuildRequires: python2-devel
 BuildArch: noarch
-Requires: python, avocado, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc
+Requires: python, avocado, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, rsync
 
 %description
 Avocado Virt Test is a plugin that lets you execute virt-tests

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -738,6 +738,13 @@ def bootstrap(options, interactive=False):
             logging.debug("Dir %s exists, not creating",
                           sub_dir_path)
 
+    base_backend_dir = data_dir.get_base_backend_dir()
+    local_backend_dir = data_dir.get_local_backend_dir()
+    logging.info("Syncing backend dirs %s -> %s", base_backend_dir,
+                 local_backend_dir)
+    process.run('rsync -rvv %s/* %s' %
+                (base_backend_dir, local_backend_dir), shell=True)
+
     test_dir = data_dir.get_backend_dir(options.vt_type)
     if options.vt_type == 'libvirt':
         step = create_config_files(test_dir, shared_dir, interactive, step,

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -476,7 +476,11 @@ def create_config_files(test_dir, shared_dir, interactive, step=None,
                 else:
                     logging.debug("Preserving existing %s file", dst_file)
             else:
-                logging.debug("Config file %s exists, not touching", dst_file)
+                if force_update:
+                    update_msg = 'Config file %s exists, equal to sample'
+                else:
+                    update_msg = 'Config file %s exists, not touching'
+                logging.debug(update_msg, dst_file)
     return step
 
 

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -133,13 +133,18 @@ def get_shared_dir():
     return SHARED_DIR
 
 
+def get_base_backend_dir():
+    return BASE_BACKEND_DIR
+
+
+def get_local_backend_dir():
+    return os.path.join(get_data_dir(), 'backends')
+
+
 def get_backend_dir(backend_type):
     if backend_type not in os.listdir(BASE_BACKEND_DIR):
         raise UnknownBackendError(backend_type)
-    dst = os.path.join(get_data_dir(), 'backends')
-    if not os.path.isdir(dst):
-        shutil.copytree(BASE_BACKEND_DIR, dst)
-    return os.path.join(dst, backend_type)
+    return os.path.join(get_local_backend_dir(), backend_type)
 
 
 def get_backend_cfg_path(backend_type, cfg_basename):


### PR DESCRIPTION
Fixes #56
Basically, in some conditions [1], the base backend dir and the local backend dir might be out of sync and some files might be missing, causing the plugins to fail. Let's play safe and use rsync to synchronize the backend directories and make sure all files are there after a vt-bootstrap.

[1] For example, user interrupts the bootstrap and starts it again