### PR TITLE
virttest.qemu_vm: Fix exception class called without params

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -50,7 +50,7 @@ class VMMigrateProtoUnsupportedError(virt_vm.VMMigrateProtoUnknownError):
     skip the test in this situation.
     """
 
-    def __init__(self, protocol, output):
+    def __init__(self, protocol=None, output=None):
         self.protocol = protocol
         self.output = output
 


### PR DESCRIPTION
I found this one while trying out custom configs. Sometimes
it's possible that the VMMigrateProtoUnsupportedError gets
called without params, in which case we should provide
default params to the class.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>