### PR TITLE
avocado-vt: Update references to virt-test

### DIFF
--- a/avocado/core/plugins/virt_test.py
+++ b/avocado/core/plugins/virt_test.py
@@ -13,7 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 """
-Avocado virt-test compatibility wrapper
+Avocado VT plugin
 """
 
 import os
@@ -34,11 +34,11 @@ from avocado.core.plugins import plugin
 from avocado.utils import stacktrace
 from avocado.utils import genio
 
-# virt-test no longer needs autotest for the majority of its functionality,
+# avocado-vt no longer needs autotest for the majority of its functionality,
 # except by:
 # 1) Run autotest on VMs
 # 2) Multi host migration
-# 3) Proper virt-test test status handling
+# 3) Proper avocado-vt test status handling
 # As in those cases we might want to use autotest, let's have a way for
 # users to specify their autotest from a git clone location.
 AUTOTEST_PATH = None
@@ -591,7 +591,7 @@ class VirtTest(test.Test):
         We have to override this method because the avocado-vt plugin
         has to override the behavior that tests shouldn't raise
         exceptions.TestNAError by themselves in avocado. In the old
-        virt-test case, that rule is not in place, so we have to be
+        avocado-vt case, that rule is not in place, so we have to be
         a little more lenient for correct test status reporting.
         """
         testMethod = getattr(self, self._testMethodName)

--- a/avocado/core/plugins/virt_test_list.py
+++ b/avocado/core/plugins/virt_test_list.py
@@ -13,7 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 """
-Avocado plugin that augments 'avocado list' with virt-test related options.
+Avocado plugin that augments 'avocado list' with avocado-virt related options.
 """
 
 import os
@@ -22,10 +22,10 @@ import sys
 from avocado.core.settings import settings
 from avocado.core.plugins import plugin
 
-# virt-test supports using autotest from a git checkout, so we'll have to
-# support that as well. The code below will pick up the environment variable
-# $AUTOTEST_PATH and do the import magic needed to make the autotest library
-# available in the system.
+# The original virt-test runner supports using autotest from a git checkout,
+# so we'll have to support that as well. The code below will pick up the
+# environment variable $AUTOTEST_PATH and do the import magic needed to make
+# the autotest library available in the system.
 AUTOTEST_PATH = None
 
 if 'AUTOTEST_PATH' in os.environ:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,7 @@ man_pages = [
 texinfo_documents = [
     ('index', 'avocado', u'Avocado Virt Test Compatibility Layer',
      u'Lucas Meneghel Rodrigues', 'avocado',
-     'Avocado plugin providing a compatibility layer to the virt-test suite.',
+     'Avocado Virtualization Testing (VT) plugin',
      'Testing'),
 ]
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -13,7 +13,7 @@ from avocado.utils import process
 
 def build_docs():
     """
-    Build virt-test HTML docs, reporting failures.
+    Build avocado-vt HTML docs, reporting failures.
     """
     ignore_list = ['No python imaging library installed',
                    'Virsh executable not set or found on path',

--- a/scripts/github/cache_populate.py
+++ b/scripts/github/cache_populate.py
@@ -11,7 +11,7 @@ gh = Github(login_or_token=raw_input("Enter github username: "),
             user_agent='PyGithub/Python')
 
 print "Enter location (<user>/<repo>)",
-repo_full_name = 'autotest/virt-test'
+repo_full_name = 'avocado-framework/avocado-vt'
 repo_full_name = raw_input("or blank for '%s': "
                            % repo_full_name).strip() or repo_full_name
 

--- a/scripts/github/example.py
+++ b/scripts/github/example.py
@@ -18,13 +18,13 @@ password = getpass.getpass('Enter github password: ')
 gh = Github(login_or_token=username,
             password=password, user_agent='PyGithub/Python')
 # needed to fetch fresh rate_limiting data
-repo = gh.get_repo('autotest/virt-test')
+repo = gh.get_repo('avocado-framework/avocado-vt')
 
 # Requests for logged in users are limited to 5000 per hour
 # or about 1 request every 0.7 seconds
 start = gh.rate_limiting
 # Open up cache and repository
-issues = GithubIssues(gh, 'autotest/virt-test')
+issues = GithubIssues(gh, 'avocado-framework/avocado-vt')
 print "Issue #125: ",
 # Any issue can be referenced by number
 print issues[125]
@@ -33,7 +33,7 @@ print "Requests used: ", start[0] - end[0]
 print "Cache hits: %s misses: %s" % (issues.cache_hits, issues.cache_misses)
 
 # Pull requests are treated as issues
-issues = GithubIssues(gh, 'autotest/virt-test')
+issues = GithubIssues(gh, 'avocado-framework/avocado-vt')
 start = end
 print "Pull #526: ",
 print issues[526]
@@ -43,7 +43,7 @@ print "Cache hits: %s misses: %s" % (issues.cache_hits, issues.cache_misses)
 
 # Listing issues requires finding the last issue
 # this takes a while when the cache is empty
-issues = GithubIssues(gh, 'autotest/virt-test')
+issues = GithubIssues(gh, 'avocado-framework/avocado-vt')
 start = end
 print "Total number of issues (this could take a while):"
 # This len() is used to force the slower binary-search
@@ -53,7 +53,7 @@ print "Requests used: ", start[0] - end[0]
 print "Cache hits: %s misses: %s" % (issues.cache_hits, issues.cache_misses)
 
 # Searches are supported and return lists of issue-numbers
-issues = GithubIssues(gh, 'autotest/virt-test')
+issues = GithubIssues(gh, 'avocado-framework/avocado-vt')
 start = end
 print "Open issues last few days without any label (could take 2-10 minutes):"
 two_days = datetime.timedelta(days=2)
@@ -72,14 +72,14 @@ for number in issues.search(criteria):
     issue = issues[number]
     # some items must be searched/compared manually
     if len(issue['labels']) < 1:
-        print ('https://github.com/autotest/virt-test/issues/%s\t"%s"'
+        print ('https://github.com/avocado-framework/avocado-vt/issues/%s\t"%s"'
                % (issue['number'], issue['summary']))
 print
 print "Requests used: ", start[0] - end[0]
 print "Cache hits: %s misses: %s" % (issues.cache_hits, issues.cache_misses)
 
 # Now that cache is populated, this will be very fast
-issues = GithubIssues(gh, 'autotest/virt-test')
+issues = GithubIssues(gh, 'avocado-framework/avocado-vt')
 start = end
 print "Total number of issues (this should be a lot faster):"
 # This length uses a cached issue count plus a 'since' criteria search

--- a/scripts/github/label_issues.py
+++ b/scripts/github/label_issues.py
@@ -30,7 +30,7 @@ gh = Github(login_or_token=raw_input("Enter github username: "),
             user_agent='PyGithub/Python')
 
 print "Enter location (<user>/<repo>)",
-repo_full_name = 'autotest/virt-test'
+repo_full_name = 'avocado-framework/avocado-vt'
 repo_full_name = raw_input("or blank for '%s': "
                            % repo_full_name).strip() or repo_full_name
 print

--- a/scripts/github/pulls_applied.py
+++ b/scripts/github/pulls_applied.py
@@ -11,7 +11,7 @@ gh = Github(login_or_token=raw_input("Enter github username: "),
             user_agent='PyGithub/Python')
 
 print "Enter location (<user>/<repo>)",
-repo_full_name = 'autotest/virt-test'
+repo_full_name = 'avocado-framework/avocado-vt'
 repo_full_name = raw_input("or blank for '%s': "
                            % repo_full_name).strip() or repo_full_name
 

--- a/scripts/github/stale_pulls.py
+++ b/scripts/github/stale_pulls.py
@@ -11,7 +11,7 @@ gh = Github(login_or_token=raw_input("Enter github username: "),
             user_agent='PyGithub/Python')
 
 print "Enter location (<user>/<repo>)",
-repo_full_name = 'autotest/virt-test'
+repo_full_name = 'avocado-framework/avocado-vt'
 repo_full_name = raw_input("or blank for '%s': "
                            % repo_full_name).strip() or repo_full_name
 

--- a/scripts/github/unassigned_issues.py
+++ b/scripts/github/unassigned_issues.py
@@ -9,7 +9,7 @@ gh = Github(login_or_token=raw_input("Enter github username: "),
             user_agent='PyGithub/Python')
 
 print "Enter location (<user>/<repo>)",
-repo_full_name = 'autotest/virt-test'
+repo_full_name = 'avocado-framework/avocado-vt'
 repo_full_name = raw_input("or blank for '%s': "
                            % repo_full_name).strip() or repo_full_name
 

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -18,9 +18,9 @@ qemu_io_binary = qemu-io
 #bios_path = /path/to/coreboot.rom
 
 # List of virtual machine object names (whitespace separated)
-vms = virt-tests-vm1
+vms = avocado-vt-vm1
 # Default virtual machine to use, when not specified by test.
-main_vm = virt-tests-vm1
+main_vm = avocado-vt-vm1
 
 # Always set optional parameters (addr, bus, ...)
 strict_mode = no

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -186,7 +186,7 @@ variants:
         setup_hugepages = yes
         # In some special conditions, such as low mem PPC systems, you might
         # want to define how many large memory pages you want to set directly.
-        # If you don't, virt-test will use an heuristic to calculate the number
+        # If you don't, avocado-vt will use an heuristic to calculate the number
         # (default). The heuristic can be found on virttest/test_setup.py
         #target_hugepages = 500
 
@@ -224,7 +224,7 @@ variants image_backend:
     - gluster:
         storage_type = glusterfs
         enable_gluster = yes
-        # please go through https://github.com/autotest/virt-test/wiki/Virt-test-support-for-GlusterFs for more details.
+        # please go through http://avocado-vt.readthedocs.org/en/latest/extra/GlusterFs.html for more details.
         #Set the brick of gluster server. If set, will try to set gluster
         gluster_brick = "images/gl_test"
         #Set the volume name of gluster.

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -190,7 +190,7 @@ class ConfigLoader:
 
 def get_known_backends():
     """
-    Return virtualization backends supported by virt-test.
+    Return virtualization backends supported by avocado-vt.
     """
     # Generic means the test can run in multiple backends, such as libvirt
     # and qemu.

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -126,7 +126,7 @@ def verify_mandatory_programs(t_type, guest_os):
         except ValueError:
             if cmd == '7za' and guest_os != defaults.DEFAULT_GUEST_OS:
                 logging.warn("Command 7za (required to uncompress JeOS) "
-                             "missing. You can still use virt-test with guest"
+                             "missing. You can still use avocado-vt with guest"
                              " OS's other than JeOS.")
                 continue
             logging.error("Required command %s is missing. You must "
@@ -606,7 +606,7 @@ def verify_selinux(datadir, imagesdir, isosdir, tmpdir,
     :param datadir: Abs. path to data-directory symlink
     :param imagesdir: Abs. path to data/images directory
     :param isosdir: Abs. path to data/isos directory
-    :param tmpdir: Abs. path to virt-test tmp dir
+    :param tmpdir: Abs. path to avocado-vt tmp dir
     :param interactive: True if running from console
     :param selinux: Whether setup SELinux contexts for shared/data
     """

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -47,7 +47,7 @@ class UnknownBackendError(Exception):
         self.backend = backend
 
     def __str__(self):
-        return ("Virt Backend %s is not currently supported by virt-test. "
+        return ("Virt Backend %s is not currently supported by avocado-vt. "
                 "Check for typos and the list of supported backends" %
                 self.backend)
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -974,7 +974,7 @@ def postprocess(test, params, env):
                 except Exception:
                     pass
         # Close the serial console session, as it'll help
-        # keeping the number of filedescriptors used by virt-test honest.
+        # keeping the number of filedescriptors used by avocado-vt honest.
         vm.cleanup_serial_console()
 
     libvirtd_inst = utils_libvirtd.Libvirtd()

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -761,8 +761,8 @@ class DevContainer(object):
             :param cmd: If set uses "-M $cmd" to force this machine type
             :return: List of added devices (including default buses)
             """
-            logging.warn('Using Q35 machine which is not yet fullytested on '
-                         'virt-test. False errors might occur.')
+            logging.warn('Using Q35 machine which is not yet fully tested on '
+                         'avocado-vt. False errors might occur.')
             devices = []
             bus = (qbuses.QPCIBus('pcie.0', 'PCIE', 'pci.0'),
                    qbuses.QStrictCustomBus(None, [['chassis'], [256]], '_PCI_CHASSIS',
@@ -890,7 +890,7 @@ class DevContainer(object):
             :return: List of added devices (including default buses)
             """
             logging.warn('Machine type isa/unknown is not supported by '
-                         'virt-test. False errors might occur')
+                         'avocado-vt. False errors might occur')
             devices = []
             devices.append(qdevices.QStringDevice('machine', cmdline=cmd))
             return devices
@@ -934,7 +934,7 @@ class DevContainer(object):
                         devices = machine_i440FX(False)
                     else:   # isapc (or other)
                         logging.warn('Machine isa/unknown is not supported by '
-                                     'virt-test. False errors might occur')
+                                     'avocado-vt. False errors might occur')
                         devices = machine_other(False)
             if not devices:
                 logging.warn('Unable to find the default machine type, using '

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -78,7 +78,7 @@ def clean_tmp_files():
     if os.path.isfile(CREATE_LOCK_FILENAME):
         os.unlink(CREATE_LOCK_FILENAME)
 
-CREATE_LOCK_FILENAME = os.path.join('/tmp', 'virt-test-vm-create.lock')
+CREATE_LOCK_FILENAME = os.path.join('/tmp', 'avocado-vt-vm-create.lock')
 
 
 class VM(virt_vm.BaseVM):

--- a/virttest/staging/backports/_itertools.py
+++ b/virttest/staging/backports/_itertools.py
@@ -1,12 +1,12 @@
 """
 This module contains some itertools functions people have been using in
-virt-test that are not present in python 2.4, the minimum supported version.
+avocado-vt that are not present in python 2.4, the minimum supported version.
 """
 
 
 def product(*args, **kwds):
     """
-    (virt-test backport)
+    (avocado-vt backport)
     Cartesian product of input iterables. Equivalent to nested for-loops.
 
     For example, product(A, B) returns the same as:  ((x,y) for x in A for y in B).

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -773,7 +773,7 @@ def bootstrap_tests(options):
 
 def cleanup_env(parser, options):
     """
-    Clean up virt-test temporary files.
+    Clean up avocado-vt temporary files.
 
     :param parser: Cartesian parser with run parameters.
     :param options: Test runner options object.

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2117,7 +2117,7 @@ def extract_qemu_cpu_models(qemu_cpu_help_text):
         if model_list is not None:
             return model_list
 
-    e_msg = ("CPU models reported by qemu -cpu ? not supported by virt-tests. "
+    e_msg = ("CPU models reported by qemu -cpu ? not supported by avocado-vt. "
              "Please work with us to add support for it")
     logging.error(e_msg)
     for line in qemu_cpu_help_text.splitlines():

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -103,7 +103,7 @@ class LibvirtNetwork(object):
     def __init__(self, net_type, address=None, iface=None, net_name=None,
                  persistent=False):
         if net_name is None:
-            self.name = 'virt-test-%s' % net_type
+            self.name = 'avocado-vt-%s' % net_type
         else:
             self.name = net_name
         self.address = address


### PR DESCRIPTION
We were still referring to virt-test in many places
of the code. Let's fix all but the ones that are
actually valid (when we refer the old virt-test runner).

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>