### PR TITLE
[V2] Ensure bootstrap always updates the local backend directory

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -477,7 +477,11 @@ def create_config_files(test_dir, shared_dir, interactive, step=None,
                 else:
                     logging.debug("Preserving existing %s file", dst_file)
             else:
-                logging.debug("Config file %s exists, not touching", dst_file)
+                if force_update:
+                    update_msg = 'Config file %s exists, equal to sample'
+                else:
+                    update_msg = 'Config file %s exists, not touching'
+                logging.debug(update_msg, dst_file)
     return step
 
 

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -1,3 +1,4 @@
+import distutils
 import logging
 import os
 import glob
@@ -737,6 +738,12 @@ def bootstrap(options, interactive=False):
         else:
             logging.debug("Dir %s exists, not creating",
                           sub_dir_path)
+
+    base_backend_dir = data_dir.get_base_backend_dir()
+    local_backend_dir = data_dir.get_local_backend_dir()
+    logging.info("Syncing backend dirs %s -> %s", base_backend_dir,
+                 local_backend_dir)
+    distutils.dir_util.copy_tree(base_backend_dir, local_backend_dir)
 
     test_dir = data_dir.get_backend_dir(options.vt_type)
     if options.vt_type == 'libvirt':

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -133,13 +133,18 @@ def get_shared_dir():
     return SHARED_DIR
 
 
+def get_base_backend_dir():
+    return BASE_BACKEND_DIR
+
+
+def get_local_backend_dir():
+    return os.path.join(get_data_dir(), 'backends')
+
+
 def get_backend_dir(backend_type):
     if backend_type not in os.listdir(BASE_BACKEND_DIR):
         raise UnknownBackendError(backend_type)
-    dst = os.path.join(get_data_dir(), 'backends')
-    if not os.path.isdir(dst):
-        shutil.copytree(BASE_BACKEND_DIR, dst)
-    return os.path.join(dst, backend_type)
+    return os.path.join(get_local_backend_dir(), backend_type)
 
 
 def get_backend_cfg_path(backend_type, cfg_basename):


### PR DESCRIPTION
Fixes #56
Basically, in some conditions [1], the base backend dir and the local backend dir might be out of sync and some files might be missing, causing the plugins to fail. Let's play safe and synchronize the backend directories and make sure all files are there after a vt-bootstrap.

[1] For example, user interrupts the bootstrap and starts it again

Changes from v1:
* Dropped the use of `rsync` to use the standard library python module `distutils`.