### PR TITLE
Add suffix & join to cartesian_config.py

### DIFF
--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -139,8 +139,9 @@ import logging
 import re
 import string
 import sys
+import copy
 
-_reserved_keys = set(("name", "shortname", "dep"))
+_reserved_keys = set(("name", "shortname", "dep", "_short_name_map_file", "_name_map_file"))
 
 num_failed_cases = 5
 
@@ -322,6 +323,15 @@ class NoFilter(NoOnlyFilter):
 
     def __repr__(self):
         return "No %s" % (self.filter)
+
+
+class JoinFilter(NoOnlyFilter):
+
+    def __str__(self):
+        return "Join %s" % (self.filter)
+
+    def __repr__(self):
+        return "Join %s" % (self.filter)
 
 
 class BlockFilter(object):
@@ -702,6 +712,16 @@ class LOnly(Token):
     identifier = "only"
 
 
+class LSuffix(Token):
+    __slots__ = []
+    identifier = "suffix"
+
+
+class LJoin(Token):
+    __slots__ = []
+    identifier = "join"
+
+
 class LNo(Token):
     __slots__ = []
     identifier = "no"
@@ -914,6 +934,31 @@ class LUpdateFileMap(LOperators):
             d[dest][self.shortname] = self.name
 
 
+class Suffix(LOperators):
+    __slots__ = []
+    identifier = "apply_suffix"
+
+    def __str__(self):
+        return "Suffix: %s" % (self.value)
+
+    def __repr__(self):
+        return "Suffix %s" % (self.value)
+
+    def __eq__(self, o):
+        if isinstance(o, self.__class__):
+            if self.value == o.value:
+                return True
+
+    def apply_to_dict(self, d):
+        for key in d.copy():
+            if key not in _reserved_keys:
+                # Store key as a tuple: (key, suffix1, suffix2, suffix3,....)
+                # This allows us to manipulate later on suffixes
+                # Add suffix to the key, remove the old key
+                new_key = (key if isinstance(key, tuple) else (key,)) + (self.value,)
+                d[new_key] = d.pop(key)
+
+
 spec_iden = "_-"
 spec_oper = "+<?"
 
@@ -1004,6 +1049,18 @@ class Lexer(object):
             if line.startswith("del "):
                 yield LDel()
                 pos = 3
+                while line[pos].isspace():
+                    pos += 1
+        elif l0 == "s":
+            if line.startswith("suffix "):
+                yield LSuffix()
+                pos = 6
+                while line[pos].isspace():
+                    pos += 1
+        elif l0 == "j":
+            if line.startswith("join "):
+                yield LJoin()
+                pos = 4
                 while line[pos].isspace():
                     pos += 1
 
@@ -1390,7 +1447,7 @@ class Parser(object):
         if not node:
             node = self.node
         block_allowed = [LVariants, LIdentifier, LOnly,
-                         LNo, LInclude, LDel, LNotCond]
+                         LNo, LInclude, LDel, LNotCond, LSuffix, LJoin]
 
         variants_allowed = [LVariant]
 
@@ -1411,6 +1468,13 @@ class Parser(object):
         # others block or operation. Increase speed almost twice.
         pre_dict = {}
         lexer.set_fast()
+
+        # Suffix should be applied as the last operator in the dictionary
+        # Reasons:
+        #     1. Escape multiply suffix operators
+        #     2. Affect all elements in current block
+        suffix = None
+
         try:
             while True:
                 lexer.set_prev_indent(prev_indent)
@@ -1419,6 +1483,9 @@ class Parser(object):
                     if pre_dict:
                         # flush pre_dict to node content.
                         pre_dict = apply_predict(lexer, node, pre_dict)
+                    if suffix:
+                        # Node has suffix, apply it to all elements
+                        node.content.append(suffix)
                     return node
 
                 indent = token.length
@@ -1697,6 +1764,27 @@ class Parser(object):
                         node.content += [(lexer.filename, lexer.linenum,
                                           NoFilter(lfilter, lexer.line))]
 
+                elif typet == LJoin:
+                    # Parse:
+                    #    join (filter=text)..aaa.bbb, xxxx
+                    # syntax is the same as for No/Only filters
+                    lfilter = parse_filter(lexer, lexer.rest_line())
+
+                    pre_dict = apply_predict(lexer, node, pre_dict)
+
+                    node.content += [(lexer.filename, lexer.linenum, JoinFilter(lfilter, lexer.line))]
+
+                elif typet == LSuffix:
+                    # Parse:
+                    #    suffix SUFFIX
+                    if pre_dict:
+                        pre_dict = apply_predict(lexer, node, pre_dict)
+                    token_type, token_val = lexer.get_next_check([LIdentifier])
+                    lexer.get_next_check([LEndL])
+                    suffix_operator = Suffix().set_operands(None, token_val)
+                    # Suffix will be applied as all other elements in current node are processed:
+                    suffix = (lexer.filename, lexer.linenum, suffix_operator)
+
                 elif typet == LInclude:
                     # Parse:
                     #    include relative file patch to working directory.
@@ -1750,7 +1838,90 @@ class Parser(object):
                                          lexer.line))
             raise
 
+    # join filter_1 filter_2 .....
+    # Multiply all dicts:
+    # all-dicts-match-filter_1 * all-dicts-match-filter_2 * ....
+    # <join only_one_filter> == <only only_one_filter>
+    # Also works: join filter_1 filter_1
+    # Transforms to: all_variants_match_filter_1 * all_variants_mats_filter_1
+    #
+    # Example:
+    # join a
+    # join a
+    # Transforms into:
+    # join a a
     def get_dicts(self, node=None, ctx=[], content=[], shortname=[], dep=[]):
+        """
+        Process 'join' entry, unpack join filter for node
+        ctx - node labels/names
+        content - previous content in plain
+        Return: dictionary
+        """
+        node = node or self.node
+
+        # Node is a current block. It has content, its contents: node.content
+        # Content withoun joins
+        new_content = []
+
+        # All joins in current node
+        joins = []
+
+        for t in node.content:
+            filename, linenum, obj = t
+
+            if not isinstance(obj, JoinFilter):
+                new_content.append(t)
+                continue
+
+            # Accummulate all joins at one node
+            joins += [t]
+
+        if not joins:
+            # Return generator
+            for d in self.get_dicts_plain(node, ctx, content, shortname, dep):
+                yield d
+        else:
+            # Rewrite all separate joins in one node as many `only'
+            onlys = []
+            for j in joins:
+                filename, linenum, obj = j
+                for word in obj.filter:
+                    f = OnlyFilter([word], str(word))
+                    onlys += [(filename, linenum, f)]
+
+            node.content = new_content
+            for d in self.multiply_join(onlys, node, ctx, content, shortname, dep):
+                yield d
+
+    # Multiply all joins. Return dictionaries one by one
+    # Each `join' is the same as `only' filter
+    # This functions is supposed to be a generator, recursive generator
+    def multiply_join(self, onlys, node=None, ctx=[], content=[], shortname=[], dep=[]):
+        # Current join/only
+        only = onlys[:1]
+        remains = onlys[1:]
+
+        orig_node = copy.deepcopy(node)
+        node.content += only
+
+        if not remains:
+            for d in self.get_dicts_plain(node, ctx, content, shortname, dep):
+                yield d
+        else:
+            for d1 in self.get_dicts_plain(node, ctx, content, shortname, dep):
+                # Current frame multiply by all variants from bottom
+                for d2 in self.multiply_join(remains, orig_node, ctx, content, shortname, dep):
+                    name_x = d1["name"]
+                    name_x += "." + d2["name"]
+                    shortname_x = d1["shortname"]
+                    shortname_x += "." + d2["shortname"]
+                    d = d1.copy()
+                    d.update(d2)
+                    d["name"] = name_x
+                    d["shortname"] = shortname_x
+                    yield d
+
+    def get_dicts_plain(self, node=None, ctx=[], content=[], shortname=[], dep=[]):
         """
         Generate dictionaries from the code parsed so far.  This should
         be called after parsing something.
@@ -1869,6 +2040,7 @@ class Parser(object):
                 del node.failed_cases[i]
                 node.failed_cases.appendleft(failed_case)
                 return
+
         # Check content and unpack it into new_content
         new_content = []
         new_external_filters = []
@@ -1904,6 +2076,21 @@ class Parser(object):
                  "shortname": ".".join([str(sn.name) for sn in shortname])}
             for _, _, op in new_content:
                 op.apply_to_dict(d)
+            # Merge suffixes
+            d_orig = d.copy()
+            for key in d_orig:
+                if key not in _reserved_keys and isinstance(key, tuple):
+                    if options.skipdups:
+                        # Drop vars with suffixes matches general var val
+                        gen_var_name = key[0]
+                        if gen_var_name in d_orig and d_orig[gen_var_name] == d_orig[key]:
+                            print("Drop: %s" % (gen_var_name,))
+                            d.pop(key)
+                            continue
+                    # reverse order of suffixes
+                    new_key = key[:1] + key[1:][::-1]
+                    new_key = ''.join((map(str, new_key)))
+                    d[new_key] = d.pop(key)
             yield d
         # If this node did not produce any dicts, remember the failed filters
         # of its descendants
@@ -2048,6 +2235,8 @@ if __name__ == "__main__":
     parser.add_option("-e", "--expand", dest="expand", type="string",
                       help="list of vartiant which should be expanded when"
                            " defaults is enabled.  \"name, name, name\"")
+    parser.add_option("-s", "--skip-dups", dest="skipdups", default=True, action="store_false",
+                      help="Don't drop variables with different suffixes and same val")
 
     options, args = parser.parse_args()
     if not args:


### PR DESCRIPTION
This commit extends cartesian config format with keywords: 'suffix' and 'join'.

Justification:

Cartesian configs were invented as a part of virt-test framework.  Purpose of
cartesian configs is flexible configuration VMs for various kinds of tests.

SpiceQE team faced with one problem: all existing configs were written to run
only one VM at same time. For example: only RHEL6 or only RHEL7. But not both
at the same time.

This commit tries to full fill this gap.

virt-test can run different VMs with different configurations, each of VMs
should have some suffix.  With extended caretesian config syntax it is possible
to use existing different configs at the same time.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>


Additional info:

<pre><code>

virttest|master ⇒ cd   
~|⇒ cat 1.cfg 
a = zero

variants:
  - one:
      # General
      suffix _one
      a = 11

variants:
  - two:
      # More specific
      suffix _two
      a = 21

# Most specifig
a = 51
suffix _bot

# Rule: add suffixes from specific to general
# a_bot = 51
# a_bot_two = 21
# a_bot_two_one = 11
~|⇒          
~|⇒ 
~|⇒ cat 2.cfg 
a = zero

variants:
  - first:
      # General
      suffix _first
      a = 1
      variants:
          - second:
              a = 22
              b = 22
              variants:
                - third:
                      a = 333
                      b = 333
                      c = 333
                      # More specific
                      suffix _third

# Most specific
suffix _b
a = 777

# Rule: add suffixes from specific to general

# Result:
#    a_b = 777
#    a_b_first_third = 333
#    b_b_first_third = 333
#    c_b_first_third = 333

~|⇒ 
~|⇒ 
~|⇒ 
~|⇒ 
~|⇒ cat 3.cfg 
a = zero

variants:
  - one:
      # General
      suffix _one

variants:
  - three:
      # More specific
      suffix _three
      a = 33

# Most specific
a = 777
suffix _b

# Rule: add suffixes from specific to general
# Result:
# dict    1:  three.one
#     a_b = 777
#     a_b_three = 33
#     a_b_three_one = zero
~|⇒ 






# cat t.cfg 
## Autogenerated by phase_cartesian_tests_cfg ##
include virt-test/qemu/cfg/guest-os.cfg
#only Client-RHEL6-x64-latest.Guest-RHEL6-x64-latest

variants:
  -win:
    only Windows
    suffix _vm1
  - lin:
    suffix _vm2
    only Linux

join lin.Linux.Fedora.19.i386 win.Windows.Win2003
[root@astepano1 qe-tests]# 
[root@astepano1 qe-tests]# 
[root@astepano1 qe-tests]# 
[root@astepano1 qe-tests]# 
[root@astepano1 qe-tests]# ./virt-test/virttest/cartesian_config.py t.cfg 
dict    1:  lin.Fedora.19.i386.win.Win2003.i386
dict    2:  lin.Fedora.19.i386.win.Win2003.x86_64
[root@astepano1 qe-tests]# 
[root@astepano1 qe-tests]# 
[root@astepano1 qe-tests]# 
[root@astepano1 qe-tests]# ./virt-test/virttest/cartesian_config.py t.cfg -c
dict    1:  lin.Fedora.19.i386.win.Win2003.i386
    _name_map_file = {'t.cfg': 'win', 'guest-os.cfg': 'Windows.Win2003.i386'}
    _short_name_map_file = {'t.cfg': 'win', 'guest-os.cfg': 'Windows.Win2003.i386'}
    cdrom_cd1_vm1 = isos/windows/winutils.iso
    cdrom_check_cdrom_pattern_vm1 = \d\s+(\w).*CD-ROM
    cdrom_check_cdrom_pattern_vm2 = /dev/cdrom-\w+|/dev/cdrom\d*
    cdrom_get_cdrom_cmd_vm1 = echo list volume > check_cdrom && echo exit >> check_cdrom && diskpart /s check_cdrom
    cdrom_get_cdrom_cmd_vm2 = ls /dev/cdrom*
    cdrom_test_cmd_vm1 = dir %s:\
    cdrom_test_cmd_vm2 = dd if=%s of=/dev/null bs=1 count=1
    cpu_chk_cmd_vm1 = echo %NUMBER_OF_PROCESSORS%
    cpu_chk_cmd_vm2 = ls /sys/devices/system/cpu | egrep -c "cpu[0-9]+$"
    dep = []
    file_transfer_client_vm1 = rss
    file_transfer_client_vm2 = scp
    file_transfer_port_vm1 = 10023
    file_transfer_port_vm2 = 22
    guest_port_file_transfer_vm1 = 10023
    guest_port_remote_shell_vm1 = 10022
    image_name_vm1 = images/win2003-32
    image_name_vm2 = images/f19-32
    image_size_vm1 = 30G
    mem_chk_cmd_vm1 = wmic memphysical
    mem_chk_cmd_vm2 = dmidecode -t 17 | awk -F: '/Size/ {print $2}'
    mem_chk_cur_cmd_vm1 = wmic memphysical
    mem_chk_cur_cmd_vm2 = grep MemTotal /proc/meminfo
    mem_chk_re_str_vm2 = [^\$]([0-9]+)
    name = lin.Linux.Fedora.19.i386.win.Windows.Win2003.i386
    os_type_vm1 = windows
    os_type_vm2 = linux
    os_variant_vm1 = win2k3
    os_variant_vm2 = fedora19
    password_vm1 = 1q2w3eP
    password_vm2 = 123456
    reboot_command_vm1 = shutdown /r /f /t 0
    reboot_command_vm2 = shutdown -r now
    redirs_vm1 =  file_transfer
    rtc_base_vm1 = localtime
    shell_client_vm1 = nc
    shell_client_vm2 = ssh
    shell_linesep_vm1 = \r\n
    shell_port_vm1 = 10022
    shell_port_vm2 = 22
    shell_prompt_vm1 = ^\w:\\.*>\s*$
    shell_prompt_vm2 = ^\[.*\][\#\$]\s*$
    shortname = lin.Fedora.19.i386.win.Win2003.i386
    shutdown_command_vm1 = shutdown /s /f /t 0
    shutdown_command_vm2 = shutdown -h now
    status_test_command_vm1 = echo %errorlevel%
    status_test_command_vm2 = echo $?
    use_libvirt_cdrom_switch_vm1 = yes
    username_vm1 = Administrator
    username_vm2 = root
    vfd_size_vm1 = 2880k
    vm_arch_name_vm1 = i686
    vm_arch_name_vm2 = i386
dict    2:  lin.Fedora.19.i386.win.Win2003.x86_64
    _name_map_file = {'t.cfg': 'win', 'guest-os.cfg': 'Windows.Win2003.x86_64'}
    _short_name_map_file = {'t.cfg': 'win', 'guest-os.cfg': 'Windows.Win2003.x86_64'}
    cdrom_cd1_vm1 = isos/windows/winutils.iso
    cdrom_check_cdrom_pattern_vm1 = \d\s+(\w).*CD-ROM
    cdrom_check_cdrom_pattern_vm2 = /dev/cdrom-\w+|/dev/cdrom\d*
    cdrom_get_cdrom_cmd_vm1 = echo list volume > check_cdrom && echo exit >> check_cdrom && diskpart /s check_cdrom
    cdrom_get_cdrom_cmd_vm2 = ls /dev/cdrom*
    cdrom_test_cmd_vm1 = dir %s:\
    cdrom_test_cmd_vm2 = dd if=%s of=/dev/null bs=1 count=1
    cpu_chk_cmd_vm1 = echo %NUMBER_OF_PROCESSORS%
    cpu_chk_cmd_vm2 = ls /sys/devices/system/cpu | egrep -c "cpu[0-9]+$"
    dep = []
    file_transfer_client_vm1 = rss
    file_transfer_client_vm2 = scp
    file_transfer_port_vm1 = 10023
    file_transfer_port_vm2 = 22
    guest_port_file_transfer_vm1 = 10023
    guest_port_remote_shell_vm1 = 10022
    image_name_vm1 = images/win2003-64
    image_name_vm2 = images/f19-32
    image_size_vm1 = 30G
    mem_chk_cmd_vm1 = wmic memphysical
    mem_chk_cmd_vm2 = dmidecode -t 17 | awk -F: '/Size/ {print $2}'
    mem_chk_cur_cmd_vm1 = wmic memphysical
    mem_chk_cur_cmd_vm2 = grep MemTotal /proc/meminfo
    mem_chk_re_str_vm2 = [^\$]([0-9]+)
    name = lin.Linux.Fedora.19.i386.win.Windows.Win2003.x86_64
    os_type_vm1 = windows
    os_type_vm2 = linux
    os_variant_vm1 = win2k3
    os_variant_vm2 = fedora19
    password_vm1 = 1q2w3eP
    password_vm2 = 123456
    reboot_command_vm1 = shutdown /r /f /t 0
    reboot_command_vm2 = shutdown -r now
    redirs_vm1 =  file_transfer
    rtc_base_vm1 = localtime
    shell_client_vm1 = nc
    shell_client_vm2 = ssh
    shell_linesep_vm1 = \r\n
    shell_port_vm1 = 10022
    shell_port_vm2 = 22
    shell_prompt_vm1 = ^\w:\\.*>\s*$
    shell_prompt_vm2 = ^\[.*\][\#\$]\s*$
    shortname = lin.Fedora.19.i386.win.Win2003.x86_64
    shutdown_command_vm1 = shutdown /s /f /t 0
    shutdown_command_vm2 = shutdown -h now
    status_test_command_vm1 = echo %errorlevel%
    status_test_command_vm2 = echo $?
    use_libvirt_cdrom_switch_vm1 = yes
    username_vm1 = Administrator
    username_vm2 = root
    vfd_size_vm1 = 2880k
    vm_arch_name_vm1 = x86_64
    vm_arch_name_vm2 = i386
[root@astepano1 qe-tests]#
</code></pre>
