### PR TITLE
docs: Change reference to old 'tools' subdir to 'scripts'

### DIFF
--- a/docs/source/extra/DownloadableImages.rst
+++ b/docs/source/extra/DownloadableImages.rst
@@ -21,7 +21,7 @@ using:
 
 ::
 
-    tools/download_manager.py
+    scripts/download_manager.py
 
 
 Winutils ISO


### PR DESCRIPTION
Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>