### PR TITLE
[V2] `--vt-type libvirt` Fixes

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -708,7 +708,7 @@ class VirtTestOptionsProcess(object):
         self.options.vt_accel = settings.get_value(
             'vt.qemu', 'accel', default='kvm')
         self.options.vt_nettype = settings.get_value(
-            'vt.qemu', 'nettype', default='user')
+            'vt.qemu', 'nettype', default='')
         self.options.vt_netdst = settings.get_value(
             'vt.qemu', 'netdst', default='virbr0')
         self.options.vt_vhost = settings.get_value(
@@ -789,6 +789,14 @@ class VirtTestOptionsProcess(object):
     def _process_bridge_mode(self):
         nettype_setting = 'config vt.qemu.nettype'
         if not self.options.vt_config:
+            # Let's select reasonable defaults depending on vt_type
+            if self.options.vt_type == 'qemu':
+                self.options.vt_nettype = (self.options.vt_nettype if
+                                           self.options.vt_nettype else 'user')
+            else:
+                self.options.vt_nettype = (self.options.vt_nettype if
+                                           self.options.vt_nettype else 'bridge')
+
             if self.options.vt_nettype not in SUPPORTED_NET_TYPES:
                 raise ValueError("Invalid %s '%s'. "
                                  "Valid values: (%s)" %

--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -21,7 +21,11 @@ mem = 1024
 arch =
 # Machine type under test
 machine_type =
-[vt.qemu]
+# Nettype (bridge, user, none)
+nettype =
+# Bridge name to be used if you select bridge as a nettype
+netdst = virbr0
+[virt_test.qemu]
 # Path to a custom qemu binary to be tested
 qemu_bin =
 # Path to a custom qemu binary to be tested for the
@@ -30,10 +34,6 @@ qemu_bin =
 qemu_dst_bin =
 # Accelerator used to run qemu (kvm or tcg)
 accel = kvm
-# Nettype (bridge, user, none)
-nettype = user
-# Bridge name to be used if you select bridge as a nettype
-netdst = virbr0
 # Whether to enable vhost for qemu (on/off/force). Depends on nettype=bridge
 vhost = off
 # Monitor type (human or qmp)

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1542,7 +1542,7 @@ class VM(virt_vm.BaseVM):
             try:
                 process.run(install_command, verbose=False)
             except process.CmdError, details:
-                stderr = details.result_obj.stderr.strip()
+                stderr = details.result.stderr.strip()
                 # This is a common newcomer mistake, be more helpful...
                 if stderr.count('IDE CDROM must use'):
                     testname = params.get('name', "")

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1540,7 +1540,7 @@ class VM(virt_vm.BaseVM):
             for item in install_command.replace(" -", " \n    -").splitlines():
                 logging.info("%s", item)
             try:
-                process.run(install_command, verbose=False)
+                process.run(install_command, verbose=False, shell=True)
             except process.CmdError, details:
                 stderr = details.result.stderr.strip()
                 # This is a common newcomer mistake, be more helpful...

--- a/virttest/staging/lv_utils.py
+++ b/virttest/staging/lv_utils.py
@@ -302,7 +302,7 @@ def lv_take_snapshot(vg_name, lv_name,
         result = process.run(cmd)
     except process.CmdError, ex:
         if ('Logical volume "%s" already exists in volume group "%s"' %
-            (lv_snapshot_name, vg_name) in ex.result_obj.stderr and
+            (lv_snapshot_name, vg_name) in ex.result.stderr and
             re.search(re.escape(lv_snapshot_name + " [active]"),
                       process.run("lvdisplay").stdout)):
             # the above conditions detect if merge of snapshot was postponed

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1102,9 +1102,11 @@ def run(test, params, env):
     except IndexError:
         raise virt_vm.VMConfigMissingError(vm.name, "serial")
 
-    log_file = utils_misc.get_path(test.debugdir,
-                                   "serial-%s-%s.log" % (serial_name,
-                                                         vm.name))
+    try:
+        log_file = vm.get_serial_console_filenames()[0]
+    except IndexError:
+        raise virt_vm.VMConfigMissingError(vm.name, "serial")
+
     logging.debug("Monitoring serial console log for completion message: %s",
                   log_file)
     serial_log_msg = ""

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -11,6 +11,7 @@ import time
 import shelve
 import remote
 import commands
+import signal
 
 from avocado.core import exceptions
 from avocado.utils import path
@@ -740,6 +741,117 @@ class IPAddress(object):
         if self.iface and other_ip.iface and self.iface != other_ip.iface:
             return False
         return True
+
+
+def raw_ping(command, timeout, session, output_func):
+    """
+    Low-level ping command execution.
+
+    :param command: Ping command.
+    :param timeout: Timeout of the ping command.
+    :param session: Local executon hint or session to execute the ping command.
+    """
+    if session is None:
+        logging.info("The command of Ping is: %s", command)
+        process = aexpect.run_bg(command, output_func=output_func,
+                                 timeout=timeout)
+
+        # Send SIGINT signal to notify the timeout of running ping process,
+        # Because ping have the ability to catch the SIGINT signal so we can
+        # always get the packet loss ratio even if timeout.
+        if process.is_alive():
+            utils_misc.kill_process_tree(process.get_pid(), signal.SIGINT)
+
+        status = process.get_status()
+        output = process.get_output()
+
+        process.close()
+        return status, output
+    else:
+        output = ""
+        try:
+            output = session.cmd_output(command, timeout=timeout,
+                                        print_func=output_func)
+        except aexpect.ShellTimeoutError:
+            # Send ctrl+c (SIGINT) through ssh session
+            session.send("\003")
+            try:
+                output2 = session.read_up_to_prompt(print_func=output_func)
+                output += output2
+            except aexpect.ExpectTimeoutError, e:
+                output += e.output
+                # We also need to use this session to query the return value
+                session.send("\003")
+
+        session.sendline(session.status_test_command)
+        try:
+            o2 = session.read_up_to_prompt()
+        except aexpect.ExpectError:
+            status = -1
+        else:
+            try:
+                status = int(re.findall("\d+", o2)[0])
+            except Exception:
+                status = -1
+
+        return status, output
+
+
+def ping(dest=None, count=None, interval=None, interface=None,
+         packetsize=None, ttl=None, hint=None, adaptive=False,
+         broadcast=False, flood=False, timeout=0,
+         output_func=logging.debug, session=None):
+    """
+    Wrapper of ping.
+
+    :param dest: Destination address.
+    :param count: Count of icmp packet.
+    :param interval: Interval of two icmp echo request.
+    :param interface: Specified interface of the source address.
+    :param packetsize: Packet size of icmp.
+    :param ttl: IP time to live.
+    :param hint: Path mtu discovery hint.
+    :param adaptive: Adaptive ping flag.
+    :param broadcast: Broadcast ping flag.
+    :param flood: Flood ping flag.
+    :param timeout: Timeout for the ping command.
+    :param output_func: Function used to log the result of ping.
+    :param session: Local executon hint or session to execute the ping command.
+    """
+    command = "ping"
+    if ":" in dest:
+        command = "ping6"
+    if dest is not None:
+        command += " %s " % dest
+    else:
+        command += " localhost "
+    if count is not None:
+        command += " -c %s" % count
+    if interval is not None:
+        command += " -i %s" % interval
+    if interface is not None:
+        command += " -I %s" % interface
+    else:
+        if dest.upper().startswith("FE80"):
+            err_msg = "Using ipv6 linklocal must assigne interface"
+            raise exceptions.TestNAError(err_msg)
+    if packetsize is not None:
+        command += " -s %s" % packetsize
+    if ttl is not None:
+        command += " -t %s" % ttl
+    if hint is not None:
+        command += " -M %s" % hint
+    if adaptive:
+        command += " -A"
+    if broadcast:
+        command += " -b"
+    if flood:
+        command += " -f -q"
+        command = "sleep %s && kill -2 `pidof ping` & %s" % (timeout, command)
+        output_func = None
+        timeout += 1
+
+    return raw_ping(command, timeout, session, output_func)
 
 
 def get_macvtap_base_iface(base_interface=None):

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -59,7 +59,7 @@ from ..libvirt_xml.devices import controller
 from ..libvirt_xml.devices import seclabel
 from ..libvirt_xml.devices import channel
 
-from __init__ import ping
+ping = utils_net.ping
 
 
 class LibvirtNetwork(object):


### PR DESCRIPTION
It's my fault and I didn't test the libvirt backend nearly enough. After these fixes, I'm able to run virsh tests. An example command line that runs 3 tests (libvirt guest `install`, one virsh test, then libvirt guest removal):

    sudo avocado run unattended_install.import.import.default_install.aio_native type_specific.io-github-autotest-libvirt.virsh.find_storage_pool_sources_as.positive_test.local_source.nfs_type remove_guest.without_disk --vt-type libvirt --vt-setup

Yes, you have to use `sudo`, because that's the way `libvirt` tests can access the `system://` session, unfortunately. And this all assumes you are running from the rpm install. For the source install, the instructions are slightly different:

    sudo scripts/avocado run unattended_install.import.import.default_install.aio_native type_specific.io-github-autotest-libvirt.virsh.find_storage_pool_sources_as.positive_test.local_source.nfs_type remove_guest.without_disk --vt-type libvirt --vt-setup

Changes from v1:
* Per @ldoktor's suggestion force 'user' default for qemu and 'bridge' default for libvirt
* Per @ldoktor's suggestion use better import/assignment practices