### PR TITLE
list cmd: extend verbose mode for discovery stage

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -319,6 +319,8 @@ class VirtTestLoader(loader.TestLoader):
             params['id'] = test_name
             test_parameters = {'name': test_name,
                                'params': params}
+	    if self.args.verbose:
+		print("Discover: %s" % test_name)
             test_suite.append((VirtTest, test_parameters))
         return test_suite
 


### PR DESCRIPTION
$ avocado list --vt-type spice -V
will print test names for discovery process immediately

Justification: list can produce huge tests-list, thousands of tests.
'list' command can stay silent for a long time.
This patch allows to print progress as cartesian dics are processed.
This allows user to know that some work is going.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>