### PR TITLE
virttest.storage: Secure the backup handling

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -317,16 +317,18 @@ class QemuImg(object):
         """
         def backup_raw_device(src, dst):
             if os.path.exists(src):
-                process.system("dd if=%s of=%s bs=4k conv=sync" % (src, dst))
+                _dst = dst + '.part'
+                process.system("dd if=%s of=%s bs=4k conv=sync" % (src, _dst))
+                os.rename(_dst, dst)
             else:
                 logging.info("No source %s, skipping dd...", src)
 
         def backup_image_file(src, dst):
             logging.debug("Copying %s -> %s", src, dst)
-            if os.path.isfile(dst) and os.path.isfile(src):
-                os.unlink(dst)
             if os.path.isfile(src):
-                shutil.copy(src, dst)
+                _dst = dst + '.part'
+                shutil.copy(src, _dst)
+                os.rename(_dst, dst)
             else:
                 logging.info("No source file %s, skipping copy...", src)
 


### PR DESCRIPTION
Hello guys,

this patch avoids partial backups on interruption. Anyway while working on this I spent some time analyzing how the backup is performed and there are few differences.

```
# virttest bootstrap

1. try to get asset file
2. unpack the asset file (7z archive)

# virttest
1. (unless --keep-image) Create first raw ".backup" backup
2. Execute test
3. (unless --keep-image-between-tests) revert the image from raw ".backup"
4. while test goto 2
```

```
# avocado-vt bootstrap

1. try to get asset file
2. unpack the asset file (7z archive)

# avocado-vt
1. (if --vt-setup) Unpack the asset file
2. Execute test
3. (unless keep_image_between_tests) revert the image from raw ".backup"
4. while test goto 2
```

I tried to unify it, but it turned out to be a bit more complicated, so I'd like to get your opinion first... So far my preferred solution would be:

1. use asset file ONLY in bootstrap
2. before every avocado-vt test (unless `keep_image`) check if `.backup` file exists. If not, create it.
3. after each test (unless `keep_image_between_test`) revert the image

Also I'd rename the `keep_image` to `backup_image` and `keep_image_between_tests` to `restore_image`|`revert_image`.

@lmr, @clebergnu any objections/suggestions?