### PR TITLE
Refine the default image backup handling

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -234,7 +234,8 @@ class VirtTestLoader(loader.TestLoader):
         add_if_not_exist('vt_arch', None)
         add_if_not_exist('vt_machine_type', None)
         add_if_not_exist('vt_keep_guest_running', False)
-        add_if_not_exist('vt_keep_image_between_tests', False)
+        add_if_not_exist('vt_backup_image_before_test', True)
+        add_if_not_exist('vt_restore_image_after_test', True)
         add_if_not_exist('vt_mem', 1024)
         add_if_not_exist('vt_no_filter', '')
         add_if_not_exist('vt_qemu_bin', None)
@@ -691,10 +692,10 @@ class VirtTestOptionsProcess(object):
         # Doing this makes things configurable yet the number of options
         # is not overwhelming.
         # setup section
-        self.options.vt_keep_image = settings.get_value(
-            'vt.setup', 'keep_image', key_type=bool)
-        self.options.vt_keep_image_between_tests = settings.get_value(
-            'vt.setup', 'keep_image_between_tests', key_type=bool)
+        self.options.vt_backup_image_before_test = settings.get_value(
+            'vt.setup', 'backup_image_before_test', key_type=bool)
+        self.options.vt_restore_image_after_test = settings.get_value(
+            'vt.setup', 'restore_image_after_test', key_type=bool)
         self.options.vt_keep_guest_running = settings.get_value(
             'vt.setup', 'keep_guest_running', key_type=bool)
         # common section
@@ -1000,10 +1001,14 @@ class VirtTestOptionsProcess(object):
             if not self.options.vt_keep_guest_running:
                 self.cartesian_parser.assign("kill_vm", "yes")
 
-    def _process_restore_image_between_tests(self):
+    def _process_restore_image(self):
         if not self.options.vt_config:
-            if not self.options.vt_keep_image_between_tests:
-                self.cartesian_parser.assign("restore_image", "yes")
+            if self.options.vt_backup_image_before_test:
+                self.cartesian_parser.assign("backup_image_before_testing",
+                                             "yes")
+            if self.options.vt_restore_image_after_test:
+                self.cartesian_parser.assign("restore_image_after_testing",
+                                             "yes")
 
     def _process_mem(self):
         self.cartesian_parser.assign("mem", self.options.vt_mem)
@@ -1043,7 +1048,7 @@ class VirtTestOptionsProcess(object):
         self._process_arch()
         self._process_machine_type()
         self._process_restart_vm()
-        self._process_restore_image_between_tests()
+        self._process_restore_image()
         self._process_mem()
         self._process_tcpdump()
         self._process_no_filter()

--- a/docs/source/advanced/VirtTestDocumentation.rst
+++ b/docs/source/advanced/VirtTestDocumentation.rst
@@ -80,7 +80,7 @@ root. However, other tests might fail due to lack of privileges.
 
 ::
 
-    avocado run type_specific.io-github-autotest-qemu.migrate.default.tcp --vt-setup --vt-test-type qemu
+    avocado run type_specific.io-github-autotest-qemu.migrate.default.tcp --vt-test-type qemu
 
 .. _run_different_tests:
 

--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -1,7 +1,4 @@
 [vt.setup]
-# Run the setup procedure (uncompress JeOS' pristine image).
-# The keys below help you customize the procedure
-run_setup=False
 # Backup image before testing (if not already backuped)
 backup_image_before_test = True
 # Restore image after testing (if backup present)

--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -2,12 +2,10 @@
 # Run the setup procedure (uncompress JeOS' pristine image).
 # The keys below help you customize the procedure
 run_setup=False
-# Don't restore the JeOS at the beginning of the test job (faster, but unsafe)
-# This has no effect unless you set run_setup=True or --vt-setup on the cmdline
-keep_image=False
-# Don't restore the JeOS between tests (faster, but unsafe)
-# This has no effect unless you set run_setup=True or --vt-setup on the cmdline
-keep_image_between_tests=False
+# Backup image before testing (if not already backuped)
+backup_image_before_test = True
+# Restore image after testing (if backup present)
+restore_image_after_test = True
 # Keep guest running between tests (faster, but unsafe)
 keep_guest_running=False
 [vt.common]

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -819,26 +819,3 @@ def bootstrap(options, interactive=False):
                  "more info", step)
     logging.info("")
     logging.info(online_docs_url)
-
-
-def setup(options):
-    """
-    Run pre tests setup (Uncompress test image(s), such as the JeOS image).
-
-    :param test_name: Test name, such as "qemu".
-    :param guest_os: Specify the guest image used for bootstrapping. By default
-            the JeOS image is used.
-    """
-    if not options.vt_keep_image:
-        test_name = options.vt_type
-        guest_os = options.vt_guest_os or defaults.DEFAULT_GUEST_OS
-        logging.info("Running pre tests setup for test type %s and guest OS %s",
-                     test_name, guest_os)
-        try:
-            for os_info in get_guest_os_info_list(test_name, guest_os):
-                asset_info = asset.get_asset_info(os_info['asset'])
-                asset.uncompress_asset(asset_info, force=True)
-        # Some guests will not have guest os info list available,
-        # So there will be no need for the uncompress phase.
-        except ValueError:
-            pass

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -263,6 +263,7 @@ def postprocess_image(test, params, image_name, vm_process_status=None):
     :param vm_process_status: (optional) vm process status like running, dead
                               or None for no vm exist.
     """
+    restored = False
     clone_master = params.get("clone_master", None)
     base_dir = data_dir.get_data_dir()
     image = qemu_storage.QemuImg(params, base_dir, image_name)
@@ -304,8 +305,10 @@ def postprocess_image(test, params, image_name, vm_process_status=None):
             # example for this is when 'unattended_install' is run.
             if params.get("backup_image", "no") == "yes":
                 image.backup_image(params, base_dir, "backup", True)
+                restored = True
             elif params.get("restore_image", "no") == "yes":
                 image.backup_image(params, base_dir, "restore", True)
+                restored = True
         except Exception, e:
             if params.get("restore_image_on_check_error", "no") == "yes":
                 image.backup_image(params, base_dir, "restore", True)
@@ -318,7 +321,8 @@ def postprocess_image(test, params, image_name, vm_process_status=None):
                 logging.warn(e.message)
             else:
                 raise e
-    if params.get("restore_image_after_testing", "no") == "yes":
+    if (not restored and
+            params.get("restore_image_after_testing", "no") == "yes"):
         image.backup_image(params, base_dir, "restore", True)
     if params.get("remove_image") == "yes":
         logging.info("Remove image on %s." % image.storage_type)

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -410,6 +410,8 @@ class QemuImg(object):
 
         for src, dst in backup_set:
             if action == 'backup' and skip_existing and os.path.exists(dst):
+                logging.debug("Image backup %s already exists, skipping...",
+                              dst)
                 continue
             backup_func(src, dst)
 


### PR DESCRIPTION
This patchset removes the `--vt-setup` and replaces the backup handling with settings: `backup_image_before_test` and `restore_image_after_test`. These are mapped to already existing values in cartesian_parser, so from virttest point of view there is no difference.

In separate patches I modified the virttest part  to improve logging and avoid double image restoration.