### PR TITLE
spec file: Add aexpect dependency

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -1,14 +1,14 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 0.27.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
 Source: avocado-plugins-vt-%{version}.tar.gz
 BuildRequires: python2-devel
 BuildArch: noarch
-Requires: python, avocado, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc
+Requires: python, avocado, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect
 
 Requires: python-imaging
 %if 0%{?el6}
@@ -45,6 +45,9 @@ Xunit output, among others.
 
 
 %changelog
+* Wed Sep 2 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.27.0-4
+- Add aexpect dependency
+
 * Tue Aug 4 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.27.0-3
 - Add video dependencies
 


### PR DESCRIPTION
For some reason, I've missed that pretty badly. aexpect
is required for the plugin to work properly, yet we don't
have it as a dependency on our spec file. Let's fix that.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>