### PR TITLE
Print test name for spice tests as sub-test variant

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -254,6 +254,11 @@ class VirtTestLoader(loader.TestLoader):
             # test in question is executed from inside avocado.
             params['avocado_inject_params'] = True
             test_name = params.get("_short_name_map_file")["subtests.cfg"]
+            if self.args.vt_type == 'spice':
+                short_name_map_file = params.get("_short_name_map_file")
+                if "tests-variants.cfg" in short_name_map_file:
+                    test_name = short_name_map_file["tests-variants.cfg"]
+
             params['id'] = test_name
             test_parameters = {'name': test_name,
                                'params': params}


### PR DESCRIPTION
Currently you suppose that 1 test == 1 entry at subtests.cfg

SpiceQE team uses one script wich can take many options at input.
Actual test name will be quite different from script name.
Test name and it meaning can be generated on second step,
depending on actual run requests.
I ask to take test-name from from different config.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>