### PR TITLE
virttest: Update providers dir whenever tp names are checked

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -8,6 +8,7 @@ import glob
 import ConfigParser
 import StringIO
 import commands
+import distutils
 
 from avocado.utils import process
 from avocado.utils import genio
@@ -206,6 +207,9 @@ def get_test_provider_names(backend=None):
     :return: List with the names of all test providers.
     """
     provider_name_list = []
+    tp_base_dir = data_dir.get_base_test_providers_dir()
+    tp_local_dir = data_dir.get_test_providers_dir()
+    distutils.dir_util.copy_tree(tp_base_dir, tp_local_dir)
     provider_dir = data_dir.get_test_providers_dir()
     for provider in glob.glob(os.path.join(provider_dir, '*.ini')):
         provider_name = os.path.basename(provider).split('.')[0]

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -212,15 +212,15 @@ TEST_PROVIDERS_DOWNLOAD_DIR = os.path.join(get_data_dir(), 'test-providers.d',
                                            'downloads')
 
 
+def get_base_test_providers_dir():
+    return TEST_PROVIDERS_DIR
+
+
 def get_test_providers_dir():
     """
     Return the base test providers dir (at the moment, test-providers.d).
     """
-    test_providers_dir = os.path.dirname(TEST_PROVIDERS_DOWNLOAD_DIR)
-    if not os.path.isdir(test_providers_dir):
-        shutil.copytree(TEST_PROVIDERS_DIR, test_providers_dir)
-        os.makedirs(TEST_PROVIDERS_DOWNLOAD_DIR)
-    return test_providers_dir
+    return os.path.dirname(TEST_PROVIDERS_DOWNLOAD_DIR)
 
 
 def get_test_provider_dir(provider):


### PR DESCRIPTION
In a similar vein to the test backend dirs, when new test
provider .ini files are added to avocado-vt, sync them with
their local avocado data dir counterparts. This way we don't
risk getting our test provider info out of sync.

This fixes a bug when running vt-bootstrap --vt-type spice
on local dir structures already created would prevent the
new test provider to be downloaded/updated.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>