### PR TITLE
shared.cfg.guest-hw: Set cd_format only for i440fx/q35

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -65,7 +65,8 @@ variants:
         drive_format=sd
     - virtio_blk:
         drive_format=virtio
-        cd_format=ide
+        i440fx:
+            cd_format=ide
         q35:
             cd_format=ahci
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer


### PR DESCRIPTION
ARM64/PPC64 doesn't support ide cd-interface. This patch only sets it
when i440fx is used (q35 already uses ahci in the same fashion)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>