### PR TITLE
Correct import distutils

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -8,7 +8,7 @@ import glob
 import ConfigParser
 import StringIO
 import commands
-import distutils
+import distutils.dir_util
 
 from avocado.utils import process
 from avocado.utils import genio

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -1,4 +1,4 @@
-import distutils
+import distutils.dir_util
 import logging
 import os
 import glob


### PR DESCRIPTION
Try to escape from:

Error loading avocado.core.plugins.vt_bootstrap -> AttributeError 'module' object has no attribute 'dir_util'
Error loading avocado.core.plugins.vt -> AttributeError 'module' object has no attribute 'dir_util'