### PR TITLE
Couple of mixed fixups [v2]

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -79,8 +79,9 @@ from virttest.standalone_test import SUPPORTED_NET_TYPES
 
 _PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_test_providers_dir(),
                                        'downloads')
-
-if len(os.listdir(_PROVIDERS_DOWNLOAD_DIR)) == 0:
+try:
+    assert len(os.listdir(_PROVIDERS_DOWNLOAD_DIR)) != 0
+except (OSError, AssertionError):
     raise EnvironmentError("Bootstrap missing. "
                            "Execute 'avocado vt-bootstrap' or disable this "
                            "plugin to get rid of this message")

--- a/avocado/core/plugins/vt_list.py
+++ b/avocado/core/plugins/vt_list.py
@@ -61,7 +61,9 @@ from virttest import data_dir
 _PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_test_providers_dir(),
                                        'downloads')
 
-if len(os.listdir(_PROVIDERS_DOWNLOAD_DIR)) == 0:
+try:
+    assert len(os.listdir(_PROVIDERS_DOWNLOAD_DIR)) != 0
+except (OSError, AssertionError):
     raise EnvironmentError("Bootstrap missing. "
                            "Execute 'avocado vt-bootstrap' or disable this "
                            "plugin to get rid of this message")

--- a/backends/libguestfs/cfg/tests.cfg
+++ b/backends/libguestfs/cfg/tests.cfg
@@ -44,7 +44,6 @@ variants:
         only bridge
         no multi_host
         only (subtest=guestfs_list_operations)
-        only vnc
         #only (subtest=type_specific)
 
 
@@ -64,6 +63,5 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
 
 only libguestfs_runner

--- a/backends/libvirt/cfg/tests.cfg
+++ b/backends/libvirt/cfg/tests.cfg
@@ -21,6 +21,5 @@ variants:
         only smallpages
         only default_bios
         only bridge
-        only vnc
 
 only libvirt_quick

--- a/backends/openvswitch/cfg/tests.cfg
+++ b/backends/openvswitch/cfg/tests.cfg
@@ -18,7 +18,6 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
         #only ovs_basic.vlan_ping
 
 
@@ -36,6 +35,5 @@ variants:
         only (image_backend=filesystem)
         only default_bios
         only bridge
-        only vnc
 
 only openvswitch_runner

--- a/backends/qemu/cfg/tests.cfg
+++ b/backends/qemu/cfg/tests.cfg
@@ -11,6 +11,5 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
 
 only qemu_kvm_jeos_quick

--- a/backends/v2v/cfg/tests.cfg
+++ b/backends/v2v/cfg/tests.cfg
@@ -46,6 +46,5 @@ variants:
         only default_bios
         only bridge
         no multi_host
-        only vnc
  
 only v2v_all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 autotest>=0.16.2
 aexpect>=1.0.0
+simplejson>=3.5.3

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -448,10 +448,11 @@ migrate_dest_pwd = PASSWORD.DEST.EXAMPLE
 # It could be put into NFS or SAN, it is used to create
 # a vm with shared_storage on source and destination
 migrate_shared_storage = SHARED_IMAGE.EXAMPLE
-# Defined VMs that can be used for migration
+# Additional VMs that can be used for migration
+# ("vms" are added on-the-fly so ${main_vm} is already there)
 # For example: "migrate_vm1 migrate_vm2 migrate_vm3"
 # So please put images of vms into NFS or SAN
-migrate_vms = "${vms}"
+migrate_vms = ""
 # A default vm for migration, it should be one of migrate_vms
 migrate_main_vm = "${main_vm}"
 # Used for loading stress for host during stress migration

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -358,22 +358,3 @@ variants:
     - network:
         nettype = network
 
-# Display
-variants:
-    - spice:
-        display = spice
-        vga = qxl
-    - @vnc:
-        display = vnc
-        Linux:
-            vga = cirrus
-        Windows:
-            vga = std
-            WinXP, Win2003:
-                vga = cirrus
-    - sdl:
-        display = sdl
-        vga = cirrus
-    - nographic:
-        display = nographic
-        vga =

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -366,6 +366,7 @@ def get_file_asset(title, src_path, destination):
 def get_asset_info(asset):
     asset_info = {}
     asset_path = os.path.join(data_dir.get_download_dir(), '%s.ini' % asset)
+    assert os.path.exists(asset_path)
     asset_cfg = ConfigLoader(asset_path)
 
     asset_info['url'] = asset_cfg.get(asset, 'url')

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -8,7 +8,7 @@ import glob
 import ConfigParser
 import StringIO
 import commands
-import distutils
+from distutils import dir_util  # virtualenv problem pylint: disable=E0611
 
 from avocado.utils import process
 from avocado.utils import genio
@@ -209,7 +209,7 @@ def get_test_provider_names(backend=None):
     provider_name_list = []
     tp_base_dir = data_dir.get_base_test_providers_dir()
     tp_local_dir = data_dir.get_test_providers_dir()
-    distutils.dir_util.copy_tree(tp_base_dir, tp_local_dir)
+    dir_util.copy_tree(tp_base_dir, tp_local_dir)
     provider_dir = data_dir.get_test_providers_dir()
     for provider in glob.glob(os.path.join(provider_dir, '*.ini')):
         provider_name = os.path.basename(provider).split('.')[0]

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -813,8 +813,11 @@ def bootstrap(options, interactive=False):
                      step)
         for os_info in get_guest_os_info_list(options.vt_type, guest_os):
             os_asset = os_info['asset']
-            asset.download_asset(os_asset, interactive=interactive,
-                                 restore_image=restore_image)
+            try:
+                asset.download_asset(os_asset, interactive=interactive,
+                                     restore_image=restore_image)
+            except AssertionError:
+                pass    # Not all files are managed via asset
 
     check_modules = []
     if options.vt_type == "qemu":

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -1,4 +1,4 @@
-import distutils
+from distutils import dir_util  # virtualenv problem pylint: disable=E0611
 import logging
 import os
 import glob
@@ -767,7 +767,7 @@ def bootstrap(options, interactive=False):
     local_backend_dir = data_dir.get_local_backend_dir()
     logging.info("Syncing backend dirs %s -> %s", base_backend_dir,
                  local_backend_dir)
-    distutils.dir_util.copy_tree(base_backend_dir, local_backend_dir)
+    dir_util.copy_tree(base_backend_dir, local_backend_dir)
 
     test_dir = data_dir.get_backend_dir(options.vt_type)
     if options.vt_type == 'libvirt':


### PR DESCRIPTION
Hello guys, while working on power I found few problems. See each patch for details. The only important ones are:

* virttest: Import distutils.dir_util properly - some versions of distutils doesn't export dir_util by default making avocado-vt unusable
* shared.cfg.base: Change the default for migrate_vms - this troubles me for a while now (internally I remove migrate_vms for about a year now). I studied the code and it should be safe to remove it completely, because it extends the list of vms of the vms before usage. Without this fix all tests with `vms = ""` create the VM, which causes false-negatives or just runs longer (of boot+shutdown time). With this patch migrate_vms ends up with the same content so it should work.
* virt-test: remove display configuration - backport of a fix already merged in virt-test

@lmr, @clebergnu would you please have a look at this, it's important for our CI (I'd like to remove my fixtures...)

Regards,
Lukáš

v1: https://github.com/avocado-framework/avocado-vt/pull/97

```
Chagnes:
    v2: Update commit message of  "virttest.bootstrap: Skip downloading non existent assets"
```