### PR TITLE
Ignore vt_guest_os for vt-type==spice at all

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -927,7 +927,7 @@ class VirtTestOptionsProcess(object):
     def _process_guest_os(self):
         guest_os_setting = 'option --vt-guest-os'
 
-        if self.options.vt_type == 'spice' and not self.options.vt_guest_os:
+        if self.options.vt_type == 'spice':
             logging.info("Ignoring predefined OS: %s", guest_os_setting)
             return
 


### PR DESCRIPTION
Problem:

list command does not setup default value for vt_guest_os
run command setups default value for vt_guest_os

run / list get different only-filters

tests from tp-spice use several different VM at same time with different OSes.
tp-spice specifies OS at config file.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>