### PR TITLE
avocado-vt: Fix unattended install

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -121,6 +121,7 @@ class VM(virt_vm.BaseVM):
         else:
             self.process = None
             self.serial_ports = []
+            self.serial_console_log = None
             self.serial_console = None
             self.redirs = {}
             self.vnc_port = None
@@ -985,6 +986,8 @@ class VM(virt_vm.BaseVM):
                                                        output_params=output_params)
             # Cause serial_console.close() to close open log file
             self.serial_console.set_log_file(output_filename)
+            self.serial_console_log = os.path.join(utils_misc.get_log_file_dir(),
+                                                   output_filename)
 
     def set_root_serial_console(self, device, remove=False):
         """
@@ -1357,6 +1360,7 @@ class VM(virt_vm.BaseVM):
                 self.serial_console.sendline("^]")
             self.serial_console.close()
             self.serial_console = None
+            self.serial_console_log = None
         if hasattr(self, "migration_file"):
             try:
                 os.unlink(self.migration_file)

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1097,14 +1097,8 @@ def run(test, params, env):
 
     start_time = time.time()
 
-    try:
-        serial_name = vm.serial_ports[0]
-    except IndexError:
-        raise virt_vm.VMConfigMissingError(vm.name, "serial")
-
-    try:
-        log_file = vm.get_serial_console_filenames()[0]
-    except IndexError:
+    log_file = vm.serial_console_log
+    if log_file is None:
         raise virt_vm.VMConfigMissingError(vm.name, "serial")
 
     logging.debug("Monitoring serial console log for completion message: %s",


### PR DESCRIPTION
A long time ago, back in 2012 (see commit
feaa5e5a21733d4d1568e08879974ac55ef7bbad), unattended
install started to use the serial log file contents
instead of the serial console aexpect session. The
change was motivated by unattended install tests
with ping pong migration, that made the finish
message to be lost because of the switch between
src and dst.

Later on, we unified libvirt and qemu unattended
install mechanism, by making both read from the
log. Unfortunately, keeping up both implementations
working simultaneously was difficult, given that
people working with libvirt rarely tested on qemu
and vice-versa.

So here we go again. The QEMU implementation got
broken by patch 319887f26ada824033fde48812aa7715a0f4317e,
by yours truly, made when working on the libvirt
subtest bugs.

This time, let's introduce a new attribute to the
VM objects in both qemu and libvirt VM classes:
vm.serial_console_log. This reflects the actual log
file, and not the socket name of the serial console
device. We made it so that it works on both the
QEMU and Libvirt VM implementations. This time around,
both implementations were tested. For the future, we
have to be more careful with changes in this code,
and require from patch senders that both backends are
tested.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>