### PR TITLE
virttest.data_dir: Simplify root dir detection

### DIFF
--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -24,14 +24,8 @@ if _INSTALLED_SYSTEM_WIDE:
 else:
     # we're running from source code directories
     virttest_init = sys.modules['virttest'].__file__
-    virttest_dir = os.path.dirname(virttest_init)
-    # Sometimes, virt-test is a symlink, other times, a real dir
-    try:
-        virttest_real_dir = os.readlink(virttest_dir)
-    except OSError:
-        virttest_real_dir = virttest_dir
-    virttest_real_dir_abs = os.path.abspath(virttest_real_dir)
-    _ROOT_PATH = os.path.dirname(virttest_real_dir_abs)
+    virttest_dir = os.path.realpath(os.path.dirname(virttest_init))
+    _ROOT_PATH = os.path.dirname(virttest_dir)
 
 ROOT_DIR = os.path.abspath(_ROOT_PATH)
 BASE_BACKEND_DIR = os.path.join(ROOT_DIR, 'backends')


### PR DESCRIPTION
Use `os.path.realpath` which returns absolute path instead of reading
the link.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>