### PR TITLE
docs..GetStartedGuide: Add --vt-type to list

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -35,9 +35,9 @@ at the top level of the avocado-vt repository has the detailed procedure.
     virt_test_compat_lister  Implements the avocado virt test options
 
 7. The next test is to see if virt-tests are also listed in the output of the
-   command `avocado list`::
+   command `avocado list` (you might leave out the --vt-type if you use default)::
 
-    $ avocado list --verbose
+    $ avocado list --vt-type qemu --verbose
 
    This should list a large amount of tests (over 1900 virt related tests)::
 


### PR DESCRIPTION
THe "avocado list" requires --vt-type when not using qemu. Let's make it
clear that people needs to supply it when not using default (qemu).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>