### PR TITLE
ovirt: Fix the missing param bug

### DIFF
--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -95,7 +95,8 @@ class VMManager(virt_vm.BaseVM):
     This class handles all basic VM operations for oVirt.
     """
 
-    def __init__(self, params, root_dir, address_cache=None, state=None):
+    def __init__(self, name, params, root_dir=None, address_cache=None,
+                 state=None):
         """
         Initialize the object and set a few attributes.
 
@@ -124,7 +125,7 @@ class VMManager(virt_vm.BaseVM):
             self.remote_sessions = []
 
         self.spice_port = 8000
-        self.name = params.get("main_vm", "")
+        self.name = name
         self.params = params
         self.root_dir = root_dir
         self.address_cache = address_cache

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -199,7 +199,7 @@ class VMCheck(object):
                                self.env.get("address_cache"))
             self.pv = libvirt.PoolVolumeTest(test, params)
         elif self.target == "ovirt":
-            self.vm = ovirt.VMManager(self.params, self.test.bindir,
+            self.vm = ovirt.VMManager(self.name, self.params, self.test.bindir,
                                       self.env.get("address_cache"))
         else:
             raise ValueError("Doesn't support %s target now" % self.target)
@@ -622,6 +622,7 @@ def import_vm_to_ovirt(params, address_cache, timeout=600):
     """
     Import VM from export domain to oVirt Data Center
     """
+    vm_name = params.get('main_vm')
     os_type = params.get('os_type')
     export_name = params.get('export_name')
     storage_name = params.get('storage_name')
@@ -635,7 +636,7 @@ def import_vm_to_ovirt(params, address_cache, timeout=600):
     logging.info("Current host list: %s", hm.list())
     sdm = ovirt.StorageDomainManager(params)
     logging.info("Current storage domain list: %s", sdm.list())
-    vm = ovirt.VMManager(params, address_cache)
+    vm = ovirt.VMManager(vm_name, params, address_cache=address_cache)
     logging.info("Current VM list: %s", vm.list())
     wait_for_up = True
     if os_type == 'windows':


### PR DESCRIPTION
All type VMs(qemu, libvirt and v2v) are using the same pattern to
create VM object in utils_env.create_vm.

Signed-off-by: Yanbing Du <ydu@redhat.com>