### PR TITLE
utils_misc: Deprecate find_command to avoid duplicate

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -31,6 +31,7 @@ from avocado.core import multiplexer
 from avocado.core import test
 from avocado.core.settings import settings
 from avocado.core.plugins import plugin
+from avocado.utils import path as utils_path
 from avocado.utils import stacktrace
 from avocado.utils import genio
 
@@ -966,7 +967,7 @@ class VirtTestOptionsProcess(object):
         Verify whether we can run tcpdump. If we can't, turn it off.
         """
         try:
-            tcpdump_path = utils_misc.find_command('tcpdump')
+            tcpdump_path = utils_path.find_command('tcpdump')
         except ValueError:
             tcpdump_path = None
 

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -5,6 +5,7 @@ import glob
 import shutil
 import sys
 
+from avocado.utils import path as utils_path
 from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils import linux_modules
@@ -108,7 +109,7 @@ def verify_recommended_programs(t_type):
         for cmd in cmd_aliases:
             found = None
             try:
-                found = utils_misc.find_command(cmd)
+                found = utils_path.find_command(cmd)
                 logging.info('%s OK', found)
                 break
             except ValueError:
@@ -129,7 +130,7 @@ def verify_mandatory_programs(t_type, guest_os):
     cmds = mandatory_programs[t_type]
     for cmd in cmds:
         try:
-            logging.info('%s OK', utils_misc.find_command(cmd))
+            logging.info('%s OK', utils_path.find_command(cmd))
         except ValueError:
             if cmd == '7za' and guest_os != defaults.DEFAULT_GUEST_OS:
                 logging.warn("Command 7za (required to uncompress JeOS) "

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -6,6 +6,7 @@ import time
 import traceback
 import Queue
 
+from avocado.utils import path as utils_path
 from avocado.core import exceptions
 
 import aexpect
@@ -72,9 +73,9 @@ def find_default_qemu_paths(options_qemu=None, options_dst_qemu=None):
         qemu_bin_path = options_qemu
     else:
         try:
-            qemu_bin_path = utils_misc.find_command('qemu-kvm')
+            qemu_bin_path = utils_path.find_command('qemu-kvm')
         except ValueError:
-            qemu_bin_path = utils_misc.find_command('kvm')
+            qemu_bin_path = utils_path.find_command('kvm')
 
     if options_dst_qemu is not None:
         if not os.path.isfile(options_dst_qemu):
@@ -89,10 +90,10 @@ def find_default_qemu_paths(options_qemu=None, options_dst_qemu=None):
     qemu_io_path = os.path.join(qemu_dirname, 'qemu-io')
 
     if not os.path.exists(qemu_img_path):
-        qemu_img_path = utils_misc.find_command('qemu-img')
+        qemu_img_path = utils_path.find_command('qemu-img')
 
     if not os.path.exists(qemu_io_path):
-        qemu_io_path = utils_misc.find_command('qemu-io')
+        qemu_io_path = utils_path.find_command('qemu-io')
 
     return [qemu_bin_path, qemu_img_path, qemu_io_path, qemu_dst_bin_path]
 
@@ -566,7 +567,7 @@ def create_config_files(options):
 
 def get_paginator():
     try:
-        less_cmd = utils_misc.find_command('less')
+        less_cmd = utils_path.find_command('less')
         return os.popen('%s -FRSX' % less_cmd, 'w')
     except ValueError:
         return sys.stdout

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -10,6 +10,7 @@ import remote
 import threading
 
 from avocado.core import exceptions
+from avocado.utils import path as utils_path
 from avocado.utils import process
 
 ENV_VERSION = 1
@@ -349,7 +350,7 @@ class Env(UserDict.IterableUserDict):
             self._tcpdump.sendline(cmd)
 
         else:
-            cmd = cmd_template % utils_misc.find_command("tcpdump")
+            cmd = cmd_template % utils_path.find_command("tcpdump")
             self._tcpdump = aexpect.Tail(command=cmd,
                                          output_func=_tcpdump_handler,
                                          output_params=(self, "tcpdump.log"))

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -27,7 +27,7 @@ import threading
 from avocado.core import status
 from avocado.core import exceptions
 from avocado.utils import git
-from avocado.utils import path
+from avocado.utils import path as utils_path
 from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils import aurl
@@ -266,20 +266,9 @@ def find_command(cmd):
     :param cmd: Command to be found.
     :raise: ValueError in case the command was not found.
     """
-    common_bin_paths = ["/usr/libexec", "/usr/local/sbin", "/usr/local/bin",
-                        "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
-    try:
-        path_paths = os.environ['PATH'].split(":")
-    except IndexError:
-        path_paths = []
-    path_paths = unique(common_bin_paths + path_paths)
-
-    for dir_path in path_paths:
-        cmd_path = os.path.join(dir_path, cmd)
-        if os.path.isfile(cmd_path):
-            return os.path.abspath(cmd_path)
-
-    raise ValueError('Missing command: %s' % cmd)
+    logging.warning("Function utils_misc.find_command is deprecated. "
+                    "Please use avocado.utils.path.find_command instead.")
+    return utils_path.find_command(cmd)
 
 
 def pid_exists(pid):
@@ -1373,7 +1362,7 @@ def create_x509_dir(path, cacert_subj, server_subj, passphrase,
     :raise OSError: if os.makedirs() fails
     """
 
-    ssl_cmd = path.command("openssl")
+    ssl_cmd = utils_path.find_command("openssl")
     path = path + os.path.sep  # Add separator to the path
     shutil.rmtree(path, ignore_errors=True)
     os.makedirs(path)
@@ -2924,7 +2913,7 @@ class KSMController(object):
                 raise KSMNotSupportedError
         else:
             try:
-                path.command("ksmctl")
+                utils_path.find_command("ksmctl")
             except ValueError:
                 raise KSMNotSupportedError
             _KSM_PARAMS = ["run", "pages_to_scan", "sleep_millisecs"]
@@ -2952,7 +2941,7 @@ class KSMController(object):
         Return ksmtuned process id(0 means not running).
         """
         try:
-            path.find_command("ksmtuned")
+            utils_path.find_command("ksmtuned")
         except ValueError:
             raise KSMTunedNotSupportedError
 

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -14,7 +14,7 @@ import commands
 import signal
 
 from avocado.core import exceptions
-from avocado.utils import path
+from avocado.utils import path as utils_path
 from avocado.utils import process
 
 import aexpect
@@ -618,7 +618,7 @@ class Macvtap(Interface):
 
     def ip_link_ctl(self, params, ignore_status=False):
         return process.run('%s %s' %
-                           (path.find_command("ip"), " ".join(params)),
+                           (utils_path.find_command("ip"), " ".join(params)),
                            ignore_status=ignore_status, verbose=False)
 
     def create(self, device, mode="vepa"):
@@ -1951,7 +1951,7 @@ class IPv6Manager(propcan.PropCanBase):
         ::param count: sending packets counts, default is 5
         """
         try:
-            path.find_command("ping6")
+            utils_path.find_command("ping6")
         except ValueError:
             raise exceptions.TestNAError("Can't find ping6 command")
         command = "ping6 -I %s %s -c %s" % (client_ifname, server_ipv6, count)
@@ -1973,7 +1973,7 @@ class IPv6Manager(propcan.PropCanBase):
         flush_cmd_pass = "Succeed to run command '%s'" % flush_cmd
         # check if ip6tables command exists on the local
         try:
-            path.find_command("ip6tables")
+            utils_path.find_command("ip6tables")
         except ValueError:
             raise exceptions.TestNAError(test_NA_err)
         # flush local ip6tables rules
@@ -2826,7 +2826,7 @@ def verify_ip_address_ownership(ip, macs, timeout=60.0):
         return True
 
     # Get the name of the bridge device for ip route cache
-    ip_cmd = utils_misc.find_command("ip")
+    ip_cmd = utils_path.find_command("ip")
     ip_cmd = "%s route get %s; %s route | grep default" % (ip_cmd, ip, ip_cmd)
     output = commands.getoutput(ip_cmd)
     devs = re.findall(r"dev\s+\S+", output, re.I)
@@ -2836,7 +2836,7 @@ def verify_ip_address_ownership(ip, macs, timeout=60.0):
         return False
     mac_regex = "|".join("(%s)" % mac for mac in macs)
     regex = re.compile(r"\b%s\b.*\b(%s)\b" % (ip, mac_regex), re.I)
-    arping_bin = utils_misc.find_command("arping")
+    arping_bin = utils_path.find_command("arping")
     for dev in devs:
         dev = dev.split()[-1]
         if dev in checked_devs:
@@ -3200,7 +3200,7 @@ def check_listening_port_by_service(service, port, listen_addr='0.0.0.0',
     try:
         if not runner:
             try:
-                path.find_command("netstat")
+                utils_path.find_command("netstat")
             except ValueError, details:
                 raise exceptions.TestNAError(details)
             output = process.system_output(cmd)

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -26,6 +26,7 @@ import time
 import sys
 
 from avocado.core import exceptions
+from avocado.utils import path as utils_path
 from avocado.utils import process
 from avocado.utils import stacktrace
 from avocado.utils import linux_modules
@@ -519,7 +520,7 @@ def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
     :return: ip_addr or nothing
     """
     try:
-        utils_misc.find_command("gluster")
+        utils_path.find_command("gluster")
     except ValueError:
         raise exceptions.TestNAError("Missing command 'gluster'")
     if not brick_path:
@@ -2248,7 +2249,7 @@ def create_scsi_disk(scsi_option, scsi_size="2048"):
     :return: scsi device if it is created successfully.
     """
     try:
-        utils_misc.find_command("lsscsi")
+        utils_path.find_command("lsscsi")
     except ValueError:
         raise exceptions.TestNAError("Missing command 'lsscsi'.")
 


### PR DESCRIPTION
The find_command in utils_misc is already implemented in
avocado.utils.path.

This command deprecate this function and show a warning logging
if some command still using it.
We can't change the existing reference of this function in
virt-test providers, since it will fail if someone still using
virt-test.

Also some reference to path.command is changed to path.find_command
since the command function no longer exists.

Signed-off-by: Hao Liu <hliu@redhat.com>