### PR TITLE
v2v.cfg: Let the default definitions have lower priority

### DIFF
--- a/backends/v2v/cfg/tests-shared.cfg
+++ b/backends/v2v/cfg/tests-shared.cfg
@@ -3,18 +3,18 @@
 # This file contains the base test set definitions, shared among single host
 # and multi host jobs.
 
+# Virtualization type (qemu, libvirt or v2v)
+vm_type = v2v
+# The hypervisor uri (default, qemu://hostname/system, etc.)
+# where default or unset means derive from installed system
+connect_uri = default
+
 # Include the base config files.
 include base.cfg
 include subtests.cfg
 include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg
-
-# Virtualization type (qemu, libvirt or v2v)
-vm_type = v2v
-# The hypervisor uri (default, qemu://hostname/system, etc.)
-# where default or unset means derive from installed system
-connect_uri = default
 
 # Modify/comment the following lines if you wish to modify the paths of the
 # image files, ISO files or qemu binaries.


### PR DESCRIPTION
Both vm_type and connect_uri should be defined before including other
config files, so they can be overwirte in specific cases, just like
the way in libvirt/cfg/test-shared.cfg.

Signed-off-by: Yanbing Du <ydu@redhat.com>