### PR TITLE
USB type device passthrough using add_hostdev

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1274,7 +1274,7 @@ class VMXML(VMXMLBase):
         dev.managed = managed
         if boot_order:
             dev.boot_order = boot_order
-        dev.source_address = dev.new_source_address(**source_address)
+        dev.source = dev.new_source(**source_address)
         self.add_device(dev)
 
     @staticmethod


### PR DESCRIPTION
Currently hostdev addition supported adding only pci type device for
passthrough. This commit has added capability to within framework to 
generate a hostdev xml section for USB device passthrough.
Guest VM xml add hostdev will now be able accept USB specific parameters
and add respective xml clause to guest VM accordingly.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>