### PR TITLE
shared/cfg/guest-os/Linux/Fedora.cfg: add wait_no_ack

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora.cfg
@@ -6,6 +6,7 @@
         boot_path = "images/pxeboot"
         kernel_params = "ks=cdrom nicdelay=60 console=ttyS0,115200 console=tty0"
         anaconda_log = "yes"
+        wait_no_ack = yes
     guest_s3:
         global_enable_s3:
             s3_support_chk_cmd = "yum install -y iasl"


### PR DESCRIPTION
In order to avoid raising VMDeadError after unattend-install,
add 'wait_no_ack' for Fedora release.

Error as following,
"/mnt/extra_disk/osc/virt-test/virttest/tests/unattended_install.py",
line 1113, in run
16:53:56 ERROR| raise e
16:53:56 ERROR| VMDeadError: VM is dead
                reason: Domain f20-test is inactive
                detail: 'shut off'
16:53:56 ERROR|
16:53:56 ERROR| FAIL
io-github-autotest-qemu.unattended_install.cdrom.extra_cdrom_ks.
default_install.aio_native -> VMDeadError: VM is dead
reason: Domain f20-test is inactive
detail: 'shut off'

FYI, Other distro support this option 'wait_no_ack' and
defined as following,
./shared/cfg/guest-os/Linux/Ubuntu.cfg:9:   wait_no_ack = yes
./shared/cfg/guest-os/Linux/SLES.cfg:8:     wait_no_ack = yes
./shared/cfg/guest-os/Linux/Debian.cfg:8:   wait_no_ack = yes
./shared/cfg/guest-os/Linux/OpenSUSE.cfg:7: wait_no_ack = yes