### PR TITLE
avocado-vt: modify SLES12.0 ssh config

### DIFF
--- a/shared/unattended/SLES-12.xml
+++ b/shared/unattended/SLES-12.xml
@@ -545,16 +545,18 @@ echo ttyS0 >> /etc/securetty]]>
       </source>
     </script>
   </chroot-scripts>
-   <init-scripts config:type="list">
+   <post-scripts config:type="list">
       <script>
         <debug config:type="boolean">true</debug>
         <filename>config</filename>
-        <source><![CDATA[chkconfig sshd on
+        <source><![CDATA[!/bin/bash
+###Enable ssh service when it is start
+chkconfig sshd on
 sed -i -e 's/\(PasswordAuthentication\s\)no/\1yes/g'  /etc/ssh/sshd_config
 service sshd restart
 ]]></source>
       </script>
-    </init-scripts>
+    </post-scripts>
    <init-scripts config:type="list">
       <script>
         <debug config:type="boolean">true</debug>


### PR DESCRIPTION
Currently ssh related config does not work in SLES12.0
This patch is to moving ssh related config to post-scripts

ID:1258777
Signed-off-by: Mike Cao \<bcao@redhat.com\>