### PR TITLE
virttest/qemu_qtree.py: Update guess_type() for QtreeDev

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -163,11 +163,8 @@ class QtreeDev(QtreeNode):
         super(QtreeDev, self).add_child(child)
 
     def guess_type(self):
-        if self.qtree['type'] == 'virtio-blk-device':
-            return QtreeDisk
-        elif ('drive' in self.qtree and
-              self.qtree['type'] != 'usb-storage' and
-              self.qtree['type'] != 'virtio-blk-pci'):
+        if ('drive' in self.qtree and
+                self.qtree['type'] != 'usb-storage'):
             # ^^ HOOK when usb-storage-containter is detected as disk
             return QtreeDisk
         else:


### PR DESCRIPTION
Make the get method can get the correct QtreeDisk device
on different platform.

Signed-off-by: Shuping Cui <scui@redhat.com>

id: 1211151