### PR TITLE
virttest/libvirt_xml/vm_xml: refactor vm_rename()

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1472,6 +1472,18 @@ def get_pid_cpu(pid):
     return list(set([_.strip() for _ in cpu_pid.splitlines()]))
 
 
+def compare_uuid(uuid1, uuid2):
+    """
+    compare UUID with uniform format
+
+    :param uuid1: UUID
+    :param uuid2: UUID
+    :return: negative if x<y, zero if x==y, positive if x>y
+    :rtype: integer
+    """
+    return cmp(uuid1.replace('-', '').lower(), uuid2.replace('-', '').lower())
+
+
 # Utility functions for numa node pinning
 
 


### PR DESCRIPTION
Main modification as following,
* Polish the docstring and comments
* Keep consistent for VM status
* No catch CmdError as same as other calls for define
* If define or undefine failed,
  No change for original VM and raise LibvirtXMLError
* Update name and uuid if rename succeeded
* Check UUID if it's expected