### PR TITLE
Lookup for unattended_file at test provider dir

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -15,6 +15,7 @@ from avocado.utils import crypto
 from avocado.utils import download
 
 from .. import virt_vm
+from .. import asset
 from .. import utils_misc
 from .. import utils_disk
 from .. import qemu_monitor
@@ -172,9 +173,33 @@ class UnattendedInstallConfig(object):
         self.tmpdir = test.tmpdir
         self.qemu_img_binary = utils_misc.get_qemu_img_binary(params)
 
+        def get_unattended_file(backend):
+            providers = asset.get_test_provider_names(backend)
+            if not providers:
+                return
+            for provider_name in providers:
+                provider_info = asset.get_test_provider_info(provider_name)
+                if backend not in provider_info["backends"]:
+                    continue
+                if "path" not in provider_info["backends"][backend]:
+                    continue
+                path = provider_info["backends"][backend]["path"]
+                tp_unattended_file = os.path.join(path, self.unattended_file)
+                if os.path.exists(tp_unattended_file):
+                    # Using unattended_file from test-provider
+                    unattended_file = tp_unattended_file
+                    # Take the first matched
+                    return unattended_file
+
         if getattr(self, 'unattended_file'):
-            self.unattended_file = os.path.join(test.virtdir,
-                                                self.unattended_file)
+            # Fail-back to general unattended_file
+            unattended_file = os.path.join(test.virtdir, self.unattended_file)
+            for backend in asset.get_known_backends():
+                found_file = get_unattended_file(backend)
+                if found_file:
+                    unattended_file = found_file
+                    break
+            self.unattended_file = unattended_file
 
         if params.get('use_ovmf_autounattend'):
             self.unattended_file = re.sub("\.", "_ovmf.",


### PR DESCRIPTION
General answer files locate at: avocado-vt/shared/unattended

SpiceQA asked few times to add special answer files

It would be fine to have ability keep such files in test-provider repo
And after this patch
shared/unattended/RHEL-6-spice.ks
shared/unattended/RHEL-7-spice.ks
can be removed from avocado-vt

Signed-off-by: Andrei Stepanov <astepano@redhat.com>