### PR TITLE
virttest.qemu_vm: Skip -boot on ARM

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1078,6 +1078,10 @@ class VM(virt_vm.BaseVM):
                 return ""
 
         def add_boot(devices, boot_order, boot_once, boot_menu, boot_strict):
+            if arch.ARCH == 'aarch64':
+                logging.warn("-boot on ARM is usually not supported, use "
+                             "bootindex instead.")
+                return ""
             cmd = " -boot"
             patterns = ["order", "once", "menu", "strict"]
             options = []


### PR DESCRIPTION
-boot is usually broken or not supported on ARM. ARM developers said
they do not care about -boot and will not fix it in the near future.
Avocado-vt doesn't yet support -bootindex properly, but in most cases
it suffice and works fine. Let's just skip -boot on ARM and let users
adjust their tests to use -bootindex instead.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>