### PR TITLE
Path to Windows ISOs should have same prefix

### DIFF
--- a/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
@@ -26,7 +26,7 @@
         - r2:
             image_name += r2
             unattended_install.cdrom, whql.support_vm_install, svirt_install:
-                cdrom_cd1 = isos/ISO/Win2012R2/en_windows_server_2012_r2_x64_dvd_2707946.iso
+                cdrom_cd1 = isos/windows/en_windows_server_2012_r2_x64_dvd_2707946.iso
                 md5sum_cd1 = 0e7c09aab20dec3cd7eab236dab90e78
                 md5sum_1m_cd1 = fab118cfa7f66d3606c38dc1330a769e
                 unattended_file = unattended/win2012r2-autounattend.xml

--- a/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -32,7 +32,7 @@
         - 1:
             image_name += .1
             unattended_install.cdrom, whql.support_vm_install, svirt_install:
-                cdrom_cd1 = isos/ISO/Win8.1/en_windows_8_1_enterprise_x86_dvd_2972289.iso
+                cdrom_cd1 = isos/windows/en_windows_8_1_enterprise_x86_dvd_2972289.iso
                 md5sum_cd1 = bf620a67b5dda1e18e9ce17d25711201
                 md5sum_1m_cd1 = 0dddab9c979407e871c007424c7f75a3
                 unattended_file = unattended/win8-32-autounattend.xml

--- a/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
@@ -40,7 +40,7 @@
         - 1:
             image_name += .1
             unattended_install.cdrom, whql.support_vm_install, svirt_install:
-                cdrom_cd1 = isos/ISO/Win8.1/en_windows_8_1_enterprise_x64_dvd_2971902.iso
+                cdrom_cd1 = isos/windows/en_windows_8_1_enterprise_x64_dvd_2971902.iso
                 md5sum_cd1 = 8e194185fcce4ea737f274ee9005ddf0
                 md5sum_1m_cd1 = ec868109e725742b83363908405d21f3
                 unattended_file = unattended/win8-64-autounattend.xml


### PR DESCRIPTION
Most Windows ISO images have prefix: isos/windows.
Only 3 fixed above ISOs had strange prefix.
It would be fine to have all ISOs at the same dir.

It is necessary to notify: Xiaoqing Wei <xwei@redhat.com>
He was a author who introduced the strange prefix.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>