### PR TITLE
vt: Adjust vt_loader to new API

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -155,8 +155,8 @@ class VirtTestLoader(loader.TestLoader):
 
     name = 'vt'
 
-    def __init__(self, args):
-        super(VirtTestLoader, self).__init__(args)
+    def __init__(self, args, extra_params):
+        super(VirtTestLoader, self).__init__(args, extra_params)
         self._fill_optional_args()
 
     def _fill_optional_args(self):


### PR DESCRIPTION
Avocado loaders must an additional extra_params argument. Current implementation silently ignores the extra_params, which is not that bad given the fact that it supports only one test_type. For a while I thought about supporting `--vt-type` as extra params, which would make it possible to define default `vt_type` in settings, but then I thought it would be more confusing.

This patch should be accepted ones https://github.com/avocado-framework/avocado/pull/810 is accepted, otherwise `avocado-vt` would stop working.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>