### PR TITLE
avocado-vt: Fix usages of avocado.utils.path.find_command

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -983,7 +983,7 @@ class VirtTestOptionsProcess(object):
         """
         try:
             tcpdump_path = utils_path.find_command('tcpdump')
-        except ValueError:
+        except utils_path.CmdNotFoundError:
             tcpdump_path = None
 
         non_root = os.getuid() != 0

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -565,7 +565,7 @@ def preprocess(test, params, env):
         for cmd in params.get("cmds_installed_host").split():
             try:
                 path.find_command(cmd)
-            except ValueError, msg:
+            except path.CmdNotFoundError, msg:
                 raise exceptions.TestNAError(msg.message)
 
     vm_type = params.get('vm_type')

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -780,12 +780,12 @@ class Iscsi(object):
             path.find_command("iscsiadm")
             path.find_command("tgtadm")
             iscsi_instance = IscsiTGT(params, root_dir)
-        except ValueError:
+        except path.CmdNotFoundError:
             try:
                 path.find_command("iscsiadm")
                 path.find_command("targetcli")
                 iscsi_instance = IscsiLIO(params, root_dir)
-            except ValueError:
+            except path.CmdNotFoundError:
                 pass
 
         return iscsi_instance

--- a/virttest/postprocess_iozone.py
+++ b/virttest/postprocess_iozone.py
@@ -353,7 +353,7 @@ class IOzonePlotter(object):
         self.active = True
         try:
             self.gnuplot = path.find_command("gnuplot")
-        except Exception:
+        except path.CmdNotFoundError:
             logging.error("Command gnuplot not found, disabling graph "
                           "generation")
             self.active = False

--- a/virttest/staging/utils_koji.py
+++ b/virttest/staging/utils_koji.py
@@ -307,7 +307,7 @@ class KojiClient(object):
                 try:
                     koji_command = path.find_command(koji_command_basename)
                     break
-                except ValueError:
+                except path.CmdNotFoundError:
                     pass
         return koji_command
 

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -41,7 +41,7 @@ def find_default_qemu_paths(options_qemu=None, options_dst_qemu=None):
     else:
         try:
             qemu_bin_path = utils_path.find_command('qemu-kvm')
-        except ValueError:
+        except utils_path.CmdNotFoundError:
             qemu_bin_path = utils_path.find_command('kvm')
 
     if options_dst_qemu is not None:

--- a/virttest/utils_conn.py
+++ b/virttest/utils_conn.py
@@ -521,7 +521,7 @@ class SSHConnection(ConnectionBase):
             toolName = tool_dict[key]
             try:
                 tool = path.find_command(toolName)
-            except ValueError:
+            except path.CmdNotFoundError:
                 logging.debug("%s executable not set or found on path,"
                               "some function of connection will fail.",
                               toolName)
@@ -829,7 +829,7 @@ class TLSConnection(ConnectionBase):
         # check and set CERTTOOL in slots
         try:
             CERTTOOL = path.find_command("certtool")
-        except ValueError:
+        except path.CmdNotFoundError:
             logging.warning("certtool executable not set or found on path, "
                             "TLS connection will not setup normally")
             CERTTOOL = '/bin/true'

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2170,10 +2170,10 @@ def get_qemu_binary(params):
         logging.debug('Could not find params qemu in %s, searching the '
                       'host PATH for one to use', qemu_binary_path)
         try:
-            qemu_binary = find_command('qemu-kvm')
+            qemu_binary = utils_path.find_command('qemu-kvm')
             logging.debug('Found %s', qemu_binary)
-        except ValueError:
-            qemu_binary = find_command('kvm')
+        except utils_path.CmdNotFoundError:
+            qemu_binary = utils_path.find_command('kvm')
             logging.debug('Found %s', qemu_binary)
     else:
         library_path = os.path.join(
@@ -2220,7 +2220,7 @@ def get_qemu_img_binary(params):
     if not os.path.isfile(qemu_img_binary_path):
         logging.debug('Could not find params qemu-img in %s, searching the '
                       'host PATH for one to use', qemu_img_binary_path)
-        qemu_img_binary = find_command('qemu-img')
+        qemu_img_binary = utils_path.find_command('qemu-img')
         logging.debug('Found %s', qemu_img_binary)
     else:
         qemu_img_binary = qemu_img_binary_path
@@ -2237,7 +2237,7 @@ def get_qemu_io_binary(params):
     if not os.path.isfile(qemu_io_binary_path):
         logging.debug('Could not find params qemu-io in %s, searching the '
                       'host PATH for one to use', qemu_io_binary_path)
-        qemu_io_binary = find_command('qemu-io')
+        qemu_io_binary = utils_path.find_command('qemu-io')
         logging.debug('Found %s', qemu_io_binary)
     else:
         qemu_io_binary = qemu_io_binary_path
@@ -2914,7 +2914,7 @@ class KSMController(object):
         else:
             try:
                 utils_path.find_command("ksmctl")
-            except ValueError:
+            except utils_path.CmdNotFoundError:
                 raise KSMNotSupportedError
             _KSM_PARAMS = ["run", "pages_to_scan", "sleep_millisecs"]
             # No _KSM_PATH needed here
@@ -2942,7 +2942,7 @@ class KSMController(object):
         """
         try:
             utils_path.find_command("ksmtuned")
-        except ValueError:
+        except utils_path.CmdNotFoundError:
             raise KSMTunedNotSupportedError
 
         process_id = process.system_output("ps -C ksmtuned -o pid=",

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1952,7 +1952,7 @@ class IPv6Manager(propcan.PropCanBase):
         """
         try:
             utils_path.find_command("ping6")
-        except ValueError:
+        except utils_path.CmdNotFoundError:
             raise exceptions.TestNAError("Can't find ping6 command")
         command = "ping6 -I %s %s -c %s" % (client_ifname, server_ipv6, count)
         result = process.run(command, ignore_status=True)
@@ -1974,7 +1974,7 @@ class IPv6Manager(propcan.PropCanBase):
         # check if ip6tables command exists on the local
         try:
             utils_path.find_command("ip6tables")
-        except ValueError:
+        except utils_path.CmdNotFoundError:
             raise exceptions.TestNAError(test_NA_err)
         # flush local ip6tables rules
         result = process.run(flush_cmd, ignore_status=True)
@@ -3201,7 +3201,7 @@ def check_listening_port_by_service(service, port, listen_addr='0.0.0.0',
         if not runner:
             try:
                 utils_path.find_command("netstat")
-            except ValueError, details:
+            except utils_path.CmdNotFoundError, details:
                 raise exceptions.TestNAError(details)
             output = process.system_output(cmd)
         else:

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -521,7 +521,7 @@ def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
     """
     try:
         utils_path.find_command("gluster")
-    except ValueError:
+    except utils_path.CmdNotFoundError:
         raise exceptions.TestNAError("Missing command 'gluster'")
     if not brick_path:
         tmpdir = os.path.join(data_dir.get_root_dir(), 'tmp')
@@ -2250,7 +2250,7 @@ def create_scsi_disk(scsi_option, scsi_size="2048"):
     """
     try:
         utils_path.find_command("lsscsi")
-    except ValueError:
+    except utils_path.CmdNotFoundError:
         raise exceptions.TestNAError("Missing command 'lsscsi'.")
 
     try:


### PR DESCRIPTION
1) replace avocado-vt.virttest.utils_misc.find_command with
   avocado.utils.path.find_command.
2) avocado.utils.path.find_command raises
   avocado.utils.path.CmdNotFoundError and not ValueError.
   This is a complement to commit eaeb01b.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>