### PR TITLE
[V2] TMP dir management updates

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -25,7 +25,7 @@ class ConfigLoader:
     Base class of the configuration parser
     """
 
-    def __init__(self, cfg, tmpdir='/tmp', raise_errors=False):
+    def __init__(self, cfg, tmpdir=data_dir.get_tmp_dir(), raise_errors=False):
         """
         Instantiate ConfigParser and load data.
 

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -35,7 +35,6 @@ DEPS_DIR = os.path.join(ROOT_DIR, 'shared', 'deps')
 BASE_DOWNLOAD_DIR = os.path.join(SHARED_DIR, 'downloads')
 DOWNLOAD_DIR = os.path.join(DATA_DIR, 'downloads')
 TEST_PROVIDERS_DIR = os.path.join(ROOT_DIR, 'test-providers.d')
-TMP_DIR = tempfile.mkdtemp()
 BACKING_DATA_DIR = None
 
 
@@ -201,7 +200,7 @@ def get_deps_dir(target=None):
 
 
 def get_tmp_dir():
-    return TMP_DIR
+    return data_dir.get_tmp_dir()
 
 
 def get_download_dir():
@@ -236,16 +235,17 @@ def get_test_provider_dir(provider):
 
 
 def clean_tmp_files():
-    if os.path.isdir(TMP_DIR):
-        hidden_paths = glob.glob(os.path.join(TMP_DIR, ".??*"))
-        paths = glob.glob(os.path.join(TMP_DIR, "*"))
+    tmp_dir = get_tmp_dir()
+    if os.path.isdir(tmp_dir):
+        hidden_paths = glob.glob(os.path.join(tmp_dir, ".??*"))
+        paths = glob.glob(os.path.join(tmp_dir, "*"))
         for path in paths + hidden_paths:
             shutil.rmtree(path, ignore_errors=True)
 
 
 if __name__ == '__main__':
     print "root dir:         " + ROOT_DIR
-    print "tmp dir:          " + TMP_DIR
+    print "tmp dir:          " + get_tmp_dir()
     print "data dir:         " + DATA_DIR
     print "deps dir:         " + DEPS_DIR
     print "backing data dir: " + BACKING_DATA_DIR

--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -255,10 +255,10 @@ def file_exists(params, filename_path):
     # should be deleted immediately when no longer needed and
     # created directory don't file tmp dir by any data.
     tmpdir = "gmount-%s" % (utils_misc.generate_random_string(6))
-    tmpdir_path = os.path.join("/tmp", tmpdir)
+    tmpdir_path = os.path.join(data_dir.get_tmp_dir(), tmpdir)
     while os.path.exists(tmpdir_path):
         tmpdir = "gmount-%s" % (utils_misc.generate_random_string(6))
-        tmpdir_path = os.path.join("/tmp", tmpdir)
+        tmpdir_path = os.path.join(data_dir.get_tmp_dir(), tmpdir)
     ret = False
     try:
         try:

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -19,6 +19,7 @@ from avocado.utils import path
 
 from . import utils_selinux
 from . import utils_net
+from . import data_dir
 
 ISCSI_CONFIG_FILE = "/etc/iscsi/initiatorname.iscsi"
 
@@ -774,7 +775,7 @@ class Iscsi(object):
     and return ISCSI instance.
     """
     @staticmethod
-    def create_iSCSI(params, root_dir="/tmp"):
+    def create_iSCSI(params, root_dir=data_dir.get_tmp_dir()):
         iscsi_instance = None
         try:
             path.find_command("iscsiadm")

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -282,7 +282,7 @@ class VM(virt_vm.BaseVM):
         # Since backup_xml() is not a function for testing,
         # we have to handle the exception here.
         try:
-            xml_file = tempfile.mktemp(dir="/tmp")
+            xml_file = tempfile.mktemp(dir=data_dir.get_tmp_dir())
 
             if active:
                 extra = ""
@@ -1485,7 +1485,9 @@ class VM(virt_vm.BaseVM):
 
         # Make sure the following code is not executed by more than one thread
         # at the same time
-        lockfile = open("/tmp/libvirt-autotest-vm-create.lock", "w+")
+        lockfilename = os.path.join(data_dir.get_tmp_dir(),
+                                    "libvirt-autotest-vm-create.lock")
+        lockfile = open(lockfilename, "w+")
         fcntl.lockf(lockfile, fcntl.LOCK_EX)
 
         try:

--- a/virttest/libvirt_xml/pool_xml.py
+++ b/virttest/libvirt_xml/pool_xml.py
@@ -8,6 +8,7 @@ import tempfile
 
 from avocado.utils import process
 
+from .. import data_dir
 from .. import libvirt_storage
 from ..libvirt_xml import base, xcepts, accessors
 
@@ -367,7 +368,7 @@ class PoolXML(PoolXMLBase):
         Backup the pool xml file.
         """
         try:
-            xml_file = tempfile.mktemp(dir="/tmp")
+            xml_file = tempfile.mktemp(dir=data_dir.get_tmp_dir())
             virsh_instance.pool_dumpxml(name, to_file=xml_file)
             return xml_file
         except Exception, detail:

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -31,6 +31,7 @@ from avocado.utils import path
 from avocado.utils import process
 
 from . import utils_misc
+from . import data_dir
 
 UNIT = "B"
 COMMON_OPTS = "--noheading --nosuffix --unit=%s" % UNIT
@@ -609,7 +610,7 @@ class LVM(object):
 
 class EmulatedLVM(LVM):
 
-    def __init__(self, params, root_dir="/tmp"):
+    def __init__(self, params, root_dir=data_dir.get_tmp_dir()):
         path.find_command("losetup")
         path.find_command("dd")
         super(EmulatedLVM, self).__init__(params)

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -15,6 +15,7 @@ import os
 from . import passfd_setup
 from . import utils_misc
 from . import cartesian_config
+from . import data_dir
 
 try:
     import json
@@ -93,7 +94,8 @@ def get_monitor_filename(vm, monitor_name):
     :param monitor_name: The monitor name.
     :return: The string of socket file name for qemu monitor.
     """
-    return "/tmp/monitor-%s-%s" % (monitor_name, vm.instance)
+    return os.path.join(data_dir.get_tmp_dir(),
+                        "monitor-%s-%s" % (monitor_name, vm.instance))
 
 
 def get_monitor_filenames(vm):

--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -185,7 +185,8 @@ class GuestWorker(object):
         out = self.session.cmd_output("echo on")
         if "on" in out:
             self.os_linux = True
-            guest_script_path = "/tmp/%s" % guest_script_py
+            guest_script_path = os.path.join(data_dir.get_tmp_dir(),
+                                             guest_script_py)
             cmd_guest_size = ("du -b %s | cut -f1"
                               % guest_script_path)
             cmd_already_compiled_chck = "ls %so" % guest_script_path

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -78,7 +78,8 @@ def clean_tmp_files():
     if os.path.isfile(CREATE_LOCK_FILENAME):
         os.unlink(CREATE_LOCK_FILENAME)
 
-CREATE_LOCK_FILENAME = os.path.join('/tmp', 'avocado-vt-vm-create.lock')
+CREATE_LOCK_FILENAME = os.path.join(data_dir.get_tmp_dir(),
+                                    'avocado-vt-vm-create.lock')
 
 
 class VM(virt_vm.BaseVM):
@@ -283,8 +284,9 @@ class VM(virt_vm.BaseVM):
         :param name: The serial port name.
         """
         if name:
-            return "/tmp/serial-%s-%s" % (name, self.instance)
-        return "/tmp/serial-%s" % self.instance
+            return os.path.join(data_dir.get_tmp_dir(),
+                                "serial-%s-%s" % (name, self.instance))
+        return os.path.join(data_dir.get_tmp_dir(), "serial-%s" % self.instance)
 
     def get_serial_console_filenames(self):
         """
@@ -496,7 +498,8 @@ class VM(virt_vm.BaseVM):
                 return ""
 
             default_id = "seabioslog_id_%s" % self.instance
-            filename = "/tmp/seabios-%s" % self.instance
+            filename = os.path.join(data_dir.get_tmp_dir(),
+                                    "seabios-%s" % self.instance)
             self.logs["seabios"] = filename
             cmd = " -chardev socket"
             cmd += _add_option("id", default_id)
@@ -511,7 +514,8 @@ class VM(virt_vm.BaseVM):
         def add_log_anaconda(devices, pci_bus='pci.0'):
             chardev_id = "anacondalog_chardev_%s" % self.instance
             vioser_id = "anacondalog_vioser_%s" % self.instance
-            filename = "/tmp/anaconda-%s" % self.instance
+            filename = os.path.join(data_dir.get_tmp_dir(),
+                                    "anaconda-%s" % self.instance)
             self.logs["anaconda"] = filename
             dev = qdevices.QCustomDevice('chardev', backend='backend')
             dev.set_param('backend', 'socket')
@@ -2495,7 +2499,9 @@ class VM(virt_vm.BaseVM):
                 qemu_command += (" -incoming " + migration_mode +
                                  ":0:%d" % self.migration_port)
             elif migration_mode == "unix":
-                self.migration_file = "/tmp/migration-unix-%s" % self.instance
+                self.migration_file = os.path.join(data_dir.get_tmp_dir(),
+                                                   "migration-unix-%s" %
+                                                   self.instance)
                 qemu_command += " -incoming unix:%s" % self.migration_file
             elif migration_mode == "exec":
                 if migration_exec_cmd is None:
@@ -3480,7 +3486,8 @@ class VM(virt_vm.BaseVM):
     @error_context.context_aware
     def migrate(self, timeout=virt_vm.BaseVM.MIGRATE_TIMEOUT, protocol="tcp",
                 cancel_delay=None, offline=False, stable_check=False,
-                clean=True, save_path="/tmp", dest_host="localhost",
+                clean=True, save_path=data_dir.get_tmp_dir(),
+                dest_host="localhost",
                 remote_port=None, not_wait_for_migration=False,
                 fd_src=None, fd_dst=None, migration_exec_cmd_src=None,
                 migration_exec_cmd_dst=None, env=None):

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -299,7 +299,7 @@ def remote_commander(client, host, port, username, password, prompt,
     :return: A ShellSession object.
     """
     if path is None:
-        path = "/tmp"
+        path = data_dir.get_tmp_dir()
     if client == "ssh":
         cmd = ("ssh -o UserKnownHostsFile=/dev/null "
                "-o PreferredAuthentications=password "

--- a/virttest/remote_build.py
+++ b/virttest/remote_build.py
@@ -4,6 +4,8 @@ import remote
 import hashlib
 import logging
 
+from . import data_dir
+
 
 class BuildError(Exception):
 
@@ -75,7 +77,8 @@ class Builder(object):
         self.username = def_helper(username, "username", "root")
         self.password = def_helper(password, "password", "redhat")
         self.make_flags = make_flags
-        self.build_dir = def_helper(build_dir, "tmp_dir", "/tmp")
+        self.build_dir = def_helper(build_dir, "tmp_dir",
+                                    data_dir.get_tmp_dir())
         if build_dir_prefix is None:
             build_dir_prefix = os.path.basename(source)
         self.full_build_path = full_build_path(self.build_dir,

--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -23,8 +23,10 @@ import signal
 import remote_interface
 import messenger as ms
 
+from .. import data_dir
 
-def daemonize(pipe_root_path="/tmp"):
+
+def daemonize(pipe_root_path=data_dir.get_tmp_dir()):
     """
     Init daemon.
 
@@ -332,7 +334,7 @@ class CmdSlave(object):
             self.basecmd._async = True
         elif self.nohup:   # start command in new daemon process
             if self.basecmd.cmd_hash is None:
-                self.basecmd.cmd_hash = gen_tmp_dir("/tmp")
+                self.basecmd.cmd_hash = gen_tmp_dir(data_dir.get_tmp_dir())
             self.basecmd.results = self.__call_nohup__(commander)
             self.basecmd._async = True
         else:  # start command in new process but wait for input.

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -661,12 +661,14 @@ class PrivateBridgeConfig(object):
                        "--listen-address %s.1 --dhcp-range %s.2,%s.254 "
                        "--dhcp-lease-max=253 "
                        "--dhcp-no-override "
-                       "--pid-file=/tmp/dnsmasq.pid "
-                       "--log-facility=/tmp/dnsmasq.log" %
-                       (self.subnet, self.subnet, self.subnet))
+                       "--pid-file=%s/dnsmasq.pid "
+                       "--log-facility=%s/dnsmasq.log" %
+                       (self.subnet, self.subnet, self.subnet,
+                        data_dir.get_tmp_dir(), data_dir.get_tmp_dir()))
         self.dhcp_server_pid = None
         try:
-            self.dhcp_server_pid = int(open('/tmp/dnsmasq.pid', 'r').read())
+            self.dhcp_server_pid = int(open('%s/dnsmasq.pid' %
+                                            data_dir.get_tmp_dir(), 'r').read())
         except ValueError:
             raise PrivateBridgeError(self.brname)
         logging.debug("Started internal DHCP server with PID %s",
@@ -741,7 +743,8 @@ class PrivateBridgeConfig(object):
                 pass
         else:
             try:
-                dhcp_server_pid = int(open('/tmp/dnsmasq.pid', 'r').read())
+                dhcp_server_pid = int(open('%s/dnsmasq.pid' %
+                                           data_dir.get_tmp_dir(), 'r').read())
             except ValueError:
                 return
             try:

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -221,6 +221,9 @@ class Env(UserDict.IterableUserDict):
             if os.path.isfile(self._filename):
                 os.unlink(self._filename)
 
+    def __del__(self):
+        self.destroy()
+
     def get_vm(self, name):
         """
         Return a VM object by its name.

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -417,7 +417,7 @@ def find_free_ports(start_port, end_port, count, address="localhost"):
 # An easy way to log lines to files when the logging system can't be used
 
 _open_log_files = {}
-_log_file_dir = "/tmp"
+_log_file_dir = data_dir.get_tmp_dir()
 _log_lock = threading.RLock()
 
 
@@ -555,7 +555,8 @@ def generate_random_id():
     return "id" + generate_random_string(6)
 
 
-def generate_tmp_file_name(file_name, ext=None, directory='/tmp/'):
+def generate_tmp_file_name(file_name, ext=None,
+                           directory=data_dir.get_tmp_dir()):
     """
     Returns a temporary file name. The file is not created.
     """
@@ -1129,7 +1130,7 @@ def install_host_kernel(job, params):
 
         rpm_url = params.get('host_kernel_rpm_url')
         k_basename = os.path.basename(rpm_url)
-        dst = os.path.join("/var/tmp", k_basename)
+        dst = os.path.join(data_dir.get_tmp_dir(), k_basename)
         k = download.get_file(rpm_url, dst)
         host_kernel = job.kernel(k)
         host_kernel.install(install_vmlinux=False)
@@ -1181,7 +1182,7 @@ def install_host_kernel(job, params):
             patch_list = patch_list.split()
         kernel_config = params.get('host_kernel_config', None)
 
-        repodir = os.path.join("/tmp", 'kernel_src')
+        repodir = os.path.join(data_dir.get_tmp_dir(), 'kernel_src')
         r = git.GitRepoHelper(uri=repo, branch=branch, destination_dir=repodir,
                               commit=commit, base_uri=repo_base)
         r.execute()

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -19,6 +19,7 @@ from avocado.utils import process
 
 import aexpect
 
+from . import data_dir
 from . import propcan
 from . import utils_misc
 from . import arch
@@ -2613,7 +2614,7 @@ class DbNet(VMNet):
         except AttributeError:
             raise DbNoLockError
 
-ADDRESS_POOL_FILENAME = os.path.join("/tmp", "address_pool")
+ADDRESS_POOL_FILENAME = os.path.join(data_dir.get_tmp_dir(), "address_pool")
 ADDRESS_POOL_LOCK_FILENAME = ADDRESS_POOL_FILENAME + ".lock"
 
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -452,7 +452,7 @@ def run_file_transfer(test, params, env):
 
     dir_name = test.tmpdir
     transfer_timeout = int(params.get("transfer_timeout"))
-    tmp_dir = params.get("tmp_dir", "/tmp/")
+    tmp_dir = params.get("tmp_dir", data_dir.get_tmp_dir())
     clean_cmd = params.get("clean_cmd", "rm -f")
     filesize = int(params.get("filesize", 4000))
     count = int(filesize / 10)
@@ -614,7 +614,7 @@ def run_virtio_serial_file_transfer(test, params, env, port_name=None,
 
     dir_name = test.tmpdir
     transfer_timeout = int(params.get("transfer_timeout", 720))
-    tmp_dir = params.get("tmp_dir", "/var/tmp/")
+    tmp_dir = params.get("tmp_dir", data_dir.get_tmp_dir())
     filesize = int(params.get("filesize", 10))
     count = int(filesize)
 
@@ -789,7 +789,7 @@ def run_autotest(vm, session, control_path, timeout,
         # result info tarball to host result dir
         session = vm.wait_for_login(timeout=360)
         results_dir = "%s/results/default" % base_results_dir
-        results_tarball = "/tmp/results.tgz"
+        results_tarball = os.path.join(data_dir.get_tmp_dir(), "results.tgz")
         compress_cmd = "cd %s && " % results_dir
         compress_cmd += "tar cjvf %s ./*" % results_tarball
         compress_cmd += " --exclude=*core*"
@@ -906,7 +906,8 @@ def run_autotest(vm, session, control_path, timeout,
         mig_timeout = float(params.get("mig_timeout", "3600"))
         mig_protocol = params.get("migration_protocol", "tcp")
 
-    compressed_autotest_path = "/tmp/autotest.tar.bz2"
+    compressed_autotest_path = os.path.join(data_dir.get_tmp_dir(),
+                                            "autotest.tar.bz2")
     destination_autotest_path = "/usr/local/autotest"
 
     # To avoid problems, let's make the test use the current AUTODIR
@@ -953,7 +954,7 @@ def run_autotest(vm, session, control_path, timeout,
     if update or not directory_exists(destination_autotest_path):
         extract(vm, compressed_autotest_path, destination_autotest_path)
 
-    g_fd, g_path = tempfile.mkstemp(dir='/tmp/')
+    g_fd, g_path = tempfile.mkstemp(dir=data_dir.get_tmp_dir())
     aux_file = os.fdopen(g_fd, 'w')
     config = section_values(('CLIENT', 'COMMON'))
     config.set('CLIENT', 'output_dir', destination_autotest_path)
@@ -1321,8 +1322,11 @@ def summary_up_result(result_file, ignore, row_head, column_mark):
     return average_list
 
 
-def get_driver_hardware_id(driver_path, mount_point="/tmp/mnt-virtio",
-                           storage_path="/tmp/prewhql.iso",
+def get_driver_hardware_id(driver_path,
+                           mount_point=os.path.join(data_dir.get_tmp_dir(),
+                                                    "mnt-virtio"),
+                           storage_path=os.path.join(data_dir.get_tmp_dir(),
+                                                     "prewhql.iso"),
                            re_hw_id="(PCI.{14,50})", run_cmd=True):
     """
     Get windows driver's hardware id from inf files.

--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -29,6 +29,7 @@ from avocado.core import exceptions
 from avocado.utils import crypto
 from avocado.utils import data_factory
 
+from .. import data_dir
 from .. import env_process
 from .. import error_context
 from .. import remote
@@ -279,7 +280,7 @@ def migrate(vm, env=None, mig_timeout=3600, mig_protocol="tcp",
             else:
                 wait_for_migration()
                 if (dest_host == 'localhost') and stable_check:
-                    save_path = None or "/tmp"
+                    save_path = None or data_dir.get_tmp_dir()
                     save1 = os.path.join(save_path, "src")
                     save2 = os.path.join(save_path, "dst")
 

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -461,7 +461,7 @@ class WindowsVMCheck(VMCheck):
         """
         sshot_file = os.path.join(data_dir.get_tmp_dir(), "vm_screenshot.ppm")
         if self.target == "ovirt":
-            vm_sshot = "/tmp/vm_screenshot.ppm"
+            vm_sshot = os.path.join(data_dir.get_tmp_dir(), "vm_screenshot.ppm")
         else:
             vm_sshot = sshot_file
         virsh.screenshot(self.name, vm_sshot, session_id=self.virsh_session_id)

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -531,7 +531,8 @@ class BaseVM(object):
         while True:
             self.instance = (time.strftime("%Y%m%d-%H%M%S-") +
                              utils_misc.generate_random_string(8))
-            if not glob.glob("/tmp/*%s" % self.instance):
+            if not glob.glob(os.path.join(data_dir.get_tmp_dir(),
+                                          "*%s" % self.instance)):
                 break
 
     def update_vm_id(self):
@@ -881,13 +882,15 @@ class BaseVM(object):
         """
         Return the testlog filename.
         """
-        return "/tmp/testlog-%s" % self.instance
+        return os.path.join(data_dir.get_tmp_dir(),
+                            "testlog-%s" % self.instance)
 
     def get_virtio_port_filename(self, port_name):
         """
         Return the filename corresponding to a givven monitor name.
         """
-        return "/tmp/virtio_port-%s-%s" % (port_name, self.instance)
+        return os.path.join(data_dir.get_tmp_dir(),
+                            "virtio_port-%s-%s" % (port_name, self.instance))
 
     def get_virtio_port_filenames(self):
         """
@@ -956,7 +959,7 @@ class BaseVM(object):
         :return: A ShellSession object.
         """
         if commander_path is None:
-            commander_path = "/tmp"
+            commander_path = data_dir.get_tmp_dir()
         error_context.context("logging into '%s'" % self.name)
         if not username:
             username = self.params.get("username", "")
@@ -1370,7 +1373,8 @@ class BaseVM(object):
 
     def migrate(self, timeout=MIGRATE_TIMEOUT, protocol="tcp",
                 cancel_delay=None, offline=False, stable_check=False,
-                clean=True, save_path="/tmp", dest_host="localhost",
+                clean=True, save_path=data_dir.get_tmp_dir(),
+                dest_host="localhost",
                 remote_port=None):
         """
         Migrate the VM.


### PR DESCRIPTION
This is a follow up to PR #155 

This PR is part of the solution to the card https://trello.com/c/YvSmaKD5/449-bug-insecure-usage-of-tmp-in-avocado-vt-virt-test

Basically this tidies up uses of `/tmp` in avocado-vt, replacing it with the securely created, per-instance avocado temporary directory. This allows the files to be created securely, solving most of the problems.

This still doesn't touch https://trello.com/c/VMoQ2DPU/390-provide-a-locking-api-for-shared-resources,
that's why the supposedly global vm lock and address db file and lock were all moved to the avocado temporary directory.

Changes from v1:
* Used os.path.join() in all path join situations as opposed to plain string substitution as recommended by @clebergnu 
* Removed incorrect avocado data_dir import noticed by @clebergnu.