### PR TITLE
git clone + user interruption safety

### DIFF
--- a/avocado/core/plugins/vt_bootstrap.py
+++ b/avocado/core/plugins/vt_bootstrap.py
@@ -108,5 +108,5 @@ class VirtBootstrap(plugin.Plugin):
             bootstrap.bootstrap(options=args, interactive=True)
             sys.exit(0)
         except (KeyboardInterrupt, process.CmdError):
-            logging.error('Bootstrap interrupted by user')
+            logging.info('Bootstrap interrupted by user')
             sys.exit(1)

--- a/avocado/core/plugins/vt_bootstrap.py
+++ b/avocado/core/plugins/vt_bootstrap.py
@@ -107,6 +107,20 @@ class VirtBootstrap(plugin.Plugin):
         try:
             bootstrap.bootstrap(options=args, interactive=True)
             sys.exit(0)
-        except (KeyboardInterrupt, process.CmdError):
+        except process.CmdError, ce:
+            if ce.result.interrupted:
+                logging.info('Bootstrap command interrupted by user')
+                logging.info('Command: %s', ce.command)
+            else:
+                logging.error('Bootstrap command failed')
+                logging.error('Command: %s', ce.command)
+                if ce.result.stderr:
+                    logging.error('stderr output:')
+                    logging.error(ce.result.stderr)
+                if ce.result.stdout:
+                    logging.error('stdout output:')
+                    logging.error(ce.result.stdout)
+            sys.exit(1)
+        except KeyboardInterrupt:
             logging.info('Bootstrap interrupted by user')
             sys.exit(1)

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -319,15 +319,23 @@ def download_test_provider(provider, update=False):
                 except process.CmdError:
                     pass
                 process.run('git pull origin %s' % branch)
-            os.chdir(download_dst)
-            process.system('git log -1')
-            os.chdir(original_dir)
         except (KeyboardInterrupt, process.CmdError):
             logging.error('Cleaning up provider %s download dir %s', provider,
                           download_dst)
             if os.path.isdir(download_dst):
                 shutil.rmtree(download_dst)
             raise
+
+        # sanity check to ensure the git repository is OK:
+        try:
+            os.chdir(download_dst)
+            process.system('git log -1')
+        except process.CmdError:
+            logging.error('Something is unexpectedly wrong with the git repository at %s',
+                          download_dst)
+            raise
+        finally:
+            os.chdir(original_dir)
 
 
 def download_all_test_providers(update=False):

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -307,6 +307,7 @@ def download_test_provider(provider, update=False):
         ref = provider_info.get('ref')
         pubkey = provider_info.get('pubkey')
         download_dst = data_dir.get_test_provider_dir(provider)
+        dir_existed = os.path.exists(download_dst)
         repo_downloaded = os.path.isdir(os.path.join(download_dst, '.git'))
         original_dir = os.getcwd()
         try:
@@ -319,10 +320,10 @@ def download_test_provider(provider, update=False):
                 except process.CmdError:
                     pass
                 process.run('git pull origin %s' % branch)
-        except (KeyboardInterrupt, process.CmdError):
-            logging.error('Cleaning up provider %s download dir %s', provider,
-                          download_dst)
-            if os.path.isdir(download_dst):
+        except:
+            if not dir_existed and os.path.isdir(download_dst):
+                logging.error('Cleaning up provider %s download dir %s', provider,
+                              download_dst)
                 shutil.rmtree(download_dst)
             raise
 

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -307,9 +307,9 @@ def download_test_provider(provider, update=False):
         ref = provider_info.get('ref')
         pubkey = provider_info.get('pubkey')
         download_dst = data_dir.get_test_provider_dir(provider)
+        repo_downloaded = os.path.isdir(os.path.join(download_dst, '.git'))
+        original_dir = os.getcwd()
         try:
-            repo_downloaded = os.path.isdir(os.path.join(download_dst, '.git'))
-            original_dir = os.getcwd()
             if not repo_downloaded or update:
                 download_dst = git.get_repo(uri=uri, branch=branch, commit=ref,
                                             destination_dir=download_dst)

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -228,10 +228,7 @@ def get_test_provider_dir(provider):
     """
     Return a specific test providers dir, inside the base dir.
     """
-    provider_dir = os.path.join(TEST_PROVIDERS_DOWNLOAD_DIR, provider)
-    if not provider_dir:
-        os.makedirs(provider_dir)
-    return provider_dir
+    return os.path.join(TEST_PROVIDERS_DOWNLOAD_DIR, provider)
 
 
 def clean_tmp_files():


### PR DESCRIPTION
This makes the git clone and bootstrap code more robust against corrupted git repositories and user interruption (issues I commented about on pull request #164). Most importantly, it won't try to delete the test provider directory unless we know it didn't exist yet and was just created by vt-boostrap.