### PR TITLE
two trivial fixes

### DIFF
--- a/shared/deps/run_autotest/boottool.py
+++ b/shared/deps/run_autotest/boottool.py
@@ -1456,8 +1456,6 @@ class Grubby(object):
             self.log.debug('No popt.h header present, skipping build')
             return False
 
-        tarball_name = os.path.basename(tarball)
-
         srcdir = os.path.join(topdir, 'src')
         srcdir = self._extract_tarball(tarball, srcdir)
         os.chdir(srcdir)
@@ -1516,7 +1514,6 @@ class Grubby(object):
         if tarball is None:
             raise GrubbyInstallException('Failed to fetch grubby tarball')
 
-        srcdir = os.path.join(topdir, 'src')
         install_root = os.path.join(topdir, 'install_root')
         os.mkdir(install_root)
 

--- a/virttest/postprocess_iozone.py
+++ b/virttest/postprocess_iozone.py
@@ -317,9 +317,9 @@ class IOzoneAnalyzer(object):
         overall = []
         record_size = []
         file_size = []
-        for path in self.list_files:
-            fileobj = open(path, 'r')
-            logging.info('FILE: %s', path)
+        for file_path in self.list_files:
+            fileobj = open(file_path, 'r')
+            logging.info('FILE: %s', file_path)
 
             results = self.parse_file(fileobj)
 


### PR DESCRIPTION
1)
virttest/postprocess_iozone: rename variable to avoid conflicts
rename a variant name to avoid conflict with the imported module.

2)
run_autotest/boottool: cleanup and remove unused variable
No need to create the path variable that won't be used.
