### PR TITLE
unattended_install.py: Bridge IP auto detection for content server

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -419,7 +419,10 @@ use_os_variant = no
 use_os_type = yes
 # if using 'url = auto' to install, url_auto_ip must match IP on
 # selected virsh network or bridge
-url_auto_ip = 192.168.122.1
+# By default, avocado-vt will try to auto detect the virbr0 IP,
+# if for some reason that doesn't work you can try to set this one
+# to what ifconfig tells your virbr0 IP is.
+url_auto_ip =
 # wait in minutes for virt-install to finish (bz still open)
 use_virt_install_wait = no
 virt_install_wait_time = 300

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -248,7 +248,12 @@ class UnattendedInstallConfig(object):
         except utils_net.NetError:
             auto_ip = None
 
-        self.url_auto_content_ip = params.get('url_auto_ip', auto_ip)
+        params_auto_ip = params.get('url_auto_ip', None)
+        if params_auto_ip:
+            self.url_auto_content_ip = params_auto_ip
+        else:
+            self.url_auto_content_ip = auto_ip
+
         self.url_auto_content_port = None
 
         # Kickstart server params


### PR DESCRIPTION
When using the http_ks variants of the unattended install
test, avocado-vt can detect the IP of the main netdst (by
default, virbr0). So instead of leaving an old hardcoded
value in base.cfg, remove it and fix the logic to ensure
the auto detected value is picked over empty values
present in the configuration file.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>