### PR TITLE
Export test instance result to env

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -516,6 +516,7 @@ class VirtTest(test.Test):
                 # Postprocess
                 try:
                     try:
+                        params['test_passed'] = str(test_passed)
                         env_process.postprocess(self, params, env)
                     except Exception, e:
                         if test_passed:


### PR DESCRIPTION
avocado-vt for each test runs post_command= (if it is supplied).
This patch pass to specified command test's result.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>