### PR TITLE
virttest/utils_misc: fix conflict with builtin module

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2361,14 +2361,14 @@ def pid_is_alive(pid):
     path = '/proc/%s/stat' % pid
 
     try:
-        stat = genio.read_one_line(path)
+        state = genio.read_one_line(path)
     except IOError:
         if not os.path.exists(path):
             # file went away
             return False
         raise
 
-    return stat.split()[2] != 'Z'
+    return state.split()[2] != 'Z'
 
 
 def signal_pid(pid, sig):


### PR DESCRIPTION
Rename a variant name 'stat' to avoid conflict with
imported module.