### PR TITLE
selftests/test_utils_env.py: Don't manually clean environment file

### DIFF
--- a/selftests/unit/test_utils_env.py
+++ b/selftests/unit/test_utils_env.py
@@ -51,10 +51,6 @@ class TestEnv(unittest.TestCase):
     def setUp(self):
         self.envfilename = "/dev/shm/EnvUnittest" + self.id()
 
-    def tearDown(self):
-        if os.path.exists(self.envfilename):
-            os.unlink(self.envfilename)
-
     def test_save(self):
         """
         1) Verify that calling env.save() with no filename where env doesn't


### PR DESCRIPTION
Now that the Environment file is cleaned by the Environment
class at the __del__ method, the tearDown method is unnecessary
(and we can get to a race - at cleanup time the environment time
is still there, but when we try to delete it, it won't be anymore).

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>