### PR TITLE
virttest.asset: Restore backup file during bootstrap

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -439,6 +439,11 @@ def uncompress_asset(asset_info, force=False):
             logging.debug('Uncompressing %s -> %s', destination,
                           destination_uncompressed)
             commands.getstatusoutput(uncompress_cmd)
+            backup_file = destination_uncompressed + '.backup'
+            if os.path.isfile(backup_file):
+                logging.debug('Copying %s -> %s', destination_uncompressed,
+                              backup_file)
+                shutil.copy(destination_uncompressed, backup_file)
 
 
 def download_file(asset_info, interactive=False, force=False):


### PR DESCRIPTION
While testing my fixes to the problem with the env
file, I've ran a lot of avocado jobs, and pressed
several Ctrl+C sequences while they were being executed
in different times.

At some point, my tests started failing every time I
ran a test, and the problem would go away if I ran
vt-bootstrap, but it would come back right after it.
After some time at a loss, I finally figured out what
was wrong: My .backup file was corrupted from one of
the Ctrl+Cs pressed during the backup procedure.
Every time the good, pristine file would be replaced
by a corrupt backup, making my tests fail.

So I propose that at asset restore time, to check
if there's a backup file present, if so, restore
it with the pristine file contents. This way, we
ensure that after --vt-bootstrap new tests are
safe to go.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>