### PR TITLE
Makefile: Use mock to build RPMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-PYTHON=`which python`
+PYTHON=$(shell which python)
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/avocado-virt
 PROJECT=avocado
 VERSION="0.29.0"
 AVOCADO_DIRNAME?=avocado
 DIRNAME=$(shell echo $${PWD\#\#*/})
+
+RELEASE_COMMIT=$(shell git log --pretty=format:'%H' -n 1 $(VERSION))
+RELEASE_SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1 $(VERSION))
+
+COMMIT=$(shell git log --pretty=format:'%H' -n 1)
+SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 
 all:
 	@echo "make source - Create source package"
@@ -16,8 +22,13 @@ all:
 	@echo "make check - Runs static checks in the source code"
 	@echo "make clean - Get rid of scratch and byte files"
 
-source:
-	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=SOURCES --prune
+source: clean
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="avocado-plugins-vt-$(COMMIT)/" -o "SOURCES/avocado-plugins-vt-$(VERSION)-$(SHORT_COMMIT).tar.gz" HEAD
+
+source-release: clean
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="avocado-plugins-vt-$(RELEASE_COMMIT)/" -o "SOURCES/avocado-plugins-vt-$(VERSION)-$(RELEASE_SHORT_COMMIT).tar.gz" $(VERSION)
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)
@@ -41,9 +52,22 @@ build-deb-all: prepare-source
 	# build both source and binary packages
 	dpkg-buildpackage -i -I -rfakeroot
 
-build-rpm-all: source
-	rpmbuild --define '_topdir %{getenv:PWD}' \
-		 -ba avocado-plugins-vt.spec
+srpm: source
+	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
+	mock --resultdir BUILD/SRPM -D "commit $(COMMIT)" --buildsrpm --spec avocado-plugins-vt.spec --sources SOURCES
+
+rpm: srpm
+	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
+	mock --resultdir BUILD/RPM -D "commit $(COMMIT)" --rebuild BUILD/SRPM/avocado-plugins-vt-$(VERSION)-*.src.rpm
+
+srpm-release: source-release
+	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
+	mock --resultdir BUILD/SRPM -D "commit $(RELEASE_COMMIT)" --buildsrpm --spec avocado.spec --sources SOURCES
+
+rpm-release: srpm-release
+	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
+	mock --resultdir BUILD/RPM -D "commit $(RELEASE_COMMIT)" --rebuild BUILD/SRPM/avocado-plugins-vt-$(VERSION)-*.src.rpm
+
 check:
 	selftests/checkall
 clean:

--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -1,3 +1,9 @@
+%global modulename avocado
+%if ! 0%{?commit:1}
+ %define commit 2b69175c21f6e77068eb53c7d78c20a149fd0c97
+%endif
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 0.29.0
@@ -5,7 +11,7 @@ Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
-Source: avocado-plugins-vt-%{version}.tar.gz
+Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildRequires: python2-devel
 BuildArch: noarch
 Requires: python, avocado, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect
@@ -23,7 +29,7 @@ with all the avocado convenience features, such as HTML report,
 Xunit output, among others.
 
 %prep
-%setup -q
+%setup -q -n %{name}-%{commit}
 
 %build
 %{__python} setup.py build


### PR DESCRIPTION
Instead of trusting in rpmbuild to do the rpm builds,
use mock - a program that builds the rpms from fresh
chroots. This ensures that BuildRequires are correct
and that the binary rpms build cleanly.

This requires a few changes to the Makefile targets
and the avocado spec file, laid out in this patch.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>