### PR TITLE
virttest: Add 'shell' parameter if using process.run function.

### DIFF
--- a/selftests/unit/test_utils_misc.py
+++ b/selftests/unit/test_utils_misc.py
@@ -140,7 +140,7 @@ node   0
         raise ValueError("Could not locate locate '%s' on fake cmd db" % cmd)
 
 
-def utils_run(cmd):
+def utils_run(cmd, shell=True):
     return FakeCmd(cmd)
 
 all_nodes_contents = "0\n"

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -776,7 +776,8 @@ def get_dev_pts_max_id():
     """
     cmd = "ls /dev/pts/ | grep '^[0-9]*$' | sort -n"
     try:
-        max_id = process.run(cmd, verbose=False).stdout.strip().split("\n")[-1]
+        max_id = process.run(cmd, verbose=False,
+                             shell=True).stdout.strip().split("\n")[-1]
     except IndexError:
         return None
     pts_file = "/dev/pts/%s" % max_id
@@ -1560,7 +1561,8 @@ def yum_install(pkg_list, session=None, timeout=300):
         else:
             status = process.run(yum_cmd.format(pkg),
                                  timeout=timeout,
-                                 ignore_status=False).exit_status
+                                 ignore_status=False,
+                                 shell=True).exit_status
         if status:
             logging.error("Failed to install package: %s"
                           % pkg)
@@ -1823,7 +1825,7 @@ class NumaNode(object):
         """
         Flush pin dict, remove the record of exited process.
         """
-        cmd = process.run("ps -eLf | awk '{print $4}'")
+        cmd = process.run("ps -eLf | awk '{print $4}'", shell=True)
         all_pids = cmd.stdout
         for i in self.cpus:
             for j in self.dict[i]:
@@ -3231,7 +3233,8 @@ def get_pci_devices_in_group(str_flag=""):
 
     :param str_flag: the match string to filter devices.
     """
-    d_lines = process.run("lspci -bDnn | grep \"%s\"" % str_flag).stdout
+    d_lines = process.run("lspci -bDnn | grep \"%s\"" % str_flag,
+                          shell=True).stdout
 
     devices = {}
     for line in d_lines.splitlines():
@@ -3301,7 +3304,8 @@ def bind_device_driver(pci_id, driver_type):
     vendor = vd_list[0].split(':')[0]
     device = vd_list[0].split(':')[1]
     bind_cmd = "echo %s %s > %s" % (vendor, device, bind_file)
-    return process.run(bind_cmd, ignore_status=True).exit_status == 0
+    return process.run(bind_cmd, ignore_status=True,
+                       shell=True).exit_status == 0
 
 
 def unbind_device_driver(pci_id):
@@ -3314,7 +3318,8 @@ def unbind_device_driver(pci_id):
         return False
     unbind_file = "/sys/bus/pci/devices/%s/driver/unbind" % pci_id
     unbind_cmd = "echo %s > %s" % (pci_id, unbind_file)
-    return process.run(unbind_cmd, ignore_status=True).exit_status == 0
+    return process.run(unbind_cmd, ignore_status=True,
+                       shell=True).exit_status == 0
 
 
 def check_device_driver(pci_id, driver_type):
@@ -3379,7 +3384,7 @@ class VFIOController(object):
         lnk = "/sys/module/vfio_iommu_type1/parameters/allow_unsafe_interrupts"
         if allow_unsafe_interrupts:
             try:
-                process.run("echo Y > %s" % lnk)
+                process.run("echo Y > %s" % lnk, shell=True)
             except process.CmdError, detail:
                 raise VFIOError(str(detail))
 
@@ -3484,7 +3489,7 @@ class SELinuxBoolean(object):
         get_sebool_cmd = "getsebool %s | awk -F'-->' '{print $2}'" % (
             self.local_bool_var)
         logging.debug("The command: %s", get_sebool_cmd)
-        result = process.run(get_sebool_cmd)
+        result = process.run(get_sebool_cmd, shell=True)
         return result.stdout.strip()
 
     def get_sebool_remote(self):
@@ -3495,7 +3500,7 @@ class SELinuxBoolean(object):
         get_sebool_cmd = "getsebool %s" % self.remote_bool_var
         cmd = ssh_cmd + "'%s'" % get_sebool_cmd + "| awk -F'-->' '{print $2}'"
         logging.debug("The command: %s", cmd)
-        result = process.run(cmd)
+        result = process.run(cmd, shell=True)
         return result.stdout.strip()
 
     def setup(self):

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -242,7 +242,7 @@ def cpu_allowed_list_by_task(pid, tid):
     """
     cmd = "cat /proc/%s/task/%s/status|grep Cpus_allowed_list:| awk '{print $2}'" % (
         pid, tid)
-    result = process.run(cmd, ignore_status=True)
+    result = process.run(cmd, ignore_status=True, shell=True)
     if result.exit_status:
         return None
     return result.stdout.strip()
@@ -787,7 +787,8 @@ def yum_install(pkg_list, session=None):
         if session:
             status = session.cmd_status(yum_cmd.format(pkg))
         else:
-            status = process.run(yum_cmd.format(pkg)).exit_status
+            status = process.run(yum_cmd.format(pkg),
+                                 shell=True).exit_status
         if status:
             raise exceptions.TestFail("Failed to install package: %s"
                                       % pkg)
@@ -846,7 +847,7 @@ class PoolVolumeTest(object):
                     shutil.rmtree(nfs_path)
             if pool_type == "logical":
                 cmd = "pvs |grep vg_logical|awk '{print $1}'"
-                pv = process.system_output(cmd)
+                pv = process.system_output(cmd, shell=True)
                 # Cleanup logical volume anyway
                 process.run("vgremove -f vg_logical", ignore_status=True)
                 process.run("pvremove %s" % pv, ignore_status=True)
@@ -988,7 +989,7 @@ class PoolVolumeTest(object):
                     image_size=image_size)
                 cmd = ("iscsiadm -m session -P 3 |grep -B3 %s| grep Host|awk "
                        "'{print $3}'" % logical_device.split('/')[2])
-                scsi_host = process.system_output(cmd)
+                scsi_host = process.system_output(cmd, shell=True)
                 scsi_pool_xml = pool_xml.PoolXML()
                 scsi_pool_xml.name = pool_name
                 scsi_pool_xml.pool_type = "scsi"
@@ -2086,7 +2087,7 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
 
         # Mount the gluster disk and create the image.
         process.run("mount -t glusterfs %s:%s /mnt; %s; umount /mnt"
-                    % (host_ip, vol_name, disk_cmd))
+                    % (host_ip, vol_name, disk_cmd), shell=True)
 
         disk_params_src = {'source_protocol': disk_src_protocol,
                            'source_name': "%s/%s" % (vol_name, dist_img),
@@ -2219,7 +2220,7 @@ def create_local_disk(disk_type, path=None,
     else:
         raise exceptions.TestError("Unknown disk type %s" % disk_type)
     if cmd:
-        process.run(cmd, ignore_status=True)
+        process.run(cmd, ignore_status=True, shell=True)
     return path
 
 
@@ -2261,7 +2262,8 @@ def create_scsi_disk(scsi_option, scsi_size="2048"):
                                   (scsi_size, scsi_option))
         # Get the scsi device name
         scsi_disk = process.run("lsscsi|grep scsi_debug|"
-                                "awk '{print $6}'").stdout.strip()
+                                "awk '{print $6}'",
+                                shell=True).stdout.strip()
         logging.info("scsi disk: %s" % scsi_disk)
         return scsi_disk
     except Exception, e:


### PR DESCRIPTION
process.run use subprocess.Popen to run a command, the command
string will be splitted to a list if shell parameter is False.
If command string includes some special characters such as
'|, &&, ||', the command wouldn't be executed correctly. It need
to set shell to 'True' in parameter for this kind of commands.

Signed-off-by: Ruifeng Bian <rbian@redhat.com>