### PR TITLE
Fix env file lock problem [v2]

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -397,10 +397,13 @@ class VirtTest(test.Test):
                             "as root may produce unexpected results!!!")
             logging.warning("")
 
-        # Open the environment file
-        env_filename = os.path.join(
-            data_dir.get_backend_dir(params.get("vm_type")),
-            params.get("env", "env"))
+        # TODO: the environment file is deprecated code, and should be removed
+        # in future versions. Right now, it's being created on an Avocado temp
+        # dir that is only persisted during the runtime of one job, which is
+        # different from the original idea of the environment file (which was
+        # persist information accross virt-test/avocado-vt job runs)
+        env_filename = os.path.join(data_dir.get_tmp_dir(),
+                                    params.get("env", "env"))
         env = utils_env.Env(env_filename, self.env_version)
 
         test_passed = False

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2735,7 +2735,7 @@ class VirtNet(DbNet, ParamsNet):
         :param nic_index_or_name: index number or name of NIC
         """
         nic = self[nic_index_or_name]
-        if nic.has_key('mac'):
+        if 'mac' in nic:
             # Reset to params definition if any, or None
             self.reset_mac(nic_index_or_name)
         self.update_db()


### PR DESCRIPTION
Fix to the trello card:

https://trello.com/c/AThbmafK/518-bug-incorrect-handling-of-the-missing-adress-pool-lock

I did take a look at the solution discussed at the Monday (2015/10/12) meeting, but I found a problem, explained at the 2nd commit message.

---

Changes from v1:
 * Put a "TODO" note about the deprecation of env file