### PR TITLE
virttest.utils_test.libvirt: Run command in a subshell

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -243,7 +243,7 @@ def cpu_allowed_list_by_task(pid, tid):
     """
     cmd = "cat /proc/%s/task/%s/status|grep Cpus_allowed_list:| awk '{print $2}'" % (
         pid, tid)
-    result = process.run(cmd, ignore_status=True)
+    result = process.run(cmd, ignore_status=True, shell=True)
     if result.exit_status:
         return None
     return result.stdout.strip()


### PR DESCRIPTION
In Subprocess module, it split command into a list as the first arg
of Popen() if shell is False, but the 'cat' command here can not run
in that way.

Signed-off-by: Yanbing Du <ydu@redhat.com>