### PR TITLE
shared.cfg.machines: Add pci-based arm64 machine [v1]

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -998,6 +998,12 @@ class VirtTestOptionsProcess(object):
                 no_filter = ", ".join(self.options.vt_no_filter.split(' '))
                 self.cartesian_parser.no_filter(no_filter)
 
+    def _process_extra_params(self):
+        if self.options.vt_extra_params:
+            for param in self.options.vt_extra_params:
+                key, value = param.split('=', 1)
+                self.cartesian_parser.assign(key, value)
+
     def _process_only_type_specific(self):
         if not self.options.vt_config:
             if self.options.vt_type_specific:
@@ -1070,6 +1076,8 @@ class VirtTestOptionsProcess(object):
             self._process_libvirt_specific_options()
         elif self.options.vt_type == 'spice':
             self._process_spice_specific_options()
+
+        self._process_extra_params()
 
     def get_parser(self):
         self._process_options()
@@ -1184,6 +1192,9 @@ class VirtTestCompatPlugin(plugin.Plugin):
                                                 "binaries will be made. "
                                                 "Current: %s" %
                                                 qemu_dst_bin_path_current))
+        vt_compat_group_qemu.add_argument("--vt-extra-params", nargs='*',
+                                          help="List of 'key=value' pairs "
+                                          "passed to cartesian parser.")
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)
         uri_current = settings.get_value('vt.libvirt', 'connect_uri',
                                          default=None)

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -38,7 +38,7 @@ variants:
             # Device selection for the NDISTest server machine
             dp_regex_servermsgdev = VirtIO Ethernet Adapter$
             dp_regex_serversupportdev = VirtIO Ethernet Adapter #2$
-        arm64:
+        arm64-mmio:
             # Currently arm only supports virtio-net-device
             nic_model = virtio-net-device
             # Currently arm does not support msix vectors
@@ -77,11 +77,13 @@ variants:
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
         image_boot=yes
-        arm64:
+        arm64-pci:
+            cd_format = scsi-cd
+            scsi_hba = virtio-scsi-pci
+        arm64-mmio:
             # Direct usage of virtio-blk-device (using mmio transports) is used
             # on arm64.
             drive_format=virtio-blk-device
-            image_boot=yes
             cd_format = scsi-cd
             scsi_hba = virtio-scsi-device
     - virtio_scsi:

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -26,11 +26,23 @@ variants:
         usb_type_usb1 = pci-ohci
         usb_controller_tablet1 = ohci
         del rtc_drift
-    - @arm64:
+    - arm64-mmio:
         only aarch64
         auto_cpu_model = "no"
         cpu_model = host
-        machine_type = virt
+        machine_type = arm64-mmio:virt
+        # No support for VGA yet
+        vga = none
+        inactivity_watcher = none
+        take_regular_screendumps = no
+        # Currently no USB support
+        usbs =
+        usb_devices =
+    - arm64-pci:
+        only aarch64
+        auto_cpu_model = "no"
+        cpu_model = host
+        machine_type = arm64-pci:virt
         # No support for VGA yet
         vga = none
         inactivity_watcher = none

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -831,7 +831,7 @@ class DevContainer(object):
                                )
             return devices
 
-        def machine_aarch64(cmd=False):
+        def machine_arm64_mmio(cmd=False):
             """
             aarch64 (arm64) doesn't support PCI bus, only MMIO transports.
             Also it requires pflash for EFI boot.
@@ -882,6 +882,67 @@ class DevContainer(object):
                                                   aobject="virtio-mmio-bus"))
             return devices
 
+        def machine_arm64_pci(cmd=False):
+            """
+            Experimental support for pci-based aarch64
+            :param cmd: If set uses "-M $cmd" to force this machine type
+            :return: List of added devices (including default buses)
+            """
+            def get_aavmf_vars(params):
+                """
+                Naive implementation of obtaining the main (first) image name
+                """
+                try:
+                    first_image = params.objects('images')[0]
+                    name = params.object_params(first_image).get('image_name')
+                    return os.path.join(data_dir.DATA_DIR,
+                                        name + "_AAVMF_VARS.fd")
+                except IndexError:
+                    raise DeviceError("Unable to map main image name to "
+                                      "AAVMF variables file.")
+            logging.warn('Support for aarch64 is highly experimental!')
+            devices = []
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd))
+            # EFI pflash
+            aavmf_code = ("-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,"
+                          "if=pflash,format=raw,unit=0,readonly=on")
+            devices.append(qdevices.QStringDevice('AAVMF_CODE',
+                                                  cmdline=aavmf_code))
+            aavmf_vars = get_aavmf_vars(params)
+            if not os.path.exists(aavmf_vars):
+                logging.warn("AAVMF variables file '%s' doesn't exist, "
+                             "recreating it from the template (this should "
+                             "only happen when you install the machine as "
+                             "there is no default boot in EFI!)")
+                shutil.copy2('/usr/share/AAVMF/AAVMF_VARS.fd', aavmf_vars)
+            aavmf_vars = ("-drive file=%s,if=pflash,format=raw,unit=1"
+                          % aavmf_vars)
+            devices.append(qdevices.QStringDevice('AAVMF_VARS',
+                                                  cmdline=aavmf_vars))
+            # Add virtio-bus
+            # TODO: Currently this uses QNoAddrCustomBus and does not
+            # set the device's properties. This means that the qemu qtree
+            # and autotest's representations are completelly different and
+            # can't be used.
+            bus = qbuses.QNoAddrCustomBus('bus', [['addr'], [32]],
+                                          'virtio-mmio-bus', 'virtio-bus',
+                                          'virtio-mmio-bus')
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
+                                                  child_bus=bus,
+                                                  aobject="virtio-mmio-bus"))
+            # And this is the pcie bus
+            bus = (qbuses.QPCIBus('pcie.0', 'PCIE', 'pci.0'),
+                   qbuses.QStrictCustomBus(None, [['chassis'], [256]],
+                                           '_PCI_CHASSIS', first_port=[1]),
+                   qbuses.QStrictCustomBus(None, [['chassis_nr'], [256]],
+                                           '_PCI_CHASSIS_NR', first_port=[1]))
+            devices.append(qdevices.QStringDevice('pci.0', child_bus=bus,
+                                                  aobject="pci.0"))
+            devices.append(qdevices.QStringDevice('gpex-root',
+                                                  {'addr': 0, 'driver': 'gpex-root'},
+                                                  parent_bus={'aobject': 'pci.0'}))
+            return devices
+
         def machine_other(cmd=False):
             """
             isapc or unknown machine type. This type doesn't add any default
@@ -898,6 +959,10 @@ class DevContainer(object):
         machine_type = params.get('machine_type')
         machine_type_extra_params = params.get('machine_type_extra_params')
         if machine_type:
+            if machine_type.startswith('arm64'):
+                arm_machine, machine_type = machine_type.split(':', 1)
+            else:
+                arm_machine = False
             m_types = []
             for _ in self.__machine_types.splitlines()[1:]:
                 m_types.append(_.split()[0])
@@ -911,8 +976,10 @@ class DevContainer(object):
                     cmd = ""
                 if 'q35' in machine_type:   # Q35 + ICH9
                     devices = machine_q35(cmd)
-                elif arch.ARCH == 'aarch64':
-                    devices = machine_aarch64(cmd)
+                elif arm_machine == 'arm64-pci':
+                    devices = machine_arm64_pci(cmd)
+                elif arm_machine == 'arm64-mmio':
+                    devices = machine_arm64_mmio(cmd)
                 elif 'isapc' not in machine_type:   # i440FX
                     devices = machine_i440FX(cmd)
                 else:   # isapc (or other)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -435,7 +435,9 @@ class VM(virt_vm.BaseVM):
             return cmd
 
         def add_serial(devices, name, filename):
-            if arch.ARCH == 'aarch64' or not devices.has_option("chardev"):
+            if (not devices.has_option("chardev") or
+                    not (devices.has_device("isa-serial") or
+                         devices.has_device("spapr-vty"))):
                 return " -serial unix:'%s',server,nowait" % filename
 
             serial_id = "serial_id_%s" % name
@@ -444,9 +446,9 @@ class VM(virt_vm.BaseVM):
             cmd += _add_option("path", filename)
             cmd += _add_option("server", "NO_EQUAL_STRING")
             cmd += _add_option("nowait", "NO_EQUAL_STRING")
-            if '86' in arch.ARCH:
+            if '86' in params.get('vm_arch_name', arch.ARCH):
                 cmd += " -device isa-serial"
-            elif 'ppc' in arch.ARCH:
+            elif 'ppc' in params.get('vm_arch_name', arch.ARCH):
                 cmd += " -device spapr-vty"
                 # Workaround for console issue, details:
                 #   lists.gnu.org/archive/html/qemu-ppc/2013-10/msg00129.html

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -526,7 +526,7 @@ class VM(virt_vm.BaseVM):
             dev.set_param("server", 'NO_EQUAL_STRING')
             dev.set_param("nowait", 'NO_EQUAL_STRING')
             devices.insert(dev)
-            if arch.ARCH == 'aarch64':
+            if params.get('machine_type').startswith("arm64-mmio"):
                 dev = QDevice('virtio-serial-device')
             else:
                 dev = QDevice('virtio-serial-pci', parent_bus=pci_bus)
@@ -1084,7 +1084,7 @@ class VM(virt_vm.BaseVM):
                 return ""
 
         def add_boot(devices, boot_order, boot_once, boot_menu, boot_strict):
-            if arch.ARCH == 'aarch64':
+            if params.get('machine_type', "").startswith("arm"):
                 logging.warn("-boot on ARM is usually not supported, use "
                              "bootindex instead.")
                 return ""
@@ -1409,7 +1409,7 @@ class VM(virt_vm.BaseVM):
                 # when the port is a virtio console.
                 if (port_params.get('virtio_port_type') == 'console' and
                         params.get('virtio_port_bus') is None):
-                    if arch.ARCH == 'aarch64':
+                    if params.get('machine_type').startswith("arm64-mmio"):
                         dev = QDevice('virtio-serial-device')
                     else:
                         dev = QDevice('virtio-serial-pci', parent_bus=pci_bus)
@@ -1418,7 +1418,7 @@ class VM(virt_vm.BaseVM):
                     devices.insert(dev)
                     no_virtio_serial_pcis += 1
                 for i in range(no_virtio_serial_pcis, bus + 1):
-                    if arch.ARCH == 'aarch64':
+                    if params.get('machine_type').startswith("arm64-mmio"):
                         dev = QDevice('virtio-serial-device')
                     else:
                         dev = QDevice('virtio-serial-pci', parent_bus=pci_bus)


### PR DESCRIPTION
Hello guys,

this PR is trying to cleanup the way other architectures are handled in order to be able to run various machine types on different host machines.

Additionally it adds `arm64-pci` machine type which is arm constructed using PCI devices (the old one is renamed to arm64-mmio). I tested it for a while, the only problem I'm having is that when the machine is installed as `arm64-pci` and then ran as `arm64-mmio` (and vice-verse), network won't start. I'll investigate this on Thursday, for now please have a look at the implementation and let me know if you see something obviously wrong.

v0: https://github.com/avocado-framework/avocado-vt/pull/187

Changes:

    v1: "--vt-additional-params" renamed to "--vt-extra-params"