### PR TITLE
virttest: Turn off export of volume through NFS

### DIFF
--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -333,3 +333,21 @@ def add_rpc_insecure(filepath):
         cmd = "sed -i '/end-volume/i \ \ \ \ option rpc-auth-allow-insecure on' %s" % filepath
         process.system(cmd, shell=True)
         process.system("service glusterd restart; sleep 2", shell=True)
+
+
+@error_context.context_aware
+def gluster_nfs_disable(vol_name):
+    """
+    Turn-off export of volume through NFS
+
+    :param vol_name: name of gluster volume
+    """
+
+    cmd = "gluster volume set %s nfs.disable on" % vol_name
+    error_context.context("Volume set nfs.disable failed")
+    process.system(cmd)
+
+    cmd = "gluster volume info %s" % vol_name
+    output = process.system_output(cmd)
+
+    return 'nfs.disable: on' in output

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -532,6 +532,8 @@ def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
         logging.debug("finish start gluster")
         gluster.gluster_vol_create(vol_name, ip_addr, brick_path, force=True)
         gluster.gluster_allow_insecure(vol_name)
+        gluster.gluster_nfs_disable(vol_name)
+        logging.debug("The contents of %s: \n%s", file_path, open(file_path).read())
         logging.debug("finish vol create in gluster")
         return ip_addr
     else:


### PR DESCRIPTION
NFS should not be used to support the lock volume used by CTDB as NFS does not currently support locking. Instead, use the Gluster native mount.