### PR TITLE
Revert "virttest.utils_env: Remove env file upon garbage collection"

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -222,9 +222,6 @@ class Env(UserDict.IterableUserDict):
             if os.path.isfile(self._filename):
                 os.unlink(self._filename)
 
-    def __del__(self):
-        self.destroy()
-
     def get_vm(self, name):
         """
         Return a VM object by its name.


### PR DESCRIPTION
Each avocado-vt test will run on a subprocess, and that means
that the environment file will be destroyed at the end of a
test, destroying any living vms in there, regardless of the
value of keep_guest_running in the config file. This was an
oversight, and recently a patch to keep the env file in
the avocado temporary dir has been accepted, which supersedes
this patch.

So let's revert commit 7aeb3c8618e19d28ff6c62103f0b8792961b29e5.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>