### PR TITLE
Replace asset storage HTTP server

### DIFF
--- a/docs/source/advanced/Networking.rst
+++ b/docs/source/advanced/Networking.rst
@@ -59,7 +59,7 @@ test windows. First, download the iso. :doc:`The get started documentation <../b
 can help you out with downloading if you like it, but the direct download
 link is here:
 
-http://lmr.fedorapeople.org/winutils/winutils.iso
+http://assets-avocadoproject.rhcloud.com/static/winutils.iso
 
 You need to put all its contents on a folder and create a new iso. Let's say you
 want to download the iso to ``/home/kermit/Downloads/winutils.iso``.

--- a/docs/source/extra/DownloadableImages.rst
+++ b/docs/source/extra/DownloadableImages.rst
@@ -30,7 +30,7 @@ Winutils ISO
 
 The windows utils file can be currently found at:
 
-http://lmr.fedorapeople.org/winutils/winutils.iso
+http://assets-avocadoproject.rhcloud.com/static/winutils.iso
 
 How to update `winutils.iso`
 ----------------------------
@@ -44,7 +44,7 @@ JeOS image
 
 You can find the JeOS images currently here:
 
-http://lmr.fedorapeople.org/jeos/
+http://assets-avocadoproject.rhcloud.com/static/
 
 You'll find .7za (p7zipped) files for versions of
 the JeOS available, as well as their MD5SUM files.

--- a/shared/downloads/jeos-19-64.ini
+++ b/shared/downloads/jeos-19-64.ini
@@ -1,6 +1,0 @@
-[jeos-19-64]
-title = JeOS 19 x86_64
-url = http://lmr.fedorapeople.org/jeos/jeos-19-64.qcow2.7z
-sha1_url = http://lmr.fedorapeople.org/jeos/SHA1SUM_JEOS19
-destination = images/jeos-19-64.qcow2.7z
-destination_uncompressed = images/jeos-19-64.qcow2

--- a/shared/downloads/jeos-20-64.ini
+++ b/shared/downloads/jeos-20-64.ini
@@ -1,6 +1,6 @@
 [jeos-20-64]
 title = JeOS 20 x86_64
-url = http://lmr.fedorapeople.org/jeos/jeos-20-64.qcow2.7z
-sha1_url = http://lmr.fedorapeople.org/jeos/SHA1SUM_JEOS20
+url = http://assets-avocadoproject.rhcloud.com/static/jeos-20-64.qcow2.7z
+sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS20
 destination = images/jeos-20-64.qcow2.7z
 destination_uncompressed = images/jeos-20-64.qcow2

--- a/shared/downloads/jeos-21-64.ini
+++ b/shared/downloads/jeos-21-64.ini
@@ -1,6 +1,6 @@
 [jeos-21-64]
 title = JeOS 21 x86_64
-url = http://lmr.fedorapeople.org/jeos/jeos-21-64.qcow2.7z
-sha1_url = http://lmr.fedorapeople.org/jeos/SHA1SUM_JEOS21
+url = http://assets-avocadoproject.rhcloud.com/static/jeos-21-64.qcow2.7z
+sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS21
 destination = images/jeos-21-64.qcow2.7z
 destination_uncompressed = images/jeos-21-64.qcow2

--- a/shared/downloads/winutils.ini
+++ b/shared/downloads/winutils.ini
@@ -1,5 +1,5 @@
 [winutils]
 title = Windows Utils ISO
-url = http://lmr.fedorapeople.org/winutils/winutils.iso
-sha1_url = http://lmr.fedorapeople.org/winutils/SHA1SUM
+url = http://assets-avocadoproject.rhcloud.com/static/winutils.iso
+sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_WINUTILS
 destination = isos/windows/winutils.iso

--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -6,14 +6,9 @@ DEFAULT_GUEST_OS = None     # populated below
 
 def get_default_guest_os_info():
     """
-    Gets the default asset and variant information depending on host OS
+    Gets the default asset and variant information
     """
-    os_info = {'asset': 'jeos-19-64', 'variant': "JeOS.19"}
+    return {'asset': 'jeos-21-64', 'variant': 'JeOS.21'}
 
-    detected = distro.detect()
-    if detected.name == 'fedora' and int(detected.version) >= 20:
-        os_info = {'asset': 'jeos-21-64', 'variant': 'JeOS.21'}
-
-    return os_info
 
 DEFAULT_GUEST_OS = get_default_guest_os_info()['variant']


### PR DESCRIPTION
This introduces a simple HTTP server, based on OpenShift, and hosted
at:

http://assets-avocadoproject.rhcloud.com

The asset information files and documentation have been updated to
use this new location.

Also, while at it, remove the F19 JeOS for two reasons: it's old and
we don't have much storage space to spare.

Signed-off-by: Cleber Rosa <crosa@redhat.com>