### PR TITLE
Test loader: replace list_tests parameter name for a better description

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -230,7 +230,7 @@ class VirtTestLoader(loader.TestLoader):
         term_support = output.TermSupport()
         return {VirtTest: term_support.healthy_str}
 
-    def discover(self, url, list_tests=False):
+    def discover(self, url, which_tests=loader.DEFAULT):
         try:
             cartesian_parser = self._get_parser()
         except Exception, details:
@@ -245,7 +245,7 @@ class VirtTestLoader(loader.TestLoader):
             # the other test plugins to handle the URL.
             except cartesian_config.LexerError:
                 return []
-        elif list_tests is loader.DEFAULT and not self.args.vt_config:
+        elif which_tests is loader.DEFAULT and not self.args.vt_config:
             # By default don't run anythinig unless vt_config provided
             return []
         # Create test_suite


### PR DESCRIPTION
The 'list_tests' parameters is used to select which tests should be
listed.  IMHO, it sounds like a boolean kind of parameter, which will
either list tests or not. Let's replace that parameter name with
'which_tests', that IMHO give a better message about its intended
usage.

Also, let's standardize the docstrings, and use the declared supported
symbols for these parameters (DEFAULT, AVAILABLE or ALL) instead of their
values (False, etc).

Signed-off-by: Cleber Rosa <crosa@redhat.com>