### PR TITLE
remove parameter "verbose" as it may access RemoteRunner

### DIFF
--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -731,7 +731,7 @@ class Factory(object):
             :return: executable name for PID 1, aka init
             :rtype:  str
             """
-            output = self.run("ps -o comm 1", verbose=False).stdout
+            output = self.run("ps -o comm 1").stdout
             return output.splitlines()[-1].strip()
 
         def get_generic_service_manager_type(self):


### PR DESCRIPTION
On RemoveRunner.run there is no parameter named "verbose"