### PR TITLE
aovcado-vt: set test.resultsdir = test.logdir

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -325,6 +325,7 @@ class VirtTest(test.Test):
                                                         self.default_params)
 
         self.debugdir = self.logdir
+        self.resultsdir = self.logdir
         utils_misc.set_log_file_dir(self.logdir)
 
     def _start_logging(self):


### PR DESCRIPTION
legency tp-qemu are still using test.resultsdir but it shows
None in avocado ,this patch is to set logdir to resultsdir
1277031
Signed-off-by: Mike Cao <bcao@redhat.com>