### PR TITLE
Revert env file handling

### DIFF
--- a/avocado/core/plugins/vt.py
+++ b/avocado/core/plugins/vt.py
@@ -399,13 +399,10 @@ class VirtTest(test.Test):
                             "as root may produce unexpected results!!!")
             logging.warning("")
 
-        # TODO: the environment file is deprecated code, and should be removed
-        # in future versions. Right now, it's being created on an Avocado temp
-        # dir that is only persisted during the runtime of one job, which is
-        # different from the original idea of the environment file (which was
-        # persist information accross virt-test/avocado-vt job runs)
-        env_filename = os.path.join(data_dir.get_tmp_dir(),
-                                    params.get("env", "env"))
+        # Open the environment file
+        env_filename = os.path.join(
+            data_dir.get_backend_dir(params.get("vm_type")),
+            params.get("env", "env"))
         env = utils_env.Env(env_filename, self.env_version)
 
         test_passed = False

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -222,9 +222,6 @@ class Env(UserDict.IterableUserDict):
             if os.path.isfile(self._filename):
                 os.unlink(self._filename)
 
-    def __del__(self):
-        self.destroy()
-
     def get_vm(self, name):
         """
         Return a VM object by its name.


### PR DESCRIPTION
This PR reverts the commits, that broke `keep_guest_running` feature. To test this you also need to apply https://github.com/avocado-framework/avocado-vt/pull/221 commit, otherwise the VM get's recreated every-time.

__Beware, you might get `IOError: [Errno 2] No such file or directory: '/var/tmp/avocado_XXXXXX/address_pool.lock'` error message, then you must remove the `env` file manually__