### PR TITLE
Fix access to auto-generated socket paths

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -633,7 +633,13 @@ class VMXML(VMXMLBase):
         if not vmxml.undefine():
             _cleanup(details="Undefine VM %s failed" % vm.name)
         # Alter the XML
+        str_old = "domain-" + vm.name
+        str_new = "domain-" + new_name
         vmxml.vm_name = new_name
+        for channel in vmxml.get_agent_channels():
+            for child in channel._children:
+                if 'path' in child.attrib.keys():
+                    child.attrib['path'] = child.attrib['path'].replace(str_old,str_new)
         if uuid is None:
             # UUID will be regenerated automatically
             del vmxml.uuid


### PR DESCRIPTION
Adding support for https://bugzilla.redhat.com/show_bug.cgi?id=1146886

(libvirt commits f1f68ca33433825ce0deed2d96f1990200bc6618,
f674dc6794e0946f89313f477aa7886a4a28188e)

Abstract from the libvirt commit:

"qemu: Fix access to auto-generated socket paths

We are automatically generating some socket paths for domains, but all
those paths end up in a directory that's the same for multiple domains.
The problem is that multiple domains can each run with different
seclabels (users, selinux contexts, etc.).  The idea here is to create a
per-domain directory labelled in a way that each domain can access its
own unix sockets."