### PR TITLE
utils_test/libvirt: cleanup for iothread option

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1500,7 +1500,6 @@ def create_disk_xml(params):
         driver_type = params.get("driver_type", "")
         driver_cache = params.get("driver_cache", "")
         driver_discard = params.get("driver_discard", "")
-        driver_iothread = params.get("driver_iothread", "")
         if driver_name:
             driver_attrs['name'] = driver_name
         if driver_type:


### PR DESCRIPTION
The 1b86901 added iothread option to create_disk_xml, but not used.
later, the fb6704d introduced iothread option for disk paramters
in set_vm_disk.

In fact, set_vm_disk calls create_disk_xml and pass the iothread
option to it by disk paramters.

The code in create_disk_xml becomes meaningless and redundant,
so remove it.