### PR TITLE
avocado-vt: fix static content in cd1

### DIFF
--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -1,11 +1,11 @@
 - i386:
     vm_arch_name = i686
     image_name += -32
-    cdrom_cd1 = isos/ISO/Win10/en_windows_10_enterprise_x86_dvd_6851156.iso
-    md5sum_cd1 = 68162933e551e55779504dacdfb0c5ae
-    md5sum_1m_cd1 = b44af2fdb8c39bc972f416bd3616566f
     unattended_install.cdrom, whql.support_vm_install, svirt_install:
         unattended_file = unattended/win10-32-autounattend.xml
+        cdrom_cd1 = isos/ISO/Win10/en_windows_10_enterprise_x86_dvd_6851156.iso
+        md5sum_cd1 = 68162933e551e55779504dacdfb0c5ae
+        md5sum_1m_cd1 = b44af2fdb8c39bc972f416bd3616566f
         floppies = "fl"
         floppy_name = images/win10-32/answer.vfd
         extra_cdrom_ks:

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -1,12 +1,12 @@
 - x86_64:
     image_name += -64
     vm_arch_name = x86_64
-    cdrom_cd1 = isos/ISO/Win10/en_windows_10_enterprise_x64_dvd_6851151.iso
-    md5sum_cd1 = a67722adfaf209c72eacb3ab910ee65e
-    md5sum_1m_cd1 = 0e246b56b7b63f0526c3367eb160ff7d
     install:
         passwd = 1q2w3eP
     unattended_install.cdrom, whql.support_vm_install, svirt_install:
+        cdrom_cd1 = isos/ISO/Win10/en_windows_10_enterprise_x64_dvd_6851151.iso
+        md5sum_cd1 = a67722adfaf209c72eacb3ab910ee65e
+        md5sum_1m_cd1 = 0e246b56b7b63f0526c3367eb160ff7d
         unattended_file = unattended/win10-64-autounattend.xml
         floppies = "fl"
         floppy_name = images/win10-64/answer.vfd


### PR DESCRIPTION
cd1 always been the installation iso in current setup
This patch is removing it for installation case 
ID: 1279315
Signed-off-by: Mike Cao <bcao@redhat.com>