### PR TITLE
Fix TypeError for IOTune and Encryption class in disk xml.

### DIFF
--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -283,7 +283,7 @@ class Disk(base.TypedDeviceBase):
                 else:
                     accessors.XMLElementInt(slot, self, parent_xpath='/',
                                             tag_name=slot)
-            super(Disk.IOTune, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<iotune/>'
 
     class Encryption(base.base.LibvirtXMLBase):
@@ -306,7 +306,7 @@ class Disk(base.TypedDeviceBase):
                                    tag_name='encryption', attribute='format')
             accessors.XMLElementDict('secret', self, parent_xpath='/',
                                      tag_name='secret')
-            super(Disk.Encryption, self).__init__(
+            super(self.__class__, self).__init__(
                 virsh_instance=virsh_instance)
             self.xml = '<encryption/>'
 


### PR DESCRIPTION
The current implementation caused the Exception:
TypeError: super(type, obj): obj must be an instance or subtype of type
It should use self.__class__ as the type parameter in this function.