### PR TITLE
shared.cfg.guest-os: Change boot_path for ppc64

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -13,10 +13,11 @@
         #extra_cdrom_ks:
         #    kernel_params += ":sr1:/ks.cfg"
         kernel_params += " nicdelay=60 "
+        boot_path = images/pxeboot
         aarch64:
             kernel_params += " efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"
         ppc64, ppc64le:
             kernel_params += " console=hvc0,38400 console=tty0"
+            boot_path = ppc/ppc64
         x86_64, i386:
             kernel_params += " console=ttyS0,115200 console=tty0"
-        boot_path = images/pxeboot


### PR DESCRIPTION
For some reason pxe initrd/vmlinuz is not located in images/pxeboot for
ppc64, but in ppc/ppc64.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>