### PR TITLE
Add OEM/KMS cd keys for Windows

### DIFF
--- a/shared/cfg/cdkeys.cfg
+++ b/shared/cfg/cdkeys.cfg
@@ -3,16 +3,255 @@
 # Replace the 'CDKEY' strings with real cdkeys where necessary.
 # Feel free to add additional guests as required.
 
+# This file is used by unattended_install test. unattended_install in its turn
+# uses:
+# * answer file to install Windows system automaticaly
+# * kickstart file to install RedHat products
+#
+# Person running tests should use their own keys, for example from MSDN
+# subscription. Keys should be kept in secret.
+
+# Microsoft has special mechanism for installing its products. This mechanism
+# has name : KMS (Key Management Server). The purpose of this method is to
+# install Microsoft product with common known key. The keys are publicly
+# accessible: https://technet.microsoft.com/en-us/library/jj612867.aspx
+# Installed Windows with KMS key cannot be activated without KMS server.
+
+# You must use your own key if you want to:
+# * activate Windows.
+# * install Windows that doesn't support KMS activation.
+
+# Info: after installation you can tell Windows to use your key.
+
+# See wich products support KMS activation at:
+# https://technet.microsoft.com/en-us/library/jj612867.aspx
+
+# RHEL
 RHEL.5.3.i386: cdkey = CDKEY
 RHEL.5.3.x86_64: cdkey = CDKEY
+
+# Windows
 Win2000: cdkey = CDKEY
-WinXP.i386: cdkey = CDKEY
-WinXP.x86_64: cdkey = CDKEY
-Win2003.i386: cdkey = CDKEY
-Win2003.x86_64: cdkey = CDKEY
-WinVista.i386: cdkey = CDKEY
-WinVista.x86_64: cdkey = CDKEY
-Win2008.i386: cdkey = CDKEY
-Win2008.x86_64: cdkey = CDKEY
-Win7.i386: cdkey = CDKEY
-Win7.x86_64: cdkey = CDKEY
+
+# * Windows XP
+# Preserving OEM Pre-Activation when Re-installing Windows XP:
+# https://technet.microsoft.com/en-us/library/bb457078.aspx
+WinXP.i386:
+    # Professional 32 bit
+    cdkey = MVF4D-W774K-MC4VM-QY6XY-R38TB
+
+WinXP.x86_64:
+    # Professional x64 bit
+    cdkey = FM634-HJ3QK-6QVTY-RJY4R-XCR9J
+
+# * Windows XP
+# Deploying Windows XP Using Windows Product Activation
+# https://technet.microsoft.com/en-us/library/bb457096.aspx
+#WinXP:
+    # Whistler Tech Beta Program (All Platforms)
+    # cdkey = PXRQ3-7VPMV-CQWXR-8Y4KX-RD786
+    # Home Edition  Full product
+    # cdkey = JKTVX-HCRXC-J2YC9-MX3K4-G9X26
+    # Home Edition Upgrade
+    # cdkey = JKTVX-HCRXC-J2YC9-MX3K4-G9X26
+    # Professional Full product
+    # cdkey = DR8GV-C8V6J-BYXHG-7PYJR-DB66Y
+    # Professional Upgrade
+    # cdkey = FKTW8-Q7MJ7-JK6GW-9J9RV-HC3C2
+    # Home Edition System Builder (Full)
+    # cdkey = KGVXT-F9HVW-XGW9X-QVYVX-HQ9RD
+    # Professional System Builder (Full)
+    # cdkey = TTGHK-3RC33-BT9DR-3BVYV-BTQ98
+
+# * Windows Server 2003 R2
+# Preserving OEM Pre-Activation when Re-installing Windows Server 2003 R2:
+# https://technet.microsoft.com/en-us/library/dd727762.aspx
+Win2003.i386:
+    # Standard Edition x86
+    cdkey = PWBJC-22697-D4CVH-FCJWW-DTF9J
+    # Enterprise Edition x86
+    # cdkey = XHPV3-PTCWJ-7Y94F-Q6BVH-J849J
+    # Datacenter Edition x86
+    # cdkey = FXYF6-VTXGX-3JPX9-HJ9K4-6TKTW
+    # Web Edition x86
+    # cdkey = GM8KD-GB7JY-QGQYP-XRV74-RT728
+
+Win2003.x86_64:
+    # Standard Edition x64
+    cdkey = XCP6P-7WVXP-F8FQ4-JV6CD-6XV28
+    # Enterprise Edition x64
+    # cdkey = WQ3GW-Y8GQW-8VJYB-JYM43-D24C8
+    # Datacenter Edition x64
+    # cdkey = KDX8X-FYW4T-C6D9J-BKM6M-M89TW
+
+
+# * Windows Vista
+WinVista:
+    # Business
+    cdkey = YFKBB-PQJJV-G996G-VWGXY-2V3X8
+    # Business N
+    # cdkey = HMBQG-8H2RH-C77VX-27R82-VMQBT
+    # Enterprise
+    # cdkey = VKK3X-68KWM-X2YGT-QR4M6-4BWMV
+    # Enterprise N
+    # cdkey = VTC42-BM838-43QHV-84HX6-XJXKV
+
+# * Windows Server 2008
+Win2008:
+    # Web
+    # cdkey = WYR28-R7TFJ-3X2YQ-YCY4H-M249D
+    # Standard
+    cdkey = TM24T-X9RMF-VWXK6-X8JC9-BFGM2
+    # Standard without Hyper-V
+    # cdkey = W7VD6-7JFBR-RX26B-YKQ3Y-6FFFJ
+    # Enterprise
+    # cdkey = YQGMW-MPWTJ-34KDK-48M3W-X4Q6V
+    # Enterprise without Hyper-V
+    # cdkey = 39BXF-X8Q23-P2WWT-38T2F-G3FPG
+    # HPC
+    # cdkey = RCTX3-KWVHP-BR6TB-RB6DM-6X7HP
+    # Datacenter
+    # cdkey = 7M67G-PC374-GR742-YH8V4-TCBY3
+    # Datacenter without Hyper-V
+    # cdkey = 22XQ2-VRXRG-P8D42-K34TD-G3QQC
+    # for Itanium-Based Systems
+    # cdkey = 4DWFP-JF3DJ-B7DTH-78FJB-PDRHK
+
+# * Windows Server 2008 R2
+Win2008..r2:
+    # Web
+    # cdkey = 6TPJF-RBVHG-WBW2R-86QPH-6RTM4
+    # HPC edition
+    # cdkey = TT8MH-CG224-D3D7Q-498W2-9QCTX
+    # Standard
+    cdkey = YC6KT-GKW9T-YTKYR-T4X34-R7VHC
+    # Enterprise
+    # cdkey = 489J6-VHDMP-X63PK-3K798-CPX3Y
+    # Datacenter
+    # cdkey = 74YFP-3QFB3-KQT8W-PMXWJ-7M648
+    # for Itanium-based Systems
+    # cdkey = GT63C-RJFQ3-4GMB6-BRFB9-CB83V
+
+# * Windows 7
+Win7:
+    # Professional
+    # cdkey = FJ82H-XT6CR-J8D7P-XQJJ2-GPDD4
+    # Professional N
+    cdkey = MRPKT-YTG23-K7D7T-X2JMM-QY7MG
+    # Professional E
+    # cdkey = W82YF-2Q76Y-63HXB-FGJG9-GF7QX
+    # Enterprise
+    # cdkey = 33PXH-7Y6KF-2VJC9-XBBR8-HVTHH
+    # Enterprise N
+    # cdkey = YDRBP-3D83W-TY26F-D46B2-XCKRJ
+    # Enterprise E
+    # cdkey = C29WB-22CC8-VJ326-GHFJW-H9DH4
+
+Win8..0:
+    # KMS:
+    # Professional
+    # cdkey = NG4HW-VH26C-733KW-K6F98-J8CK4
+    # Professional N
+    # cdkey = XCVCF-2NXM9-723PB-MHCB7-2RYQQ
+    # Enterprise
+    # cdkey = 32JNW-9KQ84-P47T8-D8GGY-CWCK7
+    # Enterprise N
+    # cdkey = JMNMF-RHW7P-DMY6X-RF3DR-X2BQT
+    #
+    # Preserving OEM keys
+    # https://www.microsoft.com/OEM/en/installation/downloads/Pages/windows-8-adk.aspx
+    # General
+    cdkey = 46V6N-VCBYR-KT9KT-6Y4YF-QGJYH
+    # Professional
+    # cdkey = V7C3N-3W6CM-PDKR2-KW8DQ-RJMRD
+    # N
+    # cdkey = 7QNT4-HJDDR-T672J-FBFP4-2J8X9
+    # Professional N
+    # cdkey = 4NX4X-C98R3-KBR22-MGBWC-D667X
+    # Single Language (Emerging Markets)
+    # cdkey = NH7GX-2BPDT-FDPBD-WD893-RJMQ4
+
+Win8..1:
+    # KMS:
+    # Professional
+    # cdkey = GCRJD-8NW9H-F2CDX-CCM8D-9D6T9
+    # Professional N
+    # cdkey = HMCNV-VVBFX-7HMBH-CTY9B-B4FXY
+    # Enterprise
+    # cdkey = MHF9N-XY6XB-WVXMC-BTDCT-MKKG7
+    # Enterprise N
+    # cdkey = TT4HM-HN7YT-62K67-RGRQJ-JFFXW
+    #
+    # Preserving OEM keys
+    # General
+    # cdkey = FJWTM-42NKR-9DPD2-8FR9Y-3GMCH
+    # Professional
+    cdkey = B478Q-FNMXX-FKYT6-D6FC8-HMGTD
+    # N
+    # cdkey = HJ924-JPN9Y-3FC9H-GCYMG-C9WJY
+    # Professional N
+    # cdkey = 2TXRD-CCNWC-CT2X8-KGDXP-PGXGF
+    # Single Language (Emerging Markets)
+    # cdkey = Y9NXP-XT8MV-PT9TG-97CT3-9D6TC 
+
+
+Win2012..r1:
+    # Server 2012
+    cdkey = BN3D2-R7TKB-3YPBD-8DRP2-27GG4
+    # Server 2012 N
+    # cdkey = 8N2M2-HWPGY-7PGT9-HGDD8-GVGGY
+    # Server 2012 Single Language
+    # cdkey = 2WN2H-YGCQR-KFX6K-CD6TF-84YXQ
+    # Server 2012 Country Specific
+    # cdkey = 4K36P-JN4VD-GDC6V-KDT89-DYFKP
+    # Server 2012 Server Standard
+    # cdkey = XC9B7-NBPP2-83J2H-RHMBY-92BT4
+    # Server 2012 MultiPoint Standard
+    # cdkey = HM7DN-YVMH3-46JC3-XYTG7-CYQJJ
+    # Server 2012 MultiPoint Premium
+    # cdkey = XNH6W-2V9GX-RGJ4K-Y8X6F-QGJ2G
+    # Server 2012 Datacenter
+    # cdkey = 48HP8-DN98B-MYWDG-T2DCC-8W83P
+
+Win2012..r2:
+    # Server 2012 R2 Server Standard
+    cdkey = D2N9P-3P6X9-2R39C-7RTCD-MDVJX
+    # Server 2012 R2 Datacenter
+    # cdkey = W3GGN-FT8W3-Y4M27-J84CP-Q3VJ9
+    # Server 2012 R2 Essentials
+    # cdkey = KNC87-3J2TX-XB4WP-VCPJV-M4FWM
+
+
+Win10:
+    # Professional
+    # cdkey = W269N-WFGWX-YVC9B-4J6C9-T83GX
+    # Professional N
+    # cdkey = MH37W-N47XK-V7XM9-C7227-GCQG9
+    # Enterprise
+    # cdkey = NPPR9-FWDCX-D2C8J-H872K-2YT43
+    # Enterprise N
+    # cdkey = DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4
+    # Education
+    # cdkey = NW6C2-QMPVW-D7KKK-3GKT6-VCFB2
+    # Education N
+    # cdkey = 2WH4N-8QGBV-H22JP-CT43Q-MDWWJ
+    # Enterprise 2015 LTSB
+    # cdkey = WNMTR-4C88C-JK8YV-HQ7T2-76DF9
+    # Enterprise 2015 LTSB N
+    # cdkey = 2F77B-TNFGY-69QQF-B8YKP-D69TJ
+    #
+    # Preserving OEM keys
+    # http://www.microsoft.com/OEM/en/products/windows/Pages/windows-10-build.aspx
+    # Home
+    # cdkey = 46J3N-RY6B3-BJFDY-VBFT9-V22HG
+    # Home N
+    # cdkey = PGGM7-N77TC-KVR98-D82KJ-DGPHV
+    # Pro
+    cdkey = RHGJR-N7FVY-Q3B8F-KBQ6V-46YP4
+    # Pro N
+    # cdkey = RHGJR-N7FVY-Q3B8F-KBQ6V-46YP4
+    # SL
+    # cdkey = GH37Y-TNG7X-PP2TK-CMRMT-D3WV4
+    # CHN SL
+    # cdkey = 68WP7-N2JMW-B676K-WR24Q-9D7YC
+


### PR DESCRIPTION
Populate cdkey list with KMS/OEM. The keys are publicly accessible. This should
simplify auto-installation.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>