### PR TITLE
Unified image name for Windows XP 64

### DIFF
--- a/shared/cfg/guest-os/Windows/WinXP/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/WinXP/x86_64.cfg
@@ -2,7 +2,7 @@
     image_name += -64
     vm_arch_name = x86_64
     install:
-        cdrom_cd1 = isos/windows/WindowsXP-64.iso
+        cdrom_cd1 = isos/windows/en_win_xp_pro_x64_vl.iso
         md5sum_cd1 = 8d3f007ec9c2060cec8a50ee7d7dc512
         md5sum_1m_cd1 = e812363ff427effc512b7801ee70e513
         user = user
@@ -12,7 +12,7 @@
     sysprep:
         unattended_file = unattended/winxp64.sif
     unattended_install.cdrom, whql.support_vm_install, svirt_install:
-        cdrom_cd1 = isos/windows/WindowsXP-64.iso
+        cdrom_cd1 = isos/windows/en_win_xp_pro_x64_vl.iso
         md5sum_cd1 = 8d3f007ec9c2060cec8a50ee7d7dc512
         md5sum_1m_cd1 = e812363ff427effc512b7801ee70e513
         unattended_file = unattended/winxp64.sif


### PR DESCRIPTION
Windows XP image name should be the same as at MSDN.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>