### PR TITLE
Unified image name for Windows XP 64

### DIFF
--- a/shared/cfg/guest-os/Windows/WinXP/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/WinXP/x86_64.cfg
@@ -2,7 +2,7 @@
     image_name += -64
     vm_arch_name = x86_64
     install:
-        cdrom_cd1 = isos/windows/WindowsXP-64.iso
+        cdrom_cd1 = isos/windows/en_win_xp_pro_x64_vl.iso
         md5sum_cd1 = 8d3f007ec9c2060cec8a50ee7d7dc512
         md5sum_1m_cd1 = e812363ff427effc512b7801ee70e513
         user = user
@@ -12,7 +12,7 @@
     sysprep:
         unattended_file = unattended/winxp64.sif
     unattended_install.cdrom, whql.support_vm_install, svirt_install:
-        cdrom_cd1 = isos/windows/WindowsXP-64.iso
+        cdrom_cd1 = isos/windows/en_win_xp_pro_x64_vl.iso
         md5sum_cd1 = 8d3f007ec9c2060cec8a50ee7d7dc512
         md5sum_1m_cd1 = e812363ff427effc512b7801ee70e513
         unattended_file = unattended/winxp64.sif


### PR DESCRIPTION
Windows XP image name should be the same as at MSDN.

PYTHONPATH=./avocado avocado-vt/scripts/cd_hash.py
avocado-data/avocado-vt/isos/windows/en_win_xp_pro_x64_vl.iso
Hash values for file en_win_xp_pro_x64_vl.iso
md5    (1m): e812363ff427effc512b7801ee70e513
sha1   (1m): f0d623c9323e9dacde270e466d04047286fb2355
md5  (full): a2fd5aee7719466bcf091c5adb8a65b3
sha1 (full): a70b118316a9a451b966a082e7c1dd0e8018718d

md5 for 1m remains the same.
md5 for full iso is different

Signed-off-by: Andrei Stepanov <astepano@redhat.com>