### PR TITLE
test providers: Change test provider download protocl to http

### DIFF
--- a/test-providers.d/io-github-autotest-libvirt.ini
+++ b/test-providers.d/io-github-autotest-libvirt.ini
@@ -1,5 +1,5 @@
 [provider]
-uri: git://github.com/autotest/tp-libvirt.git
+uri: http://github.com/autotest/tp-libvirt.git
 [libvirt]
 subdir: libvirt/
 [libguestfs]

--- a/test-providers.d/io-github-autotest-qemu.ini
+++ b/test-providers.d/io-github-autotest-qemu.ini
@@ -1,5 +1,5 @@
 [provider]
-uri: git://github.com/autotest/tp-qemu.git
+uri: http://github.com/autotest/tp-qemu.git
 [generic]
 subdir: generic/
 [qemu]


### PR DESCRIPTION
Usually, http port not be blocked by firewall,
And proxy setup steps are easy than git protocol.

Signed-off-by: Xu Tian <xutian@redhat.com>