### PR TITLE
data_dir.py: get_tmp_dir()  public argument is added

### DIFF
--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -198,8 +198,11 @@ def get_deps_dir(target=None):
                               nesting_limit)
 
 
-def get_tmp_dir():
-    return data_dir.get_tmp_dir()
+def get_tmp_dir(public=False):
+    tmp_dir = data_dir.get_tmp_dir()
+    if public:
+        os.chmod(tmp_dir, 0755)
+    return tmp_dir
 
 
 def get_download_dir():


### PR DESCRIPTION
As discussed in PR #846 a new function get_public_tmp_dir() is
added. Provides a temporary directory with less restrictive permissions.
Will be used in libvirt tests.