### PR TITLE
Change location of Windows 10 ISOs

### DIFF
--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -3,7 +3,7 @@
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install:
         unattended_file = unattended/win10-32-autounattend.xml
-        cdrom_cd1 = isos/ISO/Win10/en_windows_10_enterprise_x86_dvd_6851156.iso
+        cdrom_cd1 = isos/windows/en_windows_10_enterprise_x86_dvd_6851156.iso
         md5sum_cd1 = 68162933e551e55779504dacdfb0c5ae
         md5sum_1m_cd1 = b44af2fdb8c39bc972f416bd3616566f
         floppies = "fl"

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -4,7 +4,7 @@
     install:
         passwd = 1q2w3eP
     unattended_install.cdrom, whql.support_vm_install, svirt_install:
-        cdrom_cd1 = isos/ISO/Win10/en_windows_10_enterprise_x64_dvd_6851151.iso
+        cdrom_cd1 = isos/windows/en_windows_10_enterprise_x64_dvd_6851151.iso
         md5sum_cd1 = a67722adfaf209c72eacb3ab910ee65e
         md5sum_1m_cd1 = 0e246b56b7b63f0526c3367eb160ff7d
         unattended_file = unattended/win10-64-autounattend.xml


### PR DESCRIPTION
Windows10 ISOs should be at the same path as all another Windows ISOs

Signed-off-by: Andrei Stepanov <astepano@redhat.com>