### PR TITLE
vt_bootstrap.py: removing duplicated args.

### DIFF
--- a/avocado/core/plugins/vt_bootstrap.py
+++ b/avocado/core/plugins/vt_bootstrap.py
@@ -99,7 +99,6 @@ class VirtBootstrap(plugin.Plugin):
         args.vt_vhost = 'off'
         args.vt_malloc_perturb = 'yes'
         args.vt_qemu_sandbox = 'on'
-        args.vt_tests = ''
         args.show_job_log = False
         args.test_lister = True
 


### PR DESCRIPTION
vt_bootstrap.py has a double entry for vt_tests.
Removing one of them because they are duplicated
inside method run().

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>