### PR TITLE
data_dir.py: public permissions read flags added

### DIFF
--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -209,7 +209,7 @@ def get_tmp_dir(public=True):
     if public:
         tmp_dir_st = os.stat(tmp_dir)
         os.chmod(tmp_dir, tmp_dir_st.st_mode | stat.S_IXUSR |
-                 stat.S_IXGRP | stat.S_IXOTH)
+                 stat.S_IXGRP | stat.S_IXOTH | stat.S_IRGRP | stat.S_IROTH)
     return tmp_dir
 
 


### PR DESCRIPTION
Adding +r permissions to get_tmp_dir() public=True case.
Otherwise currently the newly created temporary
directory's contents will not be readable by public.