### PR TITLE
guest-os/Windows.cfg: update all windows tools path.

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -179,8 +179,8 @@
         set_online_cmd += " diskpart /s cmd"
         testfile_name = "I:\\format_disk-test.txt"
         writefile_cmd = "echo %s > %s &&"
-        writefile_cmd += " cd /d I:\ && D:\md5sum.exe format_disk-test.txt > format_disk-test-md5.txt"
-        md5chk_cmd = "cd /d I:\ && D:\md5sum.exe -c format_disk-test-md5.txt"
+        writefile_cmd += " cd /d I:\ && C:\\tools\md5sum.exe format_disk-test.txt > format_disk-test-md5.txt"
+        md5chk_cmd = "cd /d I:\ && C:\\tools\md5sum.exe -c format_disk-test-md5.txt"
         readfile_cmd = "type %s"
         mount_cmd = ""
         umount_cmd = ""
@@ -236,7 +236,7 @@
     balloon_check:
         free_mem_cmd = wmic os get FreePhysicalMemory
     live_snapshot_chain:
-        md5_cmd = "cd C:\test && D:\coreutils\md5sum.exe %s.blockfiles"
+        md5_cmd = "cd C:\\test && C:\\tools\md5sum.exe %s.blockfiles"
         file_create_cmd = "D:\coreutils\DummyCMD.exe C:\test\%s.blockfiles 1048576 1" 
         file_check_cmd = dir %s | find "blockfiles"
         file_dir = "C:\test"
@@ -269,7 +269,7 @@
         stop_cmd = "taskkill /T /F /IM heavyload.exe"
     qemu_disk_img:
         # md5sum binary path, eg, c:\program\md5sum.exe
-        md5sum_bin = "D:\coreutils\md5sum.exe"
+        md5sum_bin = "C:\\tools\md5sum.exe"
         guest_file_name  = "c:\test.img"
         guest_file_name_image1  = "c:\test.img"
         guest_file_name_snA = "c:\sna.img"
@@ -293,7 +293,7 @@
         prepare_op_timeout = 240
         start_bg_process = yes
         bg_cmd = copy C:\1.txt C:\2.txt /y
-        check_op = echo cd C:\ > C:\tmp.bat&& echo for /F "tokens=1,*" %%i in ('D:\coreutils\md5sum.exe C:\1.txt') do D:\coreutils\md5sum.exe C:\2.txt ^| find "%%i" >> C:\tmp.bat && C:\tmp.bat
+        check_op = echo cd C:\ > C:\\tmp.bat&& echo for /F "tokens=1,*" %%i in ('C:\\tools\md5sum.exe C:\1.txt') do C:\\tools\md5sum.exe C:\2.txt ^| find "%%i" >> C:\\tmp.bat && C:\\tmp.bat
         clean_op = dir C:\ && del C:\1.txt C:\2.txt C:\tmp.bat && dir C:\
     usb..usb_boot, usb..usb_reboot:
         deviceid_str = "VID_%s&PID_%s"


### PR DESCRIPTION
For windows guests, there is a problem that driver letter will be changed when bootup VM.
Copy those useful tools to 'C:' after OS installation to avoid such driver letter problems.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1273263