### PR TITLE
guest-os.Linux: remove "-no-kvm-pit-reinjection" for ppc as the param…

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -19,7 +19,8 @@
     cdrom_test_cmd = "dd if=%s of=/dev/null bs=1 count=1"
     cdrom_info_cmd = "cat /proc/sys/dev/cdrom/info"
     timedrift, timerdevice..boot_test:
-        extra_params += " -no-kvm-pit-reinjection"
+        !ppc64, ppc64le:
+            extra_params += " -no-kvm-pit-reinjection"
         time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
         time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"
         time_format = "%m/%d/%Y %H:%M:%S"


### PR DESCRIPTION
'Option no-kvm-pit-reinjection not supported' on powerpc, so do not set it  

ID:1285216