### PR TITLE
virttest.libvirt_vm: Perform package update if package was already installed

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2385,7 +2385,7 @@ class VM(virt_vm.BaseVM):
             else:
                 # Update the package
                 cmd = "yum update -y %s" % name
-                status, output = session.cmd_status_output(cmd, timeout=300)
+                status, output = session.cmd_status_output(cmd, timeout=600)
                 if status:
                     raise virt_vm.VMError("Update of package %s failed:\n%s"
                                           % (name, output))

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1568,6 +1568,16 @@ class VMCPUXML(base.LibvirtXMLBase):
             feature_node.update({'policy': policy})
         xml_utils.ElementTree.SubElement(node, 'feature', feature_node)
 
+    def remove_numa_cells(self):
+        """
+        Remove numa cells from xml
+        """
+        try:
+            self.xmltreefile.remove_by_xpath('/numa', remove_all=True)
+        except (AttributeError, TypeError):
+            pass  # Element already doesn't exist
+        self.xmltreefile.write()
+
 
 class VMClockXML(VMXML):
 

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -155,7 +155,7 @@ class VMXMLBase(base.LibvirtXMLBase):
                  'current_vcpu', 'os', 'cpu', 'pm', 'on_poweroff', 'on_reboot',
                  'on_crash', 'features', 'mb', 'max_mem_unit',
                  'current_mem_unit', 'memtune', 'max_mem_rt', 'max_mem_rt_unit',
-                 'max_mem_rt_slots', 'iothreads')
+                 'max_mem_rt_slots', 'iothreads', 'iothreadids')
 
     __uncompareable__ = base.LibvirtXMLBase.__uncompareable__
 
@@ -319,6 +319,13 @@ class VMXMLBase(base.LibvirtXMLBase):
                                  parent_xpath='/',
                                  tag_name='memtune',
                                  subclass=VMMemTuneXML,
+                                 subclass_dargs={
+                                     'virsh_instance': virsh_instance})
+        accessors.XMLElementNest(property_name='iothreadids',
+                                 libvirtxml=self,
+                                 parent_xpath='/',
+                                 tag_name='iothreadids',
+                                 subclass=VMIothreadidsXML,
                                  subclass_dargs={
                                      'virsh_instance': virsh_instance})
         super(VMXMLBase, self).__init__(virsh_instance=virsh_instance)
@@ -2137,3 +2144,44 @@ class VMMemTuneXML(base.LibvirtXMLBase):
                                attribute='unit')
         super(VMMemTuneXML, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<memtune/>'
+
+
+class VMIothreadidsXML(VMXML):
+
+    """
+    memoryBacking tag XML class
+
+    Elements:
+        hugepages
+        nosharepages
+        locked
+    """
+
+    __slots__ = ('iothread',)
+
+    def __init__(self, virsh_instance=base.virsh):
+        accessors.XMLElementList('iothread', self, parent_xpath='/',
+                                 marshal_from=self.marshal_from_iothreads,
+                                 marshal_to=self.marshal_to_iothreads)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
+        self.xml = '<iothread/>'
+
+    @staticmethod
+    def marshal_from_iothreads(item, index, libvirtxml):
+        """
+        Convert a string to iothread tag and attributes.
+        """
+        del index
+        del libvirtxml
+        return ('iothread', {'id': item})
+
+    @staticmethod
+    def marshal_to_iothreads(tag, attr_dict, index, libvirtxml):
+        """
+        Convert a iothread tag and attributes to a string.
+        """
+        del index
+        del libvirtxml
+        if tag != 'iothread':
+            return None
+        return attr_dict['id']


### PR DESCRIPTION
Latest package should be used for testing, we need to update packages if it's
installed, such as qemu-guest-agent, selinux-policy.

Signed-off-by: Ruifeng Bian <rbian@redhat.com>