### PR TITLE
Fix undetected unattended install success 

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1071,6 +1071,25 @@ def copy_file_from_nfs(src, dst, mount_point, image_name):
     utils_misc.umount(src, mount_point, "nfs")
 
 
+def string_in_serial_log(serial_log_file_path, string):
+    """
+    Check if string appears in serial console log file.
+
+    :param serial_log_file_path: Path to the installation serial log file.
+    :param string: String to look for in serial log file.
+    :return: Whether the string is found in serial log file.
+    :raise: IOError: Serial console log file could not be read.
+    """
+    with open(serial_log_file_path, 'r') as serial_log_file:
+        serial_log_msg = serial_log_file.read()
+
+    if string in serial_log_msg:
+        logging.debug("Message read from serial console log: %s", string)
+        return True
+    else:
+        return False
+
+
 @error_context.context_aware
 def run(test, params, env):
     """
@@ -1202,18 +1221,20 @@ def run(test, params, env):
             copy_images()
             raise e
 
-        # To ignore the try:except:finally problem in old version of python
-        try:
-            serial_log_msg = open(log_file, 'r').read()
-        except IOError:
-            # Only make noise after several failed reads
-            serial_read_fails += 1
-            if serial_read_fails > 10:
-                logging.warn("Cannot read from serial log file after %d tries",
-                             serial_read_fails)
-
-        if wait_ack and (post_finish_str in serial_log_msg):
-            break
+        if wait_ack:
+            try:
+                post_finish_str_found = string_in_serial_log(
+                    log_file, post_finish_str)
+            except IOError:
+                # Only make noise after several failed reads
+                serial_read_fails += 1
+                if serial_read_fails > 10:
+                    logging.warn(
+                        "Cannot read from serial log file after %d tries",
+                        serial_read_fails)
+            else:
+                if post_finish_str_found:
+                    break
 
         # Due to libvirt automatically start guest after import
         # we only need to wait for successful login.

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1149,6 +1149,7 @@ def run(test, params, env):
     post_finish_str = params.get("post_finish_str",
                                  "Post set up finished")
     install_timeout = int(params.get("install_timeout", 4800))
+    wait_ack = params.get("wait_no_ack", "no") == "no"
 
     migrate_background = params.get("migrate_background") == "yes"
     if migrate_background:
@@ -1187,7 +1188,7 @@ def run(test, params, env):
         # Due to a race condition, sometimes we might get a MonitorError
         # before the VM gracefully shuts down, so let's capture MonitorErrors.
         except (virt_vm.VMDeadError, qemu_monitor.MonitorError), e:
-            if params.get("wait_no_ack", "no") == "yes":
+            if not wait_ack:
                 break
             else:
                 # Print out the original exception before copying images.
@@ -1211,8 +1212,7 @@ def run(test, params, env):
                 logging.warn("Cannot read from serial log file after %d tries",
                              serial_read_fails)
 
-        if (params.get("wait_no_ack", "no") == "no" and
-                (post_finish_str in serial_log_msg)):
+        if wait_ack and (post_finish_str in serial_log_msg):
             break
 
         # Due to libvirt automatically start guest after import


### PR DESCRIPTION
Due to a race condition, when virtual machine was detected as shut down, there may not have been time for the post finish string to be read from serial log.
unattended_install then reported "ERROR" even though installation ended successfully.
The actual fix is in the third commit, the other two just do some refactoring.