### PR TITLE
virttest.libvirt_vm: Add support for osinfo-query

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -653,9 +653,12 @@ class VM(virt_vm.BaseVM):
         help_text = process.system_output("%s --help" % virt_install_binary,
                                           verbose=False)
 
-        os_text = process.system_output("%s --os-variant list" %
-                                        virt_install_binary,
-                                        verbose=False)
+        try:
+            os_text = process.system_output("osinfo-query os", verbose=False)
+        except process.CmdError:
+            os_text = process.system_output("%s --os-variant list" %
+                                            virt_install_binary,
+                                            verbose=False)
 
         # Find all supported machine types, so we can rule out an unsupported
         # machine type option passed in the configuration.

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -44,7 +44,8 @@ def normalize_connect_uri(connect_uri):
         result = virsh.canonical_uri(uri=connect_uri)
 
     if not result:
-        raise ValueError("Normalizing connect_uri '%s' failed" % connect_uri)
+        raise ValueError("Normalizing connect_uri '%s' failed, is libvirt "
+                         "running?" % connect_uri)
     return result
 
 


### PR DESCRIPTION
Hello guys,

while running on F23 I got an error saying, virt-install does not support --os-type list. This PR adds the new "osinfo-query" method to query for supported types and one error message improvement.

I'm not sure, how the `virt-install` output looks like, so I choose the simplest approach by using the full `osinfo-query` output, which looks like:

```
 debian7              | Debian Wheezy                                      | 7        | http://debian.org/debian/7              
 debian8              | Debian Jessie                                      | 8        | http://debian.org/debian/8              
 fedora-unknown       | Fedora                                             | unknown  | http://fedoraproject.org/fedora/unknown 
 fedora1              | Fedora Core 1                                      | 1        | http://fedoraproject.org/fedora/1       
 fedora10             | Fedora 10                                          | 10       | http://fedoraproject.org/fedora/10      
 fedora11             | Fedora 11                                          | 11       | http://fedoraproject.org/fedora/11      
```

If you have system with older libvirt, would you please confirm the output is similar, or that I need to postprocess it to make it compatible? I tested it with JeOS on F23 and it worked well...