### PR TITLE
virttest.libvirt_vm: Filter osinfo-query fields

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -654,7 +654,7 @@ class VM(virt_vm.BaseVM):
                                           verbose=False)
 
         try:
-            os_text = process.system_output("osinfo-query os", verbose=False)
+            os_text = process.system_output("osinfo-query os --fields short-id", verbose=False)
         except process.CmdError:
             os_text = process.system_output("%s --os-variant list" %
                                             virt_install_binary,


### PR DESCRIPTION
Use only "short-id" field in the osinfo-query to avoid possible
false-negative matches.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>