### PR TITLE
Make unattended file (kickstart) setting in kernel more flexible

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -105,6 +105,7 @@
         # Change the config below to yes if you want to use syslog
         # to get anaconda logs (leads to verbose install logs)
         syslog_server_enabled = no
+        unattended_file_kernel_param_name = ks
     suspend:
         check_s3_support_cmd = grep -q mem /sys/power/state
         set_s3_cmd = echo mem > /sys/power/state


### PR DESCRIPTION
RHEL uses "ks=" to set kickstart file in kernel.
This may not be true for other distros; i.e. Fedora uses "inst.ks="
and PowerKVM uses "kvmp.inst.auto=".
Set "ks" as default kernel_unattended_option for Linux.