### PR TITLE
utils_test.libvirt: Fix setup_or_cleanup_gluster parameter problem.

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -868,7 +868,8 @@ class PoolVolumeTest(object):
                 if os.path.exists(pool_target):
                     shutil.rmtree(pool_target)
             if pool_type == "gluster" or source_format == 'glusterfs':
-                setup_or_cleanup_gluster(False, source_name)
+                setup_or_cleanup_gluster(False, source_name,
+                                         pool_name=pool_name)
 
     def pre_pool(self, pool_name, pool_type, pool_target, emulated_image,
                  **kwargs):


### PR DESCRIPTION
setup_or_cleanup_gluster should always use "pool_name" parameter
for cleanup purpose, otherwise it will cleanup whole tmp dir.

Signed-off-by: Ruifeng Bian <rbian@redhat.com>