### PR TITLE
vt: Reorder test initialization

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -18,7 +18,7 @@ from avocado.core import exceptions
 from avocado.utils import process
 
 # Internal imports
-from .. import arch, storage, data_dir, virt_vm, utils_misc
+from .. import arch, storage, data_dir, virt_vm
 from . import qbuses
 from . import qdevices
 from .utils import (DeviceError, DeviceHotplugError, DeviceInsertError,


### PR DESCRIPTION
Currently we initialize params, env, then begin the try/finally block
where the test file is found, env_preprocess and the test is executed.
In finally block env_postprocess is executed.

There is a asymetry between env_preprocess and env_postprocess, when
the test file is not found/corrupted and only env_postprocess is
executed. It's not necessarily wrong, but can be confusing.

This patch puts the look-up for test file outside the try/finally block
as it does not modify env or anything cleanup-related. This way on
corrupted test pre- nor post-process is called (similarily to params
parsing error, ...).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>