### PR TITLE
virttest.qemu_devices.qcontainer: Remove unused import

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -18,7 +18,7 @@ from avocado.core import exceptions
 from avocado.utils import process
 
 # Internal imports
-from .. import arch, storage, data_dir, virt_vm, utils_misc
+from .. import arch, storage, data_dir, virt_vm
 from . import qbuses
 from . import qdevices
 from .utils import (DeviceError, DeviceHotplugError, DeviceInsertError,


### PR DESCRIPTION
That is breaking avocado-vt's CI, let's fix it.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>