### PR TITLE
virttest.test_setup: Fix system call to use shell

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -433,7 +433,7 @@ class HugePageConfig(object):
         if not os.path.isfile(node_page_path):
             raise ValueError("%s page size nr_hugepages file of node %s did "
                              "not exist" % (pagesize, node))
-        process.system("echo %s > %s" % (num, node_page_path))
+        process.system("echo %s > %s" % (num, node_page_path), shell=True)
 
     @error_context.context_aware
     def set_hugepages(self):


### PR DESCRIPTION
This command containing stdout redirection requires shell to be enabled
or the call will be useless.

Signed-off-by: Hao Liu <hliu@redhat.com>