### PR TITLE
Update driver_id_cmd in driver_load case

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -134,6 +134,3 @@
         sub_type = autotest_control
         test_timeout = 1800
         test_control_file = stress.control
-    driver_load:
-         driver_load_cmd = modprobe DRIVER_ID
-         driver_unload_cmd = modprobe -r DRIVER_ID

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -315,22 +315,22 @@
         i386,i686:
             install_path = "C:\Program Files\JAM Software\HeavyLoad"
     driver_load:
-        driver_id_pattern = "(.*?):"
         driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
         driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
+        driver_id_cmd = C:\devcon.exe find * | find "VirtIO"
         x86_64:
             devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
         i386:
             devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
     driver_load.with_nic:
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO Ethernet Adapter"
+        driver_id_pattern = "(.*?):.*?VirtIO Ethernet Adapter"
     driver_load.with_balloon:
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO Balloon Driver"
+        driver_id_pattern = "(.*?):.*?VirtIO Balloon Driver"
     driver_load.with_viorng:
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO RNG Device"
+        driver_id_pattern = "(.*?):.*?VirtIO RNG Device"
     driver_load.with_block:
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI Disk Device"
+        driver_id_pattern = "(.*?):.*?VirtIO SCSI Disk Device"
     driver_load.with_vioscsi:
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO SCSI pass-through controller"
+        driver_id_pattern = "(.*?):.*?VirtIO SCSI pass-through controller"
     driver_load.with_vioserial:
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO-Serial Driver"
+        driver_id_pattern = "(.*?):.*?VirtIO-Serial Driver"


### PR DESCRIPTION
instead of devcon.exe find * | find "details driver name"
as the driver name maybe updated, we can get all virtio driver
info when test failed