### PR TITLE
shared.cfg.guest-hw: fix cdrom issue with using virtio-blk interface

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -77,6 +77,8 @@ variants:
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
         image_boot=yes
+        pseries:
+            cd_format = scsi-cd
         arm64-pci:
             cd_format = scsi-cd
             scsi_hba = virtio-scsi-pci


### PR DESCRIPTION
Qemu reported following failure while installing guest with using virtio-blk interface:
> output: 'qemu-kvm: -drive snapshot=off,aio=native,media=cdrom,file=/usr/share/avocado/data/avocado-vt/isos/linux/RHEL6.7-Server-ppc64.iso,index=2,bus=0,unit=0: index cannot be used with bus and unit'

Specified `cd_format` to scsi to fix this issue.

ID: 1244701