### PR TITLE
Fix no attribute 'make_qemu_command' for 'VM' object

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -557,7 +557,7 @@ class VirtTest(test.Test):
                         logging.info("It has a %s monitor unix socket at: %s",
                                      m.protocol, m.filename)
                     logging.info("The command line used to start it was:\n%s",
-                                 vm.make_qemu_command())
+                                 vm.make_create_command())
                 raise error.JobError("Abort requested (%s)" % e)
 
         return test_passed

--- a/virt.py
+++ b/virt.py
@@ -216,5 +216,5 @@ class virt(test.test):
                             vm.name, m.protocol, m.filename)
                     logging.info(
                         "The command line used to start '%s' was:\n%s",
-                        vm.name, vm.make_qemu_command())
+                        vm.name, vm.make_create_command())
                 raise error.JobError("Abort requested (%s)" % e)

--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -102,7 +102,7 @@ class VMManager(virt_vm.BaseVM):
 
         :param name: The name of the object
         :param params: A dict containing VM params (see method
-                       make_qemu_command for a full description)
+                       make_create_command for a full description)
         :param root_dir: Base directory for relative filenames
         :param address_cache: A dict that maps MAC addresses to IP addresses
         :param state: If provided, use this as self.__dict__

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -98,7 +98,7 @@ class VM(virt_vm.BaseVM):
 
         :param name: The name of the object
         :param params: A dict containing VM params
-                (see method make_qemu_command for a full description)
+                (see method make_create_command for a full description)
         :param root_dir: Base directory for relative filenames
         :param address_cache: A dict that maps MAC addresses to IP addresses
         :param state: If provided, use this as self.__dict__
@@ -260,7 +260,7 @@ class VM(virt_vm.BaseVM):
         :param root_dir: Optional new base directory for relative filenames
         :param address_cache: A dict that maps MAC addresses to IP addresses
         :param copy_state: If True, copy the original VM's state to the clone.
-                Mainly useful for make_qemu_command().
+                Mainly useful for make_create_command().
         """
         if name is None:
             name = self.name

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -476,7 +476,7 @@ class BaseVM(object):
       consumed only by BaseVM and subclasses
     - Private API methods: name begins with double underline, to be consumed
       only by the VM subclass itself (usually implements virt specific
-      functionality: example: __make_qemu_command())
+      functionality)
 
     So called "protected" methods are intended to be used only by VM classes,
     and not be consumed by tests. Theses should respect a naming convention


### PR DESCRIPTION
The commit c405ccc changed the name of function that
used to generate a qemu command line.