### PR TITLE
qemu_monitor: increase monitor timeout in qemu_monitor module

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1143,10 +1143,10 @@ class QMPMonitor(Monitor):
     Wraps QMP monitor commands.
     """
 
-    READ_OBJECTS_TIMEOUT = 5
-    CMD_TIMEOUT = 120
-    RESPONSE_TIMEOUT = 120
-    PROMPT_TIMEOUT = 60
+    READ_OBJECTS_TIMEOUT = 10
+    CMD_TIMEOUT = 900
+    RESPONSE_TIMEOUT = 600
+    PROMPT_TIMEOUT = 90
 
     def __init__(self, vm, name, filename, suppress_exceptions=False):
         """


### PR DESCRIPTION
When host on heavy load status, monitor response very slowly,
MonitorProtocolError exception raised because not read ID
from socket, so increase related timeout to avoid this kind
of issue.

Signed-off-by: Xu Tian <xutian@redhat.com>