### PR TITLE
fix usb ehci bug on powerpc, and make the ohci as default controler

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -97,6 +97,10 @@ usb_devices = tablet1
 usb_type_tablet1 = usb-tablet
 # USB Controller type which device uses.
 usb_controller = ehci
+# PPC64 does not support uhci, and  make ohci as the deault.
+pseries:
+    usb_controller = ohci
+    usb_type_usb1 = pci-ohci
 usb_bus = usb1.0
 
 # Serial port support

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -21,10 +21,6 @@ variants:
         machine_type = pseries
         # Currently only supports standard VGA
         vga = std
-        # No support for USB-uhci
-        usb_type = pci-ohci
-        usb_type_usb1 = pci-ohci
-        usb_controller_tablet1 = ohci
         del rtc_drift
     - arm64-mmio:
         only aarch64

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1058,22 +1058,33 @@ class DevContainer(object):
         usb.set_param('firstport', firstport)
         usb.set_param('freq', freq)
         usb.set_param('addr', pci_addr)
-
         if usb_type == "ich9-usb-ehci1":
             usb.set_param('addr', '1d.7')
             usb.set_param('multifunction', 'on')
-            for i in xrange(3):
-                new_usbs.append(
-                    qdevices.QDevice('ich9-usb-uhci%d' % (i + 1), {},
-                                     usb_id))
-                new_usbs[-1].parent_bus = {'aobject': pci_bus}
-                new_usbs[-1].set_param('id', '%s.%d' % (usb_id, i))
-                new_usbs[-1].set_param('multifunction', 'on')
-                new_usbs[-1].set_param('masterbus', '%s.0' % usb_id)
-                # current qdevices doesn't support x.y addr. Plug only
-                # the 0th one into this representation.
-                new_usbs[-1].set_param('addr', '1d.%d' % (2 * i))
-                new_usbs[-1].set_param('firstport', 2 * i)
+            if arch.ARCH in ('ppc64', 'ppc64le'):
+                for i in xrange(2):
+                    new_usbs.append(qdevices.QDevice('pci-ohci', {}, usb_id))
+                    new_usbs[-1].parent_bus = {'aobject': pci_bus}
+                    new_usbs[-1].set_param('id', '%s.%d' % (usb_id, i))
+                    new_usbs[-1].set_param('multifunction', 'on')
+                    new_usbs[-1].set_param('masterbus', '%s.0' % usb_id)
+                    # current qdevices doesn't support x.y addr. Plug only
+                    # the 0th one into this representation.
+                    new_usbs[-1].set_param('addr', '1d.%d' % (3 * i))
+                    new_usbs[-1].set_param('firstport', 3 * i)
+            else:
+                for i in xrange(3):
+                    new_usbs.append(
+                        qdevices.QDevice('ich9-usb-uhci%d' % (i + 1), {},
+                                         usb_id))
+                    new_usbs[-1].parent_bus = {'aobject': pci_bus}
+                    new_usbs[-1].set_param('id', '%s.%d' % (usb_id, i))
+                    new_usbs[-1].set_param('multifunction', 'on')
+                    new_usbs[-1].set_param('masterbus', '%s.0' % usb_id)
+                    # current qdevices doesn't support x.y addr. Plug only
+                    # the 0th one into this representation.
+                    new_usbs[-1].set_param('addr', '1d.%d' % (2 * i))
+                    new_usbs[-1].set_param('firstport', 2 * i)
         return new_usbs
 
     def usbc_by_params(self, usb_name, params):


### PR DESCRIPTION
On ppc64&ppc64le platform , there is no uhci controller supported. instead of this , pci-ohci is supported. So add the pci-ohci controller to the script. 
Modified some cfg files to let it works better.