### PR TITLE
virttest.ssh_key: Add two functions from autotest

### DIFF
--- a/virttest/ssh_key.py
+++ b/virttest/ssh_key.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import aexpect
 
 from avocado.utils import process
 
@@ -50,6 +51,51 @@ def get_public_key():
     return public_key_str
 
 
+def get_remote_public_key(session):
+    """
+    Return a valid string ssh public key for the user executing autoserv or
+    autotest. If there's no DSA or RSA public key, create a DSA keypair with
+    ssh-keygen and return it.
+
+    :param session: A ShellSession for remote host
+    :returns: a ssh public key
+    :rtype: str
+    """
+    session.cmd_output("mkdir -p ~/.ssh")
+    session.cmd_output("chmod 700 ~/.ssh")
+
+    ssh_conf_path = "~/.ssh"
+    dsa_public_key_path = os.path.join(ssh_conf_path, 'id_dsa.pub')
+    dsa_private_key_path = os.path.join(ssh_conf_path, 'id_dsa')
+
+    rsa_public_key_path = os.path.join(ssh_conf_path, 'id_rsa.pub')
+    rsa_private_key_path = os.path.join(ssh_conf_path, 'id_rsa')
+
+    dsa_public_s = session.cmd_status("ls %s" % dsa_public_key_path)
+    dsa_private_s = session.cmd_status("ls %s" % dsa_private_key_path)
+    rsa_public_s = session.cmd_status("ls %s" % rsa_public_key_path)
+    rsa_private_s = session.cmd_status("ls %s" % rsa_private_key_path)
+
+    has_dsa_keypair = dsa_public_s == 0 and dsa_private_s == 0
+    has_rsa_keypair = rsa_public_s == 0 and rsa_private_s == 0
+
+    if has_dsa_keypair:
+        logging.info('DSA keypair found on %s, using it', session)
+        public_key_path = dsa_public_key_path
+
+    elif has_rsa_keypair:
+        logging.info('RSA keypair found on %s, using it', session)
+        public_key_path = rsa_public_key_path
+
+    else:
+        logging.info('Neither RSA nor DSA keypair found, '
+                     'creating DSA ssh key pair')
+        session.cmd('ssh-keygen -t dsa -q -N "" -f %s' % dsa_private_key_path)
+        public_key_path = dsa_public_key_path
+
+    return session.cmd_output("cat %s" % public_key_path)
+
+
 def setup_ssh_key(hostname, user, password, port):
     """
     Setup up remote login in another server by using public key
@@ -86,4 +132,53 @@ def setup_ssh_key(hostname, user, password, port):
         try:
             session.close()
         except Exception:
+            pass
+
+
+def setup_remote_ssh_key(hostname1, user1, password1,
+                         hostname2=None, user2=None, password2=None,
+                         port=22):
+    """
+    Setup up remote to remote login in another server by using public key
+    If hostname2 is not supplied, setup to local.
+
+    :param hostname1: the server wants to login other host
+    :param hostname2: the server to be logged in
+    :type hostname: str
+    :param user: user to login
+    :type user: str
+    :param password: password
+    :type password: str
+    :param port: port number
+    :type port: int
+    """
+    logging.debug('Performing SSH key setup on %s:%d as %s.' %
+                  (hostname1, port, user1))
+
+    try:
+        session1 = remote.remote_login(client='ssh', host=hostname1, port=port,
+                                       username=user1, password=password1,
+                                       prompt=r'[$#%]')
+        public_key = get_remote_public_key(session1)
+
+        if hostname2 is None:
+            # Simply create a session to local
+            session2 = aexpect.ShellSession("sh", linesep='\n', prompt='#')
+        else:
+            session2 = remote.remote_login(client='ssh', host=hostname2,
+                                           port=port, username=user2,
+                                           password=password2,
+                                           prompt=r'[$#%]')
+        session2.cmd_output('mkdir -p ~/.ssh')
+        session2.cmd_output('chmod 700 ~/.ssh')
+        session2.cmd_output("echo '%s' >> ~/.ssh/authorized_keys; " %
+                            public_key)
+        session2.cmd_output('chmod 600 ~/.ssh/authorized_keys')
+        logging.debug('SSH key setup on %s complete.', session2)
+    except Exception as err:
+        logging.debug('SSH key setup has failed: %s', err)
+        try:
+            session1.close()
+            session2.close()
+        except:
             pass


### PR DESCRIPTION
Add setup_remote_ssh_key() and get_remote_public_key() which exist
originally in autotest for bi_directional migration test