### PR TITLE
avocado_vt/plugins/vt.py: fix VirtTestLoader registration

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -1234,4 +1234,4 @@ class VTRun(CLI):
 
         :param args: Command line args received from the run subparser.
         """
-        loader.register_plugin(VirtTestLoader)
+        loader.loader.register_plugin(VirtTestLoader)


### PR DESCRIPTION
We have been tryging to call "register_plugin" from the loader module
instead from the loader instance. This wasn't caught before because:

1) The same loader would be registered on `vt_list.py` (on purpose)
2) The dispatcher class on Avocado core (avocado/core/dispatcher.py)
   would not propagate exceptions when running `map_method`.

This issue is a fix to the issue #322, together with other changes
on Avocado core (on the loader and dispatcher code).

Signed-off-by: Cleber Rosa <crosa@redhat.com>