### PR TITLE
avocado_vt/plugins/vt.py: loader is now imported as the instance

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -216,4 +216,4 @@ class VTRun(CLI):
 
         :param args: Command line args received from the run subparser.
         """
-        loader.loader.register_plugin(VirtTestLoader)
+        loader.register_plugin(VirtTestLoader)


### PR DESCRIPTION
And not as the module. So, the fix on a877173, while valid, now
causes breakage because of the refactor work on 76ff51e.

Signed-off-by: Cleber Rosa <crosa@redhat.com>