### PR TITLE
test providers: Change test provider download protocol to HTTPS

### DIFF
--- a/test-providers.d/io-github-autotest-libvirt.ini
+++ b/test-providers.d/io-github-autotest-libvirt.ini
@@ -1,5 +1,5 @@
 [provider]
-uri: http://github.com/autotest/tp-libvirt.git
+uri: https://github.com/autotest/tp-libvirt.git
 [libvirt]
 subdir: libvirt/
 [libguestfs]

--- a/test-providers.d/io-github-autotest-qemu.ini
+++ b/test-providers.d/io-github-autotest-qemu.ini
@@ -1,5 +1,5 @@
 [provider]
-uri: http://github.com/autotest/tp-qemu.git
+uri: https://github.com/autotest/tp-qemu.git
 [generic]
 subdir: generic/
 [qemu]


### PR DESCRIPTION
Previously on f0a1d00, the protocol was changed to from git to http,
because of firewall issues.

Then, came bug report:

 https://bugzilla.redhat.com/show_bug.cgi?id=1289984

Which showed that git on EL6 fails to retrieve content via http.

So, HTTPS seems to do the trick for everyone.

Signed-off-by: Cleber Rosa <crosa@redhat.com>