### PR TITLE
Makefile: Add "python setup.py develop --user" to the "link" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ clean:
 
 link:
 	ln -sf ../../../../$(DIRNAME)/etc/avocado/conf.d/vt.conf ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/
+	$(PYTHON) setup.py develop --user
 
 unlink:
+	$(PYTHON) setup.py develop --uninstall --user
 	test -L ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/vt.conf && rm -f ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/vt.conf || true


### PR DESCRIPTION
With the recent change in avocado, the link/unlink targets should also
call "python setup.py develop --user" (--uninstall) to enable/disable
egg links.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>

NOTE: This should be merged when https://github.com/avocado-framework/avocado/pull/966 is accepted