### PR TITLE
utils_v2v: Fix the screenshot path on a remote host

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -462,7 +462,8 @@ class WindowsVMCheck(VMCheck):
         """
         sshot_file = os.path.join(data_dir.get_tmp_dir(), "vm_screenshot.ppm")
         if self.target == "ovirt":
-            vm_sshot = os.path.join(data_dir.get_tmp_dir(), "vm_screenshot.ppm")
+            # Note: This is a screenshot path on a remote host
+            vm_sshot = os.path.join("/tmp", "vm_screenshot.ppm")
         else:
             vm_sshot = sshot_file
         virsh.screenshot(self.name, vm_sshot, session_id=self.virsh_session_id)


### PR DESCRIPTION
In commit bda251d8, it replace all '/tmp' to data_dir.get_tmp_dir(). But
for this case, we need do screenshot on a remote host where does not
have that dir, so change it back to use '/tmp'.

Signed-off-by: Yanbing Du <ydu@redhat.com>