### PR TITLE
Windows.cfg: add Windows cfg for case netkvm_in_use.

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -377,3 +377,9 @@
         driver_id_pattern = "(.*?):.*?VirtIO SCSI pass-through controller"
     driver_load.with_vioserial:
         driver_id_pattern = "(.*?):.*?VirtIO-Serial Driver"
+    netkvm_in_use:
+        netperf_server_link_win = "netserver-2.6.0.exe"
+        netperf_client_link_win = "netperf.exe"
+        target_process = ${netperf_client_link_win}
+        server_path_win = "c:\\"
+        client_path_win = "c:\\"


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1231015, 1230674, 1231007

Based on: https://github.com/autotest/tp-qemu/pull/439