### PR TITLE
qemu_vm: add debug only monitor support

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2631,6 +2631,8 @@ class VM(virt_vm.BaseVM):
             self.monitors = []
             for m_name in params.objects("monitors"):
                 m_params = params.object_params(m_name)
+                if m_params.get("debugonly", "no") == "yes":
+                    continue
                 try:
                     monitor = qemu_monitor.wait_for_create_monitor(self,
                                                                    m_name,


### PR DESCRIPTION
 User can't connection to VM's monitor during test running to do debug if VM status is incorrect.
Add below configure in your tests.cfg to add a debug-only monitor.
        monitors += " monn"
        debugonly_monn = yes
