### PR TITLE
test: Rework the params handling

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -162,7 +162,6 @@ class VirtTestLoader(loader.TestLoader):
             # the test params. This will allow users to access avocado params
             # from inside virt tests. This feature would only work if the virt
             # test in question is executed from inside avocado.
-            params['avocado_inject_params'] = True
             if "subtests.cfg" in params.get("_short_name_map_file"):
                 test_name = params.get("_short_name_map_file")["subtests.cfg"]
             if self.args.vt_type == 'spice':
@@ -172,6 +171,6 @@ class VirtTestLoader(loader.TestLoader):
 
             params['id'] = test_name
             test_parameters = {'name': test_name,
-                               'params': params}
+                               'vt_params': params}
             test_suite.append((VirtTest, test_parameters))
         return test_suite

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -23,7 +23,6 @@ import Queue
 import sys
 
 from avocado.core import exceptions
-from avocado.core import multiplexer
 from avocado.core import test
 from avocado.utils import genio
 from avocado.utils import stacktrace
@@ -76,7 +75,8 @@ class VirtTest(test.Test):
     env_version = utils_env.get_env_version()
 
     def __init__(self, methodName='runTest', name=None, params=None,
-                 base_logdir=None, tag=None, job=None, runner_queue=None):
+                 base_logdir=None, tag=None, job=None, runner_queue=None,
+                 vt_params=None):
         del name
         options = job.args
         self.bindir = data_dir.get_root_dir()
@@ -85,13 +85,13 @@ class VirtTest(test.Test):
         self.iteration = 0
         name = None
         if options.vt_config:
-            name = params.get("shortname")
+            name = vt_params.get("shortname")
         elif options.vt_type == 'spice':
-            short_name_map_file = params.get("_short_name_map_file")
+            short_name_map_file = vt_params.get("_short_name_map_file")
             if "tests-variants.cfg" in short_name_map_file:
                 name = short_name_map_file["tests-variants.cfg"]
         if name is None:
-            name = params.get("_short_name_map_file")["subtests.cfg"]
+            name = vt_params.get("_short_name_map_file")["subtests.cfg"]
         self.outputdir = None
         self.resultsdir = None
         self.logfile = None
@@ -99,28 +99,17 @@ class VirtTest(test.Test):
         self.background_errors = Queue.Queue()
         self.whiteboard = None
         super(VirtTest, self).__init__(methodName=methodName, name=name,
-                                       params=params, base_logdir=base_logdir,
+                                       params=params,
+                                       base_logdir=base_logdir,
                                        tag=tag, job=job,
                                        runner_queue=runner_queue)
         self.builddir = os.path.join(self.workdir, 'backends',
-                                     params.get("vm_type"))
+                                     vt_params.get("vm_type"))
         self.tmpdir = os.path.dirname(self.workdir)
-
-        self.params = utils_params.Params(params)
-        # Here we turn the data the multiplexer injected into the params and
-        # turn it into an AvocadoParams object, that will allow users to
-        # access data from it. Example:
-        # sleep_length = test.avocado_params.get('sleep_length', default=1)
-        p = params.get('avocado_params', None)
-        if p is not None:
-            params, mux_path = p[0], p[1]
-        else:
-            params, mux_path = [], []
-        self.avocado_params = multiplexer.AvocadoParams(params, self.name,
-                                                        self.tag,
-                                                        mux_path,
-                                                        self.default_params)
-
+        # Move self.params to self.avocado_params and initialize virttest
+        # (cartesian_config) params
+        self.avocado_params = self.params
+        self.params = utils_params.Params(vt_params)
         self.debugdir = self.logdir
         self.resultsdir = self.logdir
         utils_misc.set_log_file_dir(self.logdir)

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -31,7 +31,7 @@ class VirtTestTest(unittest.TestCase):
 
     def setUp(self):
         self.test = vt_test.VirtTest(job=FakeJob(),
-                                     params=FAKE_PARAMS)
+                                     vt_params=FAKE_PARAMS)
 
     def test_basedir(self):
         if self.test.filename is None:


### PR DESCRIPTION
This version modifies the avocado-vt loader to inject params as `vt_params`. In the `Test.__init__` it let's the superclass to init the `self.params` using the default logic, moves it into `self.avocado_params` and initialize it's own `self.params`.

~~This patch uses a new Avocado feature to initialize params directly~~
~~by superclass and then moves the self.params to the expected location~~
~~(self.avocado_params) and initialize to cartesian-based params instead.~~

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>

~~This is a second part of https://github.com/avocado-framework/avocado/pull/990~~ __this version does not require any change on avocado part.__