### PR TITLE
qemu_vm: removing unecessary arguments inside add_name.

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -389,7 +389,7 @@ class VM(virt_vm.BaseVM):
         # Each of these functions receives the output of 'qemu -help'
         # as a parameter, and should add the requested command line
         # option accordingly.
-        def add_name(devices, name):
+        def add_name(name):
             return " -name '%s'" % name
 
         def process_sandbox(devices, action):
@@ -1291,7 +1291,7 @@ class VM(virt_vm.BaseVM):
         devices.insert(StrDev('qemu', cmdline=qemu_binary))
         devices.insert(StrDev('-S', cmdline="-S"))
         # Add the VM's name
-        devices.insert(StrDev('vmname', cmdline=add_name(devices, name)))
+        devices.insert(StrDev('vmname', cmdline=add_name(name)))
 
         qemu_sandbox = params.get("qemu_sandbox")
         if qemu_sandbox == "on":


### PR DESCRIPTION
The function make_create_command() has a function called add_name() who
expect an argument "devices". But this argument is never used. So, there
is no reason to keep this argument.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>