### PR TITLE
shared.cfg.base: Fix typo and reorder usb defaults

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -97,11 +97,12 @@ usb_devices = tablet1
 usb_type_tablet1 = usb-tablet
 # USB Controller type which device uses.
 usb_controller = ehci
-# PPC64 does not support uhci, and  make ohci as the deault.
+usb_bus = usb1.0
+# PPC64 does not support uhci, use ohci as the default.
 pseries:
     usb_controller = ohci
+    usb_type = pci-ohci
     usb_type_usb1 = pci-ohci
-usb_bus = usb1.0
 
 # Serial port support
 # You can assign more than one serial to guest with this parameter.


### PR DESCRIPTION
Fix typo in comment and add the "usb_type" to avoid problems when
"usb_type" default changes.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>