### PR TITLE
virttest: Improve qemu_bin handling

### DIFF
--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -33,10 +33,14 @@ SUPPORTED_NET_TYPES = ["bridge", "user", "none"]
 
 
 def find_default_qemu_paths(options_qemu=None, options_dst_qemu=None):
+    """
+    This function returns qemu-related paths. It's not trying to be smart as
+    the real paths are discovered later in utils_misc.get_qemu_img_binary().
+    :param options_qemu: User defined qemu-bin path
+    :param options_dst_qemu: User defined destination VM qemu-bin path
+    :return: qemu_path, qemu_img_path, qemu_io_path, qemu_dst_bin_path
+    """
     if options_qemu:
-        if not os.path.isfile(options_qemu):
-            raise RuntimeError("Invalid qemu binary provided (%s)" %
-                               options_qemu)
         qemu_bin_path = options_qemu
     else:
         try:
@@ -45,9 +49,6 @@ def find_default_qemu_paths(options_qemu=None, options_dst_qemu=None):
             qemu_bin_path = utils_path.find_command('kvm')
 
     if options_dst_qemu is not None:
-        if not os.path.isfile(options_dst_qemu):
-            raise RuntimeError("Invalid dst qemu binary provided (%s)" %
-                               options_dst_qemu)
         qemu_dst_bin_path = options_dst_qemu
     else:
         qemu_dst_bin_path = None
@@ -55,12 +56,6 @@ def find_default_qemu_paths(options_qemu=None, options_dst_qemu=None):
     qemu_dirname = os.path.dirname(qemu_bin_path)
     qemu_img_path = os.path.join(qemu_dirname, 'qemu-img')
     qemu_io_path = os.path.join(qemu_dirname, 'qemu-io')
-
-    if not os.path.exists(qemu_img_path):
-        qemu_img_path = utils_path.find_command('qemu-img')
-
-    if not os.path.exists(qemu_io_path):
-        qemu_io_path = utils_path.find_command('qemu-io')
 
     return [qemu_bin_path, qemu_img_path, qemu_io_path, qemu_dst_bin_path]
 

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2199,7 +2199,7 @@ def get_qemu_cpu_models(qemu_binary):
     Get list of CPU models by parsing the output of <qemu> -cpu '?'
     """
     cmd = qemu_binary + " -cpu '?'"
-    result = process.run(cmd, verbose=False)
+    result = process.run(cmd, verbose=False, shell=True)
     return extract_qemu_cpu_models(result.stdout)
 
 


### PR DESCRIPTION
This PR clean-ups (a bit) the way qemu-bin is detected. The main reason is, that autotest supported values assignments prior to qemu command, which is broken due to different defaults in `process` (commit c78eb82)

When on it I wondered why we don't let users to also specify such commands. I used https://github.com/avocado-framework/avocado/pull/1009 functionality to parse qemu-bin-path from qemu-bin-command and now this should be possible (--vt-qemu-bin "FOO=bar qemu-kvm")
