### PR TITLE
test: Rework the params handling [v2]

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -162,7 +162,6 @@ class VirtTestLoader(loader.TestLoader):
             # the test params. This will allow users to access avocado params
             # from inside virt tests. This feature would only work if the virt
             # test in question is executed from inside avocado.
-            params['avocado_inject_params'] = True
             if "subtests.cfg" in params.get("_short_name_map_file"):
                 test_name = params.get("_short_name_map_file")["subtests.cfg"]
             if self.args.vt_type == 'spice':
@@ -172,6 +171,6 @@ class VirtTestLoader(loader.TestLoader):
 
             params['id'] = test_name
             test_parameters = {'name': test_name,
-                               'params': params}
+                               'vt_params': params}
             test_suite.append((VirtTest, test_parameters))
         return test_suite

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -31,7 +31,7 @@ class VirtTestTest(unittest.TestCase):
 
     def setUp(self):
         self.test = vt_test.VirtTest(job=FakeJob(),
-                                     params=FAKE_PARAMS)
+                                     vt_params=FAKE_PARAMS)
 
     def test_basedir(self):
         if self.test.filename is None:


### PR DESCRIPTION
This patch uses a new Avocado feature to initialize params directly
by superclass and then moves the self.params to the expected location
(self.avocado_params) and initializes the cartesian-based params instead.

v1: https://github.com/avocado-framework/avocado-vt/pull/353

Changes:

    v2: Added avocado_vt.test.Test docstrings to avoid confusion