### PR TITLE
Fix Travis CI failure and bulk fix for pre-adaption of Sphinx-1.4

### DIFF
--- a/docs/source/BuildingTestApplications.rst
+++ b/docs/source/BuildingTestApplications.rst
@@ -17,7 +17,7 @@ application. The below example shows a Makefile for the application for the
 timedrift test cases. The `remote_build` module requires that a Makefile is
 included with all test applications.
 
-::
+.. code-block:: makefile
 
     CFLAGS+=-Wall
     LDLIBS+=-lrt

--- a/docs/source/CartesianConfig.rst
+++ b/docs/source/CartesianConfig.rst
@@ -48,7 +48,9 @@ the output array. When a Cartesian configuration file contains
 two variants stanzas, the output will be all possible combination's of
 both variant contents. Variants may be nested within other variants,
 effectively nesting arbitrarily complex arrays within the cells of
-outside arrays.  For example::
+outside arrays.  For example:
+
+.. code-block:: none
 
     variants:
         - one:
@@ -71,7 +73,9 @@ name parsed will appear as the left most name component. These names can
 become quite long, and since they contain keys to distinguishing between
 results, a 'short-name' key is also used.  For example, running
 ``cartesian_config.py`` against the content above produces the following
-combinations and names::
+combinations and names:
+
+.. code-block:: none
 
     dict    1:  four.one
     dict    2:  four.two
@@ -98,7 +102,9 @@ Named variants
 
 Named variants allow assigning a parseable name to a variant set.  This enables
 an entire variant set to be used for in filters_.  All output combinations will
-inherit the named varient key, along with the specific variant name.  For example::
+inherit the named varient key, along with the specific variant name.  For example:
+
+.. code-block:: none
 
    variants var1_name:
         - one:
@@ -115,7 +121,9 @@ inherit the named varient key, along with the specific variant name.  For exampl
 
    only (var2_name=one).(var1_name=two)
 
-Results in the following outcome when parsed with ``cartesian_config.py -c``::
+Results in the following outcome when parsed with ``cartesian_config.py -c``:
+
+.. code-block:: none
 
     dict    1:  (var2_name=one).(var1_name=two)
           dep = []
@@ -126,7 +134,9 @@ Results in the following outcome when parsed with ``cartesian_config.py -c``::
           var1_name = two      # variant name in same namespace as variables.
           var2_name = one      # variant name in same namespace as variables.
 
-Named variants could also be used as normal variables.::
+Named variants could also be used as normal variables.:
+
+.. code-block:: none
 
    variants guest_os:
         - fedora:
@@ -135,7 +145,9 @@ Named variants could also be used as normal variables.::
         - virtio:
         - hda:
 
-Which then results in the following::
+Which then results in the following:
+
+.. code-block:: none
 
     dict    1:  (disk_interface=virtio).(guest_os=fedora)
         dep = []
@@ -177,7 +189,7 @@ and/or filters (see section filters_) can remove or modify dependents. For
 example, if testing unattended installs, each virtual machine must be booted
 before, and shutdown after:
 
-::
+.. code-block:: none
 
     variants:
         - one:
@@ -206,7 +218,7 @@ character(s) ‘,’ meaning OR, ‘..’ meaning AND, and ‘.’ meaning
 IMMEDIATELY-FOLLOWED-BY. When used alone, they permit modifying the list
 of key/values previously defined. For example:
 
-::
+.. code-block:: none
 
     Linux..OpenSuse:
     initrd = initrd
@@ -224,7 +236,7 @@ matching the filter. Whereas the ‘no’ keyword could be used to remove
 particular conflicting key/value sets under other variant combination
 names. For example:
 
-::
+.. code-block:: none
 
     only Linux..Fedora..64
 
@@ -236,7 +248,7 @@ variants as well. In this application, they are only evaluated when that
 variant name is selected for inclusion (implicitly or explicitly) by a
 higher-order. For example:
 
-::
+.. code-block:: none
 
     variants:
         - one:
@@ -255,7 +267,7 @@ higher-order. For example:
 
 Results in the following outcome:
 
-::
+.. code-block:: none
 
     name = default.three.one
     key1 = Hello
@@ -291,7 +303,7 @@ within a predefined top-level directory.
 
 An example of context-sensitivity,
 
-::
+.. code-block:: none
 
     key1 = default value
     key2 = default value
@@ -310,7 +322,7 @@ An example of context-sensitivity,
 
 Results in the following,
 
-::
+.. code-block:: none
 
     dict    1:  one
         dep = []
@@ -346,7 +358,7 @@ instance can be addressed. For example, a parameter ‘vms’ lists the VM
 objects names to instantiate in in the current frame’s test. Values
 specific to one of the named instances should be prefixed to the name:
 
-::
+.. code-block:: none
 
     vms = vm1 second_vm another_vm
     mem = 128

--- a/docs/source/DownloadableImages.rst
+++ b/docs/source/DownloadableImages.rst
@@ -60,7 +60,9 @@ How to update JeOS
 The JeOS can be updated by installing it, just like a normal OS. You can do
 that for example with ``avocado-vt``, selecting an unattended install test. In
 this example, we're going to use the unattended install using https kickstart
-and network install::
+and network install:
+
+.. code-block:: none
 
     $ avocado run io-github-autotest-qemu.unattended_install.url.http_ks.default_install.aio_native
 
@@ -69,12 +71,16 @@ can squeeze these zeros later with qemu img. Once the image is installed, you
 can use our helper script, located at ``scripts/package_jeos.py`` in the
 avocado-vt source tree. That script uses qemu-img to trim the zeros of the
 image, ensuring that the resulting qcow2 image is the smallest possible. The
-command is similar to::
+command is similar to:
+
+.. code-block:: none
 
     $ qemu-img convert -f qcow2 -O qcow2 jeos-file-backup.qcow2 jeos-file.qcow2
 
 Then it'll compress it using 7zip, to save space and speed up downloads for
-``avocado-vt`` users. The command is similar to::
+``avocado-vt`` users. The command is similar to:
+
+.. code-block:: none
 
     $ 7za a jeos-file.qcow2.7z jeos-file.qcow2
 

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -20,7 +20,9 @@ Fedora and Enterprise Linux
 ---------------------------
 
 Installing Avocado-VT on Fedora or Enterprise Linux is a matter of
-installing the `avocado-plugins-vt` package. Install it with::
+installing the `avocado-plugins-vt` package. Install it with:
+
+.. code-block:: none
 
   $ yum install avocado-plugins-vt
 
@@ -30,11 +32,15 @@ Bootstrapping Avocado-VT
 ------------------------
 
 After the package, a bootstrap process must be run. Choose your test backend
-(qemu, libvirt, v2v, openvswitch, etc) and run the `vt-bootstrap` command. Example::
+(qemu, libvirt, v2v, openvswitch, etc) and run the `vt-bootstrap` command. Example:
+
+.. code-block:: none
 
   $ avocado vt-bootstrap --vt-type qemu
 
-The output should be similar to::
+The output should be similar to:
+
+.. code-block:: none
 
   12:02:10 INFO | qemu test config helper
   12:02:10 INFO |
@@ -64,11 +70,15 @@ If there are missing requirements, please install them and re-run `vt-bootstrap`
 First steps with Avocado-VT
 ===========================
 
-Let's check if things went well by listing the Avocado plugins::
+Let's check if things went well by listing the Avocado plugins:
+
+.. code-block:: none
 
   $ avocado plugins
 
-That command should show the loaded plugins, and hopefully no errors. The relevant lines will be::
+That command should show the loaded plugins, and hopefully no errors. The relevant lines will be:
+
+.. code-block:: none
 
   Plugins that add new commands (avocado.plugins.cli.cmd):
   vt-bootstrap Avocado VT - implements the 'vt-bootstrap' subcommand
@@ -77,11 +87,15 @@ That command should show the loaded plugins, and hopefully no errors. The releva
   vt      Avocado VT/virt-test support to 'run' command
   vt-list Avocado-VT/virt-test support for 'list' command
 
-Then let's list the tests available with::
+Then let's list the tests available with:
+
+.. code-block:: none
 
   $ avocado list --vt-type qemu --verbose
 
-This should list a large amount of tests (over 1900 virt related tests)::
+This should list a large amount of tests (over 1900 virt related tests):
+
+.. code-block:: none
 
   ACCESS_DENIED: 0
   BROKEN_SYMLINK: 0
@@ -92,7 +106,9 @@ This should list a large amount of tests (over 1900 virt related tests)::
   SIMPLE: 3
   VT: 1906
 
-Now let's run a virt test::
+Now let's run a virt test:
+
+.. code-block:: none
 
   $ avocado run type_specific.io-github-autotest-qemu.migrate.default.tcp
   JOB ID     : <id>

--- a/docs/source/GlusterFs.rst
+++ b/docs/source/GlusterFs.rst
@@ -25,7 +25,7 @@ You can use Avocado-VT to test GlusterFS support with following steps.
 
 1) Edit qemu/cfg/tests.cfg with following changes,
 
-::
+.. code-block:: none
 
     only glusterfs_support
     remove ‘only no_glusterfs_support’ line from the file
@@ -33,7 +33,7 @@ You can use Avocado-VT to test GlusterFS support with following steps.
 2) Optionally, edit shared/cfg/guest-hw.cfg for the gluster volume name and brick path,
 default is going to be,
 
-::
+.. code-block:: none
 
     gluster_volume_name = test-vol
     gluster_brick = /tmp/gluster
@@ -46,34 +46,34 @@ The following is just an example to show how we create gluster volume and run a 
 Starting Gluster daemon
 -----------------------
 
-::
+.. code-block:: none
 
-    service glusterd start
+    $ service glusterd start
 
 
 Gluster volume creation
 -----------------------
 
-::
+.. code-block:: none
 
-    gluster volume create [volume-name]  [hostname/host_ip]:/[brick_path]
+    $ gluster volume create [volume-name]  [hostname/host_ip]:/[brick_path]
 
-E:g: `gluster volume create test-vol satheesh.ibm.com://home/satheesh/images_gluster`
+E.g.: `gluster volume create test-vol satheesh.ibm.com://home/satheesh/images_gluster`
 
 
 Qemu Img creation
 -----------------
 
-::
+.. code-block:: none
 
-    qemu-img create gluster://[hostname]:0/[volume-name]/[image-name] [size]
+    $ qemu-img create gluster://[hostname]:0/[volume-name]/[image-name] [size]
 
-E:g: `qemu-img create gluster://satheesh.ibm.com:0/test-vol/test_gluster.img 10G`
+E.g.: `qemu-img create gluster://satheesh.ibm.com:0/test-vol/test_gluster.img 10G`
 
 
 Example of qemu cmd Line
 ------------------------
 
-::
+.. code-block:: none
 
-    qemu-system-x86_64 --enable-kvm -smp 4 -m 2048 -drive file=gluster://satheesh.ibm.com/test-vol/test_gluster.img,if=virtio -net nic,macaddr=52:54:00:09:0a:0b -net tap,script=/path/to/qemu-ifupVirsh
+    $ qemu-system-x86_64 --enable-kvm -smp 4 -m 2048 -drive file=gluster://satheesh.ibm.com/test-vol/test_gluster.img,if=virtio -net nic,macaddr=52:54:00:09:0a:0b -net tap,script=/path/to/qemu-ifupVirsh

--- a/docs/source/InstallOptionalPackages.rst
+++ b/docs/source/InstallOptionalPackages.rst
@@ -15,42 +15,42 @@ Install the following packages:
 
 #. Install a toolchain in your host, which you can do with Fedora and RHEL with:
 
-::
+.. code-block:: none
 
-   yum groupinstall "Development Tools"
+   $ yum groupinstall "Development Tools"
 
 #. Install tcpdump, necessary to determine guest IPs automatically
 
-::
+.. code-block:: none
 
-   yum install tcpdump
+   $ yum install tcpdump
 
 #. Install nc, necessary to get output from the serial device and other
    qemu devices
 
-::
+.. code-block:: none
 
-   yum install nmap-ncat
+   $ yum install nmap-ncat
 
 
 #. Install the p7zip file archiver so you can uncompress the JeOS [2] image.
 
-::
+.. code-block:: none
 
-   yum install p7zip
+   $ yum install p7zip
 
 #. Install the autotest-framework package, to provide the needed autotest libs.
 
-::
+.. code-block:: none
 
-   yum install --enablerepo=updates-testing autotest-framework
+   $ yum install --enablerepo=updates-testing autotest-framework
 
 #. Install the fakeroot package, if you want to install from the CD Ubuntu and
 Debian servers without requiring root:
 
-::
+.. code-block:: none
 
-   yum install fakeroot
+   $ yum install fakeroot
 
 
 *If* you don't install the autotest-framework package (say, your distro still
@@ -59,9 +59,9 @@ you'll have to clone an autotest tree and export this path as the
 AUTOTEST_PATH variable, both as root and as your regular user. One could put the
 following on their ~/.bashrc file:
 
-::
+.. code-block:: none
 
-    export AUTOTEST_PATH="/path/to/autotest"
+    $ export AUTOTEST_PATH="/path/to/autotest"
 
 where this AUTOTEST_PATH will guide the run script to set up the needed
 libraries for all tests to work.
@@ -69,39 +69,39 @@ libraries for all tests to work.
 
 For other packages:
 
-::
+.. code-block:: none
 
-     yum install git
+     $ yum install git
 
 So you can checkout the source code. If you want to test the distro provided
 qemu-kvm binary, you can install:
 
-::
+.. code-block:: none
 
-     yum install qemu-kvm qemu-kvm-tools
+     $ yum install qemu-kvm qemu-kvm-tools
 
 
 To run libvirt tests, it's required to install the virt-install utility, for the basic purpose of building and cloning virtual machines.
 
-::
+.. code-block:: none
 
-     yum install virt-install
+     $ yum install virt-install
 
 To run all tests that involve filedescriptor passing, you need python-devel.
 The reason is, this test suite is compatible with python 2.4, whereas a
 std lib to pass filedescriptors was only introduced in python 3.2. Therefore,
 we had to introduce a C python extension that is compiled on demand.
 
-::
+.. code-block:: none
 
-    yum install python-devel.
+     $ yum install python-devel.
 
 
 It's useful to also install:
 
-::
+.. code-block:: none
 
-     yum install python-imaging
+     $ yum install python-imaging
 
 Not vital, but very handy to do imaging conversion from ppm to jpeg and
 png (allows for smaller images).
@@ -114,15 +114,15 @@ Tests that are not part of the default JeOS set
 If you want to run guest install tests, you need to be able to
 create floppies and isos to hold kickstart files:
 
-::
+.. code-block:: none
 
-     yum install mkisofs
+     $ yum install mkisofs
 
 For newer distros, such as Fedora, you'll need:
 
-::
+.. code-block:: none
 
-     yum install genisoimage
+     $ yum install genisoimage
 
 Both packages provide the same functionality, needed to create iso
 images that will be used during the guest installation process. You can
@@ -138,19 +138,19 @@ necessary. However, non root and user space networking make a good deal
 of the hardcode networking tests to not work. If you might want to use
 bridges eventually:
 
-::
+.. code-block:: none
 
-    yum install libvirt bridge-utils
+    $ yum install libvirt bridge-utils
 
 Make sure libvirtd is started:
 
-::
+.. code-block:: none
 
     [lmr@freedom autotest.lmr]$ service libvirtd start
 
 Make sure the libvirt bridge shows up on the output of brctl show:
 
-::
+.. code-block:: none
 
     [lmr@freedom autotest.lmr]$ brctl show
     bridge name bridge id       STP enabled interfaces
@@ -166,16 +166,16 @@ until it can become a more 'official' package.
 The autotest debian package repo can be found at https://launchpad.net/~lmr/+archive/autotest,
 and you can add the repos on your system putting the following on /etc/apt/sources.list:
 
-::
+.. code-block:: none
 
-   deb http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
-   deb-src http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
+   $ deb http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
+   $ deb-src http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
 
 Then update your software list:
 
-::
+.. code-block:: none
 
-   apt-get update
+    $ apt-get update
 
 This has been tested with Ubuntu 12.04, 12.10 and 13.04.
 
@@ -184,44 +184,44 @@ Install the following packages:
 
 #. Install the autotest-framework package, to provide the needed autotest libs.
 
-::
+.. code-block:: none
 
-   apt-get install autotest
+    $ apt-get install autotest
 
 
 #. Install the p7zip file archiver so you can uncompress the JeOS [2] image.
 
-::
+.. code-block:: none
 
-   apt-get install p7zip-full
+    $ apt-get install p7zip-full
 
 
 #. Install tcpdump, necessary to determine guest IPs automatically
 
-::
+.. code-block:: none
 
-   apt-get install tcpdump
+    $ apt-get install tcpdump
 
 #. Install nc, necessary to get output from the serial device and other
    qemu devices
 
-::
+.. code-block:: none
 
-   apt-get install netcat-openbsd
+    $ apt-get install netcat-openbsd
 
 
 #. Install a toolchain in your host, which you can do on Debian and Ubuntu with:
 
-::
+.. code-block:: none
 
-   apt-get install build-essential
+    $ apt-get install build-essential
 
 #. Install fakeroot if you want to install from CD debian and ubuntu, not
 requiring root:
 
-::
+.. code-block:: none
 
-   apt-get install fakeroot
+    $ apt-get install fakeroot
 
 So you install the core autotest libraries to run the tests.
 
@@ -231,9 +231,9 @@ you'll have to clone an autotest tree and export this path as the
 AUTOTEST_PATH variable, both as root and as your regular user. One could put the
 following on their ~/.bashrc file:
 
-::
+.. code-block:: none
 
-    export AUTOTEST_PATH="/path/to/autotest"
+    $ export AUTOTEST_PATH="/path/to/autotest"
 
 where this AUTOTEST_PATH will guide the run script to set up the needed
 libraries for all tests to work.
@@ -241,38 +241,38 @@ libraries for all tests to work.
 
 For other packages:
 
-::
+.. code-block:: none
 
-     apt-get install git
+    $ apt-get install git
 
 So you can checkout the source code. If you want to test the distro provided
 qemu-kvm binary, you can install:
 
-::
+.. code-block:: none
 
-     apt-get install qemu-kvm qemu-utils
+    $ apt-get install qemu-kvm qemu-utils
 
 To run libvirt tests, it's required to install the virt-install utility, for the basic purpose of building and cloning virtual machines.
 
-::
+.. code-block:: none
 
-     apt-get install virtinst
+    $ apt-get install virtinst
 
 To run all tests that involve filedescriptor passing, you need python-all-dev.
 The reason is, this test suite is compatible with python 2.4, whereas a
 std lib to pass filedescriptors was only introduced in python 3.2. Therefore,
 we had to introduce a C python extension that is compiled on demand.
 
-::
+.. code-block:: none
 
-    apt-get install python-all-dev.
+    $ apt-get install python-all-dev.
 
 
 It's useful to also install:
 
-::
+.. code-block:: none
 
-     apt-get install python-imaging
+    $ apt-get install python-imaging
 
 Not vital, but very handy to do imaging conversion from ppm to jpeg and
 png (allows for smaller images).
@@ -285,9 +285,9 @@ Tests that are not part of the default JeOS set
 If you want to run guest install tests, you need to be able to
 create floppies and isos to hold kickstart files:
 
-::
+.. code-block:: none
 
-     apt-get install genisoimage
+    $ apt-get install genisoimage
 
 
 Network tests
@@ -299,19 +299,19 @@ necessary. However, non root and user space networking make a good deal
 of the hardcode networking tests to not work. If you might want to use
 bridges eventually:
 
-::
+.. code-block:: none
 
-    apt-get install libvirt-bin python-libvirt bridge-utils
+    $ apt-get install libvirt-bin python-libvirt bridge-utils
 
 Make sure libvirtd is started:
 
-::
+.. code-block:: none
 
     $ service libvirtd start
 
 Make sure the libvirt bridge shows up on the output of brctl show:
 
-::
+.. code-block:: none
 
     $ brctl show
     bridge name bridge id       STP enabled interfaces

--- a/docs/source/InstallWinVirtio.rst
+++ b/docs/source/InstallWinVirtio.rst
@@ -167,7 +167,7 @@ SHA1 sum of it matches.
 #. As informed on the output of ``get_started.py``, the command you can
    execute to run autotest is (please run this AS ROOT or sudo)
 
-   ::
+   .. code-block:: none
 
        $HOME/Code/autotest/client/bin/autotest $HOME/Code/autotest/client/tests/kvm/control
 

--- a/docs/source/MultiHostMigration.rst
+++ b/docs/source/MultiHostMigration.rst
@@ -52,7 +52,9 @@ For example, for RHEL 6.4, the image name Avocado-VT uses is::
 
     rhel64-64.qcow2
 
-double check your files are there::
+double check your files are there:
+
+.. code-block:: none
 
     $ ls /var/lib/virt_test/images
     $ rhel64-64.qcow2
@@ -62,7 +64,9 @@ Setup step by step
 ==================
 
 First, clone the autotest repo recursively. It's a repo with lots of
-submodules, so you'll see a lot of output::
+submodules, so you'll see a lot of output:
+
+.. code-block:: none
 
     $ git clone --recursive https://github.com/autotest/autotest.git
     ... lots of output ...
@@ -85,7 +89,7 @@ then you will not be able to see the config files and modify filters prior
 to actually running the test. Therefore this documentation will instruct you
 to run the steps below manually.
 
-::
+.. code-block:: none
 
     16:11:14 INFO | qemu test config helper
     16:11:14 INFO |

--- a/docs/source/PerformanceTesting.rst
+++ b/docs/source/PerformanceTesting.rst
@@ -29,14 +29,14 @@ Environment setup
 
 Autotest supports to numa pining. Assign "numanode=-1" in tests.cfg, then vcpu threads/vhost_net threads/VM memory will be pined to last numa node. If you want to pin other processes to numa node, you can use numctl and taskset.
 
-::
+.. code-block:: none
 
   memory: numactl -m $n $cmdline
   cpu: taskset $node_mask $thread_id
 
 The following content is manual guide.
 
-::
+.. code-block:: none
 
   1.First level pinning would be to use numa pinning when starting the guest.
   e.g  numactl -c 1 -m 1 qemu-kvm  -smp 2 -m 4G <> (pinning guest memory and cpus to numa-node 1)

--- a/docs/source/RegressionTestFarm.rst
+++ b/docs/source/RegressionTestFarm.rst
@@ -106,7 +106,7 @@ can tell autotest to run a job in any machine that matches a given label.
 
 Logged as the autotest user:
 
-::
+.. code-block:: none
 
     $ /usr/local/autotest/cli/autotest-rpc-client label create -t amd64
     Created label: 
@@ -120,7 +120,7 @@ Logged as the autotest user:
 
 Then I'd create each machine with the appropriate labels
 
-::
+.. code-block:: none
 
     $ /usr/local/autotest/cli/autotest-rpc-client host create -t amd64 -b hostprovisioning foo-amd.bazcorp.com
     Added host: 
@@ -230,7 +230,7 @@ Other assumptions we have here:
 that has the Fedora 18 DVD and other ISOS. The structure for the base dir
 could look something like:
 
-::
+.. code-block:: none
 
     .
     |-- linux
@@ -247,7 +247,7 @@ for example.
 corrupted during testing, and you want people to analyze them. The structure
 would be:
 
-::
+.. code-block:: none
 
     .
     |-- foo-amd

--- a/docs/source/RunQemuUnittests.rst
+++ b/docs/source/RunQemuUnittests.rst
@@ -130,7 +130,7 @@ Step by step procedure
    the main control file (called ``control`` with the unittest one
    ``control.unittests``
 
-   ::
+   .. code-block:: none
 
        $HOME/Code/autotest/client/bin/autotest $HOME/Code/autotest/client/tests/kvm/control.unittests
 

--- a/docs/source/WritingTests/DefiningNewGuests.rst
+++ b/docs/source/WritingTests/DefiningNewGuests.rst
@@ -44,7 +44,7 @@ qcow2 format image.
 
 Other useful params to set (not an exaustive list):
 
-::
+.. code-block:: cfg
 
     # shell_prompt is a regexp used to match the prompt on aexpect.
     # if your custom os is based of some distro listed in the guest-os

--- a/docs/source/WritingTests/TestProviders.rst
+++ b/docs/source/WritingTests/TestProviders.rst
@@ -16,7 +16,7 @@ The test provider spec is divided in Provider Layout and Definition files.
 Test Provider Layout
 ====================
 
-::
+.. code-block:: none
 
     .
     |-- backend_1        -> Backend name. The actual name doesn't matter.

--- a/docs/source/WritingTests/WritingSimpleTests.rst
+++ b/docs/source/WritingTests/WritingSimpleTests.rst
@@ -14,14 +14,18 @@ Write our own, drop-in 'uptime' test - Step by Step procedure
 Now, let's go and write our uptime test, which only purpose in life is
 to pick up a living guest, connect to it via ssh, and return its uptime.
 
-#. Git clone tp-qemu.git to a convenient location, say $HOME/Code/tp-qemu::
+#. Git clone tp-qemu.git to a convenient location, say $HOME/Code/tp-qemu:
+
+.. code-block:: none
 
     $ git clone https://github.com/autotest/tp-qemu.git
 
 #. Our uptime test won't need any qemu specific feature. Thinking about
    it, we only need a vm object and stablish an ssh session to it, so we
    can run the command. So we can store our brand new test under
-   ``tests``. At the autotest root location::
+   ``tests``. At the autotest root location:
+
+.. code-block:: none
 
     $ touch generic/tests/uptime.py
     $ git add generic/tests/uptime.py
@@ -151,11 +155,15 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
    code. I strongly encourage you guys to check your code with the `inspektor`
    tool. This tool uses pylint to catch bugs on test code. You can install
    inspektor by adding the COPR repo https://copr.fedoraproject.org/coprs/lmr/Autotest/
-   and doing ::
+   and doing:
 
-    yum install inspektor
+.. code-block:: none
 
-   After you're done, you can run it::
+       $ yum install inspektor
+
+   After you're done, you can run it:
+
+.. code-block:: none
 
         $ inspekt lint generic/tests/uptime.py
         ************* Module generic.tests.uptime
@@ -183,7 +191,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
            session.close()
 
 #. Let's re-run ``inspektor`` to see if it's happy with the code
-   generated::
+   generated:
+
+.. code-block:: none
 
         $ inspekt lint generic/tests/uptime.py
         Syntax check PASS
@@ -191,16 +201,22 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
 #. So we're good. Nice! Now, as good indentation does matter to python,
    `inspekt indent` will fix indentation problems, and cut trailing
    whitespaces on your code. Very nice for tidying up your test before
-   submission::
+   submission:
+
+.. code-block:: none
 
         $ inspekt indent generic/tests/uptime.py
 
 #. Now, you can test your code. When listing the qemu tests your new test should
-   appear in the list::
+   appear in the list:
 
-        avocado list uptime
+.. code-block:: none
 
-#. Now, you can run your test to see if everything went well::
+        $ avocado list uptime
+
+#. Now, you can run your test to see if everything went well:
+
+.. code-block:: none
 
         $ avocado run --vt-type uptime
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-cd_format.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-cd_format.rst
@@ -38,5 +38,5 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `drive\_format <drive_format>`_
+-  `drive\_format <CartesianConfigReference-KVM-drive_format.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-check_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-check_image.rst
@@ -9,7 +9,7 @@ Configures if we want to run a check on the image files during post
 processing. A check usually means running 'qemu-img info' and 'qemu-img
 check'.
 
-This is currently only enabled when `image\_format <image_format>`_
+This is currently only enabled when `image\_format <CartesianConfigReference-KVM-image_format.html>`_
 is set to 'qcow2'.
 
 ::
@@ -38,9 +38,9 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `remove\_image <remove_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `remove\_image <CartesianConfigReference-KVM-remove_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-create_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-create_image.rst
@@ -8,7 +8,7 @@ Description
 Configures if we want to create an image file during pre processing, if
 it does **not** already exists. To force the creation of the image file
 even if it already exists, use
-`force\_create\_image <force_create_image>`_.
+`force\_create\_image <CartesianConfigReference-KVM-force_create_image.html>`_.
 
 To create an image file if it does **not** already exists:
 
@@ -35,10 +35,10 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `force\_create\_image <force_create_image>`_
--  `remove\_image <remove_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `force\_create\_image <CartesianConfigReference-KVM-force_create_image.html>`_
+-  `remove\_image <CartesianConfigReference-KVM-remove_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_client.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_client.rst
@@ -44,7 +44,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
--  `file\_transfer\_port <file_transfer_port>`_
--  `guest\_port\_file\_transfer <guest_port_file_transfer>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
+-  `file\_transfer\_port <CartesianConfigReference-KVM-file_transfer_port.html>`_
+-  `guest\_port\_file\_transfer <CartesianConfigReference-KVM-guest_port_file_transfer.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_port.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_port.rst
@@ -8,8 +8,8 @@ Description
 Sets the port on which the application used to transfer files to and
 from the guest will be listening on.
 
-When `file\_transfer\_client <file_transfer_client>`_ is scp, this
-is by default 22:
+When `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
+is scp, this is by default 22:
 
 ::
 
@@ -45,7 +45,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
--  `file\_transfer\_client <file_transfer_client>`_
--  `guest\_port\_file\_transfer <guest_port_file_transfer>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
+-  `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
+-  `guest\_port\_file\_transfer <CartesianConfigReference-KVM-guest_port_file_transfer.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-force_create_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-force_create_image.rst
@@ -7,7 +7,7 @@ Description
 
 Configures if we want to create an image file during pre processing,
 **even if it already exists**. To create an image file only if it **does
-not** exist, use `create\_image <create_image>`_ instead.
+not** exist, use `create\_image <CartesianConfigReference-KVM-create_image.html>`_ instead.
 
 To create an image file **even if it already exists**:
 
@@ -33,10 +33,10 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `check\_image <check_image>`_
--  `remove\_image <remove_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `check\_image <CartesianConfigReference-KVM-check_image.html>`_
+-  `remove\_image <CartesianConfigReference-KVM-remove_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port.rst
@@ -8,9 +8,9 @@ Description
 guest\_port is not a configuration item itself, but the basis (prefix)
 of other real configuration items such as:
 
--  `guest\_port\_remote\_shell <guest_port_remote_shell>`_
--  `guest\_port\_file\_transfer <guest_port_file_transfer>`_
--  `guest\_port\_unattended\_install <guest_port_unattended_install>`_
+-  `guest\_port\_remote\_shell <CartesianConfigReference-KVM-guest_port_remote_shell.html>`_
+-  `guest\_port\_file\_transfer <CartesianConfigReference-KVM-guest_port_file_transfer.html>`_
+-  `guest\_port\_unattended\_install <CartesianConfigReference-KVM-guest_port_unattended_install.html>`_
 
 Defined On
 ----------
@@ -29,5 +29,5 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `redirs <redirs>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_file_transfer.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_file_transfer.rst
@@ -8,15 +8,15 @@ Description
 Sets the port of the server application running inside guests that will
 be used for transferring files to and from this guest.
 
-On Linux VMs, the `file\_transfer\_client <file_transfer_client>`_
+On Linux VMs, the `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
 is set by default to 'scp', and this the port is set by default to the
 standard SSH port (22).
 
 For Windows guests, the
-`file\_transfer\_client <file_transfer_client>`_ is set by default
-to 'rss', and the port is set by default to 10023.
+`file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
+is set by default to 'rss', and the port is set by default to 10023.
 
-This is a specialization of the `guest\_port <guest_port>`_
+This is a specialization of the `guest\_port <CartesianConfigReference-KVM-guest_port.html>`_
 configuration entry.
 
 Example, default entry:
@@ -52,7 +52,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
--  `file\_transfer\_port <file_transfer_port>`_
--  `file\_transfer\_client <file_transfer_client>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
+-  `file\_transfer\_port <CartesianConfigReference-KVM-file_transfer_port.html>`_
+-  `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_remote_shell.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_remote_shell.rst
@@ -46,6 +46,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 -  shell\_port?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_unattended_install.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_unattended_install.rst
@@ -49,5 +49,5 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-image_format.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-image_format.rst
@@ -51,7 +51,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_size <image_size>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_size <CartesianConfigReference-KVM-image_size.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-image_name.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-image_name.rst
@@ -8,9 +8,9 @@ Description
 Sets the name of an image file.
 
 If the image file is not a block device (see
-`image\_raw\_device <image_raw_device>`_) the actual file created
-will be named accordingly (together with the extension, according to
-`image\_format <image_format>`_).
+`image\_raw\_device <CartesianConfigReference-KVM-image_raw_device.html>`_)
+the actual file created will be named accordingly (together with the extension,
+according to `image\_format <CartesianConfigReference-KVM-image_format.html>`_).
 
 When this configuration key is used without a suffix, it's setting the
 name of all images without a specific name. The net effect is that it
@@ -29,8 +29,8 @@ sets the name of the 'default' image. Example:
 
 This example means that when a Fedora 15 64 bits is installed, and has a
 backing image file created, it's going to be named starting with
-'f15-64'. If the `image\_format <image_format>`_ specified is
-'qcow2', then the complete filename will be 'f15-64.qcow2'.
+'f15-64'. If the `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+specified is 'qcow2', then the complete filename will be 'f15-64.qcow2'.
 
 When this configuration key is used with a suffix, it sets the name of a
 specific image. Example:
@@ -65,7 +65,7 @@ Referenced By
 See Also
 --------
 
--  `images <images>`_
--  `image\_format <image_format>`_
--  `image\_raw\_device <image_raw_device>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `image\_raw\_device <CartesianConfigReference-KVM-image_raw_device.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-image_size.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-image_size.rst
@@ -50,7 +50,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_unresponsive_vms.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_unresponsive_vms.rst
@@ -34,7 +34,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm <kill_vm>`_
--  `kill\_vm\_timeout <kill_vm_timeout>`_
--  `kill\_vm\_gracefully <kill_vm_gracefully>`_
+-  `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+-  `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_
+-  `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm.rst
@@ -7,8 +7,8 @@ Description
 
 Configures whether a VM should be shutdown during post processing. How
 exactly the VM will be shutdown is configured by other parameters such
-as `kill\_vm\_gracefully <kill_vm_gracefully>`_ and
-`kill\_vm\_timeout <kill_vm_timeout>`_.
+as `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
+and `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_.
 
 To force shutdown during post processing:
 
@@ -37,7 +37,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm\_timeout <kill_vm_timeout>`_
--  `kill\_vm\_gracefully <kill_vm_gracefully>`_
--  `kill\_unresponsive\_vms <kill_unresponsive_vms>`_
+-  `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_
+-  `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
+-  `kill\_unresponsive\_vms <CartesianConfigReference-KVM-kill_unresponsive_vms.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_gracefully.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_gracefully.rst
@@ -9,8 +9,8 @@ Flags whether a graceful shutdown command should be sent to the VM guest
 OS before attempting to either halt the VM at the hypervisor side
 (sending an appropriate command to QEMU or even killing its process).
 
-Of course, this is only valid when `kill\_vm <kill_vm>`_ is set to
-'yes'.
+Of course, this is only valid when `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+is set to 'yes'.
 
 To force killing VMs without using a graceful shutdown command (such as
 'shutdown -h now'):
@@ -40,7 +40,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm <kill_vm>`_
--  `kill\_vm\_timeout <kill_vm_timeout>`_
--  `kill\_unresponsive\_vms <kill_unresponsive_vms>`_
+-  `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+-  `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_
+-  `kill\_unresponsive\_vms <CartesianConfigReference-KVM-kill_unresponsive_vms.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_timeout.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_timeout.rst
@@ -8,8 +8,8 @@ Description
 Configures the amount of time, in seconds, to wait for VM shutdown
 during the post processing.
 
-This is only relevant if `kill\_vm <kill_vm>`_ is actually set to
-'yes'.
+This is only relevant if `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_ is
+actually set to 'yes'.
 
 To set the timeout to one minute:
 
@@ -36,7 +36,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm <kill_vm>`_
--  `kill\_vm\_gracefully <kill_vm_gracefully>`_
--  `kill\_unresponsive\_vms <kill_unresponsive_vms>`_
+-  `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+-  `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
+-  `kill\_unresponsive\_vms <CartesianConfigReference-KVM-kill_unresponsive_vms.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-main_monitor.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-main_monitor.rst
@@ -18,7 +18,7 @@ Human monitor:
 
 If a **main\_monitor** is not defined, the **monitor** property of a
 **VM** class instance will assume that the first monitor set in the
-`monitors <monitors>`_ list is the main monitor.
+`monitors <CartesianConfigReference-KVM-monitors.html>`_ list is the main monitor.
 
 Defined On
 ----------
@@ -39,7 +39,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `monitors <monitors>`_
--  `monitor\_type <monitor_type>`_
+-  `monitors <CartesianConfigReference-KVM-monitors.html>`_
+-  `monitor\_type <CartesianConfigReference-KVM-monitor_type.html>`_
 -  `client/virt/kvm\_monitor.py <https://github.com/autotest/autotest/blob/master/client/virt/kvm_monitor.py>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-nic_mode.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-nic_mode.rst
@@ -22,7 +22,7 @@ current default in Autotest:
 
 When **nic\_mode** is set to
 `Tap <http://wiki.qemu.org/Documentation/Networking#Tap>`_ you should
-also set a `bridge <bridge>`_.
+also set a `bridge <CartesianConfigReference-KVM-bridge.html>`_.
 
 Defined On
 ----------
@@ -45,6 +45,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `bridge <bridge>`_
--  `redirs <redirs>`_
+-  `bridge <CartesianConfigReference-KVM-bridge.html>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-post_command.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-post_command.rst
@@ -31,6 +31,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `post\_command\_timeout <post_command_timeout>`_
+-  `post\_command\_timeout <CartesianConfigReference-KVM-post_command_timeout.html>`_
 -  post\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-post_command_noncritical.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-post_command_noncritical.rst
@@ -28,6 +28,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `post\_command <post_command>`_
--  `post\_command\_timeout <post_command_timeout>`_
+-  `post\_command <CartesianConfigReference-KVM-post_command.html>`_
+-  `post\_command\_timeout <CartesianConfigReference-KVM-post_command_timeout.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-post_command_timeout.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-post_command_timeout.rst
@@ -27,6 +27,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `post\_command <post_command>`_
+-  `post\_command <CartesianConfigReference-KVM-post_command.html>`_
 -  post\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-pre_command.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-pre_command.rst
@@ -30,6 +30,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `pre\_command\_timeout <pre_command_timeout>`_
+-  `pre\_command\_timeout <CartesianConfigReference-KVM-pre_command_timeout.html>`_
 -  pre\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_noncritical.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_noncritical.rst
@@ -28,6 +28,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `pre\_command <pre_command>`_
--  `pre\_command\_timeout <pre_command_timeout>`_
+-  `pre\_command <CartesianConfigReference-KVM-pre_command.html>`_
+-  `pre\_command\_timeout <CartesianConfigReference-KVM-pre_command_timeout.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_timeout.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_timeout.rst
@@ -27,6 +27,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `pre\_command <pre_command>`_
+-  `pre\_command <CartesianConfigReference-KVM-pre_command.html>`_
 -  pre\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qemu_binary.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qemu_binary.rst
@@ -40,5 +40,5 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qemu\_img\_binary <qemu_img_binary>`_
+-  `qemu\_img\_binary <CartesianConfigReference-KVM-qemu_img_binary.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qemu_img_binary.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qemu_img_binary.rst
@@ -34,5 +34,5 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qemu\_binary <qemu_binary>`_
+-  `qemu\_binary <CartesianConfigReference-KVM-qemu_binary.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qxl.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qxl.rst
@@ -35,6 +35,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qxl\_dev\_nr <qxl_dev_nr>`_
+-  `qxl\_dev\_nr <CartesianConfigReference-KVM-qxl_dev_nr.html>`_
 -  vga?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qxl_dev_nr.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qxl_dev_nr.rst
@@ -7,7 +7,7 @@ Description
 
 Sets the number of display devices available through
 `SPICE <http://spice-space.org/faq>`_. This is only valid when
-`qxl <qxl>`_ is set.
+`qxl <CartesianConfigReference-KVM-qxl.html>`_ is set.
 
 The default configuration enables a single display device:
 
@@ -47,7 +47,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qxl <qxl>`_
+-  `qxl <CartesianConfigReference-KVM-qxl.html>`_
 -  vga?
--  `display <display>`_
+-  `display <CartesianConfigReference-KVM-display.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-redirs.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-redirs.rst
@@ -37,6 +37,6 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `guest\_port <guest_port>`_
--  `guest\_port\_remote\_shell <guest_port_remote_shell>`_
+-  `guest\_port <CartesianConfigReference-KVM-guest_port.html>`_
+-  `guest\_port\_remote\_shell <CartesianConfigReference-KVM-guest_port_remote_shell.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-remove_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-remove_image.rst
@@ -39,9 +39,9 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `force\_create\_image <force_create_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `force\_create\_image <CartesianConfigReference-KVM-force_create_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-spice.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-spice.rst
@@ -35,8 +35,8 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qxl <qxl>`_
--  `qxl\_dev\_nr <qxl_dev_nr>`_
+-  `qxl <CartesianConfigReference-KVM-qxl.html>`_
+-  `qxl\_dev\_nr <CartesianConfigReference-KVM-qxl_dev_nr.html>`_
 -  vga?
--  `display <display>`_
+-  `display <CartesianConfigReference-KVM-display.html>`_
 

--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -12,13 +12,13 @@ Filter syntax:
 
 Example:
 
-::
+.. code-block:: none
 
      qcow2..(guest_os=Fedora).14, RHEL.6..raw..boot, smp2..qcow2..migrate..ide
 
 means match all dicts whose names have:
 
-::
+.. code-block:: none
 
     (qcow2 AND ((guest_os=Fedora) IMMEDIATELY-FOLLOWED-BY 14)) OR
     ((RHEL IMMEDIATELY-FOLLOWED-BY 6) AND raw AND boot) OR
@@ -32,7 +32,7 @@ Note:
 
 Filters can be used in 3 ways:
 
-::
+.. code-block:: none
 
     only <filter>
     no <filter>
@@ -47,7 +47,7 @@ terminals and nonterminals are only for better reading of definitions.
 The base of the definitions come verbatim as follows:
 
 
-::
+.. code-block:: none
 
     E = {\\n, #, :, "-", =, +=, <=, ?=, ?+=, ?<=, !, < , del, @, variants, include, only, no, name, value}
 

--- a/virttest/staging/backports/simplejson/__init__.py
+++ b/virttest/staging/backports/simplejson/__init__.py
@@ -88,7 +88,9 @@ Specializing JSON object encoding::
     '[2.0, 1.0]'
 
 
-Using simplejson.tool from the shell to validate and pretty-print::
+Using simplejson.tool from the shell to validate and pretty-print:
+
+.. code-block:: none
 
     $ echo '{"json":"obj"}' | python -m simplejson.tool
     {

--- a/virttest/staging/backports/simplejson/tool.py
+++ b/virttest/staging/backports/simplejson/tool.py
@@ -1,6 +1,8 @@
 r"""Command-line tool to validate and pretty-print JSON
 
-Usage::
+Usage:
+
+.. code-block:: none
 
     $ echo '{"json":"obj"}' | python -m simplejson.tool
     {

--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -1272,6 +1272,7 @@ class MultihostMigrationRdma(MultihostMigration):
     dst host:
     1. Install some packages: libmlx, infiniband, rdma
     2. Create configuration for rdma network card, example:
+
         # cat /etc/sysconfig/network-scripts/ifcfg-ib0
         DEVICE=ib0
         TYPE=InfiniBand
@@ -1281,6 +1282,7 @@ class MultihostMigrationRdma(MultihostMigration):
         BROADCAST=192.168.0.255
         IPADDR=192.168.0.21
         NETMASK=255.255.255.0
+
     3. Restart related services: network, opensm, rdma
     """
 


### PR DESCRIPTION
In sphinx 1.4b, building current avocado-vt docs will generate a lot of
warning messages:

```
WARNING: Could not lex literal_block as "python3". Highlighting skipped.
```

According to the reasoning here
(https://github.com/sphinx-doc/sphinx/issues/2330). This is new feature
that preventing mistakenly highlighting code blocks using python3 pygments.

To silence this warning, we change the code block indicator `::` to
`..  code-block:: none` to explicitly disable code highlighting.

This failure is not shown until sphinx-1.4 released and applied to
Travis CI. But it's better be prepared.

This commit also fixed a incorrectly formatted inline docs failing
current Travis CI.

Signed-off-by: Hao Liu <hliu@redhat.com>