### PR TITLE
requirements: Add pygobject dependency

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -3,3 +3,4 @@ inspektor==0.2.0
 autotest==0.16.2
 aexpect==1.0.0
 simplejson==3.8.0
+pygobject==3.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 autotest>=0.16.2
 aexpect>=1.0.0
 simplejson>=3.5.3
+pygobject>=3.18.2


### PR DESCRIPTION
The virttest/step_editor.py requires pygtk.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>