### PR TITLE
Fix Travis CI doc building complaint and dead links

### DIFF
--- a/docs/source/cartesian/CartesianConfigReference-KVM-cd_format.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-cd_format.rst
@@ -38,5 +38,5 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `drive\_format <drive_format>`_
+-  `drive\_format <CartesianConfigReference-KVM-drive_format.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-check_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-check_image.rst
@@ -9,7 +9,7 @@ Configures if we want to run a check on the image files during post
 processing. A check usually means running 'qemu-img info' and 'qemu-img
 check'.
 
-This is currently only enabled when `image\_format <image_format>`_
+This is currently only enabled when `image\_format <CartesianConfigReference-KVM-image_format.html>`_
 is set to 'qcow2'.
 
 ::
@@ -38,9 +38,9 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `remove\_image <remove_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `remove\_image <CartesianConfigReference-KVM-remove_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-create_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-create_image.rst
@@ -8,7 +8,7 @@ Description
 Configures if we want to create an image file during pre processing, if
 it does **not** already exists. To force the creation of the image file
 even if it already exists, use
-`force\_create\_image <force_create_image>`_.
+`force\_create\_image <CartesianConfigReference-KVM-force_create_image.html>`_.
 
 To create an image file if it does **not** already exists:
 
@@ -35,10 +35,10 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `force\_create\_image <force_create_image>`_
--  `remove\_image <remove_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `force\_create\_image <CartesianConfigReference-KVM-force_create_image.html>`_
+-  `remove\_image <CartesianConfigReference-KVM-remove_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_client.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_client.rst
@@ -44,7 +44,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
--  `file\_transfer\_port <file_transfer_port>`_
--  `guest\_port\_file\_transfer <guest_port_file_transfer>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
+-  `file\_transfer\_port <CartesianConfigReference-KVM-file_transfer_port.html>`_
+-  `guest\_port\_file\_transfer <CartesianConfigReference-KVM-guest_port_file_transfer.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_port.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-file_transfer_port.rst
@@ -8,8 +8,8 @@ Description
 Sets the port on which the application used to transfer files to and
 from the guest will be listening on.
 
-When `file\_transfer\_client <file_transfer_client>`_ is scp, this
-is by default 22:
+When `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
+is scp, this is by default 22:
 
 ::
 
@@ -45,7 +45,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
--  `file\_transfer\_client <file_transfer_client>`_
--  `guest\_port\_file\_transfer <guest_port_file_transfer>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
+-  `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
+-  `guest\_port\_file\_transfer <CartesianConfigReference-KVM-guest_port_file_transfer.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-force_create_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-force_create_image.rst
@@ -7,7 +7,7 @@ Description
 
 Configures if we want to create an image file during pre processing,
 **even if it already exists**. To create an image file only if it **does
-not** exist, use `create\_image <create_image>`_ instead.
+not** exist, use `create\_image <CartesianConfigReference-KVM-create_image.html>`_ instead.
 
 To create an image file **even if it already exists**:
 
@@ -33,10 +33,10 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `check\_image <check_image>`_
--  `remove\_image <remove_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `check\_image <CartesianConfigReference-KVM-check_image.html>`_
+-  `remove\_image <CartesianConfigReference-KVM-remove_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port.rst
@@ -8,9 +8,9 @@ Description
 guest\_port is not a configuration item itself, but the basis (prefix)
 of other real configuration items such as:
 
--  `guest\_port\_remote\_shell <guest_port_remote_shell>`_
--  `guest\_port\_file\_transfer <guest_port_file_transfer>`_
--  `guest\_port\_unattended\_install <guest_port_unattended_install>`_
+-  `guest\_port\_remote\_shell <CartesianConfigReference-KVM-guest_port_remote_shell.html>`_
+-  `guest\_port\_file\_transfer <CartesianConfigReference-KVM-guest_port_file_transfer.html>`_
+-  `guest\_port\_unattended\_install <CartesianConfigReference-KVM-guest_port_unattended_install.html>`_
 
 Defined On
 ----------
@@ -29,5 +29,5 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `redirs <redirs>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_file_transfer.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_file_transfer.rst
@@ -8,15 +8,15 @@ Description
 Sets the port of the server application running inside guests that will
 be used for transferring files to and from this guest.
 
-On Linux VMs, the `file\_transfer\_client <file_transfer_client>`_
+On Linux VMs, the `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
 is set by default to 'scp', and this the port is set by default to the
 standard SSH port (22).
 
 For Windows guests, the
-`file\_transfer\_client <file_transfer_client>`_ is set by default
-to 'rss', and the port is set by default to 10023.
+`file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
+is set by default to 'rss', and the port is set by default to 10023.
 
-This is a specialization of the `guest\_port <guest_port>`_
+This is a specialization of the `guest\_port <CartesianConfigReference-KVM-guest_port.html>`_
 configuration entry.
 
 Example, default entry:
@@ -52,7 +52,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
--  `file\_transfer\_port <file_transfer_port>`_
--  `file\_transfer\_client <file_transfer_client>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
+-  `file\_transfer\_port <CartesianConfigReference-KVM-file_transfer_port.html>`_
+-  `file\_transfer\_client <CartesianConfigReference-KVM-file_transfer_client.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_remote_shell.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_remote_shell.rst
@@ -46,6 +46,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 -  shell\_port?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_unattended_install.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-guest_port_unattended_install.rst
@@ -49,5 +49,5 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `redirs <redirs>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-image_format.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-image_format.rst
@@ -51,7 +51,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_size <image_size>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_size <CartesianConfigReference-KVM-image_size.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-image_name.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-image_name.rst
@@ -8,9 +8,9 @@ Description
 Sets the name of an image file.
 
 If the image file is not a block device (see
-`image\_raw\_device <image_raw_device>`_) the actual file created
-will be named accordingly (together with the extension, according to
-`image\_format <image_format>`_).
+`image\_raw\_device <CartesianConfigReference-KVM-image_raw_device.html>`_)
+the actual file created will be named accordingly (together with the extension,
+according to `image\_format <CartesianConfigReference-KVM-image_format.html>`_).
 
 When this configuration key is used without a suffix, it's setting the
 name of all images without a specific name. The net effect is that it
@@ -29,8 +29,8 @@ sets the name of the 'default' image. Example:
 
 This example means that when a Fedora 15 64 bits is installed, and has a
 backing image file created, it's going to be named starting with
-'f15-64'. If the `image\_format <image_format>`_ specified is
-'qcow2', then the complete filename will be 'f15-64.qcow2'.
+'f15-64'. If the `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+specified is 'qcow2', then the complete filename will be 'f15-64.qcow2'.
 
 When this configuration key is used with a suffix, it sets the name of a
 specific image. Example:
@@ -65,7 +65,7 @@ Referenced By
 See Also
 --------
 
--  `images <images>`_
--  `image\_format <image_format>`_
--  `image\_raw\_device <image_raw_device>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `image\_raw\_device <CartesianConfigReference-KVM-image_raw_device.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-image_size.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-image_size.rst
@@ -50,7 +50,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_unresponsive_vms.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_unresponsive_vms.rst
@@ -34,7 +34,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm <kill_vm>`_
--  `kill\_vm\_timeout <kill_vm_timeout>`_
--  `kill\_vm\_gracefully <kill_vm_gracefully>`_
+-  `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+-  `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_
+-  `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm.rst
@@ -7,8 +7,8 @@ Description
 
 Configures whether a VM should be shutdown during post processing. How
 exactly the VM will be shutdown is configured by other parameters such
-as `kill\_vm\_gracefully <kill_vm_gracefully>`_ and
-`kill\_vm\_timeout <kill_vm_timeout>`_.
+as `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
+and `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_.
 
 To force shutdown during post processing:
 
@@ -37,7 +37,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm\_timeout <kill_vm_timeout>`_
--  `kill\_vm\_gracefully <kill_vm_gracefully>`_
--  `kill\_unresponsive\_vms <kill_unresponsive_vms>`_
+-  `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_
+-  `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
+-  `kill\_unresponsive\_vms <CartesianConfigReference-KVM-kill_unresponsive_vms.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_gracefully.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_gracefully.rst
@@ -9,8 +9,8 @@ Flags whether a graceful shutdown command should be sent to the VM guest
 OS before attempting to either halt the VM at the hypervisor side
 (sending an appropriate command to QEMU or even killing its process).
 
-Of course, this is only valid when `kill\_vm <kill_vm>`_ is set to
-'yes'.
+Of course, this is only valid when `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+is set to 'yes'.
 
 To force killing VMs without using a graceful shutdown command (such as
 'shutdown -h now'):
@@ -40,7 +40,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm <kill_vm>`_
--  `kill\_vm\_timeout <kill_vm_timeout>`_
--  `kill\_unresponsive\_vms <kill_unresponsive_vms>`_
+-  `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+-  `kill\_vm\_timeout <CartesianConfigReference-KVM-kill_vm_timeout.html>`_
+-  `kill\_unresponsive\_vms <CartesianConfigReference-KVM-kill_unresponsive_vms.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_timeout.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-kill_vm_timeout.rst
@@ -8,8 +8,8 @@ Description
 Configures the amount of time, in seconds, to wait for VM shutdown
 during the post processing.
 
-This is only relevant if `kill\_vm <kill_vm>`_ is actually set to
-'yes'.
+This is only relevant if `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_ is
+actually set to 'yes'.
 
 To set the timeout to one minute:
 
@@ -36,7 +36,7 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `kill\_vm <kill_vm>`_
--  `kill\_vm\_gracefully <kill_vm_gracefully>`_
--  `kill\_unresponsive\_vms <kill_unresponsive_vms>`_
+-  `kill\_vm <CartesianConfigReference-KVM-kill_vm.html>`_
+-  `kill\_vm\_gracefully <CartesianConfigReference-KVM-kill_vm_gracefully.html>`_
+-  `kill\_unresponsive\_vms <CartesianConfigReference-KVM-kill_unresponsive_vms.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-main_monitor.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-main_monitor.rst
@@ -18,7 +18,7 @@ Human monitor:
 
 If a **main\_monitor** is not defined, the **monitor** property of a
 **VM** class instance will assume that the first monitor set in the
-`monitors <monitors>`_ list is the main monitor.
+`monitors <CartesianConfigReference-KVM-monitors.html>`_ list is the main monitor.
 
 Defined On
 ----------
@@ -39,7 +39,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `monitors <monitors>`_
--  `monitor\_type <monitor_type>`_
+-  `monitors <CartesianConfigReference-KVM-monitors.html>`_
+-  `monitor\_type <CartesianConfigReference-KVM-monitor_type.html>`_
 -  `client/virt/kvm\_monitor.py <https://github.com/autotest/autotest/blob/master/client/virt/kvm_monitor.py>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-nic_mode.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-nic_mode.rst
@@ -22,7 +22,7 @@ current default in Autotest:
 
 When **nic\_mode** is set to
 `Tap <http://wiki.qemu.org/Documentation/Networking#Tap>`_ you should
-also set a `bridge <bridge>`_.
+also set a `bridge <CartesianConfigReference-KVM-bridge.html>`_.
 
 Defined On
 ----------
@@ -45,6 +45,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `bridge <bridge>`_
--  `redirs <redirs>`_
+-  `bridge <CartesianConfigReference-KVM-bridge.html>`_
+-  `redirs <CartesianConfigReference-KVM-redirs.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-post_command.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-post_command.rst
@@ -31,6 +31,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `post\_command\_timeout <post_command_timeout>`_
+-  `post\_command\_timeout <CartesianConfigReference-KVM-post_command_timeout.html>`_
 -  post\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-post_command_noncritical.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-post_command_noncritical.rst
@@ -28,6 +28,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `post\_command <post_command>`_
--  `post\_command\_timeout <post_command_timeout>`_
+-  `post\_command <CartesianConfigReference-KVM-post_command.html>`_
+-  `post\_command\_timeout <CartesianConfigReference-KVM-post_command_timeout.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-post_command_timeout.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-post_command_timeout.rst
@@ -27,6 +27,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `post\_command <post_command>`_
+-  `post\_command <CartesianConfigReference-KVM-post_command.html>`_
 -  post\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-pre_command.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-pre_command.rst
@@ -30,6 +30,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `pre\_command\_timeout <pre_command_timeout>`_
+-  `pre\_command\_timeout <CartesianConfigReference-KVM-pre_command_timeout.html>`_
 -  pre\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_noncritical.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_noncritical.rst
@@ -28,6 +28,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `pre\_command <pre_command>`_
--  `pre\_command\_timeout <pre_command_timeout>`_
+-  `pre\_command <CartesianConfigReference-KVM-pre_command.html>`_
+-  `pre\_command\_timeout <CartesianConfigReference-KVM-pre_command_timeout.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_timeout.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-pre_command_timeout.rst
@@ -27,6 +27,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `pre\_command <pre_command>`_
+-  `pre\_command <CartesianConfigReference-KVM-pre_command.html>`_
 -  pre\_command\_non\_critical?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qemu_binary.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qemu_binary.rst
@@ -40,5 +40,5 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qemu\_img\_binary <qemu_img_binary>`_
+-  `qemu\_img\_binary <CartesianConfigReference-KVM-qemu_img_binary.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qemu_img_binary.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qemu_img_binary.rst
@@ -34,5 +34,5 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qemu\_binary <qemu_binary>`_
+-  `qemu\_binary <CartesianConfigReference-KVM-qemu_binary.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qxl.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qxl.rst
@@ -35,6 +35,6 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qxl\_dev\_nr <qxl_dev_nr>`_
+-  `qxl\_dev\_nr <CartesianConfigReference-KVM-qxl_dev_nr.html>`_
 -  vga?
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-qxl_dev_nr.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-qxl_dev_nr.rst
@@ -7,7 +7,7 @@ Description
 
 Sets the number of display devices available through
 `SPICE <http://spice-space.org/faq>`_. This is only valid when
-`qxl <qxl>`_ is set.
+`qxl <CartesianConfigReference-KVM-qxl.html>`_ is set.
 
 The default configuration enables a single display device:
 
@@ -47,7 +47,7 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qxl <qxl>`_
+-  `qxl <CartesianConfigReference-KVM-qxl.html>`_
 -  vga?
--  `display <display>`_
+-  `display <CartesianConfigReference-KVM-display.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-redirs.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-redirs.rst
@@ -37,6 +37,6 @@ No other documentation currently references this configuration key.
 See also
 --------
 
--  `guest\_port <guest_port>`_
--  `guest\_port\_remote\_shell <guest_port_remote_shell>`_
+-  `guest\_port <CartesianConfigReference-KVM-guest_port.html>`_
+-  `guest\_port\_remote\_shell <CartesianConfigReference-KVM-guest_port_remote_shell.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-remove_image.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-remove_image.rst
@@ -39,9 +39,9 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `images <images>`_
--  `image\_name <image_name>`_
--  `image\_format <image_format>`_
--  `create\_image <create_image>`_
--  `force\_create\_image <force_create_image>`_
+-  `images <CartesianConfigReference-KVM-images.html>`_
+-  `image\_name <CartesianConfigReference-KVM-image_name.html>`_
+-  `image\_format <CartesianConfigReference-KVM-image_format.html>`_
+-  `create\_image <CartesianConfigReference-KVM-create_image.html>`_
+-  `force\_create\_image <CartesianConfigReference-KVM-force_create_image.html>`_
 

--- a/docs/source/cartesian/CartesianConfigReference-KVM-spice.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-spice.rst
@@ -35,8 +35,8 @@ No other documentation currently references this configuration key.
 See Also
 --------
 
--  `qxl <qxl>`_
--  `qxl\_dev\_nr <qxl_dev_nr>`_
+-  `qxl <CartesianConfigReference-KVM-qxl.html>`_
+-  `qxl\_dev\_nr <CartesianConfigReference-KVM-qxl_dev_nr.html>`_
 -  vga?
--  `display <display>`_
+-  `display <CartesianConfigReference-KVM-display.html>`_
 

--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -1272,6 +1272,7 @@ class MultihostMigrationRdma(MultihostMigration):
     dst host:
     1. Install some packages: libmlx, infiniband, rdma
     2. Create configuration for rdma network card, example:
+
         # cat /etc/sysconfig/network-scripts/ifcfg-ib0
         DEVICE=ib0
         TYPE=InfiniBand
@@ -1281,6 +1282,7 @@ class MultihostMigrationRdma(MultihostMigration):
         BROADCAST=192.168.0.255
         IPADDR=192.168.0.21
         NETMASK=255.255.255.0
+
     3. Restart related services: network, opensm, rdma
     """
 


### PR DESCRIPTION
This PR
1. Fix incorrectly formatted inline docs failing current Travis CI.
2. Fix dead links in Cartesian config documentation should solve #352. These dead links might be caused by massive renaming this files. 