### PR TITLE
SPEC file: require avocado package of the same version

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -7,14 +7,15 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 0.33.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildRequires: python2-devel, python-setuptools
 BuildArch: noarch
-Requires: python, avocado, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect
+Requires: avocado == %{version}
+Requires: python, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect
 
 Requires: python-imaging
 %if 0%{?el6}
@@ -52,6 +53,9 @@ Xunit output, among others.
 
 
 %changelog
+* Tue Feb 23 2016 Cleber Rosa <cleber@redhat.com> - 0.33.0-1
+- Require the avocado package of the exact same version
+
 * Wed Feb 17 2016 Cleber Rosa <cleber@redhat.com> - 0.33.0-0
 - Update to upstream version 0.33.0
 


### PR DESCRIPTION
So far the RPM packages have not been strict about the version
of avocado that they require.  The same version has probably
been used because of newer package availability on the repos.

Anyway, let's require the same package versions so that users
may not be surprised with breakage because of different version
and interfaces.

Signed-off-by: Cleber Rosa <crosa@redhat.com>