### PR TITLE
Change default doc highlighting and fix typos

### DIFF
--- a/docs/source/BuildingTestApplications.rst
+++ b/docs/source/BuildingTestApplications.rst
@@ -17,7 +17,7 @@ application. The below example shows a Makefile for the application for the
 timedrift test cases. The `remote_build` module requires that a Makefile is
 included with all test applications.
 
-::
+.. code-block:: makefile
 
     CFLAGS+=-Wall
     LDLIBS+=-lrt
@@ -36,40 +36,40 @@ included with all test applications.
 remote_build
 ------------
 
-To simplfy the building of applications on target, and to simplify avoiding the
+To simplify the building of applications on target, and to simplify avoiding the
 building of applications on target when they are installed pre-built, use the
 `remote_build` module. This module handles both the transfer of files, and
 running `make` on target.
 
 A simple example:
 
-::
+.. code-block:: python
 
     address = vm.get_address(0)
     source_dir = data_dir.get_deps_dir("<testapp>")
     builder = remote_build.Builder(params, address, source_dir)
     full_build_path = builder.build()
 
-In this case, we utilize the `.build()` method, which execute the neccessary
+In this case, we utilize the `.build()` method, which execute the necessary
 methods in `builder` to copy all files to target and run make (if needed). When
 done, `.build()` will return the full path on target to the application that
 was just built. Be sure to use this path when running your test application, as
 the path is changed if the parameters of the build is changed. For example:
 
-::
+.. code-block:: python
 
-    session.cmd_status(%s --test" % os.path.join(full_build_path, "testapp"))
+    session.cmd_status("%s --test" % os.path.join(full_build_path, "testapp"))
 
 The `remote_build.Builder` class can give you fine-grained control over your
 build process as well. Another way to write the above `.build()` invocation
 above is:
 
-::
+.. code-block:: python
 
     builder = remote_build.Builder(params, address, source_dir)
     if builder.sync_directories():
         builder.make()
     full_build_path = builder.full_build_path
 
-This pattern can be useful if you e.g. would like to add an additonal command
+This pattern can be useful if you e.g. would like to add an additional command
 to run before `builder.make()`, perhaps to install some extra dependencies.

--- a/docs/source/CartesianConfig.rst
+++ b/docs/source/CartesianConfig.rst
@@ -98,7 +98,7 @@ Named variants
 
 Named variants allow assigning a parseable name to a variant set.  This enables
 an entire variant set to be used for in filters_.  All output combinations will
-inherit the named varient key, along with the specific variant name.  For example::
+inherit the named variant key, along with the specific variant name.  For example::
 
    variants var1_name:
         - one:
@@ -951,7 +951,7 @@ the virtualization technology-specific directory.  For example, ``backends/qemu/
 | cfg/subtests.cfg            | Automatically generated based on the test       |
 |                             | modules and test configuration files found      |
 |                             | when the ``avocado vt-bootstrap`` is used.      |
-|                             | Modifications are discourraged since they will  |
+|                             | Modifications are discouraged since they will   |
 |                             | be lost next time bootstrap is used.            |
 +-----------------------------+-------------------------------------------------+
 | cfg/guest-os.cfg            | Automatically generated from                    |

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -22,7 +22,7 @@ Fedora and Enterprise Linux
 Installing Avocado-VT on Fedora or Enterprise Linux is a matter of
 installing the `avocado-plugins-vt` package. Install it with::
 
-  $ yum install avocado-plugins-vt
+    $ yum install avocado-plugins-vt
 
 .. _run_bootstrap:
 
@@ -32,32 +32,32 @@ Bootstrapping Avocado-VT
 After the package, a bootstrap process must be run. Choose your test backend
 (qemu, libvirt, v2v, openvswitch, etc) and run the `vt-bootstrap` command. Example::
 
-  $ avocado vt-bootstrap --vt-type qemu
+    $ avocado vt-bootstrap --vt-type qemu
 
 The output should be similar to::
 
-  12:02:10 INFO | qemu test config helper
-  12:02:10 INFO |
-  12:02:10 INFO | 1 - Updating all test providers
-  12:02:10 INFO |
-  12:02:10 INFO | 2 - Checking the mandatory programs and headers
-  12:02:10 INFO | /bin/7za OK
-  12:02:10 INFO | /sbin/tcpdump OK
-  ...
-  12:02:11 INFO | /usr/include/asm/unistd.h OK
-  12:02:11 INFO |
-  12:02:11 INFO | 3 - Checking the recommended programs
-  12:02:11 INFO | /bin/qemu-kvm OK
-  12:02:11 INFO | /bin/qemu-img OK
-  12:02:11 INFO | /bin/qemu-io OK
-  ...
-  12:02:33 INFO | 7 - Checking for modules kvm, kvm-intel
-  12:02:33 DEBUG| Module kvm loaded
-  12:02:33 DEBUG| Module kvm-intel loaded
-  12:02:33 INFO |
-  12:02:33 INFO | 8 - If you wish, you may take a look at the online docs for more info
-  12:02:33 INFO |
-  12:02:33 INFO | http://avocado-vt.readthedocs.org/
+    12:02:10 INFO | qemu test config helper
+    12:02:10 INFO |
+    12:02:10 INFO | 1 - Updating all test providers
+    12:02:10 INFO |
+    12:02:10 INFO | 2 - Checking the mandatory programs and headers
+    12:02:10 INFO | /bin/7za OK
+    12:02:10 INFO | /sbin/tcpdump OK
+    ...
+    12:02:11 INFO | /usr/include/asm/unistd.h OK
+    12:02:11 INFO |
+    12:02:11 INFO | 3 - Checking the recommended programs
+    12:02:11 INFO | /bin/qemu-kvm OK
+    12:02:11 INFO | /bin/qemu-img OK
+    12:02:11 INFO | /bin/qemu-io OK
+    ...
+    12:02:33 INFO | 7 - Checking for modules kvm, kvm-intel
+    12:02:33 DEBUG| Module kvm loaded
+    12:02:33 DEBUG| Module kvm-intel loaded
+    12:02:33 INFO |
+    12:02:33 INFO | 8 - If you wish, you may take a look at the online docs for more info
+    12:02:33 INFO |
+    12:02:33 INFO | http://avocado-vt.readthedocs.org/
 
 If there are missing requirements, please install them and re-run `vt-bootstrap`.
 
@@ -66,47 +66,47 @@ First steps with Avocado-VT
 
 Let's check if things went well by listing the Avocado plugins::
 
-  $ avocado plugins
+    $ avocado plugins
 
 That command should show the loaded plugins, and hopefully no errors. The relevant lines will be::
 
-  Plugins that add new commands (avocado.plugins.cli.cmd):
-  vt-bootstrap Avocado VT - implements the 'vt-bootstrap' subcommand
-  ...
-  Plugins that add new options to commands (avocado.plugins.cli):
-  vt      Avocado VT/virt-test support to 'run' command
-  vt-list Avocado-VT/virt-test support for 'list' command
+    Plugins that add new commands (avocado.plugins.cli.cmd):
+    vt-bootstrap Avocado VT - implements the 'vt-bootstrap' subcommand
+    ...
+    Plugins that add new options to commands (avocado.plugins.cli):
+    vt      Avocado VT/virt-test support to 'run' command
+    vt-list Avocado-VT/virt-test support for 'list' command
 
 Then let's list the tests available with::
 
-  $ avocado list --vt-type qemu --verbose
+    $ avocado list --vt-type qemu --verbose
 
 This should list a large amount of tests (over 1900 virt related tests)::
 
-  ACCESS_DENIED: 0
-  BROKEN_SYMLINK: 0
-  BUGGY: 0
-  INSTRUMENTED: 49
-  MISSING: 0
-  NOT_A_TEST: 27
-  SIMPLE: 3
-  VT: 1906
+    ACCESS_DENIED: 0
+    BROKEN_SYMLINK: 0
+    BUGGY: 0
+    INSTRUMENTED: 49
+    MISSING: 0
+    NOT_A_TEST: 27
+    SIMPLE: 3
+    VT: 1906
 
 Now let's run a virt test::
 
-  $ avocado run type_specific.io-github-autotest-qemu.migrate.default.tcp
-  JOB ID     : <id>
-  JOB LOG    : /home/<user>/avocado/job-results/job-2015-06-15T19.46-1c3da89/job.log
-  JOB HTML   : /home/<user>/avocado/job-results/job-2015-06-15T19.46-1c3da89/html/results.html
-  TESTS      : 1
-  (1/1) type_specific.io-github-autotest-qemu.migrate.default.tcp: PASS (95.76 s)
-  PASS       : 1
-  ERROR      : 0
-  FAIL       : 0
-  SKIP       : 0
-  WARN       : 0
-  INTERRUPT  : 0
-  TIME       : 95.76 s
+    $ avocado run type_specific.io-github-autotest-qemu.migrate.default.tcp
+    JOB ID     : <id>
+    JOB LOG    : /home/<user>/avocado/job-results/job-2015-06-15T19.46-1c3da89/job.log
+    JOB HTML   : /home/<user>/avocado/job-results/job-2015-06-15T19.46-1c3da89/html/results.html
+    TESTS      : 1
+    (1/1) type_specific.io-github-autotest-qemu.migrate.default.tcp: PASS (95.76 s)
+    PASS       : 1
+    ERROR      : 0
+    FAIL       : 0
+    SKIP       : 0
+    WARN       : 0
+    INTERRUPT  : 0
+    TIME       : 95.76 s
 
 If you have trouble executing the steps provided in this guide, you have a few
 options:

--- a/docs/source/GlusterFs.rst
+++ b/docs/source/GlusterFs.rst
@@ -48,7 +48,7 @@ Starting Gluster daemon
 
 ::
 
-    service glusterd start
+    $ service glusterd start
 
 
 Gluster volume creation
@@ -56,9 +56,9 @@ Gluster volume creation
 
 ::
 
-    gluster volume create [volume-name]  [hostname/host_ip]:/[brick_path]
+    $ gluster volume create [volume-name]  [hostname/host_ip]:/[brick_path]
 
-E:g: `gluster volume create test-vol satheesh.ibm.com://home/satheesh/images_gluster`
+E.g.: `gluster volume create test-vol satheesh.ibm.com://home/satheesh/images_gluster`
 
 
 Qemu Img creation
@@ -66,9 +66,9 @@ Qemu Img creation
 
 ::
 
-    qemu-img create gluster://[hostname]:0/[volume-name]/[image-name] [size]
+    $ qemu-img create gluster://[hostname]:0/[volume-name]/[image-name] [size]
 
-E:g: `qemu-img create gluster://satheesh.ibm.com:0/test-vol/test_gluster.img 10G`
+E.g.: `qemu-img create gluster://satheesh.ibm.com:0/test-vol/test_gluster.img 10G`
 
 
 Example of qemu cmd Line
@@ -76,4 +76,4 @@ Example of qemu cmd Line
 
 ::
 
-    qemu-system-x86_64 --enable-kvm -smp 4 -m 2048 -drive file=gluster://satheesh.ibm.com/test-vol/test_gluster.img,if=virtio -net nic,macaddr=52:54:00:09:0a:0b -net tap,script=/path/to/qemu-ifupVirsh
+    $ qemu-system-x86_64 --enable-kvm -smp 4 -m 2048 -drive file=gluster://satheesh.ibm.com/test-vol/test_gluster.img,if=virtio -net nic,macaddr=52:54:00:09:0a:0b -net tap,script=/path/to/qemu-ifupVirsh

--- a/docs/source/InstallOptionalPackages.rst
+++ b/docs/source/InstallOptionalPackages.rst
@@ -17,40 +17,40 @@ Install the following packages:
 
 ::
 
-   yum groupinstall "Development Tools"
+    $ yum groupinstall "Development Tools"
 
 #. Install tcpdump, necessary to determine guest IPs automatically
 
 ::
 
-   yum install tcpdump
+    $ yum install tcpdump
 
 #. Install nc, necessary to get output from the serial device and other
    qemu devices
 
 ::
 
-   yum install nmap-ncat
+    $ yum install nmap-ncat
 
 
 #. Install the p7zip file archiver so you can uncompress the JeOS [2] image.
 
 ::
 
-   yum install p7zip
+    $ yum install p7zip
 
 #. Install the autotest-framework package, to provide the needed autotest libs.
 
 ::
 
-   yum install --enablerepo=updates-testing autotest-framework
+    $ yum install --enablerepo=updates-testing autotest-framework
 
 #. Install the fakeroot package, if you want to install from the CD Ubuntu and
 Debian servers without requiring root:
 
 ::
 
-   yum install fakeroot
+    $ yum install fakeroot
 
 
 *If* you don't install the autotest-framework package (say, your distro still
@@ -61,7 +61,7 @@ following on their ~/.bashrc file:
 
 ::
 
-    export AUTOTEST_PATH="/path/to/autotest"
+    $ export AUTOTEST_PATH="/path/to/autotest"
 
 where this AUTOTEST_PATH will guide the run script to set up the needed
 libraries for all tests to work.
@@ -71,21 +71,22 @@ For other packages:
 
 ::
 
-     yum install git
+    $ yum install git
 
 So you can checkout the source code. If you want to test the distro provided
 qemu-kvm binary, you can install:
 
 ::
 
-     yum install qemu-kvm qemu-kvm-tools
+    $ yum install qemu-kvm qemu-kvm-tools
 
 
-To run libvirt tests, it's required to install the virt-install utility, for the basic purpose of building and cloning virtual machines.
+To run libvirt tests, it's required to install the virt-install utility, for
+the basic purpose of building and cloning virtual machines.
 
 ::
 
-     yum install virt-install
+    $ yum install virt-install
 
 To run all tests that involve filedescriptor passing, you need python-devel.
 The reason is, this test suite is compatible with python 2.4, whereas a
@@ -94,14 +95,14 @@ we had to introduce a C python extension that is compiled on demand.
 
 ::
 
-    yum install python-devel.
+    $ yum install python-devel
 
 
 It's useful to also install:
 
 ::
 
-     yum install python-imaging
+    $ yum install python-imaging
 
 Not vital, but very handy to do imaging conversion from ppm to jpeg and
 png (allows for smaller images).
@@ -116,13 +117,13 @@ create floppies and isos to hold kickstart files:
 
 ::
 
-     yum install mkisofs
+    $ yum install mkisofs
 
 For newer distros, such as Fedora, you'll need:
 
 ::
 
-     yum install genisoimage
+    $ yum install genisoimage
 
 Both packages provide the same functionality, needed to create iso
 images that will be used during the guest installation process. You can
@@ -140,19 +141,19 @@ bridges eventually:
 
 ::
 
-    yum install libvirt bridge-utils
+    $ yum install libvirt bridge-utils
 
 Make sure libvirtd is started:
 
 ::
 
-    [lmr@freedom autotest.lmr]$ service libvirtd start
+    $ service libvirtd start
 
 Make sure the libvirt bridge shows up on the output of brctl show:
 
 ::
 
-    [lmr@freedom autotest.lmr]$ brctl show
+    $ brctl show
     bridge name bridge id       STP enabled interfaces
     virbr0      8000.525400678eec   yes     virbr0-nic
 
@@ -168,14 +169,14 @@ and you can add the repos on your system putting the following on /etc/apt/sourc
 
 ::
 
-   deb http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
-   deb-src http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
+    $ deb http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
+    $ deb-src http://ppa.launchpad.net/lmr/autotest/ubuntu raring main
 
 Then update your software list:
 
 ::
 
-   apt-get update
+    $ apt-get update
 
 This has been tested with Ubuntu 12.04, 12.10 and 13.04.
 
@@ -186,42 +187,42 @@ Install the following packages:
 
 ::
 
-   apt-get install autotest
+    $ apt-get install autotest
 
 
 #. Install the p7zip file archiver so you can uncompress the JeOS [2] image.
 
 ::
 
-   apt-get install p7zip-full
+    $ apt-get install p7zip-full
 
 
 #. Install tcpdump, necessary to determine guest IPs automatically
 
 ::
 
-   apt-get install tcpdump
+    $ apt-get install tcpdump
 
 #. Install nc, necessary to get output from the serial device and other
    qemu devices
 
 ::
 
-   apt-get install netcat-openbsd
+    $ apt-get install netcat-openbsd
 
 
 #. Install a toolchain in your host, which you can do on Debian and Ubuntu with:
 
 ::
 
-   apt-get install build-essential
+    $ apt-get install build-essential
 
 #. Install fakeroot if you want to install from CD debian and ubuntu, not
 requiring root:
 
 ::
 
-   apt-get install fakeroot
+    $ apt-get install fakeroot
 
 So you install the core autotest libraries to run the tests.
 
@@ -233,7 +234,7 @@ following on their ~/.bashrc file:
 
 ::
 
-    export AUTOTEST_PATH="/path/to/autotest"
+    $ export AUTOTEST_PATH="/path/to/autotest"
 
 where this AUTOTEST_PATH will guide the run script to set up the needed
 libraries for all tests to work.
@@ -243,20 +244,20 @@ For other packages:
 
 ::
 
-     apt-get install git
+    $ apt-get install git
 
 So you can checkout the source code. If you want to test the distro provided
 qemu-kvm binary, you can install:
 
 ::
 
-     apt-get install qemu-kvm qemu-utils
+    $ apt-get install qemu-kvm qemu-utils
 
 To run libvirt tests, it's required to install the virt-install utility, for the basic purpose of building and cloning virtual machines.
 
 ::
 
-     apt-get install virtinst
+    $ apt-get install virtinst
 
 To run all tests that involve filedescriptor passing, you need python-all-dev.
 The reason is, this test suite is compatible with python 2.4, whereas a
@@ -265,14 +266,14 @@ we had to introduce a C python extension that is compiled on demand.
 
 ::
 
-    apt-get install python-all-dev.
+    $ apt-get install python-all-dev.
 
 
 It's useful to also install:
 
 ::
 
-     apt-get install python-imaging
+    $ apt-get install python-imaging
 
 Not vital, but very handy to do imaging conversion from ppm to jpeg and
 png (allows for smaller images).
@@ -287,7 +288,7 @@ create floppies and isos to hold kickstart files:
 
 ::
 
-     apt-get install genisoimage
+    $ apt-get install genisoimage
 
 
 Network tests
@@ -301,7 +302,7 @@ bridges eventually:
 
 ::
 
-    apt-get install libvirt-bin python-libvirt bridge-utils
+    $ apt-get install libvirt-bin python-libvirt bridge-utils
 
 Make sure libvirtd is started:
 

--- a/docs/source/InstallWinVirtio.rst
+++ b/docs/source/InstallWinVirtio.rst
@@ -92,7 +92,7 @@ SHA1 sum of it matches.
 #. Git clone autotest to a convenient location, say $HOME/Code/autotest.
    See :doc:`the download source documentation <../contributing/DownloadSource>`
    Please do use git and clone the repo to the location mentioned.
-#. Execute the ``get_started.py`` script (see the get started documentation <../basic/GetStarted>`.
+#. Execute the ``get_started.py`` script (see the `get started documentation <../basic/GetStarted>`.
    It will create the
    directories where we expect the cd files to be available. You don't
    need to download the Fedora 14 DVD, but you do need to download the
@@ -169,7 +169,7 @@ SHA1 sum of it matches.
 
    ::
 
-       $HOME/Code/autotest/client/bin/autotest $HOME/Code/autotest/client/tests/kvm/control
+       $ $HOME/Code/autotest/client/bin/autotest $HOME/Code/autotest/client/tests/kvm/control
 
 #. Profit! You automated install of Windows 7 with the virtio drivers
    will be carried out.

--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -36,10 +36,10 @@ Intel), and Intel 32 and 64 bit guest operating systems.
 About virt-test
 ---------------
 
-Virt-test is the the project that became Avocado-VT. It used to live under
+Virt-test is the project that became Avocado-VT. It used to live under
 the Autotest umbrella, under:
 
 http://github.com/autotest/virt-test
 
 That repository is now frozen and only available at that location for
-historical purporses.
+historical purposes.

--- a/docs/source/ListingGuests.rst
+++ b/docs/source/ListingGuests.rst
@@ -6,7 +6,7 @@ If you want to see all guests defined, you can use
 
 ::
 
-    avocado list -vt-type [test type] --list-guests
+    $ avocado list -vt-type [test type] --list-guests
 
 
 This will generate a list of possible guests that can be used for tests,
@@ -19,7 +19,7 @@ installed Fedora 17, 64 bits, and that --list-guests shows it as downloaded
 
 ::
 
-    avocado list --vt-type qemu --vt-list-guests
+    $ avocado list --vt-type qemu --vt-list-guests
     ...
     Linux.CentOS.6.6.i386.i440fx (missing centos66-32.qcow2)
     Linux.CentOS.6.6.x86_64.i440fx (missing centos66-64.qcow2)
@@ -30,7 +30,7 @@ only for informational purposes:
 
 ::
 
-    avocado list --vt-type qemu --vt-guest-os Linux.CentOS.6.6.i386.i440fx --verbose
+    $ avocado list --vt-type qemu --vt-guest-os Linux.CentOS.6.6.i386.i440fx --verbose
     ...
     VT           io-github-autotest-qemu.trans_hugepage.base
     VT           io-github-autotest-qemu.trans_hugepage.defrag
@@ -58,6 +58,6 @@ individual test you want and run it:
 
 ::
 
-    avocado run balloon_check --vt-type qemu --vt-guest-os Fedora.21
+    $ avocado run balloon_check --vt-type qemu --vt-guest-os Fedora.21
 
 And it'll run that particular test.

--- a/docs/source/MultiHostMigration.rst
+++ b/docs/source/MultiHostMigration.rst
@@ -137,7 +137,9 @@ Now, edit the file::
 
 In there, you have to change the EXTRA_PARAMS to restrict the number of guests
 you want to run the tests on. On this example, we're going to restrict our tests
-to RHEL 6.4. The particular section of the control file should look like::
+to RHEL 6.4. The particular section of the control file should look like:
+
+.. code-block:: python
 
     EXTRA_PARAMS = """
     only RHEL.6.4.x86_64
@@ -147,7 +149,7 @@ It is important to stress that the guests must be installed for this to work
 smoothly. Then the last step would be to run the tests. Using the same convention
 for the machine hostnames, here's the command you should use::
 
-    server/autotest-remote -m host1.foo.com,host2.foo.com server/tests/multihost_migration/control.srv
+    $ server/autotest-remote -m host1.foo.com,host2.foo.com server/tests/multihost_migration/control.srv
 
 Now, you'll see a boatload of output from the autotest remote output. This is
 normal, and you should be patient until all the tests are done.
@@ -169,7 +171,7 @@ Scheme:
 Example:
 ~~~~~~~~
 
-::
+.. code-block:: python
 
     class TestMultihostMigration(virt_utils.MultihostMigration):
         def __init__(self, test, params, env):
@@ -217,9 +219,9 @@ Example:
 
 When you call:
 
-::
+.. code-block:: python
 
-    mig = TestMultihostMigration(test, params, env):
+    mig = TestMultihostMigration(test, params, env)
 
 What happens is
 
@@ -229,9 +231,9 @@ What happens is
 
 When you call the method:
 
-::
+.. code-block:: python
 
-    migrate():
+    migrate()
 
 What happens in a diagram is:
 
@@ -252,7 +254,7 @@ What happens in a diagram is:
 It's important to note that the migrations are made using the ``tcp`` protocol,
 since the others don't support multi host migration.
 
-::
+.. code-block:: python
 
     def migrate_vms_src(self, mig_data):
         vm = mig_data.vms[0]

--- a/docs/source/Networking.rst
+++ b/docs/source/Networking.rst
@@ -12,9 +12,9 @@ bridge: Execute the command
 
 ::
 
-   echo "-I FORWARD -m physdev --physdev-is-bridged -j ACCEPT" > /etc/sysconfig/iptables-forward-bridged
-   lokkit --custom-rules=ipv4:filter:/etc/sysconfig/iptables-forward-bridged
-   service libvirtd reload
+   $ echo "-I FORWARD -m physdev --physdev-is-bridged -j ACCEPT" > /etc/sysconfig/iptables-forward-bridged
+   $ lokkit --custom-rules=ipv4:filter:/etc/sysconfig/iptables-forward-bridged
+   $ service libvirtd reload
 
 
 Configure Static IP address in Avocado-VT
@@ -22,16 +22,16 @@ Configure Static IP address in Avocado-VT
 
 Sometimes, we need to test with guest(s) which have static ip address(es).
 
-- eg. No real/emulated DHCP server in test environment.
-- eg. Test with old image we don't want to change the net config.
-- eg. Test when DHCP exists problem.
+- e.g. No real/emulated DHCP server in test environment.
+- e.g. Test with old image we don't want to change the net config.
+- e.g. Test when DHCP exists problem.
 
 Create a bridge (for example, 'vbr') in host, configure its ip to 192.168.100.1, guest
 can access host by it. And assign nic(s)' ip in tests.cfg, and execute test as usual.
 
 tests.cfg:
 
-::
+.. code-block:: cfg
 
      ip_nic1 = 192.168.100.119
      nic_mac_nic1 = 11:22:33:44:55:67
@@ -67,46 +67,46 @@ You can create the directory, go to it:
 
 ::
 
-    mkdir -p /home/kermit/Downloads
-    cd /home/kermit/Downloads
+    $ mkdir -p /home/kermit/Downloads
+    $ cd /home/kermit/Downloads
 
 Download the iso, create 2 directories, 1 for the mount, another for the
 contents:
 
 ::
 
-    wget http://people.redhat.com/mrodrigu/kvm/winutils.iso
-    mkdir original
-    sudo mount -o loop winutils.iso original
-    mkdir winutils
+    $ wget http://people.redhat.com/mrodrigu/kvm/winutils.iso
+    $ mkdir original
+    $ sudo mount -o loop winutils.iso original
+    $ mkdir winutils
 
 Copy all contents from the original cd to the new structure:
 
 ::
 
-    cp -r original/* winutils/
+    $ cp -r original/* winutils/
 
 Create the destination nttcp directory on that new structure:
 
 ::
 
-    mkdir -p winutils/NTttcp
+    $ mkdir -p winutils/NTttcp
 
-Download the installer and copy autoit script to the new structure, unmount the orginal mount:
+Download the installer and copy autoit script to the new structure, unmount the original mount:
 
 ::
 
-    cd winutils/NTttcp
-    wget http://download.microsoft.com/download/f/1/e/f1e1ac7f-e632-48ea-83ac-56b016318735/NT%20Testing%20TCP%20Tool.msi -O "winutils/NTttcp/NT Testing TCP Tool.msi"
-    cp /usr/local/autotest/client/virt/scripts/ntttcp.au3 ./
-    sudo umount original
+    $ cd winutils/NTttcp
+    $ wget http://download.microsoft.com/download/f/1/e/f1e1ac7f-e632-48ea-83ac-56b016318735/NT%20Testing%20TCP%20Tool.msi -O "winutils/NTttcp/NT Testing TCP Tool.msi"
+    $ cp /usr/local/autotest/client/virt/scripts/ntttcp.au3 ./
+    $ sudo umount original
 
 Backup the old winutils.iso and create a new winutils.iso using mkisofs:
 
 ::
 
-    sudo mv winutils.iso winutils.iso.bak
-    mkisofs -o winutils.iso -max-iso9660-filenames -relaxed-filenames -D --input-charset iso8859-1 winutils
+    $ sudo mv winutils.iso winutils.iso.bak
+    $ mkisofs -o winutils.iso -max-iso9660-filenames -relaxed-filenames -D --input-charset iso8859-1 winutils
 
 And that is it. Don't forget to keep winutils in an appropriate location that
 can be seen by Avocado-VT.

--- a/docs/source/PerformanceTesting.rst
+++ b/docs/source/PerformanceTesting.rst
@@ -31,41 +31,43 @@ Autotest supports to numa pining. Assign "numanode=-1" in tests.cfg, then vcpu t
 
 ::
 
-  memory: numactl -m $n $cmdline
-  cpu: taskset $node_mask $thread_id
+  memory:
+  $ numactl -m $n $cmdline
+  cpu:
+  $ taskset $node_mask $thread_id
 
 The following content is manual guide.
 
 ::
 
   1.First level pinning would be to use numa pinning when starting the guest.
-  e.g  numactl -c 1 -m 1 qemu-kvm  -smp 2 -m 4G <> (pinning guest memory and cpus to numa-node 1)
+  e.g.  $ numactl -c 1 -m 1 qemu-kvm  -smp 2 -m 4G <> (pinning guest memory and cpus to numa-node 1)
 
   2.For a single instance test, it would suggest trying a one to one mapping of vcpu to pyhsical core.
-  e.g
+  e.g.
   get guest vcpu threads id
-  #taskset -p 40 $vcpus1  (pinning vcpu1 thread to pyshical cpu #6 )
-  #taskset -p 80 $vcpus2  (pinning vcpu2 thread to physical cpu #7 )
+  $ taskset -p 40 $vcpus1  #(pinning vcpu1 thread to pyshical cpu #6 )
+  $ taskset -p 80 $vcpus2  #(pinning vcpu2 thread to physical cpu #7 )
 
   3.To pin vhost on host. get vhost PID and then use taskset to pin it on the same soket.
   e.g
-  taskset -p 20 $vhost (pinning vcpu2 thread to physical cpu #5 )
+  $ taskset -p 20 $vhost #(pinning vcpu2 thread to physical cpu #5 )
 
   4.In guest,pin the IRQ to one core and the netperf to another.
-  1) make sure irqbalance is off - `service irqbalance stop`
-  2) find the interrupts - `cat /proc/interrupts`
-  3) find the affinity mask for the interrupt(s) - `cat /proc/irq/<irq#>/smp_affinity`
+  1) make sure irqbalance is off - `$ service irqbalance stop`
+  2) find the interrupts - `$ cat /proc/interrupts`
+  3) find the affinity mask for the interrupt(s) - `$ cat /proc/irq/<irq#>/smp_affinity`
   4) change the value to match the proper core.make sure the vlaue is cpu mask.
-  e.g pin the IRQ to first core.
-     echo 01>/proc/irq/$virti0-input/smp_affinity
-     echo 01>/proc/irq/$virti0-output/smp_affinity
+  e.g. pin the IRQ to first core.
+     $ echo 01>/proc/irq/$virti0-input/smp_affinity
+     $ echo 01>/proc/irq/$virti0-output/smp_affinity
   5)pin the netserver to another core.
-  e.g
-  taskset -p 02 netserver
+  e.g.
+  $ taskset -p 02 netserver
 
   5.For host to guest scenario. to get maximum performance. make sure to run netperf on different cores on the same numa node as the guest.
-  e.g
-  numactl  -m 1 netperf -T 4 (pinning netperf to physical cpu #4)
+  e.g.
+  $ numactl -m 1 netperf -T 4 (pinning netperf to physical cpu #4)
 
 Execute testing
 ===============
@@ -95,8 +97,8 @@ Result files:
 
 ::
 
-  # cd /usr/local/autotest/results/8-debug_user/192.168.122.1/
-  # find .|grep RHS
+  $ cd /usr/local/autotest/results/8-debug_user/192.168.122.1/
+  $ find .|grep RHS
   kvm.repeat1.r61.virtio_blk.smp2.virtio_net.RHEL.6.1.x86_64.netperf.exhost_guest/results/netperf-result.RHS
   kvm.repeat2.r61.virtio_blk.smp2.virtio_net.RHEL.6.1.x86_64.netperf.exhost_guest/results/netperf-result.RHS
   kvm.repeat3.r61.virtio_blk.smp2.virtio_net.RHEL.6.1.x86_64.netperf.exhost_guest/results/netperf-result.RHS
@@ -107,8 +109,8 @@ Result files:
 
 ::
 
-  # cd /usr/local/autotest/results/9-debug_user/192.168.122.1/
-  # find .|grep RHS
+  $ cd /usr/local/autotest/results/9-debug_user/192.168.122.1/
+  $ find .|grep RHS
   kvm.repeat1.r61.virtio_blk.smp2.virtio_net.RHEL.6.1.x86_64.netperf.exhost_guest/results/netperf-result.RHS
   kvm.repeat2.r61.virtio_blk.smp2.virtio_net.RHEL.6.1.x86_64.netperf.exhost_guest/results/netperf-result.RHS
   kvm.repeat3.r61.virtio_blk.smp2.virtio_net.RHEL.6.1.x86_64.netperf.exhost_guest/results/netperf-result.RHS
@@ -118,7 +120,7 @@ Analysis result
 
 Config file: perf.conf
 
-::
+.. code-block:: cfg
 
   [ntttcp]
   result_file_pattern = .*.RHS
@@ -138,8 +140,8 @@ Execute regression.py to compare two results:
 ::
 
   login autotest server
-  # cd /usr/local/autotest/client/tools
-  # python regression.py netperf /usr/local/autotest/results/8-debug_user/192.168.122.1/ /usr/local/autotest/results/9-debug_user/192.168.122.1/
+  $ cd /usr/local/autotest/client/tools
+  $ python regression.py netperf /usr/local/autotest/results/8-debug_user/192.168.122.1/ /usr/local/autotest/results/9-debug_user/192.168.122.1/
 
 T-test:
 

--- a/docs/source/RegressionTestFarm.rst
+++ b/docs/source/RegressionTestFarm.rst
@@ -70,7 +70,7 @@ You'll follow the procedure described on
 
 https://github.com/autotest/autotest/wiki/AutotestServerInstallRedHat
 
-for Red Hat derivatives (such as Fedora and RHEL), and 
+for Red Hat derivatives (such as Fedora and RHEL), and
 
 https://github.com/autotest/autotest/wiki/AutotestServerInstall
 
@@ -109,13 +109,13 @@ Logged as the autotest user:
 ::
 
     $ /usr/local/autotest/cli/autotest-rpc-client label create -t amd64
-    Created label: 
+    Created label:
         'amd64'
     $ /usr/local/autotest/cli/autotest-rpc-client label create -t intel64
-    Created label: 
+    Created label:
         'intel64'
     $ /usr/local/autotest/cli/autotest-rpc-client label create hostprovisioning
-    Created label: 
+    Created label:
         'hostprovisioning'
 
 Then I'd create each machine with the appropriate labels
@@ -123,11 +123,11 @@ Then I'd create each machine with the appropriate labels
 ::
 
     $ /usr/local/autotest/cli/autotest-rpc-client host create -t amd64 -b hostprovisioning foo-amd.bazcorp.com
-    Added host: 
+    Added host:
         foo-amd.bazcorp.com
 
     $ /usr/local/autotest/cli/autotest-rpc-client host create -t amd64 -b hostprovisioning foo-intel.bazcorp.com
-    Added host: 
+    Added host:
         foo-amd.bazcorp.com
 
 
@@ -139,7 +139,7 @@ additional information for the virt jobs:
 
 ::
 
-    cp /usr/local/autotest/contrib/virt/site_job.py /usr/local/autotest/cli/
+    $ cp /usr/local/autotest/contrib/virt/site_job.py /usr/local/autotest/cli/
 
 This should be enough to enable all the extra functionality.
 
@@ -148,7 +148,7 @@ to the qemu config module:
 
 ::
 
-    cp /usr/local/autotest/contrib/virt/site-config.cfg /usr/local/autotest/client/tests/virt/qemu/cfg
+    $ cp /usr/local/autotest/contrib/virt/site-config.cfg /usr/local/autotest/client/tests/virt/qemu/cfg
 
 Be aware that you *need* to read this file well, and later, configure it to your
 testing needs. We specially stress that you might want to create private git
@@ -341,7 +341,7 @@ the autotest user, and use the command:
 
 ::
 
-    /usr/local/autotest/cli/autotest-rpc-client job create -B never -a never -s -e autotest-virt-jobs@foocorp.com -f "/usr/local/autotest/contrib/virt/control.template" -T --timestamp -m '1*hostprovisioning' -x 'only f18..sanity' "Fedora 18 koji sanity"
+    $ /usr/local/autotest/cli/autotest-rpc-client job create -B never -a never -s -e autotest-virt-jobs@foocorp.com -f "/usr/local/autotest/contrib/virt/control.template" -T --timestamp -m '1*hostprovisioning' -x 'only f18..sanity' "Fedora 18 koji sanity"
 
 As you might have guessed, this will schedule a Fedora 18 sanity job. So go
 through it and fix things step by step. If anything, you can take a look at

--- a/docs/source/RunQemuUnittests.rst
+++ b/docs/source/RunQemuUnittests.rst
@@ -132,7 +132,7 @@ Step by step procedure
 
    ::
 
-       $HOME/Code/autotest/client/bin/autotest $HOME/Code/autotest/client/tests/kvm/control.unittests
+       $ $HOME/Code/autotest/client/bin/autotest $HOME/Code/autotest/client/tests/kvm/control.unittests
 
 #. The output of a typical unittest execution looks like. Notice that
    autotest informs you where the logs of each individual unittests are

--- a/docs/source/VirtualEnvMultihost.rst
+++ b/docs/source/VirtualEnvMultihost.rst
@@ -23,7 +23,7 @@ Nested Virtualization:
 1. Emulated:
     * qemu very slow
 
-2. hardware accelerated:
+2. Hardware accelerated:
     * Hardware for the accelerated nested virtualization
       AMD Phenom and never            core extension (smv, NPT)
       Intel Nehalem and never         core extension (vmx, EPT)
@@ -79,14 +79,14 @@ Connect to host bridge with guest L0 bridge without DHCP (dhcp collision with ho
 ::
 
         # interface connected to host system bridge
-        vi /etc/sysconfig/network-scripts/ifcfg-eth0
+        $ vi /etc/sysconfig/network-scripts/ifcfg-eth0
              NM_CONTROLLED="no"
              DEVICE="eth0"
              ONBOOT="yes"
              BRIDGE=virbr0
 
         # Bridge has name virbr0 for compatibility with standard autotest settings.
-        vi /etc/sysconfig/network-scripts/ifcfg-virbr0
+        $ vi /etc/sysconfig/network-scripts/ifcfg-virbr0
             DHCP_HOSTNAME="atest-guest"
             NM_CONTROLLED="no"
             BOOTPROTO="dhcp"
@@ -111,8 +111,8 @@ Manually from host machine
 
 ::
 
-    cd autotest/client/tests/virt/qemu/
-    sudo rm -rf results.*; sudo ../../../../server/autoserv -m guestL0_1,guestL0_2 multi_host.srv
+    $ cd autotest/client/tests/virt/qemu/
+    $ sudo rm -rf results.*; sudo ../../../../server/autoserv -m guestL0_1,guestL0_2 multi_host.srv
 
 More details:
 -------------

--- a/docs/source/WritingTests/DefiningNewGuests.rst
+++ b/docs/source/WritingTests/DefiningNewGuests.rst
@@ -28,7 +28,7 @@ Which would make it possible to specify this custom guest using
 
 ::
 
-    avocado run migrate..tcp --vt-type qemu --vt-guest-os LinuxCustom.FooLinux
+    $ avocado run migrate..tcp --vt-type qemu --vt-guest-os LinuxCustom.FooLinux
     JOB ID     : 44a399b427c51530ba2fcc37087c100917e1dd8a
     JOB LOG    : /home/lmr/avocado/job-results/job-2015-07-29T03.47-44a399b/job.log
     JOB HTML   : /home/lmr/avocado/job-results/job-2015-07-29T03.47-44a399b/html/results.html
@@ -42,9 +42,9 @@ Which would make it possible to specify this custom guest using
 Provided that you have a file called images/foo-linux.qcow2, if using the
 qcow2 format image.
 
-Other useful params to set (not an exaustive list):
+Other useful params to set (not an exhaustive list):
 
-::
+.. code-block:: cfg
 
     # shell_prompt is a regexp used to match the prompt on aexpect.
     # if your custom os is based of some distro listed in the guest-os
@@ -86,13 +86,13 @@ Which would make it possible to specify this custom guest using
 
 ::
 
-    avocado run migrate..tcp --vt-type qemu --vt-guest-os WindowsCustom.FooWindows
+    $ avocado run migrate..tcp --vt-type qemu --vt-guest-os WindowsCustom.FooWindows
 
 Provided that you have a file called images/foo-windows.qcow2.
 
 Other useful params to set (not an exaustive list):
 
-::
+.. code-block:: cfg
 
     # If you plan to use a raw device, set image_device = yes
     image_raw_device = yes

--- a/docs/source/WritingTests/WritingSimpleTests.rst
+++ b/docs/source/WritingTests/WritingSimpleTests.rst
@@ -19,16 +19,18 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
     $ git clone https://github.com/autotest/tp-qemu.git
 
 #. Our uptime test won't need any qemu specific feature. Thinking about
-   it, we only need a vm object and stablish an ssh session to it, so we
+   it, we only need a vm object and establish an ssh session to it, so we
    can run the command. So we can store our brand new test under
    ``tests``. At the autotest root location::
 
     $ touch generic/tests/uptime.py
     $ git add generic/tests/uptime.py
 
-#. Ok, so that's a start. So, we have *at least* to implement a
+#. OK, so that's a start. So, we have *at least* to implement a
    function ``run_uptime``. Let's start with it and just put the keyword
-   pass, which is a no op. Our test will be like::
+   pass, which is a no op. Our test will be like:
+
+.. code-block:: python
 
        def run(test, params, env):
            """
@@ -41,7 +43,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
    name stored in our environment. Some of them have aliases. ``main_vm``
    contains the name of the main vm present in the environment, which
    is, most of the time, ``vm1``. ``env.get_vm`` returns a vm object, which
-   we'll store on the variable vm. It'll be like this::
+   we'll store on the variable vm. It'll be like this:
+
+.. code-block:: python
 
        def run(test, params, env):
            """
@@ -58,7 +62,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
    of these conditions are not satisfied due to any problem, an
    exception will be thrown and the test will fail. This requirement is
    because sometimes due to a bug the vm process might be dead on the
-   water, or the monitors are not responding::
+   water, or the monitors are not responding:
+
+.. code-block:: python
 
        def run(test, params, env):
            """
@@ -67,7 +73,7 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
            vm = env.get_vm(params["main_vm"])
            vm.verify_alive()
 
-#. Next step, we want to log into the vm. the vm method that does return
+#. Next step, we want to log into the vm. The vm method that does return
    a remote session object is called ``wait_for_login()``, and as one of
    the parameters, it allows you to adjust the timeout, that is, the
    time we want to wait to see if we can grab an ssh prompt. We have top
@@ -77,7 +83,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
    variable will affect all tests. Note that it is completely OK to just
    override this value, or pass nothing to ``wait_for_login()``, since
    this method does have a default timeout value. Back to business,
-   picking up login timeout from our dict of parameters::
+   picking up login timeout from our dict of parameters:
+
+.. code-block:: python
 
        def run(test, params, env):
            """
@@ -89,7 +97,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
 
 
 #. Now we'll call ``wait_for_login()`` and pass the timeout to it,
-   storing the resulting session object on a variable named session::
+   storing the resulting session object on a variable named session:
+
+.. code-block:: python
 
        def run(test, params, env):
            """
@@ -106,12 +116,14 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
    Assuming that things went well, now you have a session object, that
    allows you to type in commands on your guest and retrieve the
    outputs. So most of the time, we can get the output of these commands
-   throught the method ``cmd()``. It will type in the command, grab the
+   through the method ``cmd()``. It will type in the command, grab the
    stdin and stdout, return them so you can store it in a variable, and
    if the exit code of the command is != 0, it'll throw a
    aexpect.ShellError?. So getting the output of the unix command uptime
    is as simple as calling ``cmd()`` with 'uptime' as a parameter and
-   storing the result in a variable called uptime::
+   storing the result in a variable called uptime:
+
+.. code-block:: python
 
        def run(test, params, env):
            """
@@ -132,7 +144,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
    went from its beginning to its end without unhandled exceptions,
    autotest assumes the test automatically as PASSed, *no need to mark a
    test as explicitly passed*. If you have explicit points of failure,
-   for more complex tests, you might want to add some exception raising::
+   for more complex tests, you might want to add some exception raising:
+
+.. code-block:: python
 
        def run(test, params, env):
            """
@@ -153,7 +167,7 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
    inspektor by adding the COPR repo https://copr.fedoraproject.org/coprs/lmr/Autotest/
    and doing ::
 
-    yum install inspektor
+    $ yum install inspektor
 
    After you're done, you can run it::
 
@@ -166,7 +180,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
 #. Ouch. So there's this undefined variable called logging on line 10 of
    the code. It's because I forgot to import the logging library, which
    is a python library to handle info, debug, warning messages. Let's Fix it
-   and the code becomes::
+   and the code becomes:
+
+.. code-block:: python
 
        import logging
 
@@ -198,14 +214,16 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
 #. Now, you can test your code. When listing the qemu tests your new test should
    appear in the list::
 
-        avocado list uptime
+        $ avocado list uptime
 
 #. Now, you can run your test to see if everything went well::
 
         $ avocado run --vt-type uptime
 
-#. Ok, so now, we have something that can be git committed and sent to
-   the mailing list::
+#. OK, so now, we have something that can be git committed and sent to
+   the mailing list:
+
+.. code-block:: diff
 
         diff --git a/generic/tests/uptime.py b/generic/tests/uptime.py
         index e69de29..65d46fa 100644
@@ -226,7 +244,9 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
         +    logging.info("Guest uptime result is: %s", uptime)
         +    session.close()
 
-#. Oh, we forgot to add a decent docstring description. So doing it::
+#. Oh, we forgot to add a decent docstring description. So doing it:
+
+.. code-block:: python
 
        import logging
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,3 +83,4 @@ intersphinx_mapping = {'http://docs.python.org/': None,
                        'http://avocado-framework.readthedocs.org/en/latest/': None}
 
 autoclass_content = 'both'
+highlight_language = 'none'


### PR DESCRIPTION
The default Sphinx highlighting language is python is not explicitly
specified.

When using next-version Sphinx (>=1.4a) to build docs with non-python
snippets without highlighting language specified will cause a warning
message:

```
WARNING: Could not lex literal_block as "python3". Highlighting skipped.
```

This fix change default highlighting language to `none` and explicitly
specify highlighting languages each snippets pygments supported.

This fix also fixed several typos.

Signed-off-by: Hao Liu <hliu@redhat.com>