### PR TITLE
qemu_vm.py: removing unnecessary 'boot_drive' param checking.

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1520,8 +1520,6 @@ class VM(virt_vm.BaseVM):
                     if self.last_boot_index > 0:
                         image_boot = False
                     self.last_boot_index += 1
-            if image_params.get("boot_drive") == "no":
-                continue
             devs = devices.images_define_by_params(image_name, image_params,
                                                    'disk', index, image_boot,
                                                    image_bootindex)


### PR DESCRIPTION
There is a duplicate entry to check if the parameter 'boot_drive' has the
value 'no'. One is at the beginning and the other is at the end. There is no
function or line of code that changes this value to do another comparasion.

image_params = params.object_params(image_name)
if image_params.get("boot_drive") == "no":
    continue
if params.get("index_enable") == "yes":
    drive_index = image_params.get("drive_index")
[...]
else:
    if image_boot in ['yes', 'on', True]:
        if self.last_boot_index > 0:
            image_boot = False
        self.last_boot_index += 1
if image_params.get("boot_drive") == "no":
    continue

Removing the second IF to iterate to the next loop if 'boot_drive' is present.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>