### PR TITLE
add vt_config check for mem assign

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -388,7 +388,8 @@ class VirtTestOptionsProcess(object):
                                              "yes")
 
     def _process_mem(self):
-        self.cartesian_parser.assign("mem", self.options.vt_mem)
+        if not self.options.vt_config:
+            self.cartesian_parser.assign("mem", self.options.vt_mem)
 
     def _process_tcpdump(self):
         """


### PR DESCRIPTION
the mem set in test_examples doesn't work, 
/usr/bin/avocado run --vt-config ...

always read from vt.conf currently

ID: 1313650