### PR TITLE
nfs utils_misc: Fix ssh connection timeout

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -240,7 +240,8 @@ class NFSClient(object):
     def __init__(self, params):
         # Setup SSH connection
         self.ssh_obj = SSHConnection(params)
-        self.ssh_obj.conn_setup()
+        ssh_timeout = int(params.get("ssh_timeout", 10))
+        self.ssh_obj.conn_setup(timeout=ssh_timeout)
 
         self.mkdir_mount_remote = False
         self.mount_dir = params.get("nfs_mount_dir")

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3546,7 +3546,8 @@ class SELinuxBoolean(object):
         # Setup SSH connection
         from utils_conn import SSHConnection
         self.ssh_obj = SSHConnection(params)
-        self.ssh_obj.conn_setup()
+        ssh_timeout = int(params.get("ssh_timeout", 10))
+        self.ssh_obj.conn_setup(timeout=ssh_timeout)
 
         self.cleanup_local = True
         self.cleanup_remote = True


### PR DESCRIPTION
Default timeout 10 seconds is short for NFSClient and SELinuxBoolean to
create SSH connection sometimes. So new implementation will use
'ssh_timeout' to set a timeout if any.

Signed-off-by: Dan Zheng <dzheng@redhat.com>