### PR TITLE
Fixed pin cpu failed.

### DIFF
--- a/selftests/unit/test_utils_misc.py
+++ b/selftests/unit/test_utils_misc.py
@@ -120,14 +120,14 @@ node   0
 1236
 1237
 """},
-            {"cmd": "taskset -p 0x1 1230", "stdout": ""},
-            {"cmd": "taskset -p 0x2 1231", "stdout": ""},
-            {"cmd": "taskset -p 0x4 1232", "stdout": ""},
-            {"cmd": "taskset -p 0x8 1233", "stdout": ""},
-            {"cmd": "taskset -p 0x10 1234", "stdout": ""},
-            {"cmd": "taskset -p 0x20 1235", "stdout": ""},
-            {"cmd": "taskset -p 0x40 1236", "stdout": ""},
-            {"cmd": "taskset -p 0x80 1237", "stdout": ""},
+            {"cmd": "taskset -cp 0 1230", "stdout": ""},
+            {"cmd": "taskset -cp 1 1231", "stdout": ""},
+            {"cmd": "taskset -cp 2 1232", "stdout": ""},
+            {"cmd": "taskset -cp 3 1233", "stdout": ""},
+            {"cmd": "taskset -cp 4 1234", "stdout": ""},
+            {"cmd": "taskset -cp 5 1235", "stdout": ""},
+            {"cmd": "taskset -cp 6 1236", "stdout": ""},
+            {"cmd": "taskset -cp 7 1237", "stdout": ""},
 
         ]
 

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1855,7 +1855,7 @@ class NumaNode(object):
         for i in cpus:
             if (cpu is not None and cpu == i) or (cpu is None and not self.dict[i]):
                 self.dict[i].append(pid)
-                cmd = "taskset -p %s %s" % (hex(2 ** int(i)), pid)
+                cmd = "taskset -cp %s %s" % (int(i), pid)
                 logging.debug("NumaNode (%s): " % i + cmd)
                 process.run(cmd)
                 return i


### PR DESCRIPTION
When cpus great then 62, bitmask will be force convert to long integer,
so taskset failed to parse cpu mask.

Signed-off-by: Maosheng Zhang <mazhang@redhat.com>