### PR TITLE
libvirt.py: Update incorrect search pattern

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2473,7 +2473,7 @@ def connect_libvirtd(uri, read_only="", virsh_cmd="list", auth_user=None,
     Connect libvirt daemon
     """
     patterns_yes_no = r".*[Yy]es.*[Nn]o.*"
-    patterns_auth_name_comm = r".*name:.*"
+    patterns_auth_name_comm = r".*username:.*"
     patterns_auth_name_xen = r".*name.*root.*:.*"
     patterns_auth_pwd = r".*[Pp]assword.*"
 


### PR DESCRIPTION
Origin pattern to match authentication name is too short which may cause
incorrect match result. So it is safe to use 'username', not 'name'.

Signed-off-by: Dan Zheng <dzheng@redhat.com>