### PR TITLE
utils_test.libvirt: Strip output before use

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -988,7 +988,7 @@ class PoolVolumeTest(object):
                     image_size=image_size)
                 cmd = ("iscsiadm -m session -P 3 |grep -B3 %s| grep Host|awk "
                        "'{print $3}'" % logical_device.split('/')[2])
-                scsi_host = process.system_output(cmd, shell=True)
+                scsi_host = process.system_output(cmd, shell=True).strip()
                 scsi_pool_xml = pool_xml.PoolXML()
                 scsi_pool_xml.name = pool_name
                 scsi_pool_xml.pool_type = "scsi"


### PR DESCRIPTION
The output of this command could possible contains an EOL so we have
to strip it before use.

Or the generated XML will be wrong and pool creation will fail.

Signed-off-by: Hao Liu <hliu@redhat.com>