### PR TITLE
virttest/qemu_monitor.py: Small fix in migrate_set_downtime() for qmp

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1831,8 +1831,7 @@ class QMPMonitor(Monitor):
 
         :return: The command's output
         """
-        val = value * 10 ** 9
-        args = {"value": val}
+        args = {"value": value}
         return self.cmd("migrate_set_downtime", args)
 
     def live_snapshot(self, device, snapshot_file, snapshot_format="qcow2"):


### PR DESCRIPTION
For qmp monitor, the unit of set_downtim  must be in seconds,
like as: 1 is 1s, 0.1 is 100ms.

Signed-off-by: Shuping Cui <scui@redhat.com>