### PR TITLE
avocado_vt.loader: Fixup: wrong module name used for TERM_SUPPORT

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -54,7 +54,7 @@ def guest_listing(options):
             out = name
         else:
             missing = "(missing %s)" % os.path.basename(image_name)
-            out = (name + " " + output.term_support.warn_header_str(missing))
+            out = (name + " " + output.TERM_SUPPORT.warn_header_str(missing))
         LOG.debug(out)
 
 


### PR DESCRIPTION
Fixes the below issue:

Searched /usr/share/avocado/data/avocado-vt/images for guest images

Available guests in config:

Avocado crashed unexpectedly: 'module' object has no attribute 'term_support'