### PR TITLE
qemu_monitor: fix debug arg not work in function  human_monitor_cmd

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1612,7 +1612,7 @@ class QMPMonitor(Monitor):
 
         :return: The response to the command
         """
-        self._log_command(cmd, extra_str="(via Human Monitor)")
+        self._log_command(cmd, debug, extra_str="(via Human Monitor)")
 
         args = {"command-line": cmd}
         ret = self.cmd("human-monitor-command", args, timeout, False, fd)


### PR DESCRIPTION
fix human_monitor_cmd call _log_command function with default debug
argument issue.

Signed-off-by: Xu Tian <xutian@redhat.com>