### PR TITLE
avocado_vt.loader: Fix rename term_support to TERM_SUPPORT

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -54,7 +54,7 @@ def guest_listing(options):
             out = name
         else:
             missing = "(missing %s)" % os.path.basename(image_name)
-            out = (name + " " + output.term_support.warn_header_str(missing))
+            out = (name + " " + output.TERM_SUPPORT.warn_header_str(missing))
         LOG.debug(out)
 
 


### PR DESCRIPTION
The output.term_support was renamed to output.TERM_SUPPORT to match the
pep8 recommendations.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>