### PR TITLE
virttest/qemu_vm.py: Add enable_check_mig_thread option when check mi…

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3689,10 +3689,11 @@ class VM(virt_vm.BaseVM):
             if not_wait_for_migration:
                 return clone
 
-            threads_during_migrate = self.get_qemu_threads()
-            if not (len(threads_during_migrate) > len(threads_before_migrate)):
-                raise virt_vm.VMMigrateFailedError("Cannot find new thread "
-                                                   "for migration.")
+            if self.params.get("enable_check_mig_thread", "no") == "yes":
+                threads_during_migrate = self.get_qemu_threads()
+                if not (len(threads_during_migrate) > len(threads_before_migrate)):
+                    raise virt_vm.VMMigrateFailedError("Cannot find new thread"
+                                                       " for migration.")
 
             if cancel_delay:
                 error_context.context("Do migrate_cancel after %d seconds" %


### PR DESCRIPTION
…g_thread

Create the new thread when do migration only support from
Host_RHEL.7.0, so not need check it on the old host.

Signed-off-by: Shuping Cui <scui@redhat.com>

ID: 1321505