### PR TITLE
Add run_test to remote_commander.

### DIFF
--- a/virttest/remote_commander/messenger.py
+++ b/virttest/remote_commander/messenger.py
@@ -138,9 +138,10 @@ class StdIOWrapperIn(StdIOWrapper):
 
     def read(self, max_len, timeout=None):
         if timeout is not None:
-            return self._wait_for_data(max_len, timeout)
+            data = self._wait_for_data(max_len, timeout)
         else:
-            return os.read(self._obj, max_len)
+            data = os.read(self._obj, max_len)
+        return data
 
 
 class StdIOWrapperOut(StdIOWrapper):
@@ -220,7 +221,8 @@ class Messenger(object):
         pdata = cPickle.dumps(data, cPickle.HIGHEST_PROTOCOL)
         pdata = self.stdout.encode(pdata)
         len_enc = self.stdout.encode("%10d" % len(pdata))
-        return "%s%s" % (len_enc, pdata)
+        msg = "%s%s" % (len_enc, pdata)
+        return msg
 
     def flush_stdin(self):
         """

--- a/virttest/remote_commander/remote_interface.py
+++ b/virttest/remote_commander/remote_interface.py
@@ -128,6 +128,37 @@ class StdErr(StdStream):
         self.msg = state[1]
 
 
+class CmdQuery(object):
+    """Command-msg-request from VM to avocado-vt test.
+    """
+    def __init__(self, *args, **kargs):
+        """Command for asking from VM to avocado-vt.
+
+        Parameters
+        ----------
+        args : Something pickable.
+            Is irrelevant for messagenger.
+        kargs : Something pickable.
+            Is irrelevant for messagenger.
+        """
+        self.args = copy.deepcopy(args)
+        self.kargs = copy.deepcopy(kargs)
+
+
+class CmdRespond(object):
+    """Command-msg-answer from avocado-test to VM.
+    """
+    def __init__(self, respond):
+        """Command for answering avocado-vt to VM.
+
+        Parameters
+        ----------
+        respond : Something pickable.
+            Is irrelevant for messagenger.
+        """
+        self.respond = respond  # Must be pickable.
+
+
 class BaseCmd(CmdMessage):
 
     """

--- a/virttest/remote_commander/remote_master.py
+++ b/virttest/remote_commander/remote_master.py
@@ -49,6 +49,9 @@ class CmdMaster(object):
         self._results_cnt = 0
         self._stdout_cnt = 0
         self._stderr_cnt = 0
+        self.timeout = None
+        if 'timeout' in kargs:
+            self.timeout = kargs['timeout']
 
     def getbasecmd(self):
         """
@@ -114,11 +117,11 @@ class CmdMaster(object):
         """
         return self.commander.wait(self)
 
-    def wait_response(self, timeout=None):
+    def wait_response(self):
         """
         Wait until command return any cmd.
         """
-        self.commander.wait_response(self, timeout)
+        self.commander.wait_response(self)
 
     def __getattr__(self, name):
         """
@@ -202,6 +205,7 @@ class CommanderMaster(messenger.Messenger):
         super(CommanderMaster, self).__init__(stdin, stdout)
         self.cmds = {}
         self.debug = debug
+        self.responder = None
 
         self.flush_stdin()
         self.write_msg("start")
@@ -209,6 +213,9 @@ class CommanderMaster(messenger.Messenger):
         if not succ or msg != "Started":
             raise remote_interface.CommanderError("Remote commander"
                                                   " not started.")
+
+    def set_responder(self, responder):
+        self.responder = responder
 
     def close(self):
         try:
@@ -259,6 +266,15 @@ class CommanderMaster(messenger.Messenger):
                             remote_interface.MessengerError)):
             raise cmd
 
+    def listen_queries(self, cmd):
+        """Manage queries from slave side.
+        """
+        if isinstance(cmd, remote_interface.CmdQuery):
+            assert self.responder  # Should be set by set_responder()
+            data = self.responder(cmd.args, cmd.kargs)
+            reply = remote_interface.CmdRespond(data)
+            self.write_msg(reply)
+
     def listen_cmds(self, cmd):
         """
         Manage basecmds from slave side.
@@ -286,9 +302,10 @@ class CommanderMaster(messenger.Messenger):
         self.listen_errors(r_cmd)
         self.listen_streams(r_cmd)
         self.listen_cmds(r_cmd)
+        self.listen_queries(r_cmd)
         return r_cmd
 
-    def cmd(self, cmd, timeout=60):
+    def cmd(self, cmd):
         """
         Invoke command on client side.
         """
@@ -297,13 +314,13 @@ class CommanderMaster(messenger.Messenger):
         while (1):
             if cmd.basecmd.func[0] not in ["async", "nohup"]:
                 # If not async wait for finish.
-                self.wait(cmd, timeout)
+                self.wait(cmd)
             else:
-                ancmd = self.wait_response(cmd, timeout)
+                ancmd = self.wait_response(cmd)
                 cmd.update_cmd_hash(ancmd)
             return cmd
 
-    def wait(self, cmd, timeout=60):
+    def wait(self, cmd):
         """
         Wait until command return results.
         """
@@ -316,6 +333,7 @@ class CommanderMaster(messenger.Messenger):
         r_cmd = None
 
         time_step = None
+        timeout = cmd.timeout
         if timeout is not None:
             time_step = timeout / 10.0
         w = wait_timeout(timeout)
@@ -336,7 +354,7 @@ class CommanderMaster(messenger.Messenger):
         if r_cmd is None:
             raise CmdTimeout("%ss during %s" % (timeout, str(cmd)))
 
-    def wait_response(self, cmd, timeout=60):
+    def wait_response(self, cmd):
         """
         Wait until command return any cmd.
         """
@@ -349,6 +367,7 @@ class CommanderMaster(messenger.Messenger):
         r_cmd = None
 
         time_step = None
+        timeout = cmd.timeout
         if timeout is not None:
             time_step = timeout / 10.0
         w = wait_timeout(timeout)


### PR DESCRIPTION
Example follows.

VM side::

    #!/usr/bin/env python

    import logging
    import time
    import sys

    def run(helper):
        for i in range(50000):
            t = time.time()
            reply = helper.query_master(i, t)
            logging.info("Reply %s: %s", i, str(reply))

Master side::

    import os
    import copy
    import time
    import logging

    """Test example for avocado-vt for using remote_commander with run_test()
    method. The purpose of this technique is to provide remote test running on VM
    with callback. Test can be run remotelly on VM, and decision about success is
    made in one place. run_test() accpepts Python script that has run(helper)
    method. Remote test can call helper.query_master() with any picable arguments.

    More info at: https://github.com/autotest/virt-test/pull/1449
    """

    class EchoResponder(object):
        """Call-able class."""

        def __init__(self, start=0):
            self.seq = start

        def __call__(self, *args, **kargs):
            logging.info("Query from VM: args=%s, kargs=%s", str(args), str(kargs))
            seq = self.seq
            self.args = copy.deepcopy(args)
            self.kargs = copy.deepcopy(kargs)
            self.seq += 1
            # Respond with any Pickable data
            return (seq, args, kargs)

    def run(test, params, env):
        vm = env.get_all_vms()[0]
        logging.info("Try to log into VM '%s'.", vm.name)
        vm.wait_for_login()
        # Test to be copied to VM.
        tests_path = os.path.dirname(os.path.realpath(__file__))
        files_to_copy = ("test_name.py",)
        f_path = " ".join((os.path.join(tests_path, _) for _ in files_to_copy))
        vm.copy_files_to(f_path, "/tmp")
        # Commander to run test on VM.
        commander = vm.commander(commander_path="/tmp")
        callable_obj_responder = EchoResponder()
        commander.set_responder(callable_obj_responder)
        cmd = commander.run_test("/tmp/test_name.py")
        result = cmd.results
        logging.info("Test finished with result: %s", result)

Signed-off-by: Andrei Stepanov <astepano@redhat.com>