### PR TITLE
libvirt_xml: Add model attribute for panic device

### DIFF
--- a/virttest/libvirt_xml/devices/panic.py
+++ b/virttest/libvirt_xml/devices/panic.py
@@ -10,10 +10,12 @@ from virttest.libvirt_xml.devices import base
 
 class Panic(base.UntypedDeviceBase):
 
-    __slots__ = ('addr_type', 'addr_iobase', 'addr_controller', 'addr_bus',
-                 'addr_port')
+    __slots__ = ('model', 'addr_type', 'addr_iobase', 'addr_controller',
+                 'addr_bus', 'addr_port')
 
     def __init__(self, virsh_instance=base.base.virsh):
+        accessors.XMLAttribute('model', self, parent_xpath='/',
+                               tag_name="panic", attribute='model')
         accessors.XMLAttribute('addr_type', self, parent_xpath='/',
                                tag_name="address", attribute='type')
         accessors.XMLAttribute('addr_iobase', self, parent_xpath='/',


### PR DESCRIPTION
Add support for the new 'model' attribute in panic device.

More info:
http://libvirt.org/formatdomain.html#elementsPanic

Signed-off-by: Wayne Sun <gsun@redhat.com>