### PR TITLE
Add test_timeout params

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -120,6 +120,7 @@ class VirtTest(test.Test):
         self.params = utils_params.Params(vt_params)
         self.debugdir = self.logdir
         self.resultsdir = self.logdir
+        self.timeout = vt_params.get("test_timeout", self.timeout)
         utils_misc.set_log_file_dir(self.logdir)
 
     @property


### PR DESCRIPTION
      timeout = test_status.early_status.get('timeout')
      timeout = float(timeout or self.DEFAULT_TIMEOUT)

DEFAULT_TIMEOUT is always used currently, need to make timeout configuable.

