### PR TITLE
Add run_test to remote_commander.

### DIFF
--- a/virttest/remote_commander/messenger.py
+++ b/virttest/remote_commander/messenger.py
@@ -3,7 +3,8 @@
 '''
 Created on Dec 6, 2013
 
-:author: jzupka
+:author: jzupka, astepano
+:contact: Andrei Stepanov <astepano@redhat.com>
 '''
 
 import os

--- a/virttest/remote_commander/remote_interface.py
+++ b/virttest/remote_commander/remote_interface.py
@@ -1,7 +1,8 @@
 '''
 Created on Dec 11, 2013
 
-:author: jzupka
+:author: jzupka, astepano
+:contact: Andrei Stepanov <astepano@redhat.com>
 '''
 import copy
 
@@ -126,6 +127,32 @@ class StdErr(StdStream):
     def __setstate__(self, state):
         self.cmd_id = state[0]
         self.msg = state[1]
+
+
+class CmdQuery(object):
+    """Command-msg-request from VM to avocado-vt test.
+    """
+    def __init__(self, *args, **kargs):
+        """
+        Command for asking from VM to avocado-vt.
+
+        :param args: Something pickable. Is irrelevant for messenger.
+        :param kargs: Something pickable. Is irrelevant for messenger.
+        """
+        self.args = copy.deepcopy(args)
+        self.kargs = copy.deepcopy(kargs)
+
+
+class CmdRespond(object):
+    """Command-msg-answer from avocado-test to VM.
+    """
+    def __init__(self, respond):
+        """
+        Command for answering avocado-vt to VM.
+
+        :param respond: Something pickable. Is irrelevant for messenger.
+        """
+        self.respond = respond  # Must be pickable.
 
 
 class BaseCmd(CmdMessage):

--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -3,11 +3,13 @@
 '''
 Created on Dec 6, 2013
 
-:author: jzupka
+:author: jzupka, astepano
+:contact: Andrei Stepanov <astepano@redhat.com>
 '''
 
 import os
 import sys
+import imp
 import select
 import time
 import stat
@@ -304,6 +306,12 @@ class CmdSlave(object):
         if func_name[0] == "nohup":  # start command in new daemon process.
             self.nohup = True
             func_name = func_name[1:]
+        if func_name[0] == "python_file_run_with_helper" and not self.manage:
+            # the `async` and other prefixes are already consumed.
+            raise NotImplementedError(
+                "The 'python_file_run_with_helper' is only implemented for "
+                "'manage' target.  Please use "
+                "'commander.manage.python_file_run_with_helper' to run this.")
         if hasattr(commander, func_name[0]):
             obj = getattr(commander, func_name[0])
         elif func_name[0] in commander.globals:
@@ -543,6 +551,10 @@ class CommanderSlave(ms.Messenger):
                     cmd = CmdSlave(self.read_msg()[1])
                     self.cmds[cmd.cmd_id] = cmd
                     try:
+                        # There is hidden bug. We can bump into condition when
+                        # we running some function-command. That function dump
+                        # some data to stdio. But, stdio is out of
+                        # consideration at this point. It can stuck.
                         cmd(self)
                         self.write_msg(cmd.basecmd)
                     except Exception:
@@ -701,6 +713,49 @@ class CommanderSlaveCmds(CommanderSlave):
         """
         self._exit = True
         return "bye"
+
+    def python_file_run_with_helper(self, test_path):
+        """
+        Call run() function at external python module.
+
+        :param test_path: Path to python file. Call run() at this module.
+        :return: module.run().return
+        """
+        assert os.path.isfile(test_path)
+        module = imp.load_source('ext_test', test_path)
+        assert hasattr(module, "run")
+        run = getattr(module, "run")
+        helper = Helper(self)
+        run(helper)
+
+
+class Helper(object):
+    """Passed to external test on VM."""
+    __slots__ = ["messenger"]
+
+    def __init__(self, messenger):
+        self.messenger = messenger
+
+    def query_master(self, *args, **kargs):
+        """Read CmdRespond from master."""
+        # First of all, dump stdio to master. Otherwise it can block on
+        # logging.info() function.
+        msg = self.messenger
+        stdios = [msg.o_stdout, msg.o_stderr]
+        r, _, _ = select.select(stdios, [], [], 0)  # Not blocking.
+        if msg.o_stdout in r:  # Send message from stdout
+            data = os.read(msg.o_stdout, 16384)
+            msg.write_msg(remote_interface.StdOut(data))
+        if msg.o_stderr in r:  # Send message from stdout
+            data = os.read(msg.o_stderr, 16384)
+            msg.write_msg(remote_interface.StdErr(data))
+        # Sent actual request.
+        cmd = remote_interface.CmdQuery(args, kargs)
+        msg.write_msg(cmd)
+        succ, data = msg.read_msg()
+        assert succ
+        assert isinstance(data, remote_interface.CmdRespond)
+        return data.respond
 
 
 def remote_agent(in_stream_cls, out_stream_cls):


### PR DESCRIPTION
Example follows.

VM side::

    #!/usr/bin/env python

    import logging
    import time
    import sys

    def run(helper):
        for i in range(50000):
            t = time.time()
            reply = helper.query_master(i, t)
            logging.info("Reply %s: %s", i, str(reply))

Master side::

    #!/usr/bin/env python

    import os
    import copy
    import time
    import logging

    """Test example for avocado-vt for using remote_commander with run_test()
    method. The purpose of this technique is to provide remote test running on VM
    with callback. Test can be run remotelly on VM, and decision about success is
    made in one place. run_test() accpepts Python script that has run(helper)
    method. Remote test can call helper.query_master() with any picable arguments.

    More info at: https://github.com/autotest/virt-test/pull/1449
    """

    class EchoResponder(object):
        """Call-able class."""

        def __init__(self, start=0):
            self.seq = start

        def __call__(self, *args, **kargs):
            logging.info("Query from VM: args=%s, kargs=%s", str(args), str(kargs))
            seq = self.seq
            self.args = copy.deepcopy(args)
            self.kargs = copy.deepcopy(kargs)
            self.seq += 1
            # Respond with any Pickable data
            return (seq, args, kargs)

    def run(test, params, env):
        vm = env.get_all_vms()[0]
        logging.info("Try to log into VM '%s'.", vm.name)
        vm.wait_for_login()
        # Test to be copied to VM.
        tests_path = os.path.dirname(os.path.realpath(__file__))
        files_to_copy = ("test_name.py",)
        f_path = " ".join((os.path.join(tests_path, _) for _ in files_to_copy))
        vm.copy_files_to(f_path, "/tmp")
        # Commander to run test on VM.
        commander = vm.commander(commander_path="/tmp")
        callable_obj_responder = EchoResponder()
        commander.set_responder(callable_obj_responder)
        cmd = commander.run_test("/tmp/test_name.py")
        result = cmd.results
        logging.info("Test finished with result: %s", result)

Signed-off-by: Andrei Stepanov <astepano@redhat.com>