### PR TITLE
virttest.qemu_vm: remove duplicate call verify_kernel_crash

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3743,7 +3743,6 @@ class VM(virt_vm.BaseVM):
             error_context.context("after migration")
             if local:
                 time.sleep(1)
-                self.verify_kernel_crash()
                 self.verify_alive()
 
             if local and stable_check:


### PR DESCRIPTION
verify_alive has call verify_kernel_crash, so no need to call
again.

Signed-off-by: Xu Tian <xutian@redhat.com>