### PR TITLE
fixing logging error in qemu.py

### DIFF
--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -195,7 +195,7 @@ def setup_runlevel(params, session):
 
     ori_runlevel = ori_runlevel.split()[-1]
     if ori_runlevel == expect_runlevel:
-        logging.info("Guest runlevel is already %s as expected") % ori_runlevel
+        logging.info("Guest runlevel is already %s as expected", ori_runlevel)
     else:
         session.cmd("init %s" % expect_runlevel)
         tmp_runlevel = session.cmd(cmd)


### PR DESCRIPTION
Fixed minor error on line 198 in qemu.py 
logging.info("Guest runlevel is already %s as expected") % ori_runlevel

Error was causing an avocado test to fail with "TypeError: unsupported operand type(s) for %: 'NoneType' and 'str'"

Signed-off-by: Yash Mankad <ymankad@redhat.com>