### PR TITLE
utils_misc: fix import missing

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -41,6 +41,7 @@ from . import error_context
 from . import cartesian_config
 from . import utils_selinux
 from .staging import utils_koji
+from .xml_utils import XMLTreeFile
 
 ARCH = platform.machine()
 


### PR DESCRIPTION
'XMLTreeFile' is not imported.

Signed-off-by: Dan Zheng <dzheng@redhat.com>