### PR TITLE
vt.plugins: Added only filter option and enabled no filter with config option

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -406,10 +406,14 @@ class VirtTestOptionsProcess(object):
             self.cartesian_parser.assign("run_tcpdump", "no")
 
     def _process_no_filter(self):
-        if not self.options.vt_config:
-            if self.options.vt_no_filter:
-                no_filter = ", ".join(self.options.vt_no_filter.split(' '))
-                self.cartesian_parser.no_filter(no_filter)
+        if self.options.vt_no_filter:
+            for item in self.options.vt_no_filter.split(' '):
+                self.cartesian_parser.no_filter(item)
+
+    def _process_only_filter(self):
+        if self.options.vt_only_filter:
+            for item in self.options.vt_only_filter.split(' '):
+                self.cartesian_parser.only_filter(item)
 
     def _process_extra_params(self):
         if getattr(self.options, "vt_extra_params", False):
@@ -436,6 +440,7 @@ class VirtTestOptionsProcess(object):
         self._process_mem()
         self._process_tcpdump()
         self._process_no_filter()
+        self._process_only_filter()
         self._process_qemu_img()
         self._process_bridge_mode()
         self._process_only_type_specific()

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -124,9 +124,13 @@ class VTRun(CLI):
                                             help=("List of space separated "
                                                   "'no' filters to be passed "
                                                   "to the config parser. "
-                                                  "If --vt-config is "
-                                                  "provided, this will be "
-                                                  "ignored. Default: ''"))
+                                                  " Default: ''"))
+        vt_compat_group_common.add_argument("--vt-only-filter", action="store",
+                                            dest="vt_only_filter", default="",
+                                            help=("List of space separated "
+                                                  "'only' filters to be passed"
+                                                  " to the config parser. "
+                                                  " Default: ''"))
         qemu_bin = settings.get_value('vt.qemu', 'qemu_bin',
                                       default=qemu_bin_path)
         vt_compat_group_qemu.add_argument("--vt-qemu-bin", action="store",


### PR DESCRIPTION
1. Added a new option for only filters (--vt-only-filter) this will
be working even with config option enabled.
2. Enabled no filter option even with config option.

Sample Command line:
avocado run --vt-type libvirt --vt-config /usr/share/avocado/data/avocado-vt/backends/libvirt/cfg/cpu.cfg --sysinfo on --vt-only-filters "RHEL.7.2.ppc64le pseries" --vt-no-filters "xen lxc"

Addresses https://github.com/avocado-framework/avocado-vt/issues/423