### PR TITLE
virt_vm: fix TypeError in verify_illegal_instruction function

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -870,6 +870,9 @@ class BaseVM(object):
         """
         if self.serial_console is not None:
             data = self.serial_console.get_output()
+            if not data:
+                logging.warn("Unable to read serial console")
+                return
             match = re.findall(r".*trap invalid opcode.*\n", data,
                                re.MULTILINE)
 


### PR DESCRIPTION
If serial console is not ready, get output of serial console will cause TypeError issue. Fix it by return driectly if no data get.

Signed-off-by: Ping Li <pingl@redhat.com>