### PR TITLE
Escape the '?' when calling it via "process"

### DIFF
--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -578,7 +578,7 @@ class Container(unittest.TestCase):
                                                      shell=True,
                                                      verbose=False
                                                      ).and_return(QEMU_DEVICES)
-        qcontainer.process.system_output.expect_call("%s -M ?" % qemu_cmd,
+        qcontainer.process.system_output.expect_call("%s -M \?" % qemu_cmd,
                                                      timeout=10,
                                                      ignore_status=True,
                                                      shell=True,

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -98,7 +98,7 @@ class DevContainer(object):
                                                    ignore_status=True,
                                                    shell=True,
                                                    verbose=False)
-        self.__machine_types = process.system_output("%s -M ?" % qemu_binary,
+        self.__machine_types = process.system_output("%s -M \?" % qemu_binary,
                                                      timeout=10,
                                                      ignore_status=True,
                                                      shell=True,


### PR DESCRIPTION
We call "qemu ... ?" on several places, which could fail if bash
replaces it with the matching file name. Couple of these were already
fixed by escaping the '?', this patch adds the remaining ones.

PS: I'm wondering why are we not using "help" instead of '?'. Is it not supported by some qemu versions?