### PR TITLE
vt_list: Add --vt-machine-type option

### DIFF
--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -58,7 +58,7 @@ if VIRT_TEST_PATH is not None:
     sys.path.append(os.path.expanduser(VIRT_TEST_PATH))
 
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
-from virttest.defaults import DEFAULT_GUEST_OS
+from virttest import defaults
 from virttest import data_dir
 
 
@@ -110,11 +110,17 @@ class VTLister(CLI):
                                                   "available guests "
                                                   "with --vt-list-guests. "
                                                   "Default: %s" %
-                                                  DEFAULT_GUEST_OS))
+                                                  defaults.DEFAULT_GUEST_OS))
         vt_compat_group_lister.add_argument("--vt-list-guests",
                                             action="store_true",
                                             default=False,
                                             help="List available guests")
+        machine = settings.get_value('vt.common', 'machine_type',
+                                     default=defaults.DEFAULT_MACHINE_TYPE)
+        vt_compat_group_lister.add_argument("--vt-machine-type",
+                                            help="Choose the VM machine type. "
+                                            "Default: %s" % machine,
+                                            default=machine)
 
     def run(self, args):
         loader.register_plugin(VirtTestLoader)


### PR DESCRIPTION
The --vt-machine-type option is supported in avocado run command
to filter out certain machine type cases to run.

Add this option into list command to support filter certain machine
type cases.

Signed-off-by: Wayne Sun <gsun@redhat.com>