### PR TITLE
Also add vt-only-filter to vt_list

### DIFF
--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -121,6 +121,12 @@ class VTLister(CLI):
                                             help="Choose the VM machine type. "
                                             "Default: %s" % machine,
                                             default=machine)
+        vt_compat_group_lister.add_argument("--vt-only-filter", action="store",
+                                            dest="vt_only_filter", default="",
+                                            help=("List of space separated "
+                                                  "'only' filters to be passed"
+                                                  " to the config parser. "
+                                                  " Default: ''"))
 
     def run(self, args):
         loader.register_plugin(VirtTestLoader)


### PR DESCRIPTION
In a recently merged commit vt-only-filter is introduced in options
but no option is added in vt_list module. This will making avocado
failed to list any of virt test cases.

Signed-off-by: Hao Liu <hliu@redhat.com>