### PR TITLE
utils_test.libvirt: workaround to delete external disk snapshot.

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2849,6 +2849,29 @@ def valued_option_dict(options, split_pattern, start_count=0, dict_split=None):
     return option_dict
 
 
+def get_image_snapshot(image_file):
+    """
+    Get image snapshot ID and put it into a list.
+    Image snapshots like this:
+
+    Snapshot list:
+    ID        TAG                 VM SIZE                DATE       VM CLOCK
+    1         1460096943             3.1M 2016-04-08 14:29:03   00:00:00.110
+    """
+    try:
+        cmd = "qemu-img snapshot %s -l" % image_file
+        snap_info = process.run(cmd, ignore_status=False).stdout.strip()
+        snap_list = []
+        if snap_info:
+            pattern = "(\d+) +\d+ +.*"
+            for line in snap_info.splitlines():
+                snap_list.extend(re.findall(r"%s" % pattern, line))
+        return snap_list
+    except process.CmdError, detail:
+        raise exceptions.TestError("Fail to get snapshot of %s:\n%s" %
+                                   (image_file, detail))
+
+
 def get_image_info(image_file):
     """
     Get image information and put it into a dict. Image information like this:

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -493,7 +493,6 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
         _iscsi.emulated_id = _iscsi.get_target_id()
         _iscsi.cleanup()
         process.run("rm -f %s" % emulated_path)
-        process.run("vgscan --cache", ignore_status=True)
     return ""
 
 


### PR DESCRIPTION
The command cause 'Leaked clusters were noticed during image check'
error in the test.