### PR TITLE
utils_test.qemu: online hotpluged memory before check memory

### DIFF
--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -834,7 +834,8 @@ class MultihostMigration(object):
                         self.prepare_for_migration(mig_data, None)
                     elif self.hostid == dsthost:
                         if host_offline_migration != "yes":
-                            self.prepare_for_migration(mig_data, self.mig_protocol)
+                            self.prepare_for_migration(
+                                mig_data, self.mig_protocol)
                     else:
                         return
 
@@ -868,7 +869,8 @@ class MultihostMigration(object):
                                                 'wait_for_offline_mig',
                                                 self.finish_timeout)
                             if mig_data.is_dst():
-                                self.prepare_for_migration(mig_data, self.mig_protocol)
+                                self.prepare_for_migration(
+                                    mig_data, self.mig_protocol)
                             self._hosts_barrier(self.hosts,
                                                 mig_data.mig_id,
                                                 'wait2_for_offline_mig',
@@ -1722,7 +1724,7 @@ class MemoryHotplugTest(MemoryBaseTest):
             qid_dimm = "dimm-%s" % name
             dimm = vm.devices.get_by_qid(qid_dimm)[0]
         except IndexError:
-            logging.warn("'%s' is not used by any dimm" %qid_mem)
+            logging.warn("'%s' is not used by any dimm" % qid_mem)
         step = "Unplug pc-dimm '%s'" % qid_dimm
         error_context.context(step, logging.info)
         vm.devices.simple_unplug(dimm, vm.monitor)
@@ -1737,7 +1739,7 @@ class MemoryHotplugTest(MemoryBaseTest):
     @error_context.context_aware
     def get_mem_addr(self, vm, qid):
         """
-        Get guest memory address from qemu monitor.
+        Get guest memory address from qemu monitor
 
         :param vm: VM object
         :param qid: memory device qid
@@ -1745,13 +1747,11 @@ class MemoryHotplugTest(MemoryBaseTest):
         error_context.context("Get hotpluged memory address", logging.info)
         if not isinstance(vm.monitor, qemu_monitor.QMPMonitor):
             raise NotImplementedError
-        output = vm.monitor.info("memory-devices")
-        for info in output:
+        for info in vm.monitor.info("memory-devices"):
             if str(info['data']['id']) == qid:
                 address = info['data']['addr']
                 logging.info("Memory address: %s" % address)
                 return address
-        return None
 
     @error_context.context_aware
     def check_memory(self, vm=None):

--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -1648,8 +1648,8 @@ class MemoryHotplugTest(MemoryBaseTest):
             if val:
                 key = "_".join([attr, dev_type, name])
                 params[key] = val
-        if name not in vm.params.get("mem_devs"):
-            mem_devs = vm.params.objects("mem_devs")
+        mem_devs = vm.params.objects("mem_devs")
+        if name not in mem_devs:
             mem_devs.append(name)
             params["mem_devs"] = " ".join(mem_devs)
         vm.params.update(params)
@@ -1667,13 +1667,12 @@ class MemoryHotplugTest(MemoryBaseTest):
         """
         error_context.context("Update VM object after unplug memory")
         dev_type, name = dev.get_qid().split('-')
-        if name not in vm.params.get("mem_devs"):
-            return None
         mem_devs = vm.params.objects("mem_devs")
-        mem_devs.remove(name)
-        vm.params["mem_devs"] = " ".join(mem_devs)
         if dev in vm.devices:
             vm.devices.remove(dev)
+        if name in mem_devs:
+            mem_devs.remove(name)
+            vm.params["mem_devs"] = " ".join(mem_devs)
         self.env.register_vm(vm.name, vm)
 
     @error_context.context_aware

--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -1765,6 +1765,7 @@ class MemoryHotplugTest(MemoryBaseTest):
         if not vm:
             vm = self.env.get_vm(self.params["main_vm"])
         vm.verify_alive()
+        threshold = float(self.params.get("threshold", 0.10))
         timeout = float(self.params.get("wait_resume_timeout", 60))
         # Notes:
         #    some sub test will pause VM, here need to wait VM resume
@@ -1774,8 +1775,7 @@ class MemoryHotplugTest(MemoryBaseTest):
         self.os_type = self.params.get("os_type")
         guest_mem_size = super(MemoryHotplugTest, self).get_guest_total_mem(vm)
         vm_mem_size = self.get_vm_mem(vm)
-        threshold = vm_mem_size * 0.06
-        if abs(guest_mem_size - vm_mem_size) > threshold:
+        if abs(guest_mem_size - vm_mem_size) > vm_mem_size * threshold:
             msg = ("Assigned '%s MB' memory to '%s'"
                    "but, '%s MB' memory detect by OS" %
                    (vm_mem_size, vm.name, guest_mem_size))


### PR DESCRIPTION
Hotpluged memory is offline state by default, this commit online
unusable memory(offline state memory) via kernel sys filesystem
if the memory is not online by systemd.

Signed-off-by: Xu Tian <xutian@redhat.com>