### PR TITLE
utils_test.libvirt: add a parameter ignore_status

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1095,7 +1095,7 @@ class MigrationTest(object):
             self.RET_LOCK.release()
 
     def do_migration(self, vms, srcuri, desturi, migration_type, options=None,
-                     thread_timeout=60):
+                     thread_timeout=60, ignore_status=False):
         """
         Migrate vms.
 
@@ -1156,7 +1156,7 @@ class MigrationTest(object):
                     self.RET_MIGRATION = False
                     self.RET_LOCK.release()
 
-        if not self.RET_MIGRATION:
+        if not self.RET_MIGRATIONi and not ignore_status:
             raise exceptions.TestFail()
 
     def cleanup_dest_vm(self, vm, srcuri, desturi):


### PR DESCRIPTION
MigrationTest.do_migration function always raises an exception when
migration fails. But sometimes it is not needed. The fix is to provide a
way to avoid of raising an exception and just set the boolean result.

Signed-off-by: Dan Zheng <dzheng@redhat.com>