### PR TITLE
virttest.qemu_monitor: increase socket connect timeout

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -163,7 +163,7 @@ class Monitor:
 
     ACQUIRE_LOCK_TIMEOUT = 20
     DATA_AVAILABLE_TIMEOUT = 0
-    CONNECT_TIMEOUT = 30
+    CONNECT_TIMEOUT = 60
 
     def __init__(self, vm, name, filename):
         """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2271,7 +2271,7 @@ class VM(virt_vm.BaseVM):
 
     @error_context.context_aware
     def create(self, name=None, params=None, root_dir=None,
-               timeout=20, migration_mode=None,
+               timeout=120, migration_mode=None,
                migration_exec_cmd=None, migration_fd=None,
                mac_source=None):
         """


### PR DESCRIPTION
If VM memory big than 16G, original connect timeout 30s
is not enough. 60s timeout test pass with 32G VM,
so increase default timeout to 60s to avoid
MonitorConnectTimeout exception.

And original default timeout of wait_for_create_monitor
less than default socket connect timeout, it cause wait for
try to create connection only once, so increase default
create monitor timeout too.

Signed-off-by: Xu Tian <xutian@redhat.com>