### PR TITLE
shared.cfg.guest-os: Remove incorrect urls from RHEL definition

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
@@ -18,5 +18,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel70-ppc64/ks.vfd
-    unattended_install.url:
-        url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/18/Everything/ppc64/os

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
@@ -16,5 +16,3 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel7-ppc64/ks.vfd
-    unattended_install.url:
-        url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/18/Everything/ppc64/os


### PR DESCRIPTION
Somehow Fedora urls were copied over to RHEL definition. Let's remove
them to avoid confusion.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>