### PR TITLE
Fix __getinitargs__() in qemu_monitor.py

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -222,7 +222,7 @@ class Monitor:
     def __getinitargs__(self):
         # Save some information when pickling -- will be passed to the
         # constructor upon unpickling
-        return self.vm, self.name, self.filename, True
+        return self.vm, self.name, self.filename
 
     def _close_sock(self):
         try:


### PR DESCRIPTION
Reconciliation __getinitargs__() with __init__().

https://docs.python.org/2/library/pickle.html#object.__getinitargs__

    .... should return a tuple containing the arguments to be passed to the
    class constructor (init() for example).

Signed-off-by: Andrei Stepanov <astepano@redhat.com>