### PR TITLE
avocado-plugins-vt.spec: add explicit python-simplejson dep on EL6

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -19,7 +19,7 @@ Requires: python, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, gli
 
 Requires: python-imaging
 %if 0%{?el6}
-Requires: gstreamer-python, gstreamer-plugins-good
+Requires: gstreamer-python, gstreamer-plugins-good, python-simplejson
 %else
 Requires: pygobject2, gstreamer1-plugins-good
 %endif


### PR DESCRIPTION
It was observed that, on EL6 only, python-simplejson is not added as
an indirect dependency of its own dependencies.  Let's add an explicit
requirement.

Signed-off-by: Cleber Rosa <crosa@redhat.com>