### PR TITLE
Check the existence of setup_modules.py before loading it

### DIFF
--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -36,6 +36,9 @@ if 'AUTOTEST_PATH' in os.environ:
     AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
     client_dir = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
     setup_modules_path = os.path.join(client_dir, 'setup_modules.py')
+    if not os.path.exists(setup_modules_path):
+        raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
+                               "%s missing." % setup_modules_path)
     import imp
     setup_modules = imp.load_source('autotest_setup_modules',
                                     setup_modules_path)

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -50,6 +50,9 @@ if 'AUTOTEST_PATH' in os.environ:
     AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
     client_dir = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
     setup_modules_path = os.path.join(client_dir, 'setup_modules.py')
+    if not os.path.exists(setup_modules_path):
+        raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
+                               "%s missing." % setup_modules_path)
     setup_modules = imp.load_source('autotest_setup_modules',
                                     setup_modules_path)
     setup_modules.setup(base_path=client_dir,


### PR DESCRIPTION
If AUTOTEST_PATH has been declared and setup_modules.py is missing,
avocado will throw IOError for both vt_list and vt,
and without any useful details to user.
So, It's better to check if it exists.