### PR TITLE
virttest.storage: Correct the log out of backup_image_file

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -325,8 +325,8 @@ class QemuImg(object):
                 logging.info("No source %s, skipping dd...", src)
 
         def backup_image_file(src, dst):
-            logging.debug("Copying %s -> %s", src, dst)
             if os.path.isfile(src):
+                logging.debug("Copying %s -> %s", src, dst)
                 _dst = dst + '.part'
                 shutil.copy(src, _dst)
                 os.rename(_dst, dst)


### PR DESCRIPTION
We'd better to check the existence of src-file first, and then,
output the appropriate log.
Otherwise, the following is likely to mislead user.

Copying ../jeos-21-64.qcow2.backup -> ../jeos-21-64.qcow2.backup
No source file ../jeos-21-64.qcow2.backup, skipping

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>