### PR TITLE
Fixup: Initialising the filename for test

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -90,6 +90,7 @@ class VirtTest(test.Test):
         """
         del name
         options = job.args
+        self.filename = None
         self.bindir = data_dir.get_root_dir()
         self.virtdir = os.path.join(self.bindir, 'shared')
 
@@ -134,16 +135,6 @@ class VirtTest(test.Test):
         For VT tests, this always returns None. The reason is that
         individual VT tests do not map 1:1 to a file and do not provide
         the concept of a datadir.
-        """
-        return None
-
-    @property
-    def filename(self):
-        """
-        Returns the name of the file (path) that holds the current test
-
-        For VT tests, this always returns None. The reason is that
-        individual VT tests do not map 1:1 to a file.
         """
         return None
 


### PR DESCRIPTION
Changing the directory inside test makes filename property set to None
results in resetting basedir and datadir to None, Hence initialize
the filename once.

Fixes https://github.com/avocado-framework/avocado-misc-tests/issues/9
Depends on pull https://github.com/avocado-framework/avocado/pull/1142