### PR TITLE
utils_libvirtd: Add one more kwarg to pass arguments

### DIFF
--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -92,6 +92,7 @@ class LibvirtdSession(object):
 
     def __init__(self, gdb=False,
                  logging_handler=None,
+                 logging_params=(),
                  logging_pattern=r'.*'):
         """
         :param gdb: Whether call the session with gdb debugging support
@@ -110,6 +111,7 @@ class LibvirtdSession(object):
             self.libvirtd_service.stop()
 
         self.logging_handler = logging_handler
+        self.logging_params = logging_params
         self.logging_pattern = logging_pattern
 
         if gdb:
@@ -124,7 +126,7 @@ class LibvirtdSession(object):
         """
         if self.logging_handler is not None:
             if re.match(self.logging_pattern, line):
-                self.logging_handler(line)
+                self.logging_handler(line, *self.logging_params)
 
     def _termination_handler(self, status):
         """


### PR DESCRIPTION
Current logging_handler don't support passing any parameters. This
would limit the function of handler to send out any informations.

Adding a method to pass arguments to handler will make this possible.

Signed-off-by: Hao Liu <hliu@redhat.com>