### PR TITLE
avocado_vt: Move the special name handling to loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
     - if [ $TRAVIS_PYTHON_VERSION == '2.6' ]; then pip install -r requirements-travis-python26.txt; fi
     - git clone https://github.com/avocado-framework/avocado.git avocado-libs
     - cd avocado-libs
+    - pip install -r requirements-travis.txt
     - python setup.py install
     - cd ..
     - rm -rf avocado-libs

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -153,17 +153,20 @@ class VirtTestLoader(loader.TestLoader):
         # Create test_suite
         test_suite = []
         for params in (_ for _ in cartesian_parser.get_dicts()):
+            # Evaluate the proper avocado-vt test name
+            test_name = None
+            if self.args.vt_config:
+                test_name = params.get("shortname")
+            elif self.args.vt_type == "spice":
+                short_name_map_file = params.get("_short_name_map_file")
+                if "tests-variants.cfg" in short_name_map_file:
+                    test_name = short_name_map_file["tests-variants.cfg"]
+            if test_name is None:
+                test_name = params.get("_short_name_map_file")["subtests.cfg"]
             # We want avocado to inject params coming from its multiplexer into
             # the test params. This will allow users to access avocado params
             # from inside virt tests. This feature would only work if the virt
             # test in question is executed from inside avocado.
-            if "subtests.cfg" in params.get("_short_name_map_file"):
-                test_name = params.get("_short_name_map_file")["subtests.cfg"]
-            if self.args.vt_type == 'spice':
-                short_name_map_file = params.get("_short_name_map_file")
-                if "tests-variants.cfg" in short_name_map_file:
-                    test_name = short_name_map_file["tests-variants.cfg"]
-
             params['id'] = test_name
             test_parameters = {'name': test_name,
                                'vt_params': params}

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -88,21 +88,10 @@ class VirtTest(test.Test):
         :param vt_params: avocado-vt/cartesian_config params stored as
                           `self.params`.
         """
-        del name
-        options = job.args
         self.bindir = data_dir.get_root_dir()
         self.virtdir = os.path.join(self.bindir, 'shared')
 
         self.iteration = 0
-        name = None
-        if options.vt_config:
-            name = vt_params.get("shortname")
-        elif options.vt_type == 'spice':
-            short_name_map_file = vt_params.get("_short_name_map_file")
-            if "tests-variants.cfg" in short_name_map_file:
-                name = short_name_map_file["tests-variants.cfg"]
-        if name is None:
-            name = vt_params.get("_short_name_map_file")["subtests.cfg"]
         self.outputdir = None
         self.resultsdir = None
         self.logfile = None


### PR DESCRIPTION
Avocado-vt requires a special test-name handling. Currently it does that
inside the `loader` and then it drops it only to evaluate it again. This
patch moves the `VirtTest.__init__` name handling into the `loader` and
replaces the non-used handling there.

This should not have any impact on the test name whatsoever as the
original name was not used at all and the loader now creates the name
according to the originally used `VirtTest.__init__` handling, with the
only difference that the test is set earlier in the process.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>