### PR TITLE
utils_misc: Bug fix for data size convert

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2565,11 +2565,12 @@ def normalize_data_size(value_str, order_magnitude="M", factor="1024"):
     from_index = __get_unit_index(unit)
     to_index = __get_unit_index(order_magnitude)
     scale = int(factor) ** (to_index - from_index)
-    if scale > 0:
-        data_size = float(value) / abs(scale)
+    data_size = float(value) / scale
+    # Control precision to avoid scientific notaion
+    if data_size.is_integer():
+        return "%.1f" % data_size
     else:
-        data_size = float(value) * abs(scale)
-    return str(data_size)
+        return ("%.20f" % data_size).rstrip('0')
 
 
 def get_free_disk(session, mount):


### PR DESCRIPTION
    
    1. As the value of 'scale' here is always positive，so the if...else
    block is unnecessary.
    2. Using 'str' to format a long float number may output a scientific
    notaion number, which is not acceptable here. So control the precision
    by ourself when format it.
    

Signed-off-by: Yanbing Du <ydu@redhat.com>