### PR TITLE
docs: Mention "make link" in GetStartedGuide

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -16,6 +16,8 @@ Installing Avocado-VT
 
 Having installed Avocado, you should already have the right repos enabled.
 
+.. note:: If you use avocado from sources, use `make link` as described `here <http://avocado-framework.readthedocs.io/en/latest/ContributionGuide.html#hacking-and-using-avocado>`__.
+
 Fedora and Enterprise Linux
 ---------------------------
 


### PR DESCRIPTION
The "make link" is a convenient target to link and deploy all avocado
projects, let's mention it in GetStartedGuide.

The "make link" documentation is added in https://github.com/avocado-framework/avocado/pull/1171

trello: https://trello.com/c/LdXWhQ2Z/641-add-documentation-of-make-link-target