### PR TITLE
virttest/bootstrap.py: remove debug print of download files

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -269,7 +269,6 @@ def sync_download_dir(interactive):
                   "into %s", base_download_dir, download_dir)
     download_file_list = glob.glob(os.path.join(base_download_dir,
                                                 "*.ini"))
-    logging.debug("Donwload file list: %s", download_file_list)
     for src_file in download_file_list:
         dst_file = os.path.join(download_dir,
                                 os.path.basename(src_file))


### PR DESCRIPTION
This debug line was really intended for debugging during development,
it is not useful enough to users.  If there are conflicts to he
handled, then those files names are going to be printed.

Signed-off-by: Cleber Rosa <crosa@redhat.com>