### PR TITLE
avocado-plugins-vt.spec: add git to requirements

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -7,7 +7,7 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 35.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -15,7 +15,7 @@ Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-
 BuildRequires: python2-devel, python-setuptools
 BuildArch: noarch
 Requires: avocado == %{version}
-Requires: python, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect
+Requires: python, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect, git
 
 Requires: python-imaging
 %if 0%{?el6}
@@ -53,6 +53,9 @@ Xunit output, among others.
 
 
 %changelog
+* Mon May  2 2016 Cleber Rosa <cleber@redhat.com> - 35.0-1
+- Added git to requires
+
 * Wed Apr 27 2016 Cleber Rosa <cleber@redhat.com> - 35.0-0
 - Update to upstream release 35.0
 


### PR DESCRIPTION
While Avocado-VT needs additional packages, which are checked
bootstrap, the bootstrap process itself needs git.  It even crashes
without it:

   17:37:30 INFO | 3 - Updating all test providers
   Avocado crashed unexpectedly: Command 'git' could not be found
   in any of the PATH dirs: ['/bin', '/sbin', '/usr/bin',
   '/usr/local/sbin', '/usr/libexec', '/root/bin', '/usr/sbin',
   '/usr/local/bin']

Let's add it as a package requirement.

Signed-off-by: Cleber Rosa <crosa@redhat.com>