### PR TITLE
Job lock: plugin that prevents multiple runs of VT jobs [v2]

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -1,0 +1,119 @@
+import errno
+import logging
+import os
+import re
+import random
+import string
+import sys
+
+from avocado.core import exit_codes
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+from ..test import VirtTest
+
+
+class VTJobLock(JobPre, JobPost):
+
+    name = 'vt-joblock'
+    description = 'Avocado-VT Job Lock/Unlock'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.has_vt_test = False
+        self.lock_dir = settings.get_value(section="plugins.vtjoblock",
+                                           key="dir",
+                                           key_type=str,
+                                           default='/tmp')
+        self.show_lock = settings.get_value(section="plugins.vtjoblock",
+                                            key="show_lock_location",
+                                            key_type=bool,
+                                            default=False)
+        self.lock_file = None
+
+    def _abort(self, message, job):
+        """
+        Aborts the Job by exiting Avocado, adding a failure to the job status
+        """
+        self.log.error(message)
+        sys.exit(exit_codes.AVOCADO_JOB_FAIL | job.exitcode)
+
+    def _set_lock(self, job):
+        if not os.path.isdir(self.lock_dir):
+            msg = ('VT Job lock directory "%s" does not exist... '
+                   'exiting...' % self.lock_dir)
+            self._abort(msg, job)
+
+        pattern = 'avocado-vt-joblock-%(jobid)s-%(uid)s-%(random)s.pid'
+        # the job unique id is already random, but, let's add yet another one
+        rand = ''.join([random.choice(string.ascii_lowercase + string.digits)
+                        for i in xrange(8)])
+        path = pattern % {'jobid': job.unique_id,
+                          'uid': os.getuid(),
+                          'random': rand}
+        path = os.path.join(self.lock_dir, path)
+
+        try:
+            with open(path, 'w') as lockfile:
+                lockfile.write("%u" % os.getpid())
+            self.lock_file = path
+        except IOError as e:
+            msg = ('Failed to create VT Job lock file. Exiting...')
+            self._abort(msg, job)
+
+        if self.show_lock:
+            self.log.info("VT LOCK    : %s", self.lock_file)
+
+    def _get_lock_file(self):
+        if not os.path.isdir(self.lock_dir):
+            return None
+
+        try:
+            files = os.listdir(self.lock_dir)
+            if not files:
+                return None
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return None
+
+        pattern = re.compile(r'avocado-vt-joblock-[0-9a-f]{40}-[0-9]+'
+                             '-[0-9a-z]{8}\.pid')
+        for lock_file in files:
+            if pattern.match(lock_file):
+                path = os.path.join(self.lock_dir, lock_file)
+                if os.path.isfile(path):
+                    content = int(open(path, 'r').read())
+                    if int(content) > 0:
+                        return path
+        return None
+
+    def _get_lock_pid(self):
+        lockfile = self._get_lock_file()
+        if lockfile is None:
+            return 0
+        return int(open(lockfile, 'r').read())
+
+    def _lock(self, job):
+        lock_pid = self._get_lock_pid()
+        if lock_pid > 0:
+            msg = ("Avocado-VT job lock acquired by PID %u. "
+                   "Aborting..." % lock_pid)
+            self._abort(msg, job)
+        self._set_lock(job)
+
+    def _unlock(self):
+        if self.lock_file:
+            os.unlink(self.lock_file)
+
+    def pre(self, job):
+        self.has_vt_test = any(test_factory[0] is VirtTest
+                               for test_factory in job.test_suite)
+
+        if not self.has_vt_test:
+            return
+        self._lock(job)
+
+    def post(self, job):
+        if not self.has_vt_test:
+            return
+        self._unlock()

--- a/docs/source/ParallelJobs.rst
+++ b/docs/source/ParallelJobs.rst
@@ -1,0 +1,80 @@
+.. _parallel_jobs:
+
+Parallel Jobs
+=============
+
+Avocado-VT ships with a plugin that creates a lock file in a known
+public location (``/tmp`` by default, but configurable) to prevent
+multiple runs of jobs that include VT tests.
+
+The reason is that, by default, multiple jobs running at the same can
+access the same data files and cause corruption.  Example of data
+files are the guest images, which are usually modified, either
+directly or indirectly by the tests.
+
+Checking Installation
+---------------------
+
+The vt-joblock is installed and registered by default.  To make sure
+it's active, run::
+
+  $ avocado plugins
+
+The VT Job lock plugin should be listed::
+
+  Plugins that run before/after the execution of jobs (avocado.plugins.job.prepost):
+  ...
+  vt-joblock Avocado-VT Job Lock/Unlock
+  ...
+
+Configuration
+-------------
+
+The configuration for the vt-joblock plugin can be found at
+``/etc/avocado/conf.d/vt_joblock.conf``.  Example of a configuration
+file content follows::
+
+  [plugins.vtjoblock]
+  # Directory where the lock file will be located. Avocado should have permission
+  # to write to this directory.
+  dir=/tmp
+  # Whether to show the acquired job lock file location on the Avocado UI
+  show_lock_location=False
+
+The two configuration keys are:
+
+* ``dir``: the directory where Avocado will look for an existing lock
+  file before running, and create one if it doesn't exist yet.
+
+* ``show_lock_location``: if the resulting lock file location is to be
+  shown on the Avocado UI while running a VT job.
+
+Running Parallel Jobs
+---------------------
+
+Supposing that you have multiple users on a single machine, using
+different data directories, you can allow parallel VT jobs by setting
+different lock directories for each user.
+
+To do so, you can add the customized lock directory to the user's own
+Avocado configuration file.  Start by creating a lock directory::
+
+  [user1@localhost] $ mkdir ~/avocado/data/avocado-vt/lockdir
+
+Then modify the user's own configuration to point to the newly created
+lock directory::
+
+  [user1@localhost] $ cat >> ~/.config/avocado/avocado.conf <<EOF
+  [plugins.vtjoblock]
+  dir=/home/user1/avocado/data/avocado-vt/lockdir
+  EOF
+
+Then verify with::
+
+  [user1@localhost] $ avocado config | grep plugins.vtjoblock
+  ...
+  plugins.vtjoblock.dir          /home/user1/avocado/data/avocado-vt/lockdir
+  ...
+
+Do the same thing for other users and their jobs will not be locked by
+one another.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,7 @@ Contents:
    RegressionTestFarm
    InstallWinVirtio
    RunQemuUnittests
+   ParallelJobs
    contributing/index
 
 =============

--- a/etc/avocado/conf.d/vt_joblock.conf
+++ b/etc/avocado/conf.d/vt_joblock.conf
@@ -1,0 +1,6 @@
+[plugins.vtjoblock]
+# Directory where the lock file will be located. Avocado should have permission
+# to write to this directory.
+dir=/tmp
+# Whether to show the acquired job lock file location on the Avocado UI
+show_lock_location=False

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,9 @@ setup(name='avocado-plugins-vt',
               ],
           'avocado.plugins.cli.cmd': [
               'vt-bootstrap = avocado_vt.plugins.vt_bootstrap:VTBootstrap',
-              ]
+              ],
+          'avocado.plugins.job.prepost': [
+              'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock'
+              ],
           },
       )


### PR DESCRIPTION
This introduces a Pre/Post Job type of plugin, that attempts to create
a lock file in a common location before the job is started, and remove
the lock file after the job has finished.  The goal is to prevent
multiple runs of avocado (with VT tests) to corrupt files such as
guest OS images.

It's still possible to have multiple parallel jobs running on the same
machine, as long as their configuration point to different lock
directories, which should follow different data directories, to
prevent the original problem of data file corruption.

The mechanism used for locking is a simplistic one, similar to daemon
PID files.  It should be possible to either rewrite or improve the
lock mechanism completely without bringing changes to the user
expected behavior of, by default, not having multiple Avocado-VT jobs
run at once.

Now, a disclaimer: while testing for parallel execution of VT and
non-VT jobs, it was found that the VT loader has a number of issues
that make it fail to run in parallel.  Since the plugin kicks in
after the loaders are run, it can only attempt to enforce a lock
after that time.  Based on my testing, it's very effective on
preventing manual execution of VT jobs to clash with each other.
I can not ensure effectiveness when running automated parallel jobs,
since the loader issue kicks in before.

--

Changes from v1:
 * Use the in-job `test_suite` attribute
