### PR TITLE
fix c source code file not found issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(name='avocado-plugins-vt',
                 'virttest.tests',
                 'virttest.unittest_utils',
                 'virttest.utils_test'],
+      package_data={"virttest": ["*.*"]},
       data_files=get_data_files(),
       entry_points={
           'avocado.plugins.cli': [


### PR DESCRIPTION
C source file not be include in virttest packages which caused test failed. (eg, passfd.c not found caused nic_hotplug..migration test failed which exception compile error gcc exit with status 4'')

Signed-off-by: Xu Tian <xutian@redhat.com>