### PR TITLE
Windows.cfg: Add windows related cfg for case "win_virtio_driver_update_test..with_netkvm".

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -377,7 +377,7 @@
         driver_id_pattern = "(.*?):.*?VirtIO SCSI pass-through controller"
     driver_load.with_vioserial:
         driver_id_pattern = "(.*?):.*?VirtIO-Serial Driver"
-    netkvm_in_use, driver_load_stress.with_netkvm:
+    netkvm_in_use, driver_load_stress.with_netkvm, win_virtio_driver_update_test..with_netkvm:
         netperf_server_link_win = "netserver-2.6.0.exe"
         netperf_client_link_win = "netperf.exe"
         target_process = ${netperf_client_link_win}


### PR DESCRIPTION
Signed-off-by: Cong Li <coli@redhat.com>

id: 1231103

Based on: https://github.com/autotest/tp-qemu/pull/617