### PR TITLE
virttest.qemu_qtree: treat spapr-nvram as QtreeDev

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -163,12 +163,12 @@ class QtreeDev(QtreeNode):
         super(QtreeDev, self).add_child(child)
 
     def guess_type(self):
-        if ('drive' in self.qtree and
-                self.qtree['type'] != 'usb-storage'):
-            # ^^ HOOK when usb-storage-containter is detected as disk
-            return QtreeDisk
-        else:
-            return QtreeDev
+        guess = {True: QtreeDisk, False: QtreeDev}
+        is_disk = ('drive' in self.qtree)
+        # HOOK when usb-storage-containter is detected as disk
+        is_disk = (is_disk and (self.qtree['type'] != 'usb-storage'))
+        is_disk = (is_disk and (self.qtree['type'] != 'spapr-nvram'))
+        return guess[is_disk]
 
 
 class QtreeDisk(QtreeDev):


### PR DESCRIPTION
spapr-nvram is not listed in the output of 'info block', so treat it as
a QtreeDev object.

ID: 1327926