### PR TITLE
Update lvm cache timely

### DIFF
--- a/virttest/staging/lv_utils.py
+++ b/virttest/staging/lv_utils.py
@@ -202,6 +202,9 @@ def vg_create(vg_name, pv_list):
 
     if vg_check(vg_name):
         raise exceptions.TestError("Volume group '%s' already exist" % vg_name)
+    # Update cached state before create VG
+    cmd = "vgscan --cache"
+    result = process.run(cmd)
     cmd = "vgcreate %s %s" % (vg_name, pv_list)
     result = process.run(cmd)
     logging.info(result.stdout.rstrip())
@@ -220,6 +223,9 @@ def vg_remove(vg_name):
     cmd = "vgremove -f %s" % vg_name
     result = process.run(cmd)
     logging.info(result.stdout.rstrip())
+    # Update cached state after remove VG
+    cmd = "vgscane --cache"
+    result = process.run(cmd)
 
 
 def lv_check(vg_name, lv_name):

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -949,16 +949,12 @@ class PoolVolumeTest(object):
             extra = " --source-dev %s" % device_name
         elif pool_type == "logical":
             logical_device = device_name
-            cmd_pv = "pvcreate %s" % logical_device
             vg_name = "vg_%s" % pool_type
-            cmd_vg = "vgcreate %s %s" % (vg_name, logical_device)
+            lv_utils.vg_create(vg_name, logical_device)
             extra = "--source-name %s" % vg_name
-            process.run(cmd_pv)
-            process.run(cmd_vg)
             # Create a small volume for verification
             # And VG path will not exist if no any volume in.(bug?)
-            cmd_lv = "lvcreate --name default_lv --size 1M %s" % vg_name
-            process.run(cmd_lv)
+            lv_utils.lv_create(vg_name, 'default_lv', '1M')
         elif pool_type == "netfs":
             export_options = kwargs.get('export_options',
                                         "rw,async,no_root_squash")


### PR DESCRIPTION
In some cases, the new created VG/PV may not clean up completely, which
may lead to a failure when create VG next time:
    # vgcreate vg_test_0 /dev/sdd
    Incorrect metadata area header checksum on /dev/sdd at offset 4096
    Failed to write VG vg_test_0.
In fact, these  commit 2aadb5b tried to fix this problem in an inappropriate
place, and it was removed by commit 03d92e5b without a new fix.

Signed-off-by: Yanbing Du <ydu@redhat.com>