### PR TITLE
avocado_vt: Report avocado params in get_state

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -136,6 +136,15 @@ class VirtTest(test.Test):
         """
         return None
 
+    def get_state(self):
+        """
+        Avocado-vt replaces Test.params with avocado-vt params. This function
+        reports the original params on `get_state` call.
+        """
+        state = super(VirtTest, self).get_state()
+        state["params"] = self.__dict__.get("avocado_params")
+        return state
+
     def _start_logging(self):
         super(VirtTest, self)._start_logging()
         root_logger = logging.getLogger()


### PR DESCRIPTION
The `Test.get_state()` method reports basic Test's properties including
"params". The problem is that avocado-vt's VirtTest replaces the
`VirtTest.params` for avocado-vt params. This patch modifies the
`get_state` method to report the correct params instead.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>