### PR TITLE
libvirt_xml.vm_xml: Use self.vm_name instead of self

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1192,7 +1192,8 @@ class VMXML(VMXMLBase):
         devices = self.get_devices()
         for device in devices:
             if device == value:
-                logging.debug("Device %s is already in VM %s.", value, self)
+                logging.debug("Device %s is already in VM %s.",
+                              value, self.vm_name)
                 return
         devices.append(value)
         self.set_devices(devices)
@@ -1215,7 +1216,8 @@ class VMXML(VMXMLBase):
                 devices.remove(device)
                 break
         if not_found:
-            logging.debug("Device %s does not exist in VM %s.", value, self)
+            logging.debug("Device %s does not exist in VM %s.",
+                          value, self.vm_name)
             return
         self.set_devices(devices)
 


### PR DESCRIPTION
VM's name is better than the object address of VMXMLBase.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>