### PR TITLE
Adding s390x arch support

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2192,8 +2192,9 @@ def extract_qemu_cpu_models(qemu_cpu_help_text):
 
     x86_pattern_list = "x86\s+\[?([a-zA-Z0-9_-]+)\]?.*\n"
     ppc64_pattern_list = "PowerPC\s+\[?([a-zA-Z0-9_-]+\.?[0-9]?)\]?.*\n"
-
-    for pattern_list in [x86_pattern_list, ppc64_pattern_list]:
+    s390_pattern_list = "s390\s+\[?([a-zA-Z0-9_-]+)\]?.*\n"
+    
+    for pattern_list in [x86_pattern_list, ppc64_pattern_list, s390_pattern_list]:
         model_list = check_model_list(pattern_list)
         if model_list is not None:
             return model_list

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2193,7 +2193,7 @@ def extract_qemu_cpu_models(qemu_cpu_help_text):
     x86_pattern_list = "x86\s+\[?([a-zA-Z0-9_-]+)\]?.*\n"
     ppc64_pattern_list = "PowerPC\s+\[?([a-zA-Z0-9_-]+\.?[0-9]?)\]?.*\n"
     s390_pattern_list = "s390\s+\[?([a-zA-Z0-9_-]+)\]?.*\n"
-    
+
     for pattern_list in [x86_pattern_list, ppc64_pattern_list, s390_pattern_list]:
         model_list = check_model_list(pattern_list)
         if model_list is not None:


### PR DESCRIPTION
I'm not sure if this is all that's needed, but fixes the following:

2016-05-12 20:02:08,330 stacktrace L0036 ERROR|
2016-05-12 20:02:08,330 stacktrace L0039 ERROR| Reproduced traceback from: /avocado/avocado-vt/avocado_vt/test.py:393
2016-05-12 20:02:08,332 stacktrace L0042 ERROR| Traceback (most recent call last):
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| File "/avocado/avocado-vt/avocado_vt/test.py", line 169, in runTest
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| self._runTest()
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| File "/avocado/avocado-vt/avocado_vt/test.py", line 301, in _runTest
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| params = env_process.preprocess(self, params, env)
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| File "/avocado/avocado-vt/virttest/error_context.py", line 135, in new_fn
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| return fn(args, *kwargs)
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| File "/avocado/avocado-vt/virttest/env_process.py", line 658, in preprocess
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| env["cpu_model"] = utils_misc.get_qemu_best_cpu_model(params)
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| File "/avocado/avocado-vt/virttest/utils_misc.py", line 2330, in get_qemu_best_cpu_model
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| qemu_cpu_models = get_qemu_cpu_models(qemu_binary)
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| File "/avocado/avocado-vt/virttest/utils_misc.py", line 2216, in get_qemu_cpu_models
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| return extract_qemu_cpu_models(result.stdout)
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| File "/avocado/avocado-vt/virttest/utils_misc.py", line 2206, in extract_qemu_cpu_models
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| raise UnsupportedCPU(e_msg)
2016-05-12 20:02:08,333 stacktrace L0042 ERROR| UnsupportedCPU: CPU models reported by qemu -cpu ? not supported by avocado-vt. Please work with us to add support for it
2016-05-12 20:02:08,333 stacktrace L0043 ERROR|
2016-05-12 20:02:08,334 test L0567 ERROR| ERROR 1-type_specific.io-github-autotest-qemu.migrate.default.tcp -> UnsupportedCPU: CPU models r eported by qemu -cpu ? not supported by avocado-vt. Please work with us to add support for it
2016-05-12 20:02:08,334 test L0554 INFO |