### PR TITLE
asset: Adding try/except to avoid connection issues during download [v2].

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -488,9 +488,13 @@ def download_file(asset_info, interactive=False, force=False):
         else:
             answer = 'y'
         if answer == 'y':
-            download.url_download_interactive(url, destination,
-                                              "Downloading %s" % title)
-            had_to_download = True
+            try:
+                download.url_download_interactive(url, destination,
+                                                  "Downloading %s" % title)
+                had_to_download = True
+            except Exception, e:
+                logging.error("Error %s while trying to download the file. "
+                              "Do you have connection?", e)
         else:
             logging.warning("Missing file %s", destination)
     else:
@@ -513,8 +517,16 @@ def download_file(asset_info, interactive=False, force=False):
                 if answer == 'y':
                     logging.info("Updating image to the latest available...")
                     while not file_ok:
-                        download.url_download_interactive(url, destination,
-                                                          title)
+                        try:
+                            download.url_download_interactive(url, destination,
+                                                              title)
+                        except Exception, e:
+                            logging.error("Error %s while trying to download "
+                                          "the file. Do you have connection?",
+                                          e)
+                            file_ok = False
+                            break
+
                         sha1_post_download = crypto.hash_file(destination,
                                                               algorithm='sha1')
                         had_to_download = True


### PR DESCRIPTION
When you are downloading the JEOS image and you lost the connection,
avocado chrashes with an error:
...
23:48:45 INFO | 6 - Verifying (and possibly downloading) guest image
23:48:45 INFO | Verifying expected SHA1 sum from
http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23
23:49:00 INFO | Expected SHA1 sum:
b88d553e19736aa3ec61caa7653c5b30e6d4b59a
23:49:00 INFO | Found
/home/jfaracco/Desktop/c4eb/git/virt-test/tests/data/avocado-vt/images/jeos-23-64.qcow2.7z
23:49:00 INFO | Actual SHA1 sum:
da39a3ee5e6b4b0d3255bfef95601890afd80709
The file seems corrupted or outdated. Would you like to download it?
(y/n) y
23:49:13 INFO | Updating image to the latest available...
Avocado crashed unexpectedly: <urlopen error [Errno -2] Name or service
not known>
You can find details in
/var/tmp/avocado-traceback-2016-05-15_23:49:13-truuCl.log

Adding try/except will avoid this problem because urllib2 will not throw
any unexpected exception.

Signed-off-by: Julio Faracco jcfaracco@gmail.com
