### PR TITLE
avocado_vt: Avoid re-creating subtests/guest-os on run [v3]

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -23,7 +23,6 @@ import sys
 from avocado.core import loader
 from avocado.core import output
 
-from virttest import bootstrap
 from virttest import cartesian_config
 from virttest import data_dir
 from virttest import standalone_test
@@ -103,8 +102,6 @@ class VirtTestLoader(loader.TestLoader):
         add_if_not_exist('test_lister', True)
 
     def _get_parser(self):
-        bootstrap.create_guest_os_cfg(self.args.vt_type)
-        bootstrap.create_subtests_cfg(self.args.vt_type)
         options_processor = VirtTestOptionsProcess(self.args)
         return options_processor.get_parser()
 

--- a/docs/source/CartesianConfig.rst
+++ b/docs/source/CartesianConfig.rst
@@ -954,7 +954,8 @@ the virtualization technology-specific directory.  For example, ``backends/qemu/
 |                             | Modifications are discouraged since they will   |
 |                             | be lost next time bootstrap is used.            |
 +-----------------------------+-------------------------------------------------+
-| cfg/guest-os.cfg            | Automatically generated from                    |
+| cfg/guest-os.cfg            | Automatically generated when                    |
+|                             | ``avocado vt-bootstrap`` is used from           |
 |                             | files within ``shared/cfg/guest-os/``.  Defines |
 |                             | all supported guest operating system            |
 |                             | types, architectures, installation images,      |

--- a/docs/source/WritingTests/WritingSimpleTests.rst
+++ b/docs/source/WritingTests/WritingSimpleTests.rst
@@ -240,6 +240,15 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
 
     $ avocado list uptime
 
+#. OK still not there. We need to propagate the change to the actual config
+   by running `vt-bootstrap`::
+
+    $ avocado vt-bootstrap
+
+#. And now you'll finally see the test::
+
+    $ avocado list uptime
+
 #. Now, you can run your test to see if everything went well::
 
         $ avocado run --vt-type qemu uptime

--- a/docs/source/WritingTests/WritingSimpleTests.rst
+++ b/docs/source/WritingTests/WritingSimpleTests.rst
@@ -8,26 +8,29 @@ In this article, we'll talk about:
 #. Write a simple test file
 #. Try out your new test, send it to the mailing list
 
-Write our own, drop-in 'uptime' test - Step by Step procedure
--------------------------------------------------------------
+Write our own 'uptime' test - Step by Step procedure
+----------------------------------------------------
 
 Now, let's go and write our uptime test, which only purpose in life is
 to pick up a living guest, connect to it via ssh, and return its uptime.
 
-#. Git clone tp-qemu.git to a convenient location, say $HOME/Code/tp-qemu::
+#. First we need to locate our provider directory. It's inside Avocado
+   `data` directory (`avocado config --datadir`), usually in
+   `~/avocado/data/avocado-vt`. We are going to write a generic `tp-qemu`
+   test, so let's move into the right git location::
 
-    $ git clone https://github.com/autotest/tp-qemu.git
+    $ cd $AVOCADO_DATA/avocado-vt/test-providers.d/downloads/io-github-autotest-qemu
 
 #. Our uptime test won't need any qemu specific feature. Thinking about
    it, we only need a vm object and establish an ssh session to it, so we
    can run the command. So we can store our brand new test under
-   ``tests``. At the autotest root location::
+   ``generic/tests``::
 
     $ touch generic/tests/uptime.py
     $ git add generic/tests/uptime.py
 
 #. OK, so that's a start. So, we have *at least* to implement a
-   function ``run_uptime``. Let's start with it and just put the keyword
+   function ``run``. Let's start with it and just put the keyword
    pass, which is a no op. Our test will be like:
 
 .. code-block:: python
@@ -212,16 +215,37 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
         $ inspekt indent generic/tests/uptime.py
 
 #. Now, you can test your code. When listing the qemu tests your new test should
-   appear in the list::
+   appear in the list (or shouldn't it?)::
 
         $ avocado list uptime
 
+#. There is one more thing to do. Avocado-vt does not walk the directories,
+   it uses `Cartesian config` to define test and all possible variants of
+   tests. To add our test to `Cartesian config` we need yet another file::
+
+    $ touch generic/tests/cfg/uptime.cfg
+    $ git add generic/tests/cfg/uptime.cfg
+
+#. The file might look like this::
+
+    - uptime:
+        virt_test_type = qemu libvirt
+        type = uptime
+
+   where the `virt_test_type` specifies what backends can run this test and
+   `type` specifies the test file. The `.py` will be appended and it'll be
+   searched for in the usual location.
+
+#. For the second time, let's try to discover the test::
+
+    $ avocado list uptime
+
 #. Now, you can run your test to see if everything went well::
 
-        $ avocado run --vt-type uptime
+        $ avocado run --vt-type qemu uptime
 
 #. OK, so now, we have something that can be git committed and sent to
-   the mailing list:
+   the mailing list (partial):
 
 .. code-block:: diff
 


### PR DESCRIPTION
Currently the `subtests.cfg` and `guest-os.cfg` files are always re-
created on `vt-bootstrap` and during each invocation of `avocado-vt`
loader (during `avocado list` and `avocado run`), which is not optimal
and wrong for several reasons.

1. `avocado run` should not modify any configs, it should only run test
2. parallel execution of `avocado run`/`avocado list` causes issues
3. even documentation refers to update on `vt-bootstrap` on some places

This behavior is convenient for test developers, but it does not belongs
to production environment. So this patch improves the documentation and
removes the `subtests.cfg`/`guest-os.cfg` recreation from the loader.

Every since this commit test developers need to run `avocado vt-
bootstrap` to propagate the changes to subtests/guest-os!

v1: https://github.com/avocado-framework/avocado-vt/pull/490
v2: https://github.com/avocado-framework/avocado-vt/pull/497

Changes:

    v2: Change the approach from locking to recreate only in vt-bootstrap
    v3: Fix "avocado --vt-bootstrap" => "avocado vt-bootstrap"