### PR TITLE
qemu_devices.qcontainer: aio=native requried cache.direct=on

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1395,6 +1395,9 @@ class DevContainer(object):
         devices[-1].set_param('snapshot', snapshot, bool)
         devices[-1].set_param('readonly', readonly, bool)
         if 'aio' in self.get_help_text():
+            if aio == 'native' and snapshot == 'yes':
+                logging.warn('snapshot is on, fallback aio to threads.')
+                aio = 'threads'
             devices[-1].set_param('aio', aio)
         devices[-1].set_param('media', media)
         devices[-1].set_param('format', imgfmt)


### PR DESCRIPTION
so fallback aio to 'threads' if snapshot is on and
aio is not 'threads'.

Signed-off-by: XuTian <xutian@redhat.com>