### PR TITLE
Typo fix serial commented out to serials in base.cfg

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -102,7 +102,7 @@ usb_bus = usb1.0
 # Serial port support
 # You can assign more than one serial to guest with this parameter.
 # like:
-# serial = "S1 S2 S3"
+# serials = "S1 S2 S3"
 serials = "serial0"
 
 # virtio_serialport and virtio_console ports


### PR DESCRIPTION
Modify minor error in base.cfg,which is variant of serial commented out to serials
Signed-off-by: MiramDeng mdeng@redhat.com