### PR TITLE
virttest.storage: pass 'shell=True' to function get_image_filename_filesytem for resolving filename wildcards

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -186,7 +186,8 @@ def get_image_filename_filesytem(params, root_dir):
     if indirect_image_select:
         re_name = image_name
         indirect_image_select = int(indirect_image_select)
-        matching_images = process.system_output("ls -1d %s" % re_name)
+        matching_images = process.system_output("ls -1d %s" % re_name,
+                                                shell=True)
         matching_images = sorted(matching_images.split('\n'), cmp=sort_cmp)
         if matching_images[-1] == '':
             matching_images = matching_images[:-1]


### PR DESCRIPTION
Pass 'shell=True' to function get_image_filename_filesytem for resolving filename wildcards.

The issue:
```
17:43:08 INFO | Running 'ls -1d /dev/sd*'
17:43:08 DEBUG| [stderr] ls: cannot access /dev/sd*: No such file or directory
17:43:08 ERROR| Command 'ls -1d /dev/sd*' failed (rc=2)
```

ID: 1334978