### PR TITLE
virttest.utils_net: fix CmdError for get_host_default_gateway

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3289,7 +3289,7 @@ def get_host_default_gateway():
     """
     cmd = "ip route | awk '/default/ { print $3 }'"
     try:
-        output = process.system_output(cmd)
+        output = process.system_output(cmd, shell=True)
     except:
         raise exceptions.TestError("Failed to get the host's default GateWay.")
 


### PR DESCRIPTION
Set option 'shell=True' to resolve the pipe notation.
```
INFO | Running 'ip route | awk '/default/ { print $3 }''
DEBUG| [stderr] Command "|" is unknown, try "ip route help".
```
ID: 1337020