### PR TITLE
virttest.cartesian_config: enable postfix_parse

### DIFF
--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -1939,6 +1939,7 @@ class Parser(object):
             for d in self.get_dicts_plain(node, ctx, content, shortname, dep):
                 if parent:
                     self.drop_suffixes(d)
+                postfix_parse(d)
                 yield d
         else:
             # Rewrite all separate joins in one node as many `only'
@@ -1954,6 +1955,7 @@ class Parser(object):
             for d in self.multiply_join(onlys, node, ctx, content, shortname, dep):
                 if parent:
                     self.drop_suffixes(d)
+                postfix_parse(d)
                 yield d
             node.content = old_conten[:]
 


### PR DESCRIPTION
postfix string '_fixed', '_max' and '_min' doesn't work, because
'postfix_parse' not call in get_dict function. this commit enable
it, because tp-qemu tests need these params.

Signed-off-by: Xu Tian <xutian@redhat.com>