### PR TITLE
utils_misc: Fix the cleanup for one side setup

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3644,10 +3644,14 @@ class SELinuxBoolean(object):
         # Change SELinux boolean value on local host
         if self.set_bool_local == "yes":
             self.setup_local()
+        else:
+            self.cleanup_local = False
 
         # Change SELinux boolean value on remote host
         if self.set_bool_remote == "yes":
             self.setup_remote()
+        else:
+            self.cleanup_remote = False
 
     def cleanup(self, keep_authorized_keys=False):
         """


### PR DESCRIPTION
If we only setup SELinux boolean on one side, we should not clean up the
other side when done. So fix it.

Signed-off-by: Dan Zheng <dzheng@redhat.com>