### PR TITLE
define the value of 'skip_hash'

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1532,7 +1532,7 @@ class VM(virt_vm.BaseVM):
                 if not os.path.exists(iso):
                     raise virt_vm.VMImageMissingError(iso)
                 compare = False
-                if cdrom_params.get("skip_hash"):
+                if cdrom_params.get("skip_hash", "no") == "yes":
                     logging.debug("Skipping hash comparison")
                 elif cdrom_params.get("md5sum_1m"):
                     logging.debug("Comparing expected MD5 sum with MD5 sum of "

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2334,7 +2334,7 @@ class VM(virt_vm.BaseVM):
                 if not os.path.exists(iso):
                     raise virt_vm.VMImageMissingError(iso)
                 compare = False
-                if cdrom_params.get("skip_hash"):
+                if cdrom_params.get("skip_hash", "no") == "yes":
                     logging.debug("Skipping hash comparison")
                 elif cdrom_params.get("md5sum_1m"):
                     logging.debug("Comparing expected MD5 sum with MD5 sum of "


### PR DESCRIPTION
Use 'skip_hash_xx' together with 'md5sum_xx' and 'sha1sum_xx',
and it's value must be 'yes' or 'no', default is 'no'.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>