### PR TITLE
utils_test.libvirt: set disk cache

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2036,13 +2036,14 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
     secret_type = params.get("secret_type")
     secret_usage = params.get("secret_usage")
     secret_uuid = params.get("secret_uuid")
+    driver_cache = params.get("driver_cache", "none")
     disk_params = {'device_type': disk_device,
                    'disk_snapshot_attr': disk_snapshot_attr,
                    'type_name': disk_type,
                    'target_dev': disk_target,
                    'target_bus': disk_target_bus,
                    'driver_type': disk_format,
-                   'driver_cache': 'none',
+                   'driver_cache': driver_cache,
                    'driver_iothread': driver_iothread,
                    'sec_model': sec_model,
                    'relabel': relabel,


### PR DESCRIPTION
Enable to set the disk cache for the newly created disk for the guest.

Signed-off-by: Dan Zheng <dzheng@redhat.com>