### PR TITLE
Two issue about param shell

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -770,8 +770,10 @@ class VM(virt_vm.BaseVM):
                 dev = QDevice(device_driver, parent_bus=pci_bus)
             else:
                 dev = qdevices.QCustomDevice('pcidevice', parent_bus=pci_bus)
-            help_cmd = "%s -device %s,\\? 2>&1" % (qemu_binary, device_driver)
-            pcidevice_help = process.system_output(help_cmd, verbose=False)
+            help_cmd = "%s -device %s,\? 2>&1" % (qemu_binary, device_driver)
+            pcidevice_help = process.system_output(help_cmd,
+                                                   shell=True,
+                                                   verbose=False)
             dev.set_param('host', host)
             dev.set_param('id', 'id_%s' % host.replace(":", "."))
             fail_param = []

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1106,7 +1106,7 @@ class PciAssignable(object):
         """
 
         cmd = "lspci | awk '/%s/ {print $1}'" % self.pf_filter_re
-        pf_ids = [i for i in process.system_output(cmd).splitlines()]
+        pf_ids = [i for i in process.system_output(cmd, shell=True).splitlines()]
         pf_vf_dict = []
         for pf_id in pf_ids:
             pf_info = {}
@@ -1131,7 +1131,7 @@ class PciAssignable(object):
         ethnames = re.findall(self.nic_name_re, if_out)
         for eth in ethnames:
             cmd = "ethtool -i %s | awk '/bus-info/ {print $2}'" % eth
-            pci_id = process.system_output(cmd)
+            pci_id = process.system_output(cmd, shell=True)
             if not pci_id:
                 continue
             for pf in pf_vf_dict:
@@ -1236,7 +1236,7 @@ class PciAssignable(object):
         # 'virtual function' belongs to which physical card considering
         # that if the host has more than one 82576 card. PCI_ID?
         cmd = "lspci | grep '%s' | wc -l" % self.vf_filter_re
-        vf_num = int(process.system_output(cmd, verbose=False))
+        vf_num = int(process.system_output(cmd, shell=True, verbose=False))
         logging.info("Found %s vf in host", vf_num)
         return vf_num
 

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1477,7 +1477,7 @@ def get_thread_cpu(thread):
     :rtype: builtin.list
     """
     cmd = "ps -o cpuid,lwp -eL | grep -w %s$" % thread
-    cpu_thread = process.system_output(cmd)
+    cpu_thread = process.system_output(cmd, shell=True)
     if not cpu_thread:
         return []
     return list(set([_.strip().split()[0] for _ in cpu_thread.splitlines()]))

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3312,7 +3312,7 @@ def check_listening_port_by_service(service, port, listen_addr='0.0.0.0',
                 utils_path.find_command("netstat")
             except utils_path.CmdNotFoundError, details:
                 raise exceptions.TestSkipError(details)
-            output = process.system_output(cmd)
+            output = process.system_output(cmd, shell=True)
         else:
             if not runner(find_netstat_cmd):
                 raise exceptions.TestSkipError("Missing netstat command on "


### PR DESCRIPTION
commit a3657b85533cd5886594ece953622c7f02ca5c04
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Fri May 27 11:06:00 2016 +0800

    Fix CmdError caused by omitting shell=True
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>

commit 00fa76bbeae2643dfbe5286fa2a88ea1397c1e04
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Fri May 27 10:36:40 2016 +0800

    virttest.qemu_vm: fix output of system_ouput()
    
    If 'shell=True' is ommitted,
    The output of process.system_ouput() will be None.
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
