### PR TITLE
virttest.asset: Avoid providers update on asset import

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -9,7 +9,6 @@ import ConfigParser
 import StringIO
 import commands
 import shutil
-from distutils import dir_util  # virtualenv problem pylint: disable=E0611
 
 from avocado.utils import process
 from avocado.utils import genio
@@ -208,9 +207,6 @@ def get_test_provider_names(backend=None):
     :return: List with the names of all test providers.
     """
     provider_name_list = []
-    tp_base_dir = data_dir.get_base_test_providers_dir()
-    tp_local_dir = data_dir.get_test_providers_dir()
-    dir_util.copy_tree(tp_base_dir, tp_local_dir)
     provider_dir = data_dir.get_test_providers_dir()
     for provider in glob.glob(os.path.join(provider_dir, '*.ini')):
         provider_name = os.path.basename(provider).split('.')[0]

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -782,6 +782,11 @@ def bootstrap(options, interactive=False):
     logging.info("")
     step += 1
     logging.info("%d - Updating all test providers", step)
+    # First update the test-providers-ini from base to data dir
+    tp_base_dir = data_dir.get_base_test_providers_dir()
+    tp_local_dir = data_dir.get_test_providers_dir()
+    dir_util.copy_tree(tp_base_dir, tp_local_dir)
+    # Now try to download/update the providers (if necessary)
     asset.download_all_test_providers(options.vt_update_providers)
 
     logging.info("")


### PR DESCRIPTION
The test providers are defined in ini files stored in user's datadir.
For convenience these were synced from the avocado base dir on every
`virttest.asset` import, which is unexpected as only bootstrap should
update data dir. This patch moves this update to the bootstrap instead.
Note that the ini files are synced even when the providers are not
downloaded (as before).

This extends the cleanup started in https://github.com/avocado-framework/avocado-vt/pull/514

@Andrei-Stepanov, I remember that spice uses extended providers utilities, can you please double check this wont break your workflow? Basically it's the same story as the https://github.com/avocado-framework/avocado-vt/pull/514 usually nothing changes, only when test developer changes these files locally he needs to re-run the bootstrap.

@clebergnu hopefully this fixes the issue you found: https://trello.com/c/hxqiVZCy/688-bug-avocado-vt-test-loader-fails-when-run-in-parallel