### PR TITLE
RFC: Plugin interfaces: adjustments for changes in Avocado

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -21,7 +21,13 @@ import os
 from avocado.core.loader import loader
 from avocado.core.settings import settings
 from avocado.utils import path as utils_path
-from avocado.plugins.base import CLI
+
+# Avocado's plugin interface module has changed location. Let's keep
+# compatibility with old for at, least, a new LTS release
+try:
+    from avocado.core.plugin_interfaces import CLI
+except ImportError:
+    from avocado.plugins.base import CLI
 
 from virttest import data_dir
 from virttest import defaults

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -16,7 +16,13 @@ import sys
 import logging
 
 from avocado.utils import process
-from avocado.plugins.base import CLICmd
+
+# Avocado's plugin interface module has changed location. Let's keep
+# compatibility with old for at, least, a new LTS release
+try:
+    from avocado.core.plugin_interfaces import CLICmd
+except ImportError:
+    from avocado.plugins.base import CLICmd
 
 from virttest import bootstrap
 from virttest import defaults

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -21,7 +21,13 @@ import sys
 
 from avocado.core.loader import loader
 from avocado.core.settings import settings
-from avocado.plugins.base import CLI
+
+# Avocado's plugin interface module has changed location. Let's keep
+# compatibility with old for at, least, a new LTS release
+try:
+    from avocado.core.plugin_interfaces import CLI
+except ImportError:
+    from avocado.plugins.base import CLI
 
 from ..loader import VirtTestLoader
 


### PR DESCRIPTION
This adjusts, while keeping compatibility, with the proposed change
for a better module name and location for the plugin interface
definitions.

This is related to https://github.com/avocado-framework/avocado/pull/1235

Signed-off-by: Cleber Rosa <crosa@redhat.com>