### PR TITLE
Improve the output of creating monitor

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -116,18 +116,18 @@ def create_monitor(vm, monitor_name, monitor_params):
     :param monitor_name: The name of this monitor object.
     :param monitor_params: The dict for creating this monitor object.
     """
-    monitor_creator = HumanMonitor
+    MonitorClass = HumanMonitor
     if monitor_params.get("monitor_type") == "qmp":
         if not utils_misc.qemu_has_option("qmp", vm.qemu_binary):
             # Add a "human" monitor on non-qmp version of qemu.
-            logging.warn("QMP monitor is unsupported by this version of qemu,"
-                         " creating human monitor instead.")
+            logging.warn("QMP monitor is unsupported by %s,"
+                         " creating human monitor instead." % vm.qemu_version)
         else:
-            monitor_creator = QMPMonitor
+            MonitorClass = QMPMonitor
 
     monitor_filename = get_monitor_filename(vm, monitor_name)
-    logging.info("Connecting to monitor '%s'", monitor_name)
-    monitor = monitor_creator(vm, monitor_name, monitor_filename)
+    logging.info("Connecting to monitor '<%s> %s'", MonitorClass, monitor_name)
+    monitor = MonitorClass(vm, monitor_name, monitor_filename)
     monitor.verify_responsive()
 
     return monitor
@@ -329,7 +329,7 @@ class Monitor:
 
     def is_responsive(self):
         """
-        Return True iff the monitor is responsive.
+        Return True if the monitor is responsive.
         """
         try:
             self.verify_responsive()

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1244,6 +1244,8 @@ class VM(virt_vm.BaseVM):
         qemu_binary = utils_misc.get_qemu_binary(params)
 
         self.qemu_binary = qemu_binary
+        self.qemu_version = commands.getoutput("%s -version" %
+                                               qemu_binary).split(',')[0]
         support_cpu_model = commands.getoutput("%s -cpu \\?" % qemu_binary)
 
         self.last_driver_index = 0


### PR DESCRIPTION
commit 85d37a3257bbf8a03cb5c3fc9d45f4492895f5fe
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Tue May 31 10:53:27 2016 +0800

    virttest/qemu_monitor: Improve the output of creating monitor
    
    1) Output the accurate qemu version that doesn't support QMP.
    
    2) Output the type of monitor, new former '<type> <monitor_name>'.
       It's useful to distinguish the kind of monitor for user.
    
       for example,
       <virttest.qemu_monitor.HumanMonitor> hmp
       or <virttest.qemu_monitor.QMPMonitor> qmp
    
    3) Fix typo, s/iff/if
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>

commit 061b0f13448f213b8599483f9e956516c8e7ebe9
Author: Wei Jiangang <weijg.fnst@cn.fujitsu.com>
Date:   Tue May 31 10:51:07 2016 +0800

    virttest.qemu_vm: Add member 'qemu_version' for class VM
    
    Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>