### PR TITLE
Job lock: plugin that prevents multiple runs of VT jobs [v4]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ clean:
 
 link:
 	ln -sf ../../../../$(DIRNAME)/etc/avocado/conf.d/vt.conf ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/
+	ln -sf ../../../../$(DIRNAME)/etc/avocado/conf.d/vt_joblock.conf ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/
 	$(PYTHON) setup.py develop --user
 
 unlink:

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -1,0 +1,112 @@
+import errno
+import logging
+import os
+import re
+import random
+import string
+import sys
+
+from avocado.core import exit_codes
+from avocado.core.settings import settings
+from avocado.plugins.base import JobPre, JobPost
+
+from ..test import VirtTest
+
+
+class VTJobLock(JobPre, JobPost):
+
+    name = 'vt-joblock'
+    description = 'Avocado-VT Job Lock/Unlock'
+
+    def __init__(self):
+        self.log = logging.getLogger("avocado.app")
+        self.lock_dir = os.path.expanduser(settings.get_value(
+            section="plugins.vtjoblock",
+            key="dir",
+            key_type=str,
+            default='/tmp'))
+        self.lock_file = None
+
+    def _abort(self, message, job):
+        """
+        Aborts the Job by exiting Avocado, adding a failure to the job status
+        """
+        self.log.error(message)
+        sys.exit(exit_codes.AVOCADO_JOB_FAIL | job.exitcode)
+
+    def _set_lock(self, job):
+        if not os.path.isdir(self.lock_dir):
+            msg = ('VT Job lock directory "%s" does not exist... '
+                   'exiting...' % self.lock_dir)
+            self._abort(msg, job)
+
+        pattern = 'avocado-vt-joblock-%(jobid)s-%(uid)s-%(random)s.pid'
+        # the job unique id is already random, but, let's add yet another one
+        rand = ''.join([random.choice(string.ascii_lowercase + string.digits)
+                        for i in xrange(8)])
+        path = pattern % {'jobid': job.unique_id,
+                          'uid': os.getuid(),
+                          'random': rand}
+        path = os.path.join(self.lock_dir, path)
+
+        try:
+            with open(path, 'w') as lockfile:
+                lockfile.write("%u" % os.getpid())
+            self.lock_file = path
+        except IOError as e:
+            msg = ('Failed to create VT Job lock file "%s". Exiting...' % path)
+            self._abort(msg, job)
+
+    def _get_lock_file_pid(self):
+        """
+        Gets the lock file path and the process ID
+
+        If the lock file can not be located, this returns (None, 0).
+
+        :returns: the path and the (integer) process id
+        :rtype: tuple(str, int)
+        """
+        try:
+            files = os.listdir(self.lock_dir)
+            if not files:
+                return (None, 0)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return (None, 0)
+
+        pattern = re.compile(r'avocado-vt-joblock-[0-9a-f]{40}-[0-9]+'
+                             '-[0-9a-z]{8}\.pid')
+        for lock_file in files:
+            if pattern.match(lock_file):
+                path = os.path.join(self.lock_dir, lock_file)
+                if os.path.isfile(path):
+                    content = int(open(path, 'r').read())
+                    pid = int(content)
+                    if pid > 0:
+                        return (path, pid)
+        return (None, 0)
+
+    def _lock(self, job):
+        filename, lock_pid = self._get_lock_file_pid()
+        if lock_pid > 0:
+            msg = ('Avocado-VT job lock file "%s" acquired by PID %u. '
+                   'Aborting...' % (filename, lock_pid))
+            self._abort(msg, job)
+        self._set_lock(job)
+
+    def _unlock(self):
+        if self.lock_file:
+            os.unlink(self.lock_file)
+
+    def pre(self, job):
+        try:
+            if any(test_factory[0] is VirtTest
+                   for test_factory in job.test_suite):
+                self._lock(job)
+        except Exception as detail:
+            msg = "Failure trying to set Avocado-VT job lock: %s" % detail
+            self._abort(msg, job)
+
+    def post(self, job):
+        if self.lock_file is not None:
+            self._unlock()

--- a/docs/source/ParallelJobs.rst
+++ b/docs/source/ParallelJobs.rst
@@ -1,0 +1,74 @@
+.. _parallel_jobs:
+
+Parallel Jobs
+=============
+
+Avocado-VT ships with a plugin that creates a lock file in a known
+public location (``/tmp`` by default, but configurable) to prevent
+multiple runs of jobs that include VT tests.
+
+The reason is that, by default, multiple jobs running at the same can
+access the same data files and cause corruption.  Example of data
+files are the guest images, which are usually modified, either
+directly or indirectly by the tests.
+
+Checking Installation
+---------------------
+
+The vt-joblock is installed and registered by default.  To make sure
+it's active, run::
+
+  $ avocado plugins
+
+The VT Job lock plugin should be listed::
+
+  Plugins that run before/after the execution of jobs (avocado.plugins.job.prepost):
+  ...
+  vt-joblock Avocado-VT Job Lock/Unlock
+  ...
+
+Configuration
+-------------
+
+The configuration for the vt-joblock plugin can be found at
+``/etc/avocado/conf.d/vt_joblock.conf``.  Example of a configuration
+file content follows::
+
+  [plugins.vtjoblock]
+  # Directory where the lock file will be located. Avocado should have permission
+  # to write to this directory.
+  dir=/tmp
+
+The configuration key ``dir`` lets you set the directory where Avocado
+will look for an existing lock file before running, and create one
+if it doesn't exist yet.
+
+Running Parallel Jobs
+---------------------
+
+Supposing that you have multiple users on a single machine, using
+different data directories, you can allow parallel VT jobs by setting
+different lock directories for each user.
+
+To do so, you can add the customized lock directory to the user's own
+Avocado configuration file.  Start by creating a lock directory::
+
+  [user1@localhost] $ mkdir ~/avocado/data/avocado-vt/lockdir
+
+Then modify the user's own configuration to point to the newly created
+lock directory::
+
+  [user1@localhost] $ cat >> ~/.config/avocado/avocado.conf <<EOF
+  [plugins.vtjoblock]
+  dir=/home/user1/avocado/data/avocado-vt/lockdir
+  EOF
+
+Then verify with::
+
+  [user1@localhost] $ avocado config | grep plugins.vtjoblock
+  ...
+  plugins.vtjoblock.dir          /home/user1/avocado/data/avocado-vt/lockdir
+  ...
+
+Do the same thing for other users and their jobs will not be locked by
+one another.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,7 @@ Contents:
    RegressionTestFarm
    InstallWinVirtio
    RunQemuUnittests
+   ParallelJobs
    contributing/index
 
 =============

--- a/etc/avocado/conf.d/vt_joblock.conf
+++ b/etc/avocado/conf.d/vt_joblock.conf
@@ -1,0 +1,4 @@
+[plugins.vtjoblock]
+# Directory where the lock file will be located. Avocado should have permission
+# to write to this directory.
+dir=/tmp

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,9 @@ setup(name='avocado-plugins-vt',
               ],
           'avocado.plugins.cli.cmd': [
               'vt-bootstrap = avocado_vt.plugins.vt_bootstrap:VTBootstrap',
-              ]
+              ],
+          'avocado.plugins.job.prepost': [
+              'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock'
+              ],
           },
       )


### PR DESCRIPTION
This introduces a Pre/Post Job type of plugin, that attempts to create
a lock file in a common location before the job is started, and remove
the lock file after the job has finished.  The goal is to prevent
multiple runs of avocado (with VT tests) to corrupt files such as
guest OS images.

It's still possible to have multiple parallel jobs running on the same
machine, as long as their configuration point to different lock
directories, which should follow different data directories, to
prevent the original problem of data file corruption.

The mechanism used for locking is a simplistic one, similar to daemon
PID files.  It should be possible to either rewrite or improve the
lock mechanism completely without bringing changes to the user
expected behavior of, by default, not having multiple Avocado-VT jobs
run at once.

While testing for parallel execution of VT and non-VT jobs, it was
found that the VT loader had a number of issues that make it fail to
run in parallel.  Thse have been fixed and the attempt to execute jobs
in parallel works as expected.

References: https://trello.com/c/hxqiVZCy
References: https://trello.com/c/7xEPKDsJ
Signed-off-by: Cleber Rosa <crosa@redhat.com>

--

Changes from v3 (#543):
* Add config file to `make link` target
* Removed the `VT LOCK` line
* Added lock file location to error message when lock is already acquired by other process
* Allow `~/` expansions on the lock dir configuration value


Changes from v2 (#484)
 * Show path if it fails to create the lock file
 * Always show the lock file message and remove related option
 * Removed additional check for `lock_dir` directory in `_get_lock_file()`
 * Added `try/except` block in `pre()` so that any failure aborts the job
 * Removed `_get_lock_pid()` by consolidating the functionality in `_get_lock_filename()`
 * Removed `has_vt_test` attribute

Changes from v1
 * Use the in-job `test_suite` attribute  