### PR TITLE
guest-hw: skip image check step in qemu_io_blkdebug test

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -126,9 +126,13 @@ variants:
         image_format = qcow2
         image_extra_params = "compat=1.1"
         check_image = yes
+        qemu_io_blkdebug:
+            check_image = no
     - qcow2:
         image_format = qcow2
         check_image = yes
+        qemu_io_blkdebug:
+            check_image = no
     - vmdk:
         no ioquit
         image_format = vmdk


### PR DESCRIPTION
negative test steps include in qemu_io_blkdebug test, and check image after negative operation is not make sense, so skip the step.

Signed-off-by: Ping Li pingl@redhat.com