### PR TITLE
virttest.autotest: Fix timeout when running autotest

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -960,9 +960,9 @@ def run_autotest(vm, session, control_path, timeout,
             tarball_url = ("https://codeload.github.com/autotest/"
                            "autotest-client-tests/tar.gz/master")
             tarball_url = params.get("client_test_url", tarball_url)
-            timeout = int(params.get("download_tests_timeout", "600"))
+            tests_timeout = int(params.get("download_tests_timeout", "600"))
             tests_tarball = os.path.join(data_dir.get_tmp_dir(), "tests.tgz")
-            download.url_download(tarball_url, tests_tarball, timeout=timeout)
+            download.url_download(tarball_url, tests_tarball, timeout=tests_timeout)
             copy_if_hash_differs(vm, tests_tarball, tests_tarball)
             extract(vm, tests_tarball, tests_dir)
             os.remove(tests_tarball)


### PR DESCRIPTION
The parameter timeout is defined as function argument.
Here, it alway change timeout to 600s, and will cause some
jobs ended prematurely in error:

INFO | Running autotest control file ctcs.control on guest, timeout 600s
...
ERROR| ERROR ... TestError: Timeout elapsed while waiting for job to complete

Signed-off-by: Haishuang Yan <yanhaishuang@cmss.chinamobile.com>