### PR TITLE
virttest: Add named GPIOs support

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -339,6 +339,13 @@ class QtreeContainer(object):
                             current.set_qtree_prop('mmio', [])
                         current.qtree['mmio'].append(line[1])
                         line = None
+                    # qemu commit a5f5429 introduced named GPIOs, So add string
+                    # key into line[0] to distinguish GPIOs, and save exact
+                    # value into line[1].
+                    elif line[0] == 'gpio-in' or line[0] == 'gpio-out':
+                        tmp_field = line[1].split(' ', 1)
+                        line[0] = "%s %s" % (line[0], tmp_field[0])
+                        line[1] = tmp_field[1]
                 else:
                     # Corrupted qtree
                     raise ValueError('qtree line not recognized:\n%s' % line)


### PR DESCRIPTION
qemu commit a5f5429 introduced named GPIOs. Some qemu devices(say hpet)
present multiple gpio-in(s) or gpio-out(s) with different string keys
in qtree information. In this case, It causes device_option_check test
failure because it doesn't recognize the string keys, Example:

......
(monitor hmp1) Response to 'info qtree'
(monitor hmp1)    bus: main-system-bus
(monitor hmp1)      type System
(monitor hmp1)      dev: hpet, id ""
(monitor hmp1)        gpio-in "" 2
(monitor hmp1)        gpio-out "" 1
(monitor hmp1)        gpio-out "sysbus-irq" 32
......
ValueError: Property gpio-out = "" 1, not rewriting with "sysbus-irq" 32
......

This patch adds the named GPIOs support to fix this issue.

Signed-off-by: Lin Ma <lma@suse.com>