### PR TITLE
virttest.bootstrap: Avoid config_filter caching on import

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -93,13 +93,11 @@ def get_guest_os_info_list(test_name, guest_os):
     return os_info_list
 
 
-def _get_config_filter():
+def get_config_filter():
     config_filter = ['__init__', ]
     for provider_subdir in asset.get_test_provider_subdirs():
         config_filter.append(os.path.join('%s' % provider_subdir, 'cfg'))
     return config_filter
-
-config_filter = _get_config_filter()
 
 
 def verify_recommended_programs(t_type):
@@ -310,6 +308,7 @@ def create_subtests_cfg(t_type):
     specific_file_list = []
     specific_subdirs = asset.get_test_provider_subdirs(t_type)
     provider_names_specific = asset.get_test_provider_names(t_type)
+    config_filter = get_config_filter()
 
     provider_info_specific = []
     for specific_provider in provider_names_specific:
@@ -478,7 +477,7 @@ def create_config_files(test_dir, shared_dir, interactive, t_type, step=None,
     logging.info("%d - Generating config set", step)
     config_file_list = data_dir.SubdirGlobList(os.path.join(test_dir, "cfg"),
                                                "*.cfg",
-                                               config_filter)
+                                               get_config_filter())
     config_file_list = [cf for cf in config_file_list if is_file_tracked(cf)]
     config_file_list_shared = glob.glob(os.path.join(shared_dir, "cfg",
                                                      "*.cfg"))


### PR DESCRIPTION
The `config_filter` was set on import using `_get_config_filter`
function. The problem is, when the directory does not exists yet, then
this filter is incorrect and files like `test-shared.cfg` are included
in the generated `subtests.cfg` (because they are not filtered-out using
the `config_filter`).

This patch removes the cached `config_filter` and renames the
`_get_config_filter` function to `get_config_filter`, which is then used
in functions to get the filter at the time of the function invocation,
which should give the correct results.

This patch fixes the issue where `avocado vt-bootstrap --vt-type spice
--vt-no-downloads --vt-update-config` on empty `~avocado/data` generates
incorrect `subtests.cfg`.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>