### PR TITLE
virttest: Use result instead of result_obj

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1618,7 +1618,7 @@ class VM(virt_vm.BaseVM):
                                      "on cdrom  install. "
                                      "Try using the "
                                      "unattended_install.cdrom.http_ks method "
-                                     "instead." % details.result_obj)
+                                     "instead." % details.result)
                             raise exceptions.TestSkipError(e_msg)
                 if stderr.count('failed to launch bridge helper'):
                     if utils_selinux.is_enforcing():

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1716,7 +1716,7 @@ def net_state_dict(only_names=False, virsh_instance=None, **dargs):
                 persistent = True
             except process.CmdError, detail:
                 # Exception thrown, could be transient or real problem
-                if bool(str(detail.result_obj).count("ransient")):
+                if bool(str(detail.result).count("ransient")):
                     persistent = False
                 else:  # A unexpected problem happened, re-raise it.
                     raise


### PR DESCRIPTION
process.CmdError has a result attribute, not result_obj.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>