### PR TITLE
Qemu support for ibm s390

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -43,6 +43,12 @@ variants:
             nic_model = virtio-net-device
             # Currently arm does not support msix vectors
             enable_msix_vectors = no
+        s390:
+            # Currently s390 only supports virtio-net-ccw
+            nic_model = virtio-net-ccw
+            # Currently s390 does not support msix vectors
+            enable_msix_vectors = no
+
     - xennet:
         # placeholder
     - spapr-vlan:
@@ -88,6 +94,12 @@ variants:
             drive_format=virtio-blk-device
             cd_format = scsi-cd
             scsi_hba = virtio-scsi-device
+        s390:
+            # Currently s390 only supports virtio-blk-ccw on s390
+            drive_format=virtio-blk-ccw
+            cd_format = scsi-cd
+            scsi_hba = virtio-scsi-ccw
+
     - virtio_scsi:
         no WinXP
         # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,
@@ -171,8 +183,8 @@ variants:
         nettype = bridge
         # Driver (kernel module) that supports SR-IOV hardware.
         # As of today (30-11-2009), we have 2 drivers for this type of hardware:
-        # Intel® 82576 Gigabit Ethernet Controller - igb
-        # Neterion® X3100™ - vxge
+        # Intel? 82576 Gigabit Ethernet Controller - igb
+        # Neterion? X3100? - vxge
         driver = igb
         # vf_filter_re: Regex used to filter vf from lspci.
         vf_filter_re = "Virtual Function"
@@ -371,4 +383,3 @@ variants:
         nettype = user
     - network:
         nettype = network
-

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -46,3 +46,15 @@ variants:
         # Currently no USB support
         usbs =
         usb_devices =
+    - s390:
+        only s390
+        auto_cpu_model = "no"
+        cpu_model = host
+        machine_type = s390-ccw-virtio
+        # No support for VGA yet
+        vga = none
+        inactivity_watcher = none
+        take_regular_screendumps = no
+        # Currently no USB support
+        usbs =
+        usb_devices =

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -942,6 +942,26 @@ class DevContainer(object):
                                                   parent_bus={'aobject': 'pci.0'}))
             return devices
 
+        def machine_s390(cmd=False):
+            """
+            s390x (s390) doesn't support PCI bus.
+            :param cmd: If set uses "-M $cmd" to force this machine type
+            :return: List of added devices (including default buses)
+            """
+            devices = []
+            # Add virtio-bus
+            # TODO: Currently this uses QNoAddrCustomBus and does not
+            # set the device's properties. This means that the qemu qtree
+            # and autotest's representations are completelly different and
+            # can't be used.
+            bus = qbuses.QNoAddrCustomBus('bus', [['addr'], [32]],
+                                          'virtio-blk-ccw', 'virtio-bus',
+                                          'virtio-blk-ccw')
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
+                                                  child_bus=bus,
+                                                  aobject="virtio-blk-ccw"))
+            return devices
+
         def machine_other(cmd=False):
             """
             isapc or unknown machine type. This type doesn't add any default
@@ -979,6 +999,8 @@ class DevContainer(object):
                     devices = machine_arm64_pci(cmd)
                 elif arm_machine == 'arm64-mmio':
                     devices = machine_arm64_mmio(cmd)
+                elif machine_type.startswith("s390"):
+                    devices = machine_s390(cmd)
                 elif 'isapc' not in machine_type:   # i440FX
                     devices = machine_i440FX(cmd)
                 else:   # isapc (or other)
@@ -1370,6 +1392,8 @@ class DevContainer(object):
         elif fmt == 'virtio':
             dev_parent = pci_bus
         elif fmt == 'virtio-blk-device':
+            dev_parent = {'type': 'virtio-bus'}
+        elif fmt == 'virtio-blk-ccw':   # For IBM s390 platform
             dev_parent = {'type': 'virtio-bus'}
         else:
             dev_parent = {'type': fmt}

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -436,6 +436,7 @@ class VM(virt_vm.BaseVM):
         def add_serial(devices, name, filename):
             if (not devices.has_option("chardev") or
                     not (devices.has_device("isa-serial") or
+                         devices.has_device("sclpconsole") or  # For s390 console
                          devices.has_device("spapr-vty"))):
                 return " -serial unix:'%s',server,nowait" % filename
 
@@ -452,6 +453,10 @@ class VM(virt_vm.BaseVM):
                 # Workaround for console issue, details:
                 #   lists.gnu.org/archive/html/qemu-ppc/2013-10/msg00129.html
                 cmd += _add_option("reg", "0x30000000")
+            elif 's390' in params.get('vm_arch_name', arch.ARCH):
+                # Only for IBM s390 console:
+                # This is only console option supported
+                cmd += " -device sclpconsole"
             cmd += _add_option("chardev", serial_id)
             return cmd
 
@@ -568,6 +573,8 @@ class VM(virt_vm.BaseVM):
                 # value by parsing the xml file, i.e. counting all the
                 # pci devices and store the number.
                 if model == 'virtio-net-device':
+                    dev.parent_bus = {'type': 'virtio-bus'}
+                if model == 'virtio-net-ccw':  # For s390 platform
                     dev.parent_bus = {'type': 'virtio-bus'}
                 elif model != 'spapr-vlan':
                     dev.parent_bus = pci_bus
@@ -1108,6 +1115,9 @@ class VM(virt_vm.BaseVM):
                 logging.warn("-boot on ARM is usually not supported, use "
                              "bootindex instead.")
                 return ""
+            if params.get('machine_type', "").startswith("s390"):
+                logging.warn("-boot on s390 only support boot strict=on")
+                return "-boot strict=on"
             cmd = " -boot"
             patterns = ["order", "once", "menu", "strict"]
             options = []


### PR DESCRIPTION
This pull request defines IBM s390 machine.
Currently it doesn't support any buses except the 'virtio-bus'.

1) machine_type=virt, cpu_model=host, vga=none, usbs=none
2) instead of "virtio-*-pci" devices, "virtio-*-ccw" are used without the possibility of setting address
3) only set -boot strict=on for s390
4) set s390 supported sclpconsole console