### PR TITLE
Job lock: create the lock and then check for other locks

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -68,6 +68,24 @@ class VTJobLock(JobPre, JobPost):
         except Exception as e:
             raise LockCreationError(e)
 
+    def _get_lock_files(self):
+        """
+        Get the list of lock file names under the current lock dir
+
+        :returns: a list with the full path of files that match the
+                  lockfile pattern
+        :rtype: list
+        """
+        try:
+            files = os.listdir(self.lock_dir)
+            pattern = re.compile(r'avocado-vt-joblock-[0-9a-f]{40}-[0-9]+'
+                                 '-[0-9a-z]{8}\.pid')
+            return [os.path.join(self.lock_dir, _) for _ in files
+                    if pattern.match(_)]
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return []
+
     def _get_lock_file_pid(self):
         """
         Gets the lock file path and the process ID
@@ -77,25 +95,14 @@ class VTJobLock(JobPre, JobPost):
         :returns: the path and the (integer) process id
         :rtype: tuple(str, int)
         """
-        try:
-            files = os.listdir(self.lock_dir)
-            if not files:
-                return (None, 0)
-        except OSError as e:
-            if e.errno == errno.ENOENT:
-                return (None, 0)
-
-        pattern = re.compile(r'avocado-vt-joblock-[0-9a-f]{40}-[0-9]+'
-                             '-[0-9a-z]{8}\.pid')
-        for lock_file in files:
-            if pattern.match(lock_file):
-                path = os.path.join(self.lock_dir, lock_file)
-                if os.path.isfile(path):
-                    content = int(open(path, 'r').read())
-                    pid = int(content)
-                    if pid > 0:
-                        return (path, pid)
-        return (None, 0)
+        files = self._get_lock_files()
+        if not files:
+            return (None, 0)
+        path = files[0]
+        content = int(open(path, 'r').read())
+        pid = int(content)
+        if pid > 0:
+            return (path, pid)
 
     def _lock(self, job):
         filename, lock_pid = self._get_lock_file_pid()

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -52,11 +52,6 @@ class VTJobLock(JobPre, JobPost):
         :returns: the full path for the lock file created
         :rtype: str
         """
-        if not os.path.isdir(self.lock_dir):
-            msg = ('VT Job lock directory "%s" does not exist... '
-                   'exiting...' % self.lock_dir)
-            self._abort(msg, job)
-
         pattern = 'avocado-vt-joblock-%(jobid)s-%(uid)s-%(random)s.pid'
         # the job unique id is already random, but, let's add yet another one
         rand = ''.join([random.choice(string.ascii_lowercase + string.digits)


### PR DESCRIPTION
This attempts to implement the good points raised on issue #567.

It changes the behavior of how locks are acquired, by first creating the process own lock, and then checking if other exist.  If other lock files exist, check if they're stale.  If they're stale, remove them. If they're not stale, that is, the process is alive, bail out.

This requires the following fix to Avocado's `avocado.utils.process.pid_exists()`:

https://github.com/avocado-framework/avocado/pull/1267