### PR TITLE
Return code for python_file_run_with_helper

### DIFF
--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -726,7 +726,7 @@ class CommanderSlaveCmds(CommanderSlave):
         assert hasattr(module, "run")
         run = getattr(module, "run")
         helper = Helper(self)
-        run(helper)
+        return run(helper)
 
 
 class Helper(object):


### PR DESCRIPTION
Remote script can return to his caller any Python value.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>