### PR TITLE
Two iscsi related bugs fix

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -286,11 +286,14 @@ class _IscsiComm(object):
         Get device name from the target name.
         """
         cmd = "iscsiadm -m session -P 3"
-        device_name = ""
+        pattern = r"%s.*?disk\s(\w+)\s+\S+\srunning" % self.target
+        device_name = []
         if self.logged_in():
             output = process.system_output(cmd)
-            pattern = r"Target:\s+%s.*?disk\s(\w+)\s+\S+\srunning" % self.target
-            device_name = re.findall(pattern, output, re.S)
+            targets = output.split('Target: ')[1:]
+            for target in targets:
+                if self.target in target:
+                    device_name = re.findall(pattern, target, re.S)
             try:
                 device_name = "/dev/%s" % device_name[0]
             except IndexError:


### PR DESCRIPTION
1.
    utils_test.libvirt: Try to get volume repeatedly
    
    For iscsi type pool, after it start, the volume may not appear
    immediately, and the volume path(cooresponding to a scsi disk) also
    need verify.

2
    iscsi: Get the right attached disk name
    
    For now, the regex pattern may match to another target disk if the
    corresponding target disk not attached yet.
