### PR TITLE
Qemu support for s390x

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -43,6 +43,11 @@ variants:
             nic_model = virtio-net-device
             # Currently arm does not support msix vectors
             enable_msix_vectors = no
+        s390-virtio:
+            # Currently s390x only supports virtio-net-ccw
+            nic_model = virtio-net-ccw
+            # Currently s390x does not support msix vectors
+            enable_msix_vectors = no
     - xennet:
         # placeholder
     - spapr-vlan:
@@ -88,6 +93,12 @@ variants:
             drive_format=virtio-blk-device
             cd_format = scsi-cd
             scsi_hba = virtio-scsi-device
+        s390-virtio:
+            # Direct usage of virtio-blk-ccw is used
+            # on s390x
+            drive_format=virtio-blk-ccw
+            cd_format = scsi-cd
+            scsi_hba = virtio-scsi-ccw
     - virtio_scsi:
         no WinXP
         # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -46,3 +46,15 @@ variants:
         # Currently no USB support
         usbs =
         usb_devices =
+    - s390-virtio:
+        only s390x
+        auto_cpu_model = "no"
+        cpu_model = host
+        machine_type = s390-ccw-virtio
+        # No support for VGA yet
+        vga = none
+        inactivity_watcher = none
+        take_regular_screendumps = no
+        # Currently no USB support
+        usbs =
+        usb_devices =

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -942,6 +942,27 @@ class DevContainer(object):
                                                   parent_bus={'aobject': 'pci.0'}))
             return devices
 
+        def machine_s390x_virtio(cmd=False):
+            """
+            s390x (s390) doesn't support PCI bus.
+            :param cmd: If set uses "-M $cmd" to force this machine type
+            :return: List of added devices (including default buses)
+            """
+            devices = []
+            # Add virtio-bus
+            # TODO: Currently this uses QNoAddrCustomBus and does not
+            # set the device's properties. This means that the qemu qtree
+            # and autotest's representations are completelly different and
+            # can't be used.
+            logging.warn('Support for s390x is highly experimental!')
+            bus = qbuses.QNoAddrCustomBus('bus', [['addr'], [64]],
+                                          'virtio-blk-ccw', 'virtio-bus',
+                                          'virtio-blk-ccw')
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
+                                                  child_bus=bus,
+                                                  aobject="virtio-blk-ccw"))
+            return devices
+
         def machine_other(cmd=False):
             """
             isapc or unknown machine type. This type doesn't add any default
@@ -979,6 +1000,8 @@ class DevContainer(object):
                     devices = machine_arm64_pci(cmd)
                 elif arm_machine == 'arm64-mmio':
                     devices = machine_arm64_mmio(cmd)
+                elif machine_type.startswith("s390"):
+                    devices = machine_s390x_virtio(cmd)
                 elif 'isapc' not in machine_type:   # i440FX
                     devices = machine_i440FX(cmd)
                 else:   # isapc (or other)
@@ -1370,6 +1393,8 @@ class DevContainer(object):
         elif fmt == 'virtio':
             dev_parent = pci_bus
         elif fmt == 'virtio-blk-device':
+            dev_parent = {'type': 'virtio-bus'}
+        elif fmt == 'virtio-blk-ccw':   # For IBM s390 platform
             dev_parent = {'type': 'virtio-bus'}
         else:
             dev_parent = {'type': fmt}

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -942,7 +942,7 @@ class DevContainer(object):
                                                   parent_bus={'aobject': 'pci.0'}))
             return devices
 
-        def machine_s390x_virtio(cmd=False):
+        def machine_s390_virtio(cmd=False):
             """
             s390x (s390) doesn't support PCI bus.
             :param cmd: If set uses "-M $cmd" to force this machine type
@@ -1001,7 +1001,7 @@ class DevContainer(object):
                 elif arm_machine == 'arm64-mmio':
                     devices = machine_arm64_mmio(cmd)
                 elif machine_type.startswith("s390"):
-                    devices = machine_s390x_virtio(cmd)
+                    devices = machine_s390_virtio(cmd)
                 elif 'isapc' not in machine_type:   # i440FX
                     devices = machine_i440FX(cmd)
                 else:   # isapc (or other)


### PR DESCRIPTION
Refer the PR of  #577, I resubmitted it again.



This pull request defines IBM s390x machine.
Currently it doesn't support any buses except the 'virtio-bus'.

1) machine_type=virt, cpu_model=host, vga=none, usbs=none
2) instead of "virtio--pci" devices, "virtio--ccw" are used without the possibility of setting address
3) only set -boot strict=on for s390
4) set s390 supported sclpconsole console
