### PR TITLE
Fixup: import error due to changes in modules names and location

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -8,7 +8,7 @@ import sys
 
 from avocado.core import exit_codes
 from avocado.core.settings import settings
-from avocado.plugins.base import JobPre, JobPost
+from avocado.core.plugin_interfaces import JobPre, JobPost
 
 from ..test import VirtTest
 


### PR DESCRIPTION
Due to the recent changes in modules names and location in avocado modified by
commit 88cd82619f8d5bf4ce72ed12393a43c5dc4a1cce there is an import error on
vt_joblock plugin, while running avocado-vt tests, this patch fixes the same.