### PR TITLE
Job lock create then check v2

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -8,7 +8,13 @@ import sys
 
 from avocado.core import exit_codes
 from avocado.core.settings import settings
-from avocado.plugins.base import JobPre, JobPost
+
+# Avocado's plugin interface module has changed location. Let's keep
+# compatibility with old for at, least, a new LTS release
+try:
+    from avocado.core.plugin_interfaces import JobPre, JobPost
+except ImportError:
+    from avocado.plugins.base import JobPre, JobPost
 
 from ..test import VirtTest
 

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -8,6 +8,7 @@ import sys
 
 from avocado.core import exit_codes
 from avocado.core.settings import settings
+from avocado.utils.process import pid_exists
 
 # Avocado's plugin interface module has changed location. Let's keep
 # compatibility with old for at, least, a new LTS release
@@ -27,6 +28,13 @@ class LockCreationError(Exception):
     pass
 
 
+class OtherProcessHoldsLockError(Exception):
+
+    """
+    Represents a condition where other process has the lock
+    """
+
+
 class VTJobLock(JobPre, JobPost):
 
     name = 'vt-joblock'
@@ -40,13 +48,6 @@ class VTJobLock(JobPre, JobPost):
             key_type=str,
             default='/tmp'))
         self.lock_file = None
-
-    def _abort(self, message, job):
-        """
-        Aborts the Job by exiting Avocado, adding a failure to the job status
-        """
-        self.log.error(message)
-        sys.exit(exit_codes.AVOCADO_JOB_FAIL | job.exitcode)
 
     def _create_self_lock_file(self, job):
         """
@@ -92,35 +93,17 @@ class VTJobLock(JobPre, JobPost):
             if e.errno == errno.ENOENT:
                 return []
 
-    def _get_lock_file_pid(self):
-        """
-        Gets the lock file path and the process ID
-
-        If the lock file can not be located, this returns (None, 0).
-
-        :returns: the path and the (integer) process id
-        :rtype: tuple(str, int)
-        """
-        files = self._get_lock_files()
-        if not files:
-            return (None, 0)
-        path = files[0]
-        content = int(open(path, 'r').read())
-        pid = int(content)
-        if pid > 0:
-            return (path, pid)
-
     def _lock(self, job):
-        filename, lock_pid = self._get_lock_file_pid()
-        if lock_pid > 0:
-            msg = ('Avocado-VT job lock file "%s" acquired by PID %u. '
-                   'Aborting...' % (filename, lock_pid))
-            self._abort(msg, job)
         self.lock_file = self._create_self_lock_file(job)
-
-    def _unlock(self):
-        if self.lock_file:
-            os.unlink(self.lock_file)
+        lock_files = self._get_lock_files()
+        lock_files.remove(self.lock_file)
+        for path in lock_files:
+            lock_pid = int(open(path, 'r').read())
+            if pid_exists(lock_pid):
+                msg = 'File "%s" acquired by PID %u. ' % (path, lock_pid)
+                raise OtherProcessHoldsLockError(msg)
+            else:
+                os.unlink(path)
 
     def pre(self, job):
         try:
@@ -129,8 +112,9 @@ class VTJobLock(JobPre, JobPost):
                 self._lock(job)
         except Exception as detail:
             msg = "Failure trying to set Avocado-VT job lock: %s" % detail
-            self._abort(msg, job)
+            self.log.error(msg)
+            sys.exit(exit_codes.AVOCADO_JOB_FAIL | job.exitcode)
 
     def post(self, job):
         if self.lock_file is not None:
-            self._unlock()
+            os.unlink(self.lock_file)

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -9,6 +9,7 @@ import sys
 from avocado.core import exit_codes
 from avocado.core.settings import settings
 from avocado.utils.process import pid_exists
+from avocado.utils.stacktrace import log_exc_info
 
 # Avocado's plugin interface module has changed location. Let's keep
 # compatibility with old for at, least, a new LTS release
@@ -113,6 +114,7 @@ class VTJobLock(JobPre, JobPost):
         except Exception as detail:
             msg = "Failure trying to set Avocado-VT job lock: %s" % detail
             self.log.error(msg)
+            log_exc_info(sys.exc_info(), self.log.name)
             sys.exit(exit_codes.AVOCADO_JOB_FAIL | job.exitcode)
 
     def post(self, job):

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -58,11 +58,6 @@ class VTJobLock(JobPre, JobPost):
         :returns: the full path for the lock file created
         :rtype: str
         """
-        if not os.path.isdir(self.lock_dir):
-            msg = ('VT Job lock directory "%s" does not exist... '
-                   'exiting...' % self.lock_dir)
-            self._abort(msg, job)
-
         pattern = 'avocado-vt-joblock-%(jobid)s-%(uid)s-%(random)s.pid'
         # the job unique id is already random, but, let's add yet another one
         rand = ''.join([random.choice(string.ascii_lowercase + string.digits)

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -19,6 +19,14 @@ except ImportError:
 from ..test import VirtTest
 
 
+class LockCreationError(Exception):
+
+    """
+    Represents any error situation when attempting to create a lock file
+    """
+    pass
+
+
 class VTJobLock(JobPre, JobPost):
 
     name = 'vt-joblock'
@@ -40,7 +48,16 @@ class VTJobLock(JobPre, JobPost):
         self.log.error(message)
         sys.exit(exit_codes.AVOCADO_JOB_FAIL | job.exitcode)
 
-    def _set_lock(self, job):
+    def _create_self_lock_file(self, job):
+        """
+        Creates the lock file for this job process
+
+        :param job: the currently running job
+        :type job: :class:`avocado.core.job.Job`
+        :raises: :class:`LockCreationError`
+        :returns: the full path for the lock file created
+        :rtype: str
+        """
         if not os.path.isdir(self.lock_dir):
             msg = ('VT Job lock directory "%s" does not exist... '
                    'exiting...' % self.lock_dir)
@@ -58,10 +75,9 @@ class VTJobLock(JobPre, JobPost):
         try:
             with open(path, 'w') as lockfile:
                 lockfile.write("%u" % os.getpid())
-            self.lock_file = path
-        except IOError as e:
-            msg = ('Failed to create VT Job lock file "%s". Exiting...' % path)
-            self._abort(msg, job)
+            return path
+        except Exception as e:
+            raise LockCreationError(e)
 
     def _get_lock_file_pid(self):
         """
@@ -98,7 +114,7 @@ class VTJobLock(JobPre, JobPost):
             msg = ('Avocado-VT job lock file "%s" acquired by PID %u. '
                    'Aborting...' % (filename, lock_pid))
             self._abort(msg, job)
-        self._set_lock(job)
+        self.lock_file = self._create_self_lock_file(job)
 
     def _unlock(self):
         if self.lock_file:


### PR DESCRIPTION
This attempts to implement the good points raised on issue #567.

It changes the behavior of how locks are acquired, by first creating the process own lock, and then checking if other exist.  If other lock files exist, check if they're stale.  If they're stale, remove them. If they're not stale, that is, the process is alive, bail out.

--

Changes from v1 (#578):
 * Added the stack trace output when lock is failed to be acquired
 * Adapted to the the change of plugin interface location