### PR TITLE
virttest.utils_test.qemu: Fix missed param 'driver'

### DIFF
--- a/virttest/utils_test/qemu.py
+++ b/virttest/utils_test/qemu.py
@@ -173,7 +173,7 @@ def setup_win_driver_verifier(session, driver, vm, timeout=300):
     logging.info("%s verifier is enabled already" % driver)
 
 
-def clear_win_driver_verifier(session, vm, timeout=300):
+def clear_win_driver_verifier(session, driver, vm, timeout=300):
     """
     Clear the driver verifier in windows guest.
 


### PR DESCRIPTION
33aeebc introduces check_driver_verifier() to
check driver verifier status, which needs 'driver'.
But no param passed in it's caller clear_win_driver_verifier.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>