### PR TITLE
virttest: Add ",rombar=0" to virtio nic on aarch64

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -578,6 +578,8 @@ class VM(virt_vm.BaseVM):
                     for key, val in nic_extra_params:
                         dev.set_param(key, val)
                 dev.set_param("bootindex", bootindex)
+                if 'aarch64' in params.get('vm_arch_name', arch.ARCH):
+                    dev.set_param("rombar", 0)
             else:
                 dev = qdevices.QCustomDevice('net', backend='type')
                 dev.set_param('type', 'nic')


### PR DESCRIPTION
Currently qemu fails when missing rom even though it's not being used.
At the same time arm guys decided they really don't want to ship the
unused binaries which together makes qemu fail, unless the rom is
disabled by by using rombar=0.

This is the same approach libvirt is going to use according to:

    https://bugzilla.redhat.com/show_bug.cgi?id=1337510

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>