### PR TITLE
avocado_vt: Make vt_joblock more lenient [v2]

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -104,7 +104,10 @@ class VTJobLock(JobPre, JobPost):
                 msg = 'File "%s" acquired by PID %u. ' % (path, lock_pid)
                 raise OtherProcessHoldsLockError(msg)
             else:
-                os.unlink(path)
+                try:
+                    os.unlink(path)
+                except OSError:
+                    self.log.warn("Unable to remove stale lock: %s", path)
 
     def pre(self, job):
         try:


### PR DESCRIPTION
The locks are usually created on tmpfs, which does not allow removing
other users files, which makes the vt_joblock fail even on non-existing
pids. This patch only logs a warning when it fails to remove the lock.

Note the process still fails when it's unable to read the file or when
the file does not contain pid.

v1: https://github.com/avocado-framework/avocado-vt/pull/592

Changes:

```yaml
v2: Stalled -> stale
v2: Use arguments to format string in log
```