### PR TITLE
virttest: Fix the execute_qemu and "rombar" property setting

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -439,6 +439,7 @@ class DevContainer(object):
                                      ignore_status=True, shell=True,
                                      verbose=False)
             self.__execute_qemu_out = str(result.stdout)
+        self.__execute_qemu_last = options
         return self.__execute_qemu_out
 
     def get_buses(self, bus_spec, type_test=False):

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -427,10 +427,18 @@ class DevContainer(object):
         """
         if self.__execute_qemu_last != options:
             cmd = "%s %s 2>&1" % (self.__qemu_binary, options)
-            self.__execute_qemu_out = str(process.run(cmd, timeout=timeout,
-                                                      ignore_status=True,
-                                                      shell=True,
-                                                      verbose=False).stdout)
+            result = process.run(cmd, timeout=timeout,
+                                 ignore_status=True,
+                                 shell=True,
+                                 verbose=False)
+            if result.exit_status and "machine specified" in result.stdout:
+                # TODO: Arm requires machine to be specified, let's try again
+                # with dummy "virt" machine
+                result = process.run("%s -machine virt %s 2>&1"
+                                     % (self.__qemu_binary, options),
+                                     ignore_status=True, shell=True,
+                                     verbose=False)
+            self.__execute_qemu_out = str(result.stdout)
         return self.__execute_qemu_out
 
     def get_buses(self, bus_spec, type_test=False):

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -585,7 +585,9 @@ class VM(virt_vm.BaseVM):
                         dev.set_param(key, val)
                 dev.set_param("bootindex", bootindex)
                 if 'aarch64' in params.get('vm_arch_name', arch.ARCH):
-                    dev.set_param("rombar", 0)
+                    if "rombar" in devices.execute_qemu("-device %s,?"
+                                                        % model):
+                        dev.set_param("rombar", 0)
             else:
                 dev = qdevices.QCustomDevice('net', backend='type')
                 dev.set_param('type', 'nic')


### PR DESCRIPTION
Hello guys, especially @xutian, I'm sorry but although the https://github.com/avocado-framework/avocado-vt/pull/594 fixed the `aarch64-pci` machine it broke the `aarch64-mmio`, because the `rombar` property is not available on `virtio-net-device`. Instead of hardcoding this patch checks whether `rombar` is supported and sets it only when available.

While working on this I noticed the `execute_qemu` is broken on arm as it requires `-machine` to be specified even to query for `-device ...,?`. I incorporated the patches here as well.

@xutian would you please take a look at this as this time I broke my other setup by that PR? This one seems to be working fine on both (I'm sorry for not checking this previously)