### PR TITLE
virttest: Add support for virtio-scsi-ccw and add F23.s390x definition

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/23.s390x.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/23.s390x.cfg
@@ -1,0 +1,22 @@
+- 23.s390x:
+    install_timeout = 10800
+    image_name = images/f23-s390x
+    vm_arch_name = s390x
+    os_variant = fedora23
+    no unattended_install..floppy_ks
+    boot_path = images
+    unattended_file_kernel_param_name = ks
+    unattended_install, svirt_install:
+        # TODO: The virtio-serial ports are not yet supported by avocado on s390
+        # enable anaconda_log when it's supported
+        anaconda_log = no
+        kernel_params = 'ks=cdrom nicdelay=60 console=ttysclp0'
+        unattended_file = unattended/Fedora-23.ks
+        cdrom_unattended = images/f23-ppc64le/ks.iso
+        kernel = images/f23-s390x/kernel.img
+        initrd = images/f23-s390x/initrd.img
+        syslog_server_proto = tcp
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-DVD-s390x-23.iso
+        md5sum_cd1 = 754b4d669f492c9d2e511985bc5b2d46
+        md5sum_1m_cd1 = 076fb723a19c21cb110b0b4c0d69288b

--- a/shared/unattended/Fedora-23.ks
+++ b/shared/unattended/Fedora-23.ks
@@ -24,7 +24,9 @@ python
 %end
 
 %post
-function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
 ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1365,14 +1365,15 @@ class DevContainer(object):
             if scsi_hba != "virtio-scsi-pci":
                 num_queues = None
             addr_spec = None
-            if scsi_hba == 'lsi53c895a' or scsi_hba == 'spapr-vscsi':
+            if scsi_hba == 'lsi53c895a':
                 addr_spec = [8, 16384]
             elif scsi_hba == 'virtio-scsi-pci':
                 addr_spec = [256, 16384]
             elif scsi_hba == 'virtio-scsi-device':
                 addr_spec = [256, 16384]
                 pci_bus = {'type': 'virtio-bus'}
-            if scsi_hba == 'spapr-vscsi':
+            if scsi_hba in ('spapr-vscsi', "virtio-scsi-ccw"):
+                addr_spec = [8, 16384]
                 pci_bus = None
             _, bus, dev_parent = define_hbas('SCSI', scsi_hba, bus, unit, port,
                                              qbuses.QSCSIBus, pci_bus,


### PR DESCRIPTION
This PR adds Fedora.23.s390x profile along with necessary fixes to be able to run `unattended_install` test.

@liwbj as you are the `s390x` author, would you please also take a look at this?

PS: I tested this a week ago on s390 machine and it worked well. Now I rebased and polished it a bit so I need to re-run the functional test, still waiting for a free machine. Anyway the changes were minimal and I verified it produces the correct cmdline on `x86` machine using `avocado run unattended_install.cdrom.extra_cdrom_ks.default_install.aio_threads --vt-arch s390x --vt-machine-type s390-virtio --vt-guest-os Fedora.23 --show-job-log --vt-qemu-bin /usr/local/bin/qemu-system-s390x --vt-extra-params enable_kvm=no`. I'll let you know when the real test on s390 machine finishes (as emulation of s390 on x86 does not work).