### PR TITLE
Update aexpect version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 autotest>=0.16.2
-aexpect>=1.0.0
+aexpect>=1.2.0
 simplejson>=3.5.3


### PR DESCRIPTION
An extra argument "safe" was added to aexpect.ShellSession.cmd_output(),
which is used in virttest/virsh.py. It will break in earlier aexpect versions.