### PR TITLE
Guest OS Support: add Fedora 24 (x86_64)

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/24.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/24.x86_64.cfg
@@ -1,0 +1,24 @@
+- 24.x86_64:
+    image_name = images/f24-64
+    vm_arch_name = x86_64
+    os_variant = fedora24
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel_params = 'inst.repo=cdrom:/dev/disk/by-label/Fedora-S-24-x86_64'
+        kernel_params += ' nicdelay=60 console=ttyS0,115200 console=tty0'
+        unattended_file = unattended/Fedora-24.ks
+        kernel = images/f24-64/vmlinuz
+        initrd = images/f24-64/initrd.img
+        syslog_server_proto = tcp
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-dvd-x86_64-24-1.2.iso
+        md5sum_cd1 = 712011463c432f387a0d6a57aa133957
+        md5sum_1m_cd1 = 9ec198429b299636ccfa97d779ca3a6e
+    unattended_install.cdrom:
+        # Fedora 24 KS that hangs when more than one cdrom is provided.
+        # this issue is tracked at: https://trello.com/c/GIjmYWc3
+        no extra_cdrom_ks
+    unattended_install.url:
+        url = http://dl.fedoraproject.org/pub/fedora/linux/releases/24/Server/x86_64/os
+        sha1sum_vmlinuz = eb435614cbecf84be2ed39d011b4df642eade3e1
+        sha1sum_initrd = c843aa1c9dfc3cd4a38a55b1df19a3cf8f781e67

--- a/shared/unattended/Fedora-24.ks
+++ b/shared/unattended/Fedora-24.ks
@@ -1,0 +1,40 @@
+install
+KVM_TEST_MEDIUM
+text
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+autopart
+
+%packages
+@standard
+python
+%end
+
+%post
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+dnf -y groupinstall c-development development-tools
+ECHO 'Post set up finished'
+%end


### PR DESCRIPTION
Let's add the newly released Fedora as a valid guest OS.  As can be
seen in the configuration file, there's a possible bug preventing
unattended_install from working with `extra_cdrom_ks`.

Other tests may also fail with this image, given it has a brand new
compiler version.  One example of such test is described at:

 https://trello.com/c/QErTN6Fi

Some other Autotest based tests will run OK, which demonstrate that
the development packages are being installed properly during
unattended install tests.  One such test that was used during this
addition was io-github-autotest-qemu.autotest.dbench.

Signed-off-by: Cleber Rosa crosa@redhat.com
