### PR TITLE
Throw an error if SR-IOV VF device creation on host fails

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -286,11 +286,14 @@ class _IscsiComm(object):
         Get device name from the target name.
         """
         cmd = "iscsiadm -m session -P 3"
-        device_name = ""
+        pattern = r"%s.*?disk\s(\w+)\s+\S+\srunning" % self.target
+        device_name = []
         if self.logged_in():
             output = process.system_output(cmd)
-            pattern = r"Target:\s+%s.*?disk\s(\w+)\s+\S+\srunning" % self.target
-            device_name = re.findall(pattern, output, re.S)
+            targets = output.split('Target: ')[1:]
+            for target in targets:
+                if self.target in target:
+                    device_name = re.findall(pattern, target, re.S)
             try:
                 device_name = "/dev/%s" % device_name[0]
             except IndexError:

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -930,7 +930,9 @@ class PciAssignable(object):
                 if "allow_unsafe_assigned_interrupts" in i:
                     self.auai_path = i
         if self.setup:
-            self.sr_iov_setup()
+            if not self.sr_iov_setup():
+                msg = "SR-IOV setup on host failed"
+                logging.error(msg)
 
     def add_device(self, device_type="vf", name=None, mac=None):
         """
@@ -1356,6 +1358,9 @@ class PciAssignable(object):
                                       "command '%s'" % (self.driver, cmd),
                                       logging.info)
                 status = process.system(cmd, ignore_status=True)
+            if not self.check_vfs_count():
+            # Even after re-probe there are no VFs created
+                return False
             dmesg = process.system_output("dmesg", timeout=60,
                                           ignore_status=True,
                                           verbose=False)

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -15,6 +15,7 @@ from avocado.utils import wait
 from avocado.utils import genio
 from avocado.utils import build
 from avocado.utils import path
+from avocado.core import exceptions
 
 from . import data_dir
 from . import error_context
@@ -932,7 +933,7 @@ class PciAssignable(object):
         if self.setup:
             if not self.sr_iov_setup():
                 msg = "SR-IOV setup on host failed"
-                logging.error(msg)
+                raise exceptions.TestSetupFail(msg)
 
     def add_device(self, device_type="vf", name=None, mac=None):
         """
@@ -1108,7 +1109,8 @@ class PciAssignable(object):
         """
 
         cmd = "lspci | awk '/%s/ {print $1}'" % self.pf_filter_re
-        pf_ids = [i for i in process.system_output(cmd, shell=True).splitlines()]
+        pf_ids = [i for i in process.system_output(
+            cmd, shell=True).splitlines()]
         pf_vf_dict = []
         for pf_id in pf_ids:
             pf_info = {}
@@ -1359,7 +1361,7 @@ class PciAssignable(object):
                                       logging.info)
                 status = process.system(cmd, ignore_status=True)
             if not self.check_vfs_count():
-            # Even after re-probe there are no VFs created
+                # Even after re-probe there are no VFs created
                 return False
             dmesg = process.system_output("dmesg", timeout=60,
                                           ignore_status=True,

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2569,11 +2569,12 @@ def normalize_data_size(value_str, order_magnitude="M", factor="1024"):
     from_index = __get_unit_index(unit)
     to_index = __get_unit_index(order_magnitude)
     scale = int(factor) ** (to_index - from_index)
-    if scale > 0:
-        data_size = float(value) / abs(scale)
+    data_size = float(value) / scale
+    # Control precision to avoid scientific notaion
+    if data_size.is_integer():
+        return "%.1f" % data_size
     else:
-        data_size = float(value) * abs(scale)
-    return str(data_size)
+        return ("%.20f" % data_size).rstrip('0')
 
 
 def get_free_disk(session, mount):

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -362,7 +362,7 @@ def check_blockjob(vm_name, target, check_point="none", value="0"):
 
     try:
         cmd_result = virsh.blockjob(
-            vm_name, target, "--info", ignore_status=True)
+            vm_name, target, "--info", debug=True, ignore_status=True)
         output = cmd_result.stdout.strip()
         err = cmd_result.stderr.strip()
         status = cmd_result.exit_status
@@ -2081,15 +2081,9 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
                          emulated_image=emu_image,
                          image_size=image_size)
             # Get volume name
-            cmd_result = virsh.vol_list(pool_name)
-            try:
-                vol_name = re.findall(r"(\S+)\ +(\S+)[\ +\n]",
-                                      str(cmd_result.stdout))[1][0]
-            except IndexError:
-                raise exceptions.TestError("Fail to get volume name in "
-                                           "pool %s" % pool_name)
-            emulated_path = virsh.vol_path(vol_name, pool_name,
-                                           debug=True).stdout.strip()
+            vols = get_vol_list(pool_name)
+            vol_name = vols.keys()[0]
+            emulated_path = vols[vol_name]
         else:
             # Setup iscsi target
             if is_login:
@@ -2815,3 +2809,33 @@ def update_polkit_rule(params, pattern, new_value):
         polkit.polkitd.restart()
     except IOError, e:
         logging.error(e)
+
+
+def get_vol_list(pool_name, vol_check=True, timeout=5):
+    """
+    This is a wrapper to get all volumes of a pool, especially for
+    iscsi type pool as the volume may not appear immediately after
+    iscsi target login.
+
+    :param pool_name: Libvirt pool name
+    :param vol_check: Check if volume and volume path exist
+    :param timeout: Timeout in seconds.
+    :return: A dict include volumes' name(key) and path(value).
+    """
+    poolvol = libvirt_storage.PoolVolume(pool_name=pool_name)
+    vols = utils_misc.wait_for(poolvol.list_volumes, timeout,
+                               text='Waitting for volume show up')
+    if not vol_check:
+        return vols
+
+    # Check volume name
+    if not vols:
+        raise exceptions.TestError("No volume in pool %s" % pool_name)
+
+    # Check volume
+    for vol_path in vols.itervalues():
+        if not utils_misc.wait_for(lambda: os.path.exists(vol_path), timeout,
+                                   text='Waitting for vol path created'):
+            raise exceptions.TestError("Volume path %s not exist" % vol_path)
+
+    return vols


### PR DESCRIPTION
    This patch addresses below two current issues:
    1. If SR-IOV VF device creation fails on the KVM host
    due to some reason, then current code not throwing any error
    messages to users.
    2. Return value from sr_iov_setup function is not considered
    to validate if SR-IOV VF creation on host succeeded or not.