### PR TITLE
Create target for dir type pool

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -922,8 +922,9 @@ class PoolVolumeTest(object):
                                                  emulated_image=emulated_image,
                                                  image_size=image_size)
 
-        if pool_type == "dir" and not persistent:
-            pool_target = os.path.join(self.tmpdir, pool_target)
+        if pool_type == "dir":
+            if not os.path.isdir(pool_target):
+                pool_target = os.path.join(self.tmpdir, pool_target)
             if not os.path.exists(pool_target):
                 os.mkdir(pool_target)
         elif pool_type == "disk":


### PR DESCRIPTION
If the given pool target is not a valid path, create it in the tmp dir.

Signed-off-by: Yanbing Du <ydu@redhat.com>