### PR TITLE
avocado_vt: Couple of improvements to vt-list plugin

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -16,6 +16,7 @@
 Avocado VT plugin
 """
 
+import copy
 import logging
 import os
 import sys
@@ -107,7 +108,10 @@ class VirtTestLoader(loader.TestLoader):
 
     def get_extra_listing(self):
         if self.args.vt_list_guests:
-            guest_listing(self.args)
+            args = copy.copy(self.args)
+            args.vt_config = None
+            args.vt_guest_os = None
+            guest_listing(args)
 
     @staticmethod
     def get_type_label_mapping():

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -39,9 +39,9 @@ def guest_listing(options):
     if options.vt_type == 'lvsb':
         raise ValueError("No guest types available for lvsb testing")
     index = 0
-    LOG.debug("Searched %s for guest images\n",
+    LOG.debug("Using %s for guest images\n",
               os.path.join(data_dir.get_data_dir(), 'images'))
-    LOG.debug("Available guests in config:\n")
+    LOG.info("Available guests in config:")
     guest_name_parser = standalone_test.get_guest_name_parser(options)
     guest_name_parser.only_filter('i440fx')
     for params in guest_name_parser.get_dicts():
@@ -55,6 +55,7 @@ def guest_listing(options):
             missing = "(missing %s)" % os.path.basename(image_name)
             out = (name + " " + output.TERM_SUPPORT.warn_header_str(missing))
         LOG.debug(out)
+    LOG.debug("")
 
 
 class VirtTestLoader(loader.TestLoader):

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -109,7 +109,6 @@ class VirtTestLoader(loader.TestLoader):
     def get_extra_listing(self):
         if self.args.vt_list_guests:
             guest_listing(self.args)
-            sys.exit(0)
 
     @staticmethod
     def get_type_label_mapping():

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -43,7 +43,6 @@ def guest_listing(options):
               os.path.join(data_dir.get_data_dir(), 'images'))
     LOG.info("Available guests in config:")
     guest_name_parser = standalone_test.get_guest_name_parser(options)
-    guest_name_parser.only_filter('i440fx')
     for params in guest_name_parser.get_dicts():
         index += 1
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -19,7 +19,6 @@ Avocado VT plugin
 import copy
 import logging
 import os
-import sys
 
 from avocado.core import loader
 from avocado.core import output
@@ -37,6 +36,9 @@ LOG = logging.getLogger("avocado.app")
 
 
 def guest_listing(options):
+    """
+    List available guest os and info about image availability
+    """
     if options.vt_type == 'lvsb':
         raise ValueError("No guest types available for lvsb testing")
     index = 0
@@ -60,6 +62,10 @@ def guest_listing(options):
 
 class VirtTestLoader(loader.TestLoader):
 
+    """
+    Avocado loader plugin to load avocado-vt tests
+    """
+
     name = 'vt'
 
     def __init__(self, args, extra_params):
@@ -67,40 +73,40 @@ class VirtTestLoader(loader.TestLoader):
         self._fill_optional_args()
 
     def _fill_optional_args(self):
-        def add_if_not_exist(arg, value):
+        def _add_if_not_exist(arg, value):
             if not hasattr(self.args, arg):
                 setattr(self.args, arg, value)
-        add_if_not_exist('vt_config', None)
-        add_if_not_exist('vt_verbose', True)
-        add_if_not_exist('vt_log_level', 'debug')
-        add_if_not_exist('vt_console_level', 'debug')
-        add_if_not_exist('vt_datadir', data_dir.get_data_dir())
-        add_if_not_exist('vt_config', None)
-        add_if_not_exist('vt_arch', None)
-        add_if_not_exist('vt_machine_type', None)
-        add_if_not_exist('vt_keep_guest_running', False)
-        add_if_not_exist('vt_backup_image_before_test', True)
-        add_if_not_exist('vt_restore_image_after_test', True)
-        add_if_not_exist('vt_mem', 1024)
-        add_if_not_exist('vt_no_filter', '')
-        add_if_not_exist('vt_qemu_bin', None)
-        add_if_not_exist('vt_dst_qemu_bin', None)
-        add_if_not_exist('vt_nettype', 'user')
-        add_if_not_exist('vt_only_type_specific', False)
-        add_if_not_exist('vt_tests', '')
-        add_if_not_exist('vt_connect_uri', 'qemu:///system')
-        add_if_not_exist('vt_accel', 'kvm')
-        add_if_not_exist('vt_monitor', 'human')
-        add_if_not_exist('vt_smp', 1)
-        add_if_not_exist('vt_image_type', 'qcow2')
-        add_if_not_exist('vt_nic_model', 'virtio_net')
-        add_if_not_exist('vt_disk_bus', 'virtio_blk')
-        add_if_not_exist('vt_vhost', 'off')
-        add_if_not_exist('vt_malloc_perturb', 'yes')
-        add_if_not_exist('vt_qemu_sandbox', 'on')
-        add_if_not_exist('vt_tests', '')
-        add_if_not_exist('show_job_log', False)
-        add_if_not_exist('test_lister', True)
+        _add_if_not_exist('vt_config', None)
+        _add_if_not_exist('vt_verbose', True)
+        _add_if_not_exist('vt_log_level', 'debug')
+        _add_if_not_exist('vt_console_level', 'debug')
+        _add_if_not_exist('vt_datadir', data_dir.get_data_dir())
+        _add_if_not_exist('vt_config', None)
+        _add_if_not_exist('vt_arch', None)
+        _add_if_not_exist('vt_machine_type', None)
+        _add_if_not_exist('vt_keep_guest_running', False)
+        _add_if_not_exist('vt_backup_image_before_test', True)
+        _add_if_not_exist('vt_restore_image_after_test', True)
+        _add_if_not_exist('vt_mem', 1024)
+        _add_if_not_exist('vt_no_filter', '')
+        _add_if_not_exist('vt_qemu_bin', None)
+        _add_if_not_exist('vt_dst_qemu_bin', None)
+        _add_if_not_exist('vt_nettype', 'user')
+        _add_if_not_exist('vt_only_type_specific', False)
+        _add_if_not_exist('vt_tests', '')
+        _add_if_not_exist('vt_connect_uri', 'qemu:///system')
+        _add_if_not_exist('vt_accel', 'kvm')
+        _add_if_not_exist('vt_monitor', 'human')
+        _add_if_not_exist('vt_smp', 1)
+        _add_if_not_exist('vt_image_type', 'qcow2')
+        _add_if_not_exist('vt_nic_model', 'virtio_net')
+        _add_if_not_exist('vt_disk_bus', 'virtio_blk')
+        _add_if_not_exist('vt_vhost', 'off')
+        _add_if_not_exist('vt_malloc_perturb', 'yes')
+        _add_if_not_exist('vt_qemu_sandbox', 'on')
+        _add_if_not_exist('vt_tests', '')
+        _add_if_not_exist('show_job_log', False)
+        _add_if_not_exist('test_lister', True)
 
     def _get_parser(self):
         options_processor = VirtTestOptionsProcess(self.args)

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -27,7 +27,7 @@ from avocado.utils import path as utils_path
 try:
     from avocado.core.plugin_interfaces import CLI
 except ImportError:
-    from avocado.plugins.base import CLI
+    from avocado.plugins.base import CLI    # pylint: disable=E0611,E0401
 
 from virttest import data_dir
 from virttest import defaults

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -49,6 +49,71 @@ except (OSError, AssertionError):
                            "plugin to get rid of this message")
 
 
+def add_basic_vt_options(parser):
+    """
+    Add basic vt options to parser
+    """
+    parser.add_argument("--vt-config", action="store", dest="vt_config",
+                        help="Explicitly choose a cartesian config. When "
+                        "choosing this, some options will be ignored (see "
+                        "options below)")
+    msg = "Choose test type (%s). " % ", ".join(SUPPORTED_TEST_TYPES)
+    parser.add_argument("--vt-type", action="store", dest="vt_type",
+                        help=msg + "Default: %(default)s", default='qemu')
+    arch = settings.get_value('vt.common', 'arch', default=None)
+    parser.add_argument("--vt-arch", help="Choose the VM architecture. "
+                        "Default: %(default)s", default=arch)
+    machine = settings.get_value('vt.common', 'machine_type',
+                                 default=defaults.DEFAULT_MACHINE_TYPE)
+    parser.add_argument("--vt-machine-type", help="Choose the VM machine type."
+                        " Default: %(default)s", default=machine)
+    parser.add_argument("--vt-guest-os", action="store",
+                        dest="vt_guest_os", default=defaults.DEFAULT_GUEST_OS,
+                        help="Select the guest OS to be used. If --vt-config "
+                        "is provided, this will be ignored. Default: "
+                        "%(default)s")
+    parser.add_argument("--vt-no-filter", action="store", dest="vt_no_filter",
+                        default="", help="List of space separated 'no' filters"
+                        " to be passed to the config parser.  Default: "
+                        "'%(default)s'")
+    parser.add_argument("--vt-only-filter", action="store",
+                        dest="vt_only_filter", default="", help="List of space"
+                        " separated 'only' filters to be passed to the config "
+                        "parser.  Default: '%(default)s'")
+
+
+def add_qemu_bin_vt_option(parser):
+    """
+    Add qemu-bin vt option to parser
+    """
+    def _str_or_none(arg):
+        if arg is None:
+            return "Could not find one"
+        else:
+            return arg
+
+    try:
+        qemu_bin_path = standalone_test.find_default_qemu_paths()[0]
+    except (RuntimeError, utils_path.CmdNotFoundError):
+        qemu_bin_path = None
+    qemu_bin = settings.get_value('vt.qemu', 'qemu_bin',
+                                  default=qemu_bin_path)
+    parser.add_argument("--vt-qemu-bin", action="store", dest="vt_qemu_bin",
+                        default=qemu_bin, help="Path to a custom qemu binary "
+                        "to be tested. If --vt-config is provided and this "
+                        "flag is omitted, no attempt to set the qemu binaries "
+                        "will be made. Current: %s" % _str_or_none(qemu_bin))
+    qemu_dst = settings.get_value('vt.qemu', 'qemu_dst_bin',
+                                  default=qemu_bin_path)
+    parser.add_argument("--vt-qemu-dst-bin", action="store",
+                        dest="vt_dst_qemu_bin", default=qemu_dst, help="Path "
+                        "to a custom qemu binary to be tested for the "
+                        "destination of a migration, overrides --vt-qemu-bin. "
+                        "If --vt-config is provided and this flag is omitted, "
+                        "no attempt to set the qemu binaries will be made. "
+                        "Current: %s" % _str_or_none(qemu_dst))
+
+
 class VTRun(CLI):
 
     """
@@ -64,26 +129,14 @@ class VTRun(CLI):
 
         :param parser: Main test runner parser.
         """
-        def str_or_none(arg):
-            if arg is None:
-                return "Could not find one"
-            else:
-                return arg
         run_subcommand_parser = parser.subcommands.choices.get('run', None)
         if run_subcommand_parser is None:
             return
-
-        try:
-            qemu_bin_path = standalone_test.find_default_qemu_paths()[0]
-        except (RuntimeError, utils_path.CmdNotFoundError):
-            qemu_bin_path = None
 
         qemu_nw_msg = "QEMU network option (%s). " % ", ".join(
             SUPPORTED_NET_TYPES)
         qemu_nw_msg += "Default: user"
 
-        vt_compat_group_setup = run_subcommand_parser.add_argument_group(
-            'Virt-Test compat layer - VM Setup options')
         vt_compat_group_common = run_subcommand_parser.add_argument_group(
             'Virt-Test compat layer - Common options')
         vt_compat_group_qemu = run_subcommand_parser.add_argument_group(
@@ -91,94 +144,22 @@ class VTRun(CLI):
         vt_compat_group_libvirt = run_subcommand_parser.add_argument_group(
             'Virt-Test compat layer - Libvirt options')
 
-        vt_compat_group_common.add_argument("--vt-config", action="store",
-                                            dest="vt_config",
-                                            help=("Explicitly choose a "
-                                                  "cartesian config. "
-                                                  "When choosing this, "
-                                                  "some options will be "
-                                                  "ignored (see options "
-                                                  "below)"))
-        vt_compat_group_common.add_argument("--vt-type", action="store",
-                                            dest="vt_type",
-                                            help=("Choose test type (%s). "
-                                                  "Default: qemu" %
-                                                  ", ".join(
-                                                      SUPPORTED_TEST_TYPES)),
-                                            default='qemu')
-        arch = settings.get_value('vt.common', 'arch', default=None)
-        vt_compat_group_common.add_argument("--vt-arch",
-                                            help="Choose the VM architecture. "
-                                            "Default: %s" % arch,
-                                            default=arch)
-        machine = settings.get_value('vt.common', 'machine_type',
-                                     default=defaults.DEFAULT_MACHINE_TYPE)
-        vt_compat_group_common.add_argument("--vt-machine-type",
-                                            help="Choose the VM machine type. "
-                                            "Default: %s" % machine,
-                                            default=machine)
-        vt_compat_group_common.add_argument("--vt-guest-os", action="store",
-                                            dest="vt_guest_os",
-                                            default=defaults.DEFAULT_GUEST_OS,
-                                            help=("Select the guest OS to "
-                                                  "be used. If --vt-config is "
-                                                  "provided, this will be "
-                                                  "ignored. Default: %s" %
-                                                  defaults.DEFAULT_GUEST_OS))
-        vt_compat_group_common.add_argument("--vt-no-filter", action="store",
-                                            dest="vt_no_filter", default="",
-                                            help=("List of space separated "
-                                                  "'no' filters to be passed "
-                                                  "to the config parser. "
-                                                  " Default: ''"))
-        vt_compat_group_common.add_argument("--vt-only-filter", action="store",
-                                            dest="vt_only_filter", default="",
-                                            help=("List of space separated "
-                                                  "'only' filters to be passed"
-                                                  " to the config parser. "
-                                                  " Default: ''"))
-        qemu_bin = settings.get_value('vt.qemu', 'qemu_bin',
-                                      default=qemu_bin_path)
-        vt_compat_group_qemu.add_argument("--vt-qemu-bin", action="store",
-                                          dest="vt_qemu_bin",
-                                          default=qemu_bin,
-                                          help=("Path to a custom qemu binary "
-                                                "to be tested. If --vt-config "
-                                                "is provided and this flag is "
-                                                "omitted, no attempt to set "
-                                                "the qemu binaries will be "
-                                                "made. Current: %s" %
-                                                str_or_none(qemu_bin)))
-        qemu_dst = settings.get_value('vt.qemu', 'qemu_dst_bin',
-                                      default=qemu_bin_path)
-        vt_compat_group_qemu.add_argument("--vt-qemu-dst-bin", action="store",
-                                          dest="vt_dst_qemu_bin",
-                                          default=qemu_dst,
-                                          help=("Path to a custom qemu binary "
-                                                "to be tested for the "
-                                                "destination of a migration, "
-                                                "overrides --vt-qemu-bin. "
-                                                "If --vt-config is provided "
-                                                "and this flag is omitted, "
-                                                "no attempt to set the qemu "
-                                                "binaries will be made. "
-                                                "Current: %s" %
-                                                str_or_none(qemu_dst)))
+        add_basic_vt_options(vt_compat_group_common)
+        add_qemu_bin_vt_option(vt_compat_group_qemu)
         vt_compat_group_qemu.add_argument("--vt-extra-params", nargs='*',
                                           help="List of 'key=value' pairs "
                                           "passed to cartesian parser.")
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)
+        msg = ("Choose test connect uri for libvirt (E.g: %s). "
+               % supported_uris)
         uri_current = settings.get_value('vt.libvirt', 'connect_uri',
                                          default=None)
         vt_compat_group_libvirt.add_argument("--vt-connect-uri",
                                              action="store",
                                              dest="vt_connect_uri",
                                              default=uri_current,
-                                             help=("Choose test connect uri "
-                                                   "for libvirt (E.g: %s). "
-                                                   "Current: %s" %
-                                                   (supported_uris,
-                                                    uri_current)))
+                                             help=msg +
+                                             "Current: %(default)s")
 
     def run(self, args):
         """

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -29,6 +29,7 @@ try:
 except ImportError:
     from avocado.plugins.base import CLI
 
+from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 from ..loader import VirtTestLoader
 
 
@@ -66,8 +67,6 @@ else:
 if VIRT_TEST_PATH is not None:
     sys.path.append(os.path.expanduser(VIRT_TEST_PATH))
 
-from virttest.standalone_test import SUPPORTED_TEST_TYPES
-from virttest import defaults
 from virttest import data_dir
 
 
@@ -103,39 +102,14 @@ class VTLister(CLI):
 
         vt_compat_group_lister = list_subcommand_parser.add_argument_group(
             'Virt-Test compat layer - Lister options')
-        vt_compat_group_lister.add_argument("--vt-type", action="store",
-                                            dest="vt_type",
-                                            help="Choose test type (%s). "
-                                                 "Default: qemu" %
-                                            ", ".join(SUPPORTED_TEST_TYPES),
-                                            default='qemu')
-        vt_compat_group_lister.add_argument("--vt-guest-os", action="store",
-                                            dest="vt_guest_os",
-                                            default=None,
-                                            help=("Select the guest OS to be "
-                                                  "used (different guests "
-                                                  "support different test "
-                                                  "lists). You can list "
-                                                  "available guests "
-                                                  "with --vt-list-guests. "
-                                                  "Default: %s" %
-                                                  defaults.DEFAULT_GUEST_OS))
         vt_compat_group_lister.add_argument("--vt-list-guests",
                                             action="store_true",
                                             default=False,
-                                            help="List available guests")
-        machine = settings.get_value('vt.common', 'machine_type',
-                                     default=defaults.DEFAULT_MACHINE_TYPE)
-        vt_compat_group_lister.add_argument("--vt-machine-type",
-                                            help="Choose the VM machine type. "
-                                            "Default: %s" % machine,
-                                            default=machine)
-        vt_compat_group_lister.add_argument("--vt-only-filter", action="store",
-                                            dest="vt_only_filter", default="",
-                                            help=("List of space separated "
-                                                  "'only' filters to be passed"
-                                                  " to the config parser. "
-                                                  " Default: ''"))
+                                            help="Also list the available "
+                                            "guests (this option ignores the "
+                                            "--vt-config and --vt-guest-os)")
+        add_basic_vt_options(vt_compat_group_lister)
+        add_qemu_bin_vt_option(vt_compat_group_lister)
 
     def run(self, args):
         loader.register_plugin(VirtTestLoader)

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -27,7 +27,7 @@ from avocado.core.settings import settings
 try:
     from avocado.core.plugin_interfaces import CLI
 except ImportError:
-    from avocado.plugins.base import CLI
+    from avocado.plugins.base import CLI    # pylint: disable=E0401,E0611
 
 from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 from ..loader import VirtTestLoader
@@ -41,15 +41,15 @@ AUTOTEST_PATH = None
 
 if 'AUTOTEST_PATH' in os.environ:
     AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
-    client_dir = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
-    setup_modules_path = os.path.join(client_dir, 'setup_modules.py')
-    if not os.path.exists(setup_modules_path):
+    CLIENT_DIR = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
+    SETUP_MODULES_PATH = os.path.join(CLIENT_DIR, 'SETUP_MODULES.py')
+    if not os.path.exists(SETUP_MODULES_PATH):
         raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
-                               "%s missing." % setup_modules_path)
+                               "%s missing." % SETUP_MODULES_PATH)
     import imp
-    setup_modules = imp.load_source('autotest_setup_modules',
-                                    setup_modules_path)
-    setup_modules.setup(base_path=client_dir,
+    SETUP_MODULES = imp.load_source('autotest_setup_modules',
+                                    SETUP_MODULES_PATH)
+    SETUP_MODULES.setup(base_path=CLIENT_DIR,
                         root_module_name="autotest.client")
 
 # The code below is used by this plugin to find the virt test directory,
@@ -67,7 +67,7 @@ else:
 if VIRT_TEST_PATH is not None:
     sys.path.append(os.path.expanduser(VIRT_TEST_PATH))
 
-from virttest import data_dir
+from virttest import data_dir   # pylint: disable=C0413
 
 
 _PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_test_providers_dir(),

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -48,14 +48,14 @@ AUTOTEST_PATH = None
 
 if 'AUTOTEST_PATH' in os.environ:
     AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
-    client_dir = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
-    setup_modules_path = os.path.join(client_dir, 'setup_modules.py')
-    if not os.path.exists(setup_modules_path):
+    CLIENT_DIR = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
+    SETUP_MODULES_PATH = os.path.join(CLIENT_DIR, 'SETUP_MODULES.py')
+    if not os.path.exists(SETUP_MODULES_PATH):
         raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
-                               "%s missing." % setup_modules_path)
-    setup_modules = imp.load_source('autotest_setup_modules',
-                                    setup_modules_path)
-    setup_modules.setup(base_path=client_dir,
+                               "%s missing." % SETUP_MODULES_PATH)
+    SETUP_MODULES = imp.load_source('autotest_setup_modules',
+                                    SETUP_MODULES_PATH)
+    SETUP_MODULES.setup(base_path=CLIENT_DIR,
                         root_module_name="autotest.client")
 
 from autotest.client.shared import error

--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -1,8 +1,6 @@
 import platform
 ARCH = platform.machine()
-# Set the default machine to i440fx for unidentifed arch also
-# Below line can be removed once support for all possible arch is covered
-DEFAULT_MACHINE_TYPE = "i440fx"
+DEFAULT_MACHINE_TYPE = None
 
 if ARCH in ('ppc64', 'ppc64le'):
     DEFAULT_MACHINE_TYPE = "pseries"

--- a/virttest/scan_autotest_results.py
+++ b/virttest/scan_autotest_results.py
@@ -94,8 +94,8 @@ if __name__ == "__main__":
     import glob
     import os
     dirname = os.path.dirname(sys.modules[__name__].__file__)
-    client_dir = os.path.abspath(os.path.join(dirname, ".."))
-    resfiles = glob.glob(os.path.join(client_dir, 'results', '*', 'status*'))
+    CLIENT_DIR = os.path.abspath(os.path.join(dirname, ".."))
+    resfiles = glob.glob(os.path.join(CLIENT_DIR, 'results', '*', 'status*'))
 
     if len(sys.argv) > 1:
         if sys.argv[1] == "-h" or sys.argv[1] == "--help":


### PR DESCRIPTION
This PR fixes few issues in the `vt-list` plugin, changes the defaults and in the end adds couple of missing options from `vt` plugin also to the `vt-list` plugin as they are quite useful (eg. the `--vt-arch`, or `--vt-config`). Additionally it adds few pylint fixes.

Trello: https://trello.com/c/aumjDJde/715-add-vt-list-machines-and-vt-list-archs