### PR TITLE
scripts/package_jeos.py: add compatibility flags to qemu-img

### DIFF
--- a/scripts/package_jeos.py
+++ b/scripts/package_jeos.py
@@ -33,7 +33,7 @@ def package_jeos(img):
     shutil.move(img, backup)
     logging.info("Backup %s saved", backup)
 
-    process.system("%s convert -f qcow2 -O qcow2 %s %s" % (qemu_img, backup, img))
+    process.system("%s convert -f qcow2 -O qcow2 -o compat=0.10 %s %s" % (qemu_img, backup, img))
     logging.info("Sparse file %s created successfully", img)
 
     archiver = utils_misc.find_command('7za')


### PR DESCRIPTION
Older versions of QEMU are be able to use Qcow2 images created by
newer versions.  That was the case with the first version of the
JeOS.23 image, which has now been updated with with an image that was
created with "0.10" compatibility level.

Let's make that the norm for newly created JeOS images, by means of
this utility script.

Reference: https://trello.com/c/1RlcP6Ji
Signed-off-by: Cleber Rosa <crosa@redhat.com>