### PR TITLE
iscsi: Add discovery for iscsi target export function.

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -766,6 +766,8 @@ class IscsiLIO(_IscsiComm):
                          "cache_dynamic_acls=1"))
             output = process.system_output(auth_cmd + attr_cmd)
             logging.info("Define access rights: %s" % output)
+            # Discovery the target
+            self.portal_visible()
 
         # Save configuration
         process.system("targetcli / saveconfig")

--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -10,7 +10,6 @@ This exports:
 import re
 import logging
 
-from avocado.core import exceptions
 from avocado.utils import process
 
 from . import storage
@@ -410,7 +409,7 @@ class StoragePool(object):
                      (source_host, source_name, extra))
             self.virsh_instance.pool_define_as(name, "rbd", "",
                                                extra, ignore_status=False)
-        except exceptions.CmdError:
+        except process.CmdError:
             logging.error("Define rbd pool '%s' failed.", name)
             return False
         logging.info("Define pool '%s'", name)


### PR DESCRIPTION
Libvirt don't discovery iscsi target automatically currently, it
lead to fail to create iscsi pool. Add discovery step in target
export function.