### PR TITLE
virttest/utils_env: update the check for tcpdump status

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -356,8 +356,8 @@ class Env(UserDict.IterableUserDict):
                                          output_func=_tcpdump_handler,
                                          output_params=(self, "tcpdump.log"))
 
-        if utils_misc.wait_for(lambda: not self._tcpdump.is_alive(),
-                               0.1, 0.1, 1.0):
+        if not utils_misc.wait_for(lambda: self._tcpdump.is_alive(),
+                                   1.0, 0.1, 0.1):
             logging.warn("Could not start tcpdump")
             logging.warn("Status: %s", self._tcpdump.get_status())
             msg = utils_misc.format_str_for_message(self._tcpdump.get_output())


### PR DESCRIPTION
IMHO, 'timeout' should be greater than 'first' and 'step' for
utils_misc.wait_for().

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>