### PR TITLE
virttest.qemu_vm: Fix add_nic model conditions

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -573,7 +573,7 @@ class VM(virt_vm.BaseVM):
                 # pci devices and store the number.
                 if model == 'virtio-net-device':
                     dev.parent_bus = {'type': 'virtio-bus'}
-                if model == 'virtio-net-ccw':  # For s390x platform
+                elif model == 'virtio-net-ccw':  # For s390x platform
                     dev.parent_bus = {'type': 'virtio-bus'}
                 elif model != 'spapr-vlan':
                     dev.parent_bus = pci_bus


### PR DESCRIPTION
The s390x branch should be part of the big if/elif/elif condition, it
should not start a new block.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>