### PR TITLE
virttest.env_process: Silence the "qemu -help" output

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -689,7 +689,8 @@ def preprocess(test, params, env):
             kvm_userspace_version = "Unknown"
     else:
         qemu_path = utils_misc.get_qemu_binary(params)
-        version_output = avocado_process.system_output("%s -help" % qemu_path)
+        version_output = avocado_process.system_output("%s -help" % qemu_path,
+                                                       verbose=False)
         version_line = version_output.split('\n')[0]
         matches = re.findall("[Vv]ersion .*?,", version_line)
         if matches:


### PR DESCRIPTION
Recently a "qemu -help" command was added to detect the version. There
is no need to have this verbose as the version is logged on the next
line.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>