### PR TITLE
virttest: Initial work to support arm64 with libvirt provider

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -38,15 +38,8 @@ variants:
             # Device selection for the NDISTest server machine
             dp_regex_servermsgdev = VirtIO Ethernet Adapter$
             dp_regex_serversupportdev = VirtIO Ethernet Adapter #2$
-        arm64-mmio:
-            # Currently arm only supports virtio-net-device
-            nic_model = virtio-net-device
-            # Currently arm does not support msix vectors
-            enable_msix_vectors = no
-        s390-virtio:
-            # Currently s390x only supports virtio-net-ccw
-            nic_model = virtio-net-ccw
-            # Currently s390x does not support msix vectors
+        arm64-mmio, s390-virtio:
+            # Currently arm/s390x does not support msix vectors
             enable_msix_vectors = no
     - xennet:
         # placeholder
@@ -82,23 +75,6 @@ variants:
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
         image_boot=yes
-        pseries:
-            cd_format = scsi-cd
-        arm64-pci:
-            cd_format = scsi-cd
-            scsi_hba = virtio-scsi-pci
-        arm64-mmio:
-            # Direct usage of virtio-blk-device (using mmio transports) is used
-            # on arm64.
-            drive_format=virtio-blk-device
-            cd_format = scsi-cd
-            scsi_hba = virtio-scsi-device
-        s390-virtio:
-            # Direct usage of virtio-blk-ccw is used
-            # on s390x
-            drive_format=virtio-blk-ccw
-            cd_format = scsi-cd
-            scsi_hba = virtio-scsi-ccw
     - virtio_scsi:
         no WinXP
         # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -29,6 +29,7 @@ variants:
         machine_type = arm64-mmio:virt
         # No support for VGA yet
         vga = none
+        vir_domain_undefine_nvram = yes
         inactivity_watcher = none
         take_regular_screendumps = no
         # Currently no USB support

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -230,12 +230,12 @@ class VM(virt_vm.BaseVM):
         """
         return virsh.domain_exists(self.name, uri=self.connect_uri)
 
-    def undefine(self):
+    def undefine(self, options=None):
         """
         Undefine the VM.
         """
         try:
-            virsh.undefine(self.name, uri=self.connect_uri,
+            virsh.undefine(self.name, options=options, uri=self.connect_uri,
                            ignore_status=False)
         except process.CmdError, detail:
             logging.error("Undefined VM %s failed:\n%s", self.name, detail)
@@ -1808,7 +1808,12 @@ class VM(virt_vm.BaseVM):
 
     def remove(self):
         self.destroy(gracefully=True, free_mac_addresses=False)
-        if not self.undefine():
+        # If the current machine contains nvram, we have to set --nvram
+        if self.params.get("vir_domain_undefine_nvram") == "yes":
+            options = "--nvram"
+        else:
+            options = None
+        if not self.undefine(options):
             raise virt_vm.VMRemoveError("VM '%s' undefine error" % self.name)
         self.destroy(gracefully=False, free_mac_addresses=True)
         logging.debug("VM '%s' was removed", self.name)

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -777,7 +777,10 @@ class VM(virt_vm.BaseVM):
         if location:
             virt_install_cmd += add_location(help_text, location)
 
-        if params.get("display") == "vnc":
+        # Disable display when vga is disabled (used mainly by machines.cfg)
+        if params.get("vga") == "none":
+            virt_install_cmd += add_nographic(help_text)
+        elif params.get("display") == "vnc":
             if params.get("vnc_autoport") == "yes":
                 vm.vnc_autoport = True
             else:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -561,7 +561,13 @@ class VM(virt_vm.BaseVM):
                 if not model:
                     model = "rtl8139"
                 elif model == "virtio":
-                    model = "virtio-net-pci"
+                    machine_type = self.params.get("machine_type")
+                    if "s390" in machine_type:
+                        model = "virtio-net-ccw"
+                    elif "mmio" in machine_type:
+                        model = "virtio-net-device"
+                    else:
+                        model = "virtio-net-pci"
                 dev = QDevice(model)
                 if ctrl_mac_addr and ctrl_mac_addr in ["on", "off"]:
                     dev.set_param('ctrl_mac_addr', ctrl_mac_addr)


### PR DESCRIPTION
The `arm64` works quite well with `qemu` provider, but it fails terribly on `libvirt` provider. This is a initial patchset to make arm64 supported by both. Note that `arm64-pci` definition is not yet supported at least on RHEL's libvirt.

Please see the details in each commit. Also note that this only prepares the ground to start using `--vt-provider libvirt` along with `--vt-machine-type arm64-mmio`, more work is needed to declare it stable.