### PR TITLE
Update devcon path

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -355,9 +355,9 @@
         driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
         driver_id_cmd = C:\devcon.exe find * | find "VirtIO"
         x86_64:
-            devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+            devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C:\ /Y"
         i386:
-            devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+            devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C:\ /Y"
     driver_load.with_nic:
         driver_id_pattern = "(.*?):.*?VirtIO Ethernet Adapter"
     driver_load.with_balloon:


### PR DESCRIPTION
devcon.exe is copied to C:  in xcopy option, so C:devcon.exe is available,
but  C:\devcon.exe is used when run devcon.exe cmd, so always show not available cmd
update C: to C:\ in xcopy

Signed-off-by: Suqin Huang <shuang@redhat.com>