### PR TITLE
Add some iothread virsh commands support

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1763,7 +1763,7 @@ class VMCPUTuneXML(base.LibvirtXMLBase):
     """
 
     __slots__ = ('vcpupins', 'emulatorpin', 'shares', 'period', 'quota',
-                 'emulator_period', 'emulator_quota')
+                 'emulator_period', 'emulator_quota', 'iothreadpins')
 
     def __init__(self, virsh_instance=base.virsh):
         accessors.XMLElementList('vcpupins', self, parent_xpath='/',
@@ -1771,6 +1771,9 @@ class VMCPUTuneXML(base.LibvirtXMLBase):
                                  marshal_to=self.marshal_to_vcpupins)
         accessors.XMLAttribute('emulatorpin', self, parent_xpath='/',
                                tag_name='emulatorpin', attribute='cpuset')
+        accessors.XMLElementList('iothreadpins', self, parent_xpath='/',
+                                 marshal_from=self.marshal_from_iothreadpins,
+                                 marshal_to=self.marshal_to_iothreadpins)
         for slot in self.__all_slots__:
             if slot in ('shares', 'period', 'quota', 'emulator_period',
                         'emulator_quota'):
@@ -1800,6 +1803,30 @@ class VMCPUTuneXML(base.LibvirtXMLBase):
         del index
         del libvirtxml
         if tag != 'vcpupin':
+            return None
+        return dict(attr_dict)
+
+    @staticmethod
+    def marshal_from_iothreadpins(item, index, libvirtxml):
+        """
+        Convert a dict to iothreadpin tag and attributes.
+        """
+        del index
+        del libvirtxml
+        if not isinstance(item, dict):
+            raise xcepts.LibvirtXMLError("Expected a dictionary of host "
+                                         "attributes, not a %s"
+                                         % str(item))
+        return ('iothreadpin', dict(item))
+
+    @staticmethod
+    def marshal_to_iothreadpins(tag, attr_dict, index, libvirtxml):
+        """
+        Convert a iothreadpin tag and attributes to a dict.
+        """
+        del index
+        del libvirtxml
+        if tag != 'iothreadpin':
             return None
         return dict(attr_dict)
 
@@ -2179,12 +2206,10 @@ class VMMemTuneXML(base.LibvirtXMLBase):
 class VMIothreadidsXML(VMXML):
 
     """
-    memoryBacking tag XML class
+    iothreadids tag XML class
 
     Elements:
-        hugepages
-        nosharepages
-        locked
+        iothread
     """
 
     __slots__ = ('iothread',)
@@ -2194,7 +2219,7 @@ class VMIothreadidsXML(VMXML):
                                  marshal_from=self.marshal_from_iothreads,
                                  marshal_to=self.marshal_to_iothreads)
         super(self.__class__, self).__init__(virsh_instance=virsh_instance)
-        self.xml = '<iothread/>'
+        self.xml = '<iothreadids/>'
 
     @staticmethod
     def marshal_from_iothreads(item, index, libvirtxml):

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2855,3 +2855,37 @@ def get_vol_list(pool_name, vol_check=True, timeout=5):
             raise exceptions.TestError("Volume path %s not exist" % vol_path)
 
     return vols
+
+
+def get_iothreadsinfo(vm_name, options=None):
+    """
+    Parse domain iothreadinfo.
+
+    :param vm_name: Domain name
+    :return: The dict of domain iothreads
+
+    ::
+        # virsh iothreadinfo vm2
+        IOThread ID CPU Affinity
+        ---------------------------------------------------
+        2 3
+        1 0-4
+        4 0-7
+        3 0-7
+
+    The function return a dict like:
+
+    ::
+        {'2': '3', '1': '0-4', '4': '0-7', '3': '0-7'}
+    """
+    info_dict = {}
+    ret = virsh.iothreadinfo(vm_name, options,
+                             debug=True, ignore_status=True)
+    if ret.exit_status:
+        logging.warning(ret.stderr.strip())
+        return info_dict
+    info_list = re.findall(r"(\d+) +(\S+)", ret.stdout, re.M)
+    for info in info_list:
+        info_dict[info[0]] = info[1]
+
+    return info_dict

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -4194,3 +4194,71 @@ def click_button(name, left_button=True, **dargs):
     cmd = "mouse_button 0"
     qemu_monitor_command(name=name, cmd=cmd, options='--hmp', **dargs)
     time.sleep(1)
+
+
+def iothreadadd(name, thread_id, options=None, **dargs):
+    """
+    Add an IOThread to the guest domain.
+
+    :param name: domain name
+    :param thread_id: domain iothread ID
+    :param options: options may be live, config and current
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult instance
+    """
+    cmd = "iothreadadd %s %s" % (name, thread_id)
+    if options:
+        cmd += " %s" % options
+
+    return command(cmd, **dargs)
+
+
+def iothreaddel(name, thread_id, options=None, **dargs):
+    """
+    Delete an IOThread from the guest domain.
+
+    :param name: domain name
+    :param thread_id: domain iothread ID
+    :param options: options may be live, config and current
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult instance
+    """
+    cmd = "iothreaddel %s %s" % (name, thread_id)
+    if options:
+        cmd += " %s" % options
+
+    return command(cmd, **dargs)
+
+
+def iothreadinfo(name, options=None, **dargs):
+    """
+    View domain IOThreads.
+
+    :param name: domain name
+    :param options: options may be live, config and current
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult instance
+    """
+    cmd = "iothreadinfo %s" % name
+    if options:
+        cmd += " %s" % options
+
+    return command(cmd, **dargs)
+
+
+def iothreadpin(name, thread_id, cpuset, options=None, **dargs):
+    """
+    Control domain IOThread affinity.
+
+    :param name: domain name
+    :param thread_id: domain iothread ID
+    :param cpuset: host cpu number(s) to set
+    :param options: options may be live, config and current
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult instance
+    """
+    cmd = "iothreadpin %s %s %s" % (name, thread_id, cpuset)
+    if options:
+        cmd += " %s" % options
+
+    return command(cmd, **dargs)


### PR DESCRIPTION
The new commands are for Get/Add/Delete domain IOThreads, and
control domain IOThread affinity.

Signed-off-by: Ruifeng Bian <rbian@redhat.com>