### PR TITLE
Fixup vm_xml.py

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1228,7 +1228,10 @@ class VMXML(VMXMLBase):
         :param passwd: Password you want to set
         """
         devices = vmxml.devices
-        graphics_index = devices.index(devices.by_device_tag('graphics')[0])
+        try:
+            graphics_index = devices.index(devices.by_device_tag('graphics')[0])
+        except IndexError:
+            raise xcepts.LibvirtXMLError("No graphics device defined in guest xml")
         graphics = devices[graphics_index]
         graphics.passwd = passwd
         vmxml.devices = devices


### PR DESCRIPTION
Traceback observed if graphics device is not defined in guest xml, this
patch handles it.