### PR TITLE
avocado_vt.loader: List archs/machine_types and some tweaks

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -84,6 +84,7 @@ class VirtTestLoader(loader.TestLoader):
     def __init__(self, args, extra_params):
         super(VirtTestLoader, self).__init__(args, extra_params)
         self._fill_optional_args()
+        self.__extra_listing_used = False
 
     def _fill_optional_args(self):
         def _add_if_not_exist(arg, value):
@@ -131,11 +132,13 @@ class VirtTestLoader(loader.TestLoader):
             args.vt_config = None
             args.vt_guest_os = None
             guest_listing(args)
+            self.__extra_listing_used = True
         if self.args.vt_list_archs:
             args = copy.copy(self.args)
             args.vt_machine_type = None
             args.vt_arch = None
             arch_listing(args)
+            self.__extra_listing_used = True
 
     @staticmethod
     def get_type_label_mapping():
@@ -157,6 +160,8 @@ class VirtTestLoader(loader.TestLoader):
         return {VirtTest: term_support.healthy_str}
 
     def discover(self, url, which_tests=loader.DEFAULT):
+        if self.__extra_listing_used:   # Skip normal test discovery
+            return []                   # on extra_listing
         try:
             cartesian_parser = self._get_parser()
         except Exception, details:

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -58,6 +58,21 @@ def guest_listing(options):
     LOG.debug("")
 
 
+def arch_listing(options):
+    """
+    List available machine/archs for given guest os
+    """
+    if options.vt_guest_os:
+        extra = " for guest os \"%s\"" % options.vt_guest_os
+    else:
+        extra = ""
+    LOG.info("Available machine_type/arch profiles%s", extra)
+    guest_name_parser = standalone_test.get_guest_name_parser(options)
+    for params in guest_name_parser.get_dicts():
+        LOG.debug(params["name"])
+    LOG.debug("")
+
+
 class VirtTestLoader(loader.TestLoader):
 
     """
@@ -116,6 +131,11 @@ class VirtTestLoader(loader.TestLoader):
             args.vt_config = None
             args.vt_guest_os = None
             guest_listing(args)
+        if self.args.vt_list_archs:
+            args = copy.copy(self.args)
+            args.vt_machine_type = None
+            args.vt_arch = None
+            arch_listing(args)
 
     @staticmethod
     def get_type_label_mapping():

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -41,13 +41,11 @@ def guest_listing(options):
     """
     if options.vt_type == 'lvsb':
         raise ValueError("No guest types available for lvsb testing")
-    index = 0
     LOG.debug("Using %s for guest images\n",
               os.path.join(data_dir.get_data_dir(), 'images'))
     LOG.info("Available guests in config:")
     guest_name_parser = standalone_test.get_guest_name_parser(options)
     for params in guest_name_parser.get_dicts():
-        index += 1
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())
         image_name = storage.get_image_filename(params, base_dir)
         name = params['name']

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -105,12 +105,12 @@ class VTLister(CLI):
         vt_compat_group_lister.add_argument("--vt-list-guests",
                                             action="store_true",
                                             default=False,
-                                            help="Also list the available "
+                                            help="List the available "
                                             "guests (this option ignores the "
                                             "--vt-config and --vt-guest-os)")
         vt_compat_group_lister.add_argument("--vt-list-archs", default=False,
                                             action="store_true",
-                                            help="Also list the available "
+                                            help="List the available "
                                             "arch/machines for the given "
                                             "guest os. (Use \"--vt-guest-os "
                                             "''\" to see all combinations; "

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -108,6 +108,14 @@ class VTLister(CLI):
                                             help="Also list the available "
                                             "guests (this option ignores the "
                                             "--vt-config and --vt-guest-os)")
+        vt_compat_group_lister.add_argument("--vt-list-archs", default=False,
+                                            action="store_true",
+                                            help="Also list the available "
+                                            "arch/machines for the given "
+                                            "guest os. (Use \"--vt-guest-os "
+                                            "''\" to see all combinations; "
+                                            "--vt-config --vt-machine-type "
+                                            "and --vt-arch args are ignored)")
         add_basic_vt_options(vt_compat_group_lister)
         add_qemu_bin_vt_option(vt_compat_group_lister)
 


### PR DESCRIPTION
This PR adds the support to list archs/machine_types. As cartesian_config knows nothing about these, the way it works is it lists full variant names of the current guest_os without arch/machine_type filter. It's be possible to do the extract the real information by removing the guest_os part and using `unique` on the product, but this version seems less hackish and more valuable.

Additionally there is a commit which reverts to the previous behavior and it disables test discovery of avocado-vt tests in case extra_listing is used. My motivation is that extra listing is very fast, on the other hand test listing is very, very long. I as a user would rather run the command twice to get both, then to wait several seconds every time I need to see the available guest oses. Note that the original behavior exited using `sys.exit` after it's listing, which is really hackish and I haven't restored that part. This patch only disables the avocado-vt test discovery when extra_listing is enabled.

Trello: https://trello.com/c/aumjDJde/715-add-vt-list-machines-and-vt-list-archs