### PR TITLE
virttest.qemu_deivces.qcontainer: rename pci contorller type param

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1745,7 +1745,7 @@ class DevContainer(object):
         :warning: x3130-upstream device creates only x3130-upstream device
                   and you are responsible for creating the downstream ports.
         """
-        driver = params.get('type', 'ioh3420')
+        driver = params.get('bus_type', 'ioh3420')
         if driver in ('ioh3420', 'x3130-upstream', 'x3130'):
             bus_type = 'PCIE'
         else:


### PR DESCRIPTION
Rename pci controller type param to avoid conflict with preserved
params 'type'.

Signed-off-by: Xu Tian <xutian@redhat.com>