### PR TITLE
libvirt_xml.vm_xml: Added function to get cpu topology

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -727,6 +727,17 @@ class VMXML(VMXMLBase):
             raise xcepts.LibvirtXMLError(
                 "The cpu mode '%s' is invalid!" % mode)
 
+    def get_cpu_topology(self):
+        """
+        Return cpu topology dict
+        """
+        topology = {}
+        try:
+            topology = self.cpu.topology
+        except:
+            logging.error("Can't find <cpu>/<topology> element")
+        return topology
+
     def get_disk_all(self):
         """
         Return VM's disk from XML definition, None if not set


### PR DESCRIPTION
Added function which returns the cpu topology as dict
for example:
cputopology content in vm xml:
` <topology sockets='1' cores='4' threads='8'/>`

function returns:
{'cores': '4', 'threads': '8', 'sockets': '1'}