### PR TITLE
Fixup libvirt.py

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1175,6 +1175,8 @@ class MigrationTest(object):
                 migration_thread.start()
                 eclipse_time = 0
                 if func:
+                    # Need time for thread to start migration before executing func
+                    time.sleep(5)
                     stime = int(time.time())
                     func(func_params)
                     eclipse_time = int(time.time()) - stime


### PR DESCRIPTION
Added sleep time to make sure migration is started to execute
command in parallel.

Eg: For postcopy migration, cmd "virsh migrate-postcopy domain name"
needs to be executed during migration. Without sleep time below error
is observed.

"Requested operation is not valid: post-copy can only be started while
outgoing migration is in progress"