### PR TITLE
Allow to use asset .INI files at any directory.

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -376,28 +376,39 @@ def get_file_asset(title, src_path, destination):
     return None
 
 
-def get_asset_info(asset):
+def get_asset_info(asset, ini_dir=None, section=None):
+    """"
+    Parse $asset.ini file and returns a dictionary suitable for
+    asset.download_file()
+
+    :param asset: Asset name. A file ending in .ini.
+    :param ini_dir: Directory where to search .ini file.
+    :param section: Name of the [] section in .ini file. If None, then use
+                    asset name.
+    """
     asset_info = {}
-    asset_path = os.path.join(data_dir.get_download_dir(), '%s.ini' % asset)
-    assert os.path.exists(asset_path)
+    ini_dir = ini_dir or data_dir.get_download_dir()
+    asset_path = os.path.join(ini_dir, '%s.ini' % asset)
+    assert os.path.exists(asset_path), "Missing asset file %s" % asset_path
     asset_cfg = ConfigLoader(asset_path)
 
-    asset_info['url'] = asset_cfg.get(asset, 'url')
-    asset_info['sha1_url'] = asset_cfg.get(asset, 'sha1_url')
-    asset_info['title'] = asset_cfg.get(asset, 'title')
-    destination = asset_cfg.get(asset, 'destination')
+    section = section or asset
+    asset_info['url'] = asset_cfg.get(section, 'url')
+    asset_info['sha1_url'] = asset_cfg.get(section, 'sha1_url')
+    asset_info['title'] = asset_cfg.get(section, 'title')
+    destination = asset_cfg.get(section, 'destination')
     if not os.path.isabs(destination):
         destination = os.path.join(data_dir.get_data_dir(), destination)
     asset_info['destination'] = destination
     asset_info['asset_exists'] = os.path.isfile(destination)
 
     # Optional fields
-    d_uncompressed = asset_cfg.get(asset, 'destination_uncompressed')
+    d_uncompressed = asset_cfg.get(section, 'destination_uncompressed')
     if d_uncompressed is not None and not os.path.isabs(d_uncompressed):
         d_uncompressed = os.path.join(data_dir.get_data_dir(),
                                       d_uncompressed)
     asset_info['destination_uncompressed'] = d_uncompressed
-    asset_info['uncompress_cmd'] = asset_cfg.get(asset, 'uncompress_cmd')
+    asset_info['uncompress_cmd'] = asset_cfg.get(section, 'uncompress_cmd')
 
     return asset_info
 


### PR DESCRIPTION
Previously location for .INI asset files had strictly predefined
  location: avocado-vt/shared/downloads/asset_name.ini.

  This commit allows to specify path to .INI file. This would allow to
  test-providers use their own .INI asset files, as well as, it is
  possible to use multi-section .INI files. For example, SpiceQE team
  need to have asset file for SeleniumHQ stand-alone-server. This asset
  is useful only for SpiceQE team. It doesn't have any usage for other
  QE teams. Moreover, SpiceQE would have a way to define the version and
  location of Selenium stand-alone-server necessary for SpiceQE tests.

  Example usage
  -------------

    Selenium asset ini file located at "$provider_download_dir/assets/selenium.ini":

        [Selenium]
        title = SeleniumHQ
        url = http://selenium-release.storage.googleapis.com/3.0-beta2/selenium-server-standalone-3.0.0-beta2.jar
        destination = selenium-server-standalone.jar

    Use code:

        from virttest import asset
        asset_name = "selenium"
        asset_dir = os.path.join(provider_download_dir, "assets")
        asset_section = "Selenium"
        asset_info = asset.get_asset_info(asset_name, dir_=asset_dir,
                                         section=asset_section)
        logging.info("Asset info: %s" % asset_info)
        asset.download_file(asset_info)
        dst = asset_info['destination']
        logging.info("Asset saved at: %s" % dst)