### PR TITLE
Revert "virttest.cartesian_config: enable postfix_parse"

### DIFF
--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -2241,6 +2241,9 @@ def compare_string(str1, str2):
 def postfix_parse(dic):
     tmp_dict = {}
     for key in dic:
+        # Bypass the case that use tuple as key value
+        if isinstance(key, tuple):
+            continue
         if key.endswith("_max"):
             tmp_key = key.split("_max")[0]
             if (not dic.has_key(tmp_key) or


### PR DESCRIPTION
This reverts commit 81c6ce860b2f625ec31533779c479cf9bf14af38.

I cannot parse cartesian config for SpiceQE with the above commit. The
error is:

  File "/mnt/tests/spice/qe-tests/avocado-vt/virttest/cartesian_config.py", line 2145, in get_dicts_plain
    for d in self.get_dicts(n, ctx, new_content, shortname, dep):
  File "/mnt/tests/spice/qe-tests/avocado-vt/virttest/cartesian_config.py", line 1942, in get_dicts
    postfix_parse(d)
  File "/mnt/tests/spice/qe-tests/avocado-vt/virttest/cartesian_config.py", line 2244, in postfix_parse
    if key.endswith("_max"):
AttributeError: 'tuple' object has no attribute 'endswith'

Signed-off-by: Andrei Stepanov <astepano@redhat.com>