### PR TITLE
Fix SR-IOV VF release dev

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1032,7 +1032,7 @@ class PciAssignable(object):
             logging.info("Run command in host: %s" % cmd)
             try:
                 output = None
-                output = process.system_output(cmd, timeout=60)
+                output = process.system_output(cmd, shell=True, timeout=60)
             except Exception:
                 msg = "Command %s fail with output %s" % (cmd, output)
                 logging.error(msg)
@@ -1043,13 +1043,18 @@ class PciAssignable(object):
             logging.info("Run command in host: %s" % cmd)
             try:
                 output = None
-                output = process.system_output(cmd, timeout=60)
+                output = process.system_output(cmd, shell=True, timeout=60)
             except Exception:
                 msg = "Command %s fail with output %s" % (cmd, output)
                 logging.error(msg)
                 return False
         if self.is_binded_to_stub(pci_id):
             return False
+        else:
+            for pf in self.pf_vf_info:
+                for vf in pf["vf_ids"]:
+                    if vf["vf_id"] == pci_id:
+                        vf["occupied"] = False
         return True
 
     def get_vf_status(self, vf_id):


### PR DESCRIPTION
Currently once we use available free VFs [got via _get_vf_pci_id] for any operation.. "occupied" flag for that VF would get set to "True". But when we release that vf device [via _release_dev] we are not resetting the "occupied" flag for the VF. Newly committed code in this PR will fix this issue.