### PR TITLE
Fix can't find setup_modules problem

### DIFF
--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -42,7 +42,7 @@ AUTOTEST_PATH = None
 if 'AUTOTEST_PATH' in os.environ:
     AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
     CLIENT_DIR = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
-    SETUP_MODULES_PATH = os.path.join(CLIENT_DIR, 'SETUP_MODULES.py')
+    SETUP_MODULES_PATH = os.path.join(CLIENT_DIR, 'setup_modules.py')
     if not os.path.exists(SETUP_MODULES_PATH):
         raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
                                "%s missing." % SETUP_MODULES_PATH)

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -49,7 +49,7 @@ AUTOTEST_PATH = None
 if 'AUTOTEST_PATH' in os.environ:
     AUTOTEST_PATH = os.path.expanduser(os.environ['AUTOTEST_PATH'])
     CLIENT_DIR = os.path.join(os.path.abspath(AUTOTEST_PATH), 'client')
-    SETUP_MODULES_PATH = os.path.join(CLIENT_DIR, 'SETUP_MODULES.py')
+    SETUP_MODULES_PATH = os.path.join(CLIENT_DIR, 'setup_modules.py')
     if not os.path.exists(SETUP_MODULES_PATH):
         raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
                                "%s missing." % SETUP_MODULES_PATH)


### PR DESCRIPTION
If AUTOTEST_PATH is set in env, then load the setup_modules will
fail due to wrong file name.

Signed-off-by: Wayne Sun <gsun@redhat.com>