### PR TITLE
shared.unattended.JeOS-23.ks: Disable selinux

### DIFF
--- a/shared/unattended/JeOS-23.ks
+++ b/shared/unattended/JeOS-23.ks
@@ -7,7 +7,7 @@ keyboard us
 network --bootproto dhcp --hostname atest-guest
 rootpw 123456
 firewall --enabled --ssh
-selinux --enforcing
+selinux --disable
 timezone --utc America/New_York
 firstboot --disable
 bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"


### PR DESCRIPTION
The `selinux-policy` is not installed, while the `selinux` is set as
enabled. For some reason this works on Fedora.23, but it's quite
dangerous running with selinux enabled without policies defined.

My motivation is that I use this KS to create RHEL.7 kickstart and the
latest builds started failing with "Failed to load SELinux policy.".

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>