### PR TITLE
Windows.cfg: revert "Update shell_client of rng test to telnet".

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -263,7 +263,7 @@
         copy_from_command = copy %s\notepad.exe c:\ /y
         compare_command = fc /b c:\windows\system32\notepad.exe c:\notepad.exe
         check_result_key_word = no difference
-    rng_bat, viorng_in_use, with_viorng, rng_hotplug:
+    rng_bat, viorng_in_use, driver_load.with_viorng, rng_hotplug:
         shell_client = telnet
         shell_port = 23
     floppy_test:


### PR DESCRIPTION
This reverts commit d113ba6cbe1803a6f569f6ea22424c2dde6df64f,
which introduces error "Escape character is '^]'".

Signed-off-by: Cong Li <coli@redhat.com>

id: 1369428