### PR TITLE
update default rng_device to make it appendable

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -313,7 +313,7 @@ variants:
     - @no_virtio_rng:
     - virtio_rng:
         no Host_RHEL.m5 Host_RHEL.m6.u0 Host_RHEL.m6.u1 Host_RHEL.m6.u2 Host_RHEL.m6.u3 Host_RHEL.m6.u4 Host_RHEL.m6.u5
-        virtio_rngs = "rng0"
+        virtio_rngs += " rng0"
         #max-bytes_virtio-rng-pci =
         #period_virtio-rng-pci =
         variants:


### PR DESCRIPTION
rng devices set in case will be covered by guest-hw.cfg
update default to += " rng0"

Signed-off-by: Suqin Huang <shuang@redhat.com>