### PR TITLE
virttest.utils_misc: unloading calltrace in host dmesg

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1151,7 +1151,9 @@ def postprocess(test, params, env):
     if err:
         raise virt_vm.VMError("Failures occurred while postprocess:%s" % err)
     if params.get("verify_host_dmesg", "yes") == "yes":
-        utils_misc.verify_host_dmesg()
+        dmesg_log_file = params.get("host_dmesg_logfile", "host_dmesg.log")
+        dmesg_log_file = utils_misc.get_path(test.debugdir, dmesg_log_file)
+        utils_misc.verify_host_dmesg(dmesg_log_file=dmesg_log_file)
 
 
 def postprocess_on_error(test, params, env):

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3295,6 +3295,7 @@ def verify_host_dmesg(dmesg_log_file=None, trace_re=None):
             else:
                 err += " Please check host dmesg log in debug log."
                 logging.debug(d_log)
+            process.system("dmesg -C", ignore_status=True)
             raise exceptions.TestError(err)
 
 


### PR DESCRIPTION
to avoid calltrace in host dmesg impact comming test if
"verify_host_dmesg = yes" option in test params, we need
to unloading host dmesg.

Signed-off-by: Xu Tian <xutian@redhat.com>