### PR TITLE
Fixup: VM with multiple interfaces boot failure

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -73,6 +73,11 @@ netdst = virbr0
 #advanced network configuration of the host
 #host_ip_addr = ""
 
+# Set this parameter to 'yes' inorder to get IP from
+# any network interface incase of multiple interface
+# present in VM, default is 'no'
+flexible_nic_index = no
+
 # List of block device object names (whitespace separated)
 images = image1
 # List of block device object names with order (whitespace separated)


### PR DESCRIPTION
When VM have multiple interfaces and
when IP gets assigned to random interface,
get_address hang on single interface and timeout for boot(import)test results to failure.

This patch will address it by introducing
a parameter""flexible_nic_index"",
when set it will try to poke all the interface and
check which has valid IP and connect to it.

Fixes: https://github.com/avocado-framework/avocado-vt/issues/617
