### PR TITLE
nfs.py: Ensure rpcbind running before starting nfs

### DIFF
--- a/selftests/unit/test_nfs.py
+++ b/selftests/unit/test_nfs.py
@@ -45,6 +45,8 @@ class nfs_test(unittest.TestCase):
         path.find_command.expect_call("exportfs")
         service.Factory.create_service.expect_call("nfs").and_return(
             FakeService("nfs"))
+        service.Factory.create_service.expect_call("rpcbind").and_return(
+            FakeService("rpcbind"))
         mount_src = self.nfs_params.get("nfs_mount_src")
         export_dir = (self.nfs_params.get("export_dir") or
                       mount_src.split(":")[-1])

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -158,6 +158,7 @@ class Nfs(object):
             path.find_command("service")
             path.find_command("exportfs")
             self.nfs_service = service.Factory.create_service("nfs")
+            self.rpcbind_service = service.Factory.create_service("rpcbind")
 
             self.export_dir = (params.get("export_dir") or
                                self.mount_src.split(":")[-1])
@@ -199,6 +200,7 @@ class Nfs(object):
         if self.nfs_setup:
             if not self.nfs_service.status():
                 logging.debug("Restart NFS service.")
+                self.rpcbind_service.restart()
                 self.nfs_service.restart()
 
             if not os.path.isdir(self.export_dir):


### PR DESCRIPTION
The nfs service will fail to start with "rpc.nfsd: unable to set any
sockets for nfsd" when the rpcbind service is not running. So the fix is
to ensure rpcbind is running before starting the nfs service.

Signed-off-by: Dan Zheng <dzheng@redhat.com>