### PR TITLE
shared.cfg: add e1000e configuration in guest-hw.cfg

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -21,6 +21,10 @@ variants:
     - e1000-82545em:
         no ppc64 ppc64le
         nic_model = e1000-82545em
+    - e1000e:
+        only q35
+        nic_model = e1000e
+        nic_pci_bus = pcie_switch
     - virtio_net:
         nic_model = virtio
         # Assign the queue number of nic device


### PR DESCRIPTION
Signed-off-by: Xu Tian <xutian@redhat.com>