### PR TITLE
Adding maxcpus for given arch in guest capability

### DIFF
--- a/selftests/unit/test_libvirt_xml.py
+++ b/selftests/unit/test_libvirt_xml.py
@@ -34,8 +34,8 @@ threads='1'/><feature name='vme'/></cpu><power_management><suspend_mem/>
 <topology><cells num='1'><cell id='0'><cpus num='1'><cpu id='0'/></cpus></cell>
 </cells></topology><secmodel><model>selinux</model><doi>0</doi></secmodel>
 </host><guest><os_type>hvm</os_type><arch name='x86_64'><wordsize>64</wordsize>
-<emulator>/usr/libexec/qemu-kvm</emulator><machine>rhel6.3.0</machine><machine
-canonical='rhel6.3.0'>pc</machine><domain type='qemu'></domain><domain
+<emulator>/usr/libexec/qemu-kvm</emulator><machine maxCpus='255'>rhel6.3.0</machine><machine
+canonical='rhel6.3.0' maxCpus='255'>pc</machine><domain type='qemu'></domain><domain
 type='kvm'><emulator>/usr/libexec/qemu-kvm</emulator></domain></arch><features>
 <cpuselection/><deviceboot/><acpi default='on' toggle='yes'/><apic default='on'
 toggle='no'/></features></guest></capabilities>"""
@@ -620,6 +620,7 @@ class TestLibvirtXML(LibvirtXMLTestBase):
         expected_guest = {'wordsize': '64',
                           'emulator': '/usr/libexec/qemu-kvm',
                           'machine': ['rhel6.3.0', 'pc'],
+                          'maxcpus': '255',
                           'domain_qemu': {},
                           'domain_kvm': {'emulator': '/usr/libexec/qemu-kvm'}}
         expected = {expected_os: {expected_arch: expected_guest}}

--- a/virttest/libvirt_xml/capability_xml.py
+++ b/virttest/libvirt_xml/capability_xml.py
@@ -99,6 +99,13 @@ class CapabilityXML(base.LibvirtXMLBase):
                 arch_prop = guest_arch.get(arch_name, {})
                 arch_prop['wordsize'] = arch.find('wordsize').text
                 arch_prop['emulator'] = arch.find('emulator').text
+                # TODO: maxcpus differs for machine in a given arch.
+                # Right now takes first machine as default for the given
+                # arch and assigns maxcpu for the arch, ideally below machine
+                # list to get popluated with maxcpu for each machine
+                # not modifying as no requirement for now and as it would break
+                # other places where machine list is used.
+                arch_prop['maxcpus'] = arch.findall('machine')[0].get('maxCpus')
                 m_list = []
                 for machine in arch.findall('machine'):
                     machine_text = machine.text


### PR DESCRIPTION
Added maxcpus field in a guest capability method
to get the default maxcpus for a given arch.

Right now it takes the maxcpus of a default(first)
machine for a given arch which is needed for
the https://github.com/autotest/tp-libvirt/pull/878
the same can be extended further for each machine later
when there is a requirement as identified in TODO.