### PR TITLE
Revert "Minor fix: Fail testcase with proper message"

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1128,7 +1128,8 @@ def __init_openvswitch(func):
                 if (not __ovs.check()):
                     raise Exception("Check of OpenVSwitch failed.")
             except Exception, e:
-                raise exceptions.TestFail("Host does not support OpenVSwitch")
+                logging.debug("Host does not support OpenVSwitch: %s", e)
+
         return func(*args, **kargs)
     return wrap_init
 
@@ -3122,8 +3123,7 @@ def windows_mac_ip_maps(session):
     out = session.cmd_output(cmd)
     for line in out.splitlines():
         try:
-            mac = re.search(
-                "\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2}", line).group(0)
+            mac = re.search("\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2}", line).group(0)
         except Exception:
             continue
         inets = re.findall("\"([\w.:]*)\"", line)


### PR DESCRIPTION
The commit 0953cecf24864697029f27fe11b01edc6512e295 makes all executions
fail when OpenVSwitch is not available, even though it's not needed for
the execution. IIRC OpenVSwitch is optional (at least it was for many
years) and that commit broke all my CI checks.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>