### PR TITLE
unattended_install: update QCOW image version to v3

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -542,6 +542,61 @@ class QemuImg(storage.QemuImg):
                     "Image format %s is not checkable, skipping check",
                     self.image_format)
 
+    def amend(self, params, cache_mode=None, ignore_status=False):
+        """
+        Amend the image format specific options for the image
+
+        :param params: dictionary containing the test parameters
+        :param cache_mode: the cache mode used to write the output disk image,
+                           the valid options are: 'none', 'writeback'
+                           (default), 'writethrough', 'directsync' and
+                           'unsafe'.
+        :param ignore_status: Whether to raise an exception when command
+                              returns =! 0 (False), or not (True).
+
+        :note: params may contain amend options:
+
+               amend_size
+                   virtual disk size of the image (a string qemu-img can
+                   understand, such as '10G')
+               amend_compat
+                   compatibility level (0.10 or 1.1)
+               amend_backing_file
+                   file name of a base image
+               amend_backing_fmt
+                   image format of the base image
+               amend_encryption
+                   encrypt the image, allowed values: on and off.
+                   Default is "off"
+               amend_cluster_size
+                   cluster size for the image
+               amend_preallocation
+                   preallocation mode when create image, allowed values: off,
+                   metadata. Default is "off"
+               amend_lazy_refcounts
+                   postpone refcount updates, allowed values: on and off.
+                   Default is "off"
+               amend_refcount_bits
+                   width of a reference count entry in bits
+               amend_extra_params
+                   additional options, used for extending amend
+
+        :return: process.CmdResult object containing the result of the
+                command
+        """
+        cmd_list = [self.image_cmd, 'amend']
+        options = ["%s=%s" % (key[6:], val) for key, val in params.iteritems()
+                   if key.startswith('amend_')]
+        if cache_mode:
+            cmd_list.append("-t %s" % cache_mode)
+        if options:
+            cmd_list.append("-o %s" %
+                            ",".join(options).replace("extra_params=", ""))
+        cmd_list.append("-f %s %s" % (self.image_format, self.image_filename))
+        logging.info("Amend image %s" % self.image_filename)
+        cmd_result = process.run(" ".join(cmd_list), ignore_status=False)
+        return cmd_result
+
 
 class Iscsidev(storage.Iscsidev):
 

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -28,6 +28,7 @@ from .. import utils_test
 from .. import funcatexit
 from .. import storage
 from .. import error_context
+from .. import qemu_storage
 
 
 # Whether to print all shell commands called
@@ -1129,7 +1130,14 @@ def run(test, params, env):
                 logging.warn(e)
             from virttest import utils_test
             error_context.context("Copy image from NFS Server")
+            image = params.get("images").split()[0]
+            t_params = params.object_params(image)
+            qemu_image = qemu_storage.QemuImg(t_params, data_dir.get_data_dir(), image)
+            ver_to = utils_test.get_image_version(qemu_image)
             utils_test.run_image_copy(test, params, env)
+            qemu_image = qemu_storage.QemuImg(t_params, data_dir.get_data_dir(), image)
+            ver_from = utils_test.get_image_version(qemu_image)
+            utils_test.update_qcow2_image_version(qemu_image, ver_from, ver_to)
 
     src = params.get('images_good')
     base_dir = params.get("images_base_dir", data_dir.get_data_dir())

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -352,6 +352,43 @@ def get_memory_info(lvms):
 
 
 @error_context.context_aware
+def get_image_version(qemu_image):
+    """
+    Get image version of qcow2 image
+
+    :param qemu_image: Object QemuImg
+
+    :return: compatibility level
+    """
+    error_context.context("Get qcow2 image('%s') version"
+                          % qemu_image.image_filename, logging.info)
+    info_out = qemu_image.info()
+    compat = re.search(r'compat: +(.*)', info_out, re.M)
+    if compat:
+        return compat.group(1)
+    return '0.10'
+
+
+@error_context.context_aware
+def update_qcow2_image_version(qemu_image, ver_from, ver_to):
+    """
+    Update qcow2 image version.
+
+    :param qemu_image: Object QemuImg
+    :param ver_from: Original version of qcow2 image. Valid values: '0.10'
+                 and '1.1'
+    :param ver_to: Version which is expected to be set. Valid values: '0.10'
+               and '1.1'
+    """
+    if ver_from == ver_to:
+        return None
+    error_context.context("Update qcow2 image version from %s to %s"
+                          % (ver_from, ver_to), logging.info)
+    qemu_image.params.update({"amend_compat": "%s" % ver_to})
+    qemu_image.amend(qemu_image.params)
+
+
+@error_context.context_aware
 def run_image_copy(test, params, env):
     """
     Copy guest images from nfs server.


### PR DESCRIPTION
1. Add function for suncommand amend of qemu-img
2. Add function to update qcow2 image version
3. When failed to install a guest, will copy an existed image.
   Upgrade the image version if the version is older.

Signed-off-by: Ping Li pingl@redhat.com

ID: 1363946
