### PR TITLE
Ignore hardcoded network settings for tp-spice.

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -158,6 +158,9 @@ class VirtTestOptionsProcess(object):
             if self.options.vt_type == 'qemu':
                 self.options.vt_nettype = (self.options.vt_nettype if
                                            self.options.vt_nettype else 'user')
+            elif self.options.vt_type == 'spice':
+                self.options.vt_nettype = (self.options.vt_nettype if
+                                           self.options.vt_nettype else 'none')
             else:
                 self.options.vt_nettype = (self.options.vt_nettype if
                                            self.options.vt_nettype else 'bridge')


### PR DESCRIPTION
Ignore network options from vt.conf for tp-spice. SpiceQE team need to have an
ability to vary and dynamically choose network type for different tests.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>