### PR TITLE
avocado_vt: Don't override nettype=none

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -177,8 +177,6 @@ class VirtTestOptionsProcess(object):
                 self.cartesian_parser.assign("netdst", self.options.vt_netdst)
             elif self.options.vt_nettype == 'user':
                 self.cartesian_parser.assign("nettype", "user")
-            elif self.options.vt_nettype == 'none':
-                self.cartesian_parser.assign("nettype", "none")
         else:
             logging.info("Config provided, ignoring %s", nettype_setting)
 


### PR DESCRIPTION
By default nettype value from params is overridden by per-execution
value from config (net_type). The supported options are "user", "bridge"
and "none", where the "none" is not to set the type to none, but to get
the option from cartesian (test config). This patch removes the
cartesian assignment, which returns the correct handling.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>