### PR TITLE
utils_test: Directly load stress tool on host

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1660,12 +1660,14 @@ class HostStress(object):
         load stress tool on host.
         """
         # Run stress tool on host.
-        from autotest.client import common
-        autotest_client_dir = os.path.dirname(common.__file__)
-        autotest_local_path = os.path.join(autotest_client_dir,
-                                           "autotest-local")
-        args = [autotest_local_path, '--args=%s' % self.stress_args,
-                self.control_path, '--verbose']
+        try:
+            path.find_command(self.stress_type)
+        except path.CmdNotFoundError, detail:
+            raise exceptions.TestSkipError("Stress tool %s is missing: %s"
+                                           % (self.stress_type, str(detail)))
+
+        args = [self.stress_type, '--args=%s' % self.stress_args,
+                '--verbose']
         logging.info("Start sub-process by args: %s", args)
         self.host_stress_process = subprocess.Popen(args,
                                                     stdout=subprocess.PIPE,


### PR DESCRIPTION
Loading stress tool on host can be much easiler. There is no need to
depend on autotest.

Signed-off-by: Dan Zheng <dzheng@redhat.com>