### PR TITLE
shared.guest-hw.cfg: set "cd_format=ide" for win_virtio_drive…

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -99,6 +99,10 @@ variants:
         cd_format=scsi-cd
         scsi_hba=virtio-scsi-pci
         libvirt_controller=virtio-scsi
+        win_virtio_driver_update_test.with_vioscsi:
+            cd_format = ide
+            q35:
+                cd_format = ahci
         q35:
             disk_pci_bus = pcie_switch
             cdrom_pci_bus = ${disk_pci_bus}


### PR DESCRIPTION
…r_update_test.with_vioscsi.

cdrom won't be recognized if virtio_scsi driver is uninstalled,
which will cause install driver failed after uninstall.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1231072