### PR TITLE
Update path of devcon cmd

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -96,13 +96,14 @@
         check_running_cmd = "tasklist|findstr /I fio"
         kill_bg_stress_cmd = "taskkill /T /F /IM fio.exe"
     migrate_multi_host.with_module_reload:
-        driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-        driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO"
         i386, i686:
-            devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C: /Y"
+            driver_load_cmd = "WIN_UTILS:\devcon\wnet_x86\devcon.exe enable @DRIVER_ID"
+            driver_unload_cmd = "WIN_UTILS:\devcon\wnet_x86\devcon.exe disable @DRIVER_ID"
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_x86\devcon.exe find * | find "VirtIO"'
         x86_64:
-            devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C: /Y"
+            driver_load_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe enable @DRIVER_ID"
+            driver_unload_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe disable @DRIVER_ID"
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
         virtio_net:
             driver_id_pattern = "(.*?):.*?VirtIO Ethernet Adapter"
         e1000:
@@ -350,14 +351,15 @@
         event_cmd = ${reboot_command}
     qmp_event_notification.qmp_system_powerdown.from_guest:
         event_cmd = ${shutdown_command}
-    driver_load, driver_load_stress:
-        driver_load_cmd = C:\devcon.exe enable @DRIVER_ID
-        driver_unload_cmd = C:\devcon.exe disable @DRIVER_ID
-        driver_id_cmd = C:\devcon.exe find * | find "VirtIO"
+    driver_load:
         x86_64:
-            devcon = "xcopy %s:\devcon\wnet_amd64\devcon.exe C:\ /Y"
+            driver_load_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe enable @DRIVER_ID"
+            driver_unload_cmd = "WIN_UTILS:\devcon\wnet_amd64\devcon.exe disable @DRIVER_ID"
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_amd64\devcon.exe find * | find "VirtIO"'
         i386:
-            devcon = "xcopy %s:\devcon\wnet_x86\devcon.exe C:\ /Y"
+            driver_load_cmd = "WIN_UTILS:\devcon\wnet_x86\devcon.exe enable @DRIVER_ID"
+            driver_unload_cmd = "WIN_UTILS:\devcon\wnet_x86\devcon.exe disable @DRIVER_ID"
+            driver_id_cmd = 'WIN_UTILS:\devcon\wnet_x86\devcon.exe find * | find "VirtIO"'
     driver_load.with_nic:
         driver_id_pattern = "(.*?):.*?VirtIO Ethernet Adapter"
     driver_load.with_balloon:


### PR DESCRIPTION
devcon copy is dropped from driver_load.py, 
devcon.exe is put in winutils.iso, update the path 

Signed-off-by: Suqin Huang <shuang@redhat.com>