### PR TITLE
Enable test setup for Mellanox CX4 SR-IOV on ppc64le

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -3,6 +3,7 @@ inspektor==0.2.2
 autotest==0.16.2
 aexpect==1.0.0
 simplejson==3.8.0
+netaddr>=0.7.18
 argparse==1.3.0; python_version < '2.7'
 logutils==0.3.3; python_version < '2.7'
 importlib==1.0.3; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 autotest>=0.16.2
 aexpect>=1.2.0
 simplejson>=3.5.3
+netaddr>=0.7.18

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -177,15 +177,22 @@ variants:
         # As of today (30-11-2009), we have 2 drivers for this type of hardware:
         # Intel® 82576 Gigabit Ethernet Controller - igb
         # Neterion® X3100™ - vxge
+        # On PowerPC [Power 8] linux servers SR-IOV hardware supported:
+        # Mellanox CX4 MT27700 Family
+        # For PowerPC driver (kernel module) that supports SR-IOV hardware is
+        # mlx5_core
         driver = igb
         # vf_filter_re: Regex used to filter vf from lspci.
         vf_filter_re = "Virtual Function"
         # pf_filter_re: Regex used to filter pf from lspci. It will be used
         # when device_name could not filter the pf.
+        # For PowerPC: pf_filter_re = "MT27700 Family \[ConnectX-4\]"
         pf_filter_re = "82576 Gigabit Network"
         # Driver option to specify the maximum number of virtual functions
         # (on vxge the option is , for example, is max_config_dev)
         # the default below is for the igb driver
+        # For PowerPC with mlx5_core: driver_option = "10" where 10 is numer of
+        # virtual functions (VF). Maximum supported is 63 VF per port
         driver_option = "max_vfs=7"
         mac_ip_filter = "inet (.\d+.\d+.\d+.\d+).*?ether (.\w+:\w+:\w+:\w+:\w+:\w+)"
         RHEL.6, RHEL.5:
@@ -374,4 +381,3 @@ variants:
         nettype = user
     - network:
         nettype = network
-

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1769,7 +1769,13 @@ class VM(virt_vm.BaseVM):
             else:
                 device_driver = nic_params.get("device_driver", "pci-assign")
                 pci_id = vm.pa_pci_ids[iov]
-                pci_id = ":".join(pci_id.split(":")[1:])
+                # On Power architecture using short id would result in
+                # pci device lookup failure while writing vendor id to
+                # stub_new_id/stub_remove_id. Instead we should be using
+                # pci id as-is for vendor id.
+                if arch.ARCH != 'ppc64le':
+                    pci_id = ":".join(pci_id.split(":")[1:])
+
                 add_pcidevice(devices, pci_id, params=nic_params,
                               device_driver=device_driver,
                               pci_bus=pci_bus)
@@ -2544,7 +2550,11 @@ class VM(virt_vm.BaseVM):
                             vf_filter_re=params.get("vf_filter_re"),
                             pf_filter_re=params.get("pf_filter_re"),
                             device_driver=device_driver,
-                            nic_name_re=params.get("nic_name_re"))
+                            nic_name_re=params.get("nic_name_re"),
+                            static_ip=int(params.get("static_ip", 0)),
+                            start_addr_PF=params.get("start_addr_PF", None),
+                            net_mask=params.get("net_mask", None))
+
                     # Virtual Functions (VF) assignable devices
                     if pa_type == "vf":
                         self.pci_assignable.add_device(device_type=pa_type,


### PR DESCRIPTION
This patch introduces support for setting up SR-IOV devices
on Mellanox CX4 hardware on ppc64le platform.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>