### PR TITLE
Added check for SMT state in power system before test run

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -560,6 +560,16 @@ def preprocess(test, params, env):
     :param env: The environment (a dict-like object).
     """
     error_context.context("preprocessing")
+
+    # For KVM to work in Power8 systems we need to have SMT=off
+    # and it needs to be done as root, here we do a check whether
+    # we satisfy that condition, if not try to make it off
+    # otherwise throw TestError with respective error message
+    cmd = "grep cpu /proc/cpuinfo | awk '{print $3}' | head -n 1"
+    cpu_output = avocado_process.system_output(cmd, shell=True).strip().upper()
+    if "POWER8" in cpu_output:
+        test_setup.disable_smt()
+
     # First, let's verify if this test does require root or not. If it
     # does and the test suite is running as a regular user, we shall just
     # throw a TestSkipError exception, which will skip the test.

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1904,3 +1904,18 @@ class StraceQemu(object):
                 logging.info("stop strace process: %s" % pid)
                 process.kill_process_tree(pid)
         self._compress_log()
+
+
+def disable_smt():
+    """
+    Checks whether smt is on, if so disables it in PowerPC system
+    This function is used in env_process to check & disable smt in Power8
+    """
+    smt_output = process.system_output("ppc64_cpu --smt", shell=True).strip()
+    if smt_output != "SMT is off":
+        try:
+            utils_misc.verify_running_as_root()
+            process.run("ppc64_cpu --smt=off", verbose=True, shell=True)
+            logging.debug("SMT turned off successfully")
+        except process.CmdError, info:
+            raise exceptions.TestSetupFail("VM can not be started :%s", info)


### PR DESCRIPTION
For KVM to work in POWER8 systems we need to have SMT=off and it is common
that we have it SMT=on by default in all the distributions.
    
This patch checks whether we are satisfying that condition for POWER8,
if not it will make it off, otherwise errors out.
    
Signed-off-by: Balamuruhan S bala24@linux.vnet.ibm.com
Signed-off-by: Satheesh Rajendran sathnaga@linux.vnet.ibm.com
