### PR TITLE
Pylint fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ import sys
 class DocBuildError(Exception):
     pass
 
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/scripts/github/label_issues.py
+++ b/scripts/github/label_issues.py
@@ -25,6 +25,7 @@ def set_labels(mutable_issue):
     if len(labels) > 0:
         mutable_issue['labels'] = labels
 
+
 gh = Github(login_or_token=raw_input("Enter github username: "),
             password=getpass.getpass('Enter github password: '),
             user_agent='PyGithub/Python')

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -96,19 +96,19 @@ class Sample(object):
             for i in range(len(files)):
                 fd = open(files[i], "r")
                 f = []
-                for l in fd.readlines():
-                    l = l.strip()
-                    if re.findall("^### ", l):
-                        if "kvm-userspace-ver" in l:
-                            self.kvmver = l.split(':')[-1]
-                        elif "kvm_version" in l:
-                            self.hostkernel = l.split(':')[-1]
-                        elif "guest-kernel-ver" in l:
-                            self.guestkernel = l.split(':')[-1]
-                        elif "session-length" in l:
-                            self.len = l.split(':')[-1]
+                for line in fd.readlines():
+                    line = line.strip()
+                    if re.findall("^### ", line):
+                        if "kvm-userspace-ver" in line:
+                            self.kvmver = line.split(':')[-1]
+                        elif "kvm_version" in line:
+                            self.hostkernel = line.split(':')[-1]
+                        elif "guest-kernel-ver" in line:
+                            self.guestkernel = line.split(':')[-1]
+                        elif "session-length" in line:
+                            self.len = line.split(':')[-1]
                     else:
-                        f.append(l.strip())
+                        f.append(line.strip())
                 self.files_dict.append(f)
                 fd.close()
 
@@ -151,8 +151,8 @@ class Sample(object):
             testidx = None
             job_dict = []
             test_dict = []
-            for l in data:
-                s = l.split()
+            for line in data:
+                s = line.split()
                 if not testidx:
                     testidx = s[0]
                 if testidx != s[0]:
@@ -317,10 +317,10 @@ Please check sysinfo directory in autotest result to get more details.
             ret.append(func(data_list))
 
         if avg_update:
-            for i in avg_update.split('|'):
-                l = i.split(',')
-                ret[int(l[0])] = "%f" % (float(ret[int(l[1])]) /
-                                         float(ret[int(l[2])]))
+            for row in avg_update.split('|'):
+                items = row.split(',')
+                ret[int(items[0])] = "%f" % (float(ret[int(items[1])]) /
+                                             float(ret[int(items[2])]))
         if merge:
             return "|".join(ret)
         return ret

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -8,9 +8,9 @@ run_rc() {
     fi
     echo ""
 }
-run_rc 'inspekt lint'
-run_rc 'inspekt indent'
-run_rc 'inspekt style'
+run_rc 'inspekt --exclude=.git lint'
+run_rc 'inspekt --exclude=.git indent'
+run_rc 'inspekt --exclude=.git style'
 run_rc 'selftests/run'
 exit ${GR}
 

--- a/selftests/run
+++ b/selftests/run
@@ -26,6 +26,7 @@ def test_suite():
                                        top_level_dir=basedir))
     return suite
 
+
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()
     result = runner.run(test_suite())

--- a/selftests/unit/test_cartesian_config.py
+++ b/selftests/unit/test_cartesian_config.py
@@ -753,5 +753,6 @@ class CartesianConfigTest(unittest.TestCase):
         self._checkConfigDump('testcfg.huge/test1.cfg',
                               'testcfg.huge/test1.cfg.repr.gz')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_libvirt_network.py
+++ b/selftests/unit/test_libvirt_network.py
@@ -150,5 +150,6 @@ class NetworkXMLTest(NetworkTestBase):
             else:
                 self.assertEqual(state, new_state)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_propcan.py
+++ b/selftests/unit/test_propcan.py
@@ -278,5 +278,6 @@ class TestPropCan(unittest.TestCase):
             self.assertTrue(testcan == {'bar': value})
             self.assertEqual(str(testcan), str({'bar': value}))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -1155,5 +1155,6 @@ fdc
         out = qdev.cmdline()
         assert out == exp, (out, exp)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/selftests/unit/test_qemu_qtree.py
+++ b/selftests/unit/test_qemu_qtree.py
@@ -47,6 +47,7 @@ def combine(first, second, offset):
         out += '\n' + offset + line
     return out
 
+
 # Dummy variables
 qtree_header = """bus: main-system-bus
   type System

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -93,5 +93,6 @@ class RemoteFileTest(unittest.TestCase):
         test_data = self._read_test_file()
         self.assertEqual(test_data, self.default_data)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -23,6 +23,7 @@ class FakeJob(object):
         self.args = argparse.Namespace()
         self.args.vt_config = True
 
+
 FAKE_PARAMS = {'shortname': 'fake',
                'vm_type': 'fake'}
 
@@ -42,6 +43,7 @@ class VirtTestTest(unittest.TestCase):
 
     def test_filename(self):
         self.assertIsNone(self.test.filename)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_cgroup.py
+++ b/selftests/unit/test_utils_cgroup.py
@@ -161,5 +161,6 @@ class CgroupTest(unittest.TestCase):
             finally:
                 os.remove(mount_file_path)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_config.py
+++ b/selftests/unit/test_utils_config.py
@@ -429,5 +429,6 @@ class LibvirtConfigTest(unittest.TestCase):
         finally:
             os.remove(config_path)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_env.py
+++ b/selftests/unit/test_utils_env.py
@@ -218,5 +218,6 @@ class TestEnv(unittest.TestCase):
         finally:
             termination_event.set()
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/unit/test_utils_misc.py
+++ b/selftests/unit/test_utils_misc.py
@@ -143,6 +143,7 @@ node   0
 def utils_run(cmd, shell=True):
     return FakeCmd(cmd)
 
+
 all_nodes_contents = "0\n"
 online_nodes_contents = "0\n"
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ def get_data_files():
 
     return data_files
 
+
 setup(name='avocado-plugins-vt',
       version=VERSION,
       description='Avocado Virt Test Compatibility Layer plugin',

--- a/shared/deps/run_autotest/boottool.py
+++ b/shared/deps/run_autotest/boottool.py
@@ -162,25 +162,25 @@ class EfiVar(object):
         '''
         Returns the variable name in a list ready for struct.pack()
         '''
-        l = []
+        normalized_name = []
         for i in range(512):
-            l.append(0)
+            normalized_name.append(0)
 
         for i in range(len(self.name)):
-            l[i] = ord(self.name[i])
-        return l
+            normalized_name[i] = ord(self.name[i])
+        return normalized_name
 
     def get_data(self):
         '''
         Returns the variable data in a list ready for struct.pack()
         '''
-        l = []
+        normalized_data = []
         for i in range(512):
-            l.append(0)
+            normalized_data.append(0)
 
         for i in range(len(self.data)):
-            l[i] = ord(self.data[i])
-        return l
+            normalized_data[i] = ord(self.data[i])
+        return normalized_data
 
     def get_packed(self):
         '''

--- a/shared/deps/serial/windows_support.py
+++ b/shared/deps/serial/windows_support.py
@@ -42,15 +42,15 @@ class WinBufferedReadFile(object):
         while True:  # emulate blocking IO
             if self._n >= n:
                 frags = []
-                l = 0
+                frags_length = 0
                 if self.verbose:
                     txt = "get %s, | bufs = %s " % (n, self._n)
                     txt += "[%s]" % ','.join(map(lambda x: str(len(x)),
                                                  self._bufs))
                     print(txt)
-                while l < n:
+                while frags_length < n:
                     frags.append(self._bufs.pop(0))
-                    l += len(frags[-1])
+                    frags_length += len(frags[-1])
                 self._n -= n
                 whole = ''.join(frags)
                 ret = whole[:n]

--- a/shared/scripts/cb.py
+++ b/shared/scripts/cb.py
@@ -130,6 +130,7 @@ def main(argv):
         text = clipboard.wait_for_text()
         print 'clipboard=' + str(text)
 
+
 if __name__ == "__main__":
     main(sys.argv[1:])
     sys.exit(0)

--- a/shared/scripts/check_cpu_flag.py
+++ b/shared/scripts/check_cpu_flag.py
@@ -15,5 +15,6 @@ def check_cpu_flag():
             print err_msg
             raise check_error(err_msg)
 
+
 if __name__ == "__main__":
     check_cpu_flag()

--- a/shared/scripts/key_event_form.py
+++ b/shared/scripts/key_event_form.py
@@ -31,6 +31,7 @@ class TestForm(gtk.Window):
         input_file.write("{0} ".format(event.keyval))
         input_file.close()
 
+
 if __name__ == "__main__":
     TestForm()
     gtk.main()

--- a/virttest/element_path.py
+++ b/virttest/element_path.py
@@ -166,6 +166,7 @@ class Path:
                 return []
             nodeset = set
 
+
 _cache = {}
 
 #

--- a/virttest/element_tree.py
+++ b/virttest/element_tree.py
@@ -408,6 +408,7 @@ class _ElementInterface(object):
             nodes.extend(node.getiterator(tag))
         return nodes
 
+
 # compatibility
 _Element = _ElementInterface
 
@@ -488,6 +489,7 @@ def ProcessingInstruction(target, text=None):
     if text:
         element.text = element.text + " " + text
     return element
+
 
 PI = ProcessingInstruction
 
@@ -751,6 +753,7 @@ def _encode(s, encoding):
     except AttributeError:
         return s  # 1.5.2: assume the string uses the right encoding
 
+
 if sys.version[:3] == "1.5":
     _escape = re.compile(r"[&<>\"\x80-\xff]+")  # 1.5.2
 else:
@@ -991,6 +994,7 @@ def XMLID(text):
         if id:
             ids[id] = elem
     return tree, ids
+
 
 #
 # Parses an XML document from a string constant.  Same as {@link #XML}.
@@ -1268,6 +1272,7 @@ class XMLTreeBuilder(object):
         tree = self._target.close()
         del self._target, self._parser  # get rid of circular references
         return tree
+
 
 # compatibility
 XMLParser = XMLTreeBuilder

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -77,6 +77,7 @@ def clean_tmp_files():
     if os.path.isfile(CREATE_LOCK_FILENAME):
         os.unlink(CREATE_LOCK_FILENAME)
 
+
 CREATE_LOCK_FILENAME = os.path.join(data_dir.get_tmp_dir(),
                                     'avocado-vt-vm-create.lock')
 

--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -831,6 +831,7 @@ def remote_agent(in_stream_cls, out_stream_cls):
         sys.stderr.write(e)
         # traceback.print_exc()
 
+
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         if sys.argv[1] == "agent":

--- a/virttest/staging/backports/__init__.py
+++ b/virttest/staging/backports/__init__.py
@@ -104,6 +104,7 @@ def _bin(number):
     tmp = [BIN_HEX_DICT[hstr] for hstr in hex(number)[2:]]
     return BIN_ZSTRIP.sub('0b', ''.join(tmp))
 
+
 if not hasattr(__builtins__, 'next'):
     next = _next
 else:

--- a/virttest/staging/backports/collections/namedtuple.py
+++ b/virttest/staging/backports/collections/namedtuple.py
@@ -8,7 +8,7 @@ from keyword import iskeyword as _iskeyword
 import sys as _sys
 
 
-# pylint: disable=I0011,R0914,W0141,W0122,W0612,C0103,W0212,R0912
+# pylint: disable=I0011,R0914,W0122,W0612,C0103,W0212,R0912
 def namedtuple(typename, field_names, verbose=False, rename=False):
     """
     Returns a new subclass of tuple with named fields.
@@ -46,7 +46,7 @@ def namedtuple(typename, field_names, verbose=False, rename=False):
     if isinstance(field_names, basestring):
         field_names = field_names.replace(
             ',', ' ').split()  # names separated by whitespace and/or commas
-    field_names = tuple(map(str, field_names))
+    field_names = tuple(str(name) for name in field_names)
     if rename:
         names = list(field_names)
         seen = set()

--- a/virttest/staging/backports/simplejson/__init__.py
+++ b/virttest/staging/backports/simplejson/__init__.py
@@ -119,6 +119,8 @@ def _import_OrderedDict():
     except AttributeError:
         import ordered_dict
         return ordered_dict.OrderedDict
+
+
 OrderedDict = _import_OrderedDict()
 
 
@@ -128,6 +130,7 @@ def _import_c_make_encoder():
         return make_encoder
     except ImportError:
         return None
+
 
 _default_encoder = JSONEncoder(
     skipkeys=False,

--- a/virttest/staging/backports/simplejson/decoder.py
+++ b/virttest/staging/backports/simplejson/decoder.py
@@ -13,6 +13,8 @@ def _import_c_scanstring():
         return scanstring
     except ImportError:
         return None
+
+
 c_scanstring = _import_c_scanstring()
 
 __all__ = ['JSONDecoder']
@@ -28,6 +30,7 @@ def _floatconstants():
         _BYTES = _BYTES[:8][::-1] + _BYTES[8:][::-1]
     nan, inf = struct.unpack('dd', _BYTES)
     return nan, inf, -inf
+
 
 NaN, PosInf, NegInf = _floatconstants()
 

--- a/virttest/staging/backports/simplejson/encoder.py
+++ b/virttest/staging/backports/simplejson/encoder.py
@@ -10,6 +10,8 @@ def _import_speedups():
         return _speedups.encode_basestring_ascii, _speedups.make_encoder
     except ImportError:
         return None, None
+
+
 c_encode_basestring_ascii, c_make_encoder = _import_speedups()
 
 from decoder import PosInf

--- a/virttest/staging/backports/simplejson/scanner.py
+++ b/virttest/staging/backports/simplejson/scanner.py
@@ -9,6 +9,8 @@ def _import_c_make_scanner():
         return make_scanner
     except ImportError:
         return None
+
+
 c_make_scanner = _import_c_make_scanner()
 
 __all__ = ['make_scanner']
@@ -76,5 +78,6 @@ def py_make_scanner(context):
             memo.clear()
 
     return scan_once
+
 
 make_scanner = c_make_scanner or py_make_scanner

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -19,6 +19,7 @@ def _variant_only_file(filename):
     return ", ".join([_.strip() for _ in open(filename)
                       if not _.lstrip().startswith('#')])
 
+
 SUPPORTED_TEST_TYPES = [
     'qemu', 'libvirt', 'libguestfs', 'openvswitch', 'v2v', 'lvsb', 'spice']
 

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -386,11 +386,11 @@ class UnattendedInstallConfig(object):
         dummy_logging_re = r'\bKVM_TEST_LOGGING\b'
         if re.search(dummy_logging_re, contents):
             if self.syslog_server_enabled == 'yes':
-                l = 'logging --host=%s --port=%s --level=debug'
-                l = l % (self.syslog_server_ip, self.syslog_server_port)
+                log = 'logging --host=%s --port=%s --level=debug'
+                log = log % (self.syslog_server_ip, self.syslog_server_port)
             else:
-                l = ''
-            contents = re.sub(dummy_logging_re, l, contents)
+                log = ''
+            contents = re.sub(dummy_logging_re, log, contents)
 
         dummy_graphical_re = re.compile('GRAPHICAL_OR_TEXT')
         if dummy_graphical_re.search(contents):

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2736,6 +2736,7 @@ class DbNet(VMNet):
         except AttributeError:
             raise DbNoLockError
 
+
 ADDRESS_POOL_FILENAME = os.path.join(data_dir.get_tmp_dir(), "address_pool")
 ADDRESS_POOL_LOCK_FILENAME = ADDRESS_POOL_FILENAME + ".lock"
 

--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -51,6 +51,7 @@ class RestoreconError(SelinuxError):
         return ("Output from the restorecon command"
                 "does not match the expected format")
 
+
 STATUS_LIST = ['enforcing', 'permissive', 'disabled']
 
 

--- a/virttest/version.py
+++ b/virttest/version.py
@@ -138,5 +138,6 @@ def get_pretty_version_info():
         version_str += ", SHA1 '%s'" % top_commit
     return version_str
 
+
 if __name__ == "__main__":
     print get_pretty_version_info()


### PR DESCRIPTION
This PR covers the issues related to the updated pep8/pylint and as the last commit adds the fix to `selftests/checkall` already used in `avocado` to avoid checking `.git` directory.

In the E741 fix I tried to use the most fitting variable names, but I'm not familiar with all the places I fixed, therefor feel free to disagree and suggest better ones. But hopefully they are fitting well enough.

Issue https://github.com/avocado-framework/avocado-vt/issues/760