### PR TITLE
shared.cfg.machines: Add the "--nvram" to arm64-pci

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -54,6 +54,7 @@ variants:
         machine_type = arm64-pci:virt
         # No support for VGA yet
         vga = none
+        vir_domain_undefine_nvram = yes
         inactivity_watcher = none
         take_regular_screendumps = no
         # Currently no USB support


### PR DESCRIPTION
The 6801faa1f6cff32869a510d7a2c79f3b366d5fd4 added the necessary
`--nvram` to arm64-mmio variant. This is fine as arm64-pci is not yet
supported by libvirt, but let's keep the definitions in sync to avoid
confusion when it is.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>