### PR TITLE
virttest.qemu_monitor: rename monitor log file

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -198,7 +198,7 @@ class Monitor:
         self._passfd = None
         self._supported_cmds = []
         self.debug_log = False
-        self.log_file = os.path.basename(self.filename + ".log")
+        self.log_file = "%s-%s.log" % (name, vm.name)
         self.open_log_files = {}
 
         try:


### PR DESCRIPTION
Follow seabios and serial logfile name format to rename
monitor logfile name to '${monitor}-${vm-name}.log'.

ID: 1218964

Signed-off-by: Xu Tian <xutian@redhat.com>