### PR TITLE
virttest.env_process: optimize the check for kvm module

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -672,7 +672,10 @@ def preprocess(test, params, env):
             except Exception:
                 kvm_version = os.uname()[2]
         else:
-            logging.warning("KVM module not loaded")
+            warning_msg = "KVM module not loaded"
+            if params.get("enable_kvm", "yes") == "yes":
+                raise exceptions.TestSkipError(warning_msg)
+            logging.warning(warning_msg)
             kvm_version = "Unknown"
 
     logging.debug("KVM version: %s" % kvm_version)


### PR DESCRIPTION
we should throw an exception earlier if /dev/kvm doesn't exist.
No need to add "enable-kvm" option in make_create_command(),
which will lead the following error,

"Could not access KVM kernel module: No such file or directory\n
 failed to initialize KVM: No such file or directory'"

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>