### PR TITLE
qemu_vm:windows 32bit guest's maximum mem limit to 3G

### DIFF
--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -1,5 +1,5 @@
 - i386:
-    maxmem = 4G
+    maxmem = 3G
     vm_arch_name = i686
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:

--- a/shared/cfg/guest-os/Windows/Win7/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/i386.cfg
@@ -1,5 +1,5 @@
 - i386:
-    maxmem = 4G
+    maxmem = 3G
     vm_arch_name = i686
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:

--- a/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -1,5 +1,5 @@
 - i386:
-    maxmem = 4G
+    maxmem = 3G
     vm_arch_name = i686
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:


### PR DESCRIPTION
qemu_vm:
1.modify function add_memorys for 32bit windows guest
2.correct pep8 error

Signed-off-by: Aihua Liang<aliang@redhat.com>

ID:1388321,1388309