### PR TITLE
Ignoring node-name in new `info block' output

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -398,6 +398,8 @@ class QtreeDisksContainer(object):
         """
         additional = 0
         missing = 0
+        keys = info.keys()
+        info[re.sub("\ \(#\w+\)", "", keys[0])] = info.pop(keys[0])
         for i in xrange(len(self.disks)):
             disk = self.disks[i]
             name = disk.get_qname()


### PR DESCRIPTION
Since commit 8d6adccd in Qemu (>= 2.3.0) the output of the command `info
block' on the HMP interface changed so it also shows node-names as in
the example:

  (qemu) info block
  drive-virtio-disk5 (#block190): vms/Debian-8-server-2016-04-01.qcow2 (raw)

This patch ignores the node-name part of the output (in this case
" (#block190)" and keeps only the actual name "drive-virtio-disk5" to
run the tests and keep the retro-compatibility with other parts of
avocado-vt.

Signed-off-by: Eduardo Otubo <eduardo.otubo@profitbricks.com>