### PR TITLE
iscsi: Avoid failure when logout all without existing session

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -140,7 +140,17 @@ def iscsi_logout(target_name=None):
         cmd = "iscsiadm --mode node --logout -T %s" % target_name
     else:
         cmd = "iscsiadm --mode node --logout all"
-    output = process.system_output(cmd)
+
+    output = ''
+    try:
+        output = process.system_output(cmd)
+    except process.CmdError as detail:
+        # iscsiadm will fail when no matching sessions found
+        # This failure makes no sense when target name is not specified
+        if not target_name and 'No matching sessions' in detail.result.stderr:
+            logging.info("%s: %s", detail, detail.result.stderr)
+        else:
+            raise
 
     target_logout = ""
     if "successful" in output:


### PR DESCRIPTION
When calling `iscsiadm` to log out existing sessions, command will fail
when no existing session matches. This failure makes sense when logging
out a specific target. But when logging out all sessions, this failure
does not match common sense.

This issue can be easily reproduced by calling following command:

```
python -c "from virttest import iscsi; iscsi.iscsi_logout()"
```

This patch fix this issue by catching and forgiving this failure if
target name is not given.

Signed-off-by: Hao Liu <hliu@redhat.com>