### PR TITLE
shared.cfg.guest-os.Windows:update iso for Win10-32&Win10-64

### DIFF
--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -1,12 +1,12 @@
 - i386:
-    maxmem = 4G
+    maxmem = 3G
     vm_arch_name = i686
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
         unattended_file = unattended/win10-32-autounattend.xml
-        cdrom_cd1 = isos/windows/en_windows_10_enterprise_x86_dvd_6851156.iso
-        md5sum_cd1 = 68162933e551e55779504dacdfb0c5ae
-        md5sum_1m_cd1 = b44af2fdb8c39bc972f416bd3616566f
+        cdrom_cd1 = isos/windows/en_windows_10_enterprise_version_1607_updated_jul_2016_x86_dvd_9060097.iso
+        md5sum_cd1 = dfb7e70fcd434cf345f7c07972473374
+        md5sum_1m_cd1 = ebbb5dd88a83a211f4bea42e89b7cc9c
         floppies = "fl"
         floppy_name = images/win10-32/answer.vfd
         extra_cdrom_ks:

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -5,9 +5,9 @@
     install:
         passwd = 1q2w3eP
     unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
-        cdrom_cd1 = isos/windows/en_windows_10_enterprise_x64_dvd_6851151.iso
-        md5sum_cd1 = a67722adfaf209c72eacb3ab910ee65e
-        md5sum_1m_cd1 = 0e246b56b7b63f0526c3367eb160ff7d
+        cdrom_cd1 = isos/windows/en_windows_10_enterprise_version_1607_updated_jul_2016_x64_dvd_9054264.iso
+        md5sum_cd1 = 06fc1188353f10b007c1e4a8f08b36b6
+        md5sum_1m_cd1 = 133640f1cc02ebf3542c1d88d5b59518
         unattended_file = unattended/win10-64-autounattend.xml
         floppies = "fl"
         floppy_name = images/win10-64/answer.vfd


### PR DESCRIPTION
Win10.i386:
1.update Win10-32 iso and its md5.
2.update its maxmem to 3G

Win10.x86_64:
1.update Win10-64 iso and its md5.

Signed-off-by: Aihua Liang<aliang@redhat.com>

ID:1386122