### PR TITLE
fix an error with function get_backingfile

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1004,8 +1004,9 @@ class HumanMonitor(Monitor):
         """
         backing_file = None
         block_info = self.query("block")
+        block_info = block_info.replace('\n',' ')
         try:
-            pattern = "%s:.*backing_file=([^\s]*)" % device
+            pattern = "%s.*:.*Backing file:\s*([^\s]*)" % device
             backing_file = re.search(pattern, block_info, re.M).group(1)
         except Exception:
             pass


### PR DESCRIPTION
qemu-kvm 2.5 in centos.
get result from self.query("block"):
(qemu) info block
drive_image1 (#block856): /tmp/hhh (qcow2)
    Cache mode:       writethrough
    Backing file:     jeos-23-64.qcow2 (chain depth: 1)

then we can not get backing_file from      pattern = "%s.*:.*Backing file:\s*([^\s]*)" % device,   
two errors:
first ,there are '\n' in block_info, pattern not work
second,it is 'Backing file' not 'backing_file'