### PR TITLE
 Fix an error with function get_backingfile

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1005,8 +1005,8 @@ class HumanMonitor(Monitor):
         backing_file = None
         block_info = self.query("block")
         try:
-            pattern = "%s:.*backing_file=([^\s]*)" % device
-            backing_file = re.search(pattern, block_info, re.M).group(1)
+            pattern = "%s.*[Bb]acking[_\s]file[:=]\s?([^\s]*)" % device
+            backing_file = re.search(pattern, block_info, re.S | re.M).group(1)
         except Exception:
             pass
         return backing_file


### PR DESCRIPTION
qemu-kvm 2.5 in centos.

get result from self.query("block"):
(qemu) info block
drive_image1 (#block856): /tmp/hhh (qcow2)
    Cache mode:       writethrough
    Backing file:     jeos-23-64.qcow2 (chain depth: 1)

Then we can not get backing_file from      pattern = "%s:.*backing_file=([^\s]*)" % device

First ,there are '\n' in block_info, pattern not work
Second,it is 'Backing file' not 'backing_file'