### PR TITLE
utils_test: Revert mistakenly removed importing

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -52,6 +52,17 @@ from .. import utils_net
 from .. import virt_vm
 from ..staging import utils_memory
 
+# Get back to importing submodules
+# This is essential for accessing these submodules directly from
+# utils_test namespace like:
+# >>> from virttest import utils_test
+# >>> utils_test.qemu.SomeClass()
+#
+# pylint: disable=unused-import
+from . import qemu
+from . import libvirt
+from . import libguestfs
+
 
 # This is so that other tests won't break when importing the names
 # 'ping' and 'raw_ping' from this namespace


### PR DESCRIPTION
These three imports are mistakenly removed in commit 6e1d2bc4.
They looks like unused imports, but is acctually useful to make these
submodules accessible directly from utils_test name space.

Removing these imports will make many test cases those using this way
fail. Added comments and a pylint disablement to avoid future removal.

Signed-off-by: Hao Liu <hliu@redhat.com>