### PR TITLE
avocado_vt: Change default for --vt-qemu-bin

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -98,12 +98,18 @@ def add_qemu_bin_vt_option(parser):
     except (RuntimeError, utils_path.CmdNotFoundError):
         qemu_bin_path = None
     qemu_bin = settings.get_value('vt.qemu', 'qemu_bin',
-                                  default=qemu_bin_path)
+                                  default=None)
+    if qemu_bin is None:    # Allow default to be None when not set in setting
+        default_qemu_bin = None
+        qemu_bin = qemu_bin_path
+    else:
+        default_qemu_bin = qemu_bin
     parser.add_argument("--vt-qemu-bin", action="store", dest="vt_qemu_bin",
-                        default=qemu_bin, help="Path to a custom qemu binary "
-                        "to be tested. If --vt-config is provided and this "
-                        "flag is omitted, no attempt to set the qemu binaries "
-                        "will be made. Current: %s" % _str_or_none(qemu_bin))
+                        default=default_qemu_bin, help="Path to a custom qemu"
+                        " binary to be tested. If --vt-config is provided and"
+                        " this flag is omitted, no attempt to set the qemu "
+                        "binaries will be made. Current: %s"
+                        % _str_or_none(qemu_bin))
     qemu_dst = settings.get_value('vt.qemu', 'qemu_dst_bin',
                                   default=qemu_bin_path)
     parser.add_argument("--vt-qemu-dst-bin", action="store",


### PR DESCRIPTION
The `vt_qemu_bin` defines which qemu binary will be used in testing. It
has several special handlings to allow various manipulations, one of
them is that when `vt_qemu_bin` is None and `vt_config` is used, it
won't try to determine `qemu_binary` related params in order to allow
cartesian config to set those.

The problem is, that when `vt_qemu_bin` default is the current qemu
path, it won't allow users to set it to None, therefor this feature is
unavailable and the cartesian config params are overridden by `options`,
which might not be desired.

Even by setting the default to `None` the `qemu_binary` will be
processed and suitable binary found, therefor in reality the default is
still the same, only set later in the code (unless `--vt-qemu-bin` is
used).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>