### PR TITLE
Fixup: Changed to log xml content during failure

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -608,8 +608,8 @@ class VMXML(VMXMLBase):
         if not self.define(virsh_instance=virsh_instance):
             if backup:
                 backup.define(virsh_instance=virsh_instance)
-            raise xcepts.LibvirtXMLError("Failed to define %s, from %s."
-                                         % (self.vm_name, self.xml))
+            raise xcepts.LibvirtXMLError("Failed to define %s, from xml:\n%s."
+                                         % (self.vm_name, self.xmltree))
 
     @staticmethod
     def vm_rename(vm, new_name, uuid=None, virsh_instance=base.virsh):


### PR DESCRIPTION
It will be helpful to get xml file content in
case of failure rather than the temporary xml filename.

This patches changes the error log to print the
failed xml file content.

Signed-off-by: Satheesh Rajendran sathnaga@linux.vnet.ibm.com