### PR TITLE
Utils_test: update shell_prompt default param with proper regex

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1953,7 +1953,7 @@ class RemoteDiskManager(object):
 
 
 def check_dest_vm_network(vm, vm_ip, remote_host, username, password,
-                          shell_prompt=None, timeout=60):
+                          shell_prompt=r"[\#\$]\s*$", timeout=60):
     """
     Ping migrated vms on remote host.
     """


### PR DESCRIPTION
shell_prompt=None as default parameter fails even for successful login by timing out if the API is called without regex for shell prompt. This patch fixes it.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>