### PR TITLE
virttest.virsh: Add one parameter for virsh option

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1726,7 +1726,7 @@ class VM(virt_vm.BaseVM):
             lockfile.close()
 
     def migrate(self, dest_uri="", option="--live --timeout 60", extra="",
-                ignore_status=False, debug=False):
+                ignore_status=False, debug=False, virsh_opt=""):
         """
         Migrate a VM to a remote host.
 
@@ -1740,7 +1740,7 @@ class VM(virt_vm.BaseVM):
         result = virsh.migrate(self.name, dest_uri, option,
                                extra, uri=self.connect_uri,
                                ignore_status=ignore_status,
-                               debug=debug)
+                               debug=debug, virsh_opt=virsh_opt)
         # Close down serial_console logging process
         self.cleanup_serial_console()
         # On successful migration, point to guests new hypervisor.

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1136,7 +1136,8 @@ class MigrationTest(object):
         self.ret = None
 
     def thread_func_migration(self, vm, desturi, options=None,
-                              ignore_status=False):
+                              ignore_status=False, virsh_opt="",
+                              extra_opts=""):
         """
         Thread for virsh migrate command.
 
@@ -1157,7 +1158,8 @@ class MigrationTest(object):
             stime = int(time.time())
             self.ret = vm.migrate(desturi, option=options,
                                   ignore_status=ignore_status,
-                                  debug=True)
+                                  debug=True, virsh_opt=virsh_opt,
+                                  extra=extra_opts)
             etime = int(time.time())
             self.mig_time[vm.name] = etime - stime
             if self.ret.exit_status != 0:
@@ -1223,9 +1225,10 @@ class MigrationTest(object):
             # continue
             pass
 
-    def do_migration(self, vms, srcuri, desturi, migration_type, options=None,
-                     thread_timeout=60, ignore_status=False, func=None,
-                     **args):
+    def do_migration(self, vms, srcuri, desturi, migration_type,
+                     options=None, thread_timeout=60,
+                     ignore_status=False, func=None, virsh_opt="",
+                     extra_opts="", **args):
         """
         Migrate vms.
 
@@ -1248,7 +1251,8 @@ class MigrationTest(object):
             for vm in vms:
                 migration_thread = threading.Thread(target=self.thread_func_migration,
                                                     args=(vm, desturi, options,
-                                                          ignore_status))
+                                                          ignore_status, virsh_opt,
+                                                          extra_opts))
                 migration_thread.start()
                 eclipse_time = 0
                 if func:

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -626,6 +626,7 @@ def command(cmd, **dargs):
 
     virsh_exec = dargs.get('virsh_exec', VIRSH_EXEC)
     uri = dargs.get('uri', None)
+    virsh_opt = dargs.get('virsh_opt', '')
     debug = dargs.get('debug', False)
     # Caller deals with errors
     ignore_status = dargs.get('ignore_status', True)
@@ -673,8 +674,7 @@ def command(cmd, **dargs):
         else:
             uri_arg = " "  # No uri argument being used
 
-        cmd = "%s%s%s" % (virsh_exec, uri_arg, cmd)
-
+        cmd = "%s%s%s%s" % (virsh_exec, virsh_opt, uri_arg, cmd)
         if unprivileged_user:
             # Run cmd as unprivileged user
             cmd = "su - %s -c '%s'" % (unprivileged_user, cmd)


### PR DESCRIPTION
Add a parameter providing virsh option when executing virsh command.
Migration function also adds this parameter for its caller to use.

Signed-off-by: Dan Zheng <dzheng@redhat.com>