### PR TITLE
Fixup: VM with multiple interfaces boot failure[V2]

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -73,6 +73,11 @@ netdst = virbr0
 #advanced network configuration of the host
 #host_ip_addr = ""
 
+# Set this parameter to 'yes' inorder to get IP from
+# any network interface incase of multiple interface
+# present in VM, default is 'no'
+flexible_nic_index = no
+
 # List of block device object names (whitespace separated)
 images = image1
 # List of block device object names with order (whitespace separated)

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1467,7 +1467,7 @@ class VM(virt_vm.BaseVM):
     def wait_for_login(self, nic_index=0, timeout=None,
                        internal_timeout=None,
                        serial=False, restart_network=False,
-                       username=None, password=None):
+                       username=None, password=None, flexible_index=False):
         """
         Override the wait_for_login method of virt_vm to support other
         guest in libvirt.
@@ -1494,7 +1494,8 @@ class VM(virt_vm.BaseVM):
         return super(VM, self).wait_for_login(nic_index, timeout,
                                               internal_timeout,
                                               serial, restart_network,
-                                              username, password)
+                                              username, password,
+                                              flexible_index)
 
     @error_context.context_aware
     def create(self, name=None, params=None, root_dir=None, timeout=5.0,


### PR DESCRIPTION
When VM have multiple interfaces and
IP address can get assigned to any(index) interface

Right now, get_address hang on single interface and
timeout for boot(import) test.

This patch will address it by introducing
a parameter""flexible_nic_index"",
when set it will try to poke all the interface and
check which has valid IP and tries connect to it.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>