### PR TITLE
utils_netperf: Extract "prompt,linesep and status_test_command" as params

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -3,6 +3,7 @@
     shutdown_command = shutdown -h now
     reboot_command = shutdown -r now
     status_test_command = echo $?
+    shell_linesep = \n
     username = root
     password = 123456
     shell_client = ssh


### PR DESCRIPTION
utils_netperf:
1.extract shell,linesep and status_test_command as params for both "ssh" and "nc"

Signed-off-by: Aihua Liang<aliang@redhat.com>

ID:1261786,1263919