### PR TITLE
cartesian: Parsing suffix before yielding dict

### DIFF
--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -1939,7 +1939,6 @@ class Parser(object):
             for d in self.get_dicts_plain(node, ctx, content, shortname, dep):
                 if parent:
                     self.drop_suffixes(d)
-                postfix_parse(d)
                 yield d
         else:
             # Rewrite all separate joins in one node as many `only'
@@ -1955,7 +1954,6 @@ class Parser(object):
             for d in self.multiply_join(onlys, node, ctx, content, shortname, dep):
                 if parent:
                     self.drop_suffixes(d)
-                postfix_parse(d)
                 yield d
             node.content = old_conten[:]
 
@@ -2152,13 +2150,13 @@ class Parser(object):
                  "shortname": ".".join([str(sn.name) for sn in shortname])}
             for _, _, op in new_content:
                 op.apply_to_dict(d)
+            postfix_parse(d)
             yield d
 
 
 def print_dicts_default(options, dicts):
     """Print dictionaries in the default mode"""
     for count, dic in enumerate(dicts):
-        postfix_parse(dic)
         if options.fullname:
             print "dict %4d:  %s" % (count + 1, dic["name"])
         else:
@@ -2175,7 +2173,6 @@ def print_dicts_repr(options, dicts):
     import pprint
     print "["
     for dic in dicts:
-        postfix_parse(dic)
         print "%s," % (pprint.pformat(dic))
     print "]"
 


### PR DESCRIPTION
The current Cartesian parsing performance is very low. It'll take
several minutes to list all the cases in a test provider.

After some CPU performance profiling, we can find the bottleneck of
current Cartesian parsing process is a function named postfix_parse.
This function is used to clip the range of a value if its key ends with
'_min', '_max' or '_fixed' and is called after the whole configuration
is combined and generated. Since the combination may generates very huge
number possible results, this function then will be called too many
times.

This patch reduce the calculation by calling this function right before
parser reach a leaf node. This will greatly decrease the number of
calling this function thus increase the performance of list large number
of test cases.

Signed-off-by: Hao Liu <hliu@redhat.com>