### PR TITLE
virttest: fix _open_log_file namespace issue

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -260,9 +260,10 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
         session.close()
         raise
     if log_filename:
+        log_file = utils_misc.get_log_filename(log_filename)
         session.set_output_func(utils_misc.log_line)
-        session.set_output_params((log_filename,))
-        session.set_log_file(log_filename)
+        session.set_output_params((log_file,))
+        session.set_log_file(os.path.basename(log_file))
     return session
 
 
@@ -326,9 +327,10 @@ def remote_commander(client, host, port, username, password, prompt,
         session.close()
         raise
     if log_filename:
+        log_file = utils_misc.get_log_filename(log_filename)
         session.set_output_func(utils_misc.log_line)
-        session.set_output_params((log_filename,))
-        session.set_log_file(log_filename)
+        session.set_output_params((log_file,))
+        session.set_log_file(os.path.basename(log_file))
 
     session.send_ctrl("raw")
     # Wrap io interfaces.

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -459,8 +459,11 @@ class MemoryBaseTest(object):
         """
         os_type = vm.params.get("os_type")
         timeout = float(vm.params.get("login_timeout", 600))
-        session = vm.wait_for_login(timeout=timeout)
-        return utils_misc.get_free_mem(session, os_type)
+        try:
+            session = vm.wait_for_login(timeout=timeout)
+            return utils_misc.get_free_mem(session, os_type)
+        finally:
+            session.close()
 
     @classmethod
     def get_guest_used_mem(cls, vm):


### PR DESCRIPTION
close function of session object use variable '_open_log_file'
in module 'aexpect.utils.genio' to collect opened fds, this
commit put fd opened by 'log_line' function in it to avoid
fd not closed after close session.

ID: 1408179

Signed-off-by: Xu Tian <xutian@redhat.com>