### PR TITLE
Sysconfig file location is set for RHEL by default

### DIFF
--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 import ConfigParser
 import StringIO
+import platform
 
 
 class ConfigError(Exception):
@@ -431,7 +432,11 @@ class LibvirtdSysConfig(LibvirtConfigCommon):
     """
     Class for sysconfig libvirtd config file.
     """
-    conf_path = '/etc/sysconfig/libvirtd'
+    distro = platform.dist()
+    if 'Ubuntu' in distro:
+        conf_path = '/etc/default/libvirtd'
+    else:
+        conf_path = '/etc/sysconfig/libvirtd'
     __option_types__ = {
         'LIBVIRTD_CONFIG': 'string',
         'LIBVIRTD_ARGS': 'string',


### PR DESCRIPTION
The sysconfig file location is set for RHEL by default, but it different for Ubuntu. This patch setting the config path based on the distro.

Signed-off-by: Sudeesh John sudeesh@linux.vnet.ibm.com