### PR TITLE
cfg.base:use xhci as the default controller on ppc platform

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -103,11 +103,11 @@ usb_type_tablet1 = usb-tablet
 # USB Controller type which device uses.
 usb_controller = ehci
 usb_bus = usb1.0
-# PPC64 does not support uhci, use ohci as the default.
+#use xhci as the default controller on ppc platform.
 pseries:
-    usb_controller = ohci
-    usb_type = pci-ohci
-    usb_type_usb1 = pci-ohci
+    usb_controller = xhci
+    usb_type = nex-usb-xhci
+    usb_type_usb1 = nex-usb-xhci
 
 # Serial port support
 # You can assign more than one serial to guest with this parameter.


### PR DESCRIPTION
cfg.base:use xhci as the default controller on ppc platform
Signed-off-by: Xujun Ma <xuma@redhat.com>
ID:1410309