### PR TITLE
virttest.qemu_vm: add vm status check

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4112,12 +4112,14 @@ class VM(virt_vm.BaseVM):
         Pause the VM operation.
         """
         self.monitor.cmd("stop")
+        self.verify_status("paused")
 
     def resume(self):
         """
         Resume the VM operation in case it's stopped.
         """
         self.monitor.cmd("cont")
+        self.verify_status("running")
 
     def set_link(self, netdev_name, up):
         """


### PR DESCRIPTION
need to check VM status after send monitor command pause
or cont to ensure the command take effect really.

Signed-off-by: Xu Tian <xutian@redhat.com>