### PR TITLE
Moving get_distro() from libvirt_vm.py to virt_vm.py

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2461,24 +2461,6 @@ class VM(virt_vm.BaseVM):
         session.close()
         return mac.strip()
 
-    def get_distro(self):
-        """
-        Get distribution name of the vm instance.
-        """
-        distro = ""
-        session = self.wait_for_login()
-        cmd = "cat /etc/os-release | grep '^ID='"
-        try:
-            status, output = session.cmd_status_output(cmd, timeout=300)
-            if status:
-                raise virt_vm.VMError("Unable to get the distro name: %s"
-                                      % output)
-            else:
-                distro = output.split('=')[1].strip()
-        finally:
-            session.close()
-            return distro
-
     def install_package(self, name):
         """
         Install a package on VM.

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -610,6 +610,23 @@ class BaseVM(object):
         if self.is_dead():
             raise VMDeadError
 
+    def get_distro(self):
+        """
+        Get distribution name of the vm instance.
+        """
+        distro = ""
+        session = self.wait_for_login()
+        cmd = "cat /etc/os-release | grep '^ID='"
+        try:
+            status, output = session.cmd_status_output(cmd, timeout=300)
+            if status:
+                logging.debug("Unable to get the distro name: %s" % output)
+            else:
+                distro = output.split('=')[1].strip()
+        finally:
+            session.close()
+            return distro
+
     def get_mac_address(self, nic_index=0):
         """
         Return the MAC address of a NIC.


### PR DESCRIPTION
As get_distro() can be used from both libvirt and qemu tests,
placed it in virt_vm.py

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>