### PR TITLE
virttest.qemu_vm: fix bug of assigning reg for multiple spapr-vty devices

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -453,8 +453,9 @@ class VM(virt_vm.BaseVM):
             elif 'ppc' in params.get('vm_arch_name', arch.ARCH):
                 cmd += " -device spapr-vty"
                 # Workaround for console issue, details:
-                #   lists.gnu.org/archive/html/qemu-ppc/2013-10/msg00129.html
-                cmd += _add_option("reg", "0x30000000")
+                # http://lists.gnu.org/archive/html/qemu-ppc/2013-10/msg00129.html
+                reg = 0x30000000 + 0x1000 * self.serial_ports.index(name)
+                cmd += _add_option("reg", hex(reg))
             elif 's390x' in params.get('vm_arch_name', arch.ARCH):
                 # Only for s390x console:
                 # This is only console option supported now.
@@ -2648,6 +2649,10 @@ class VM(virt_vm.BaseVM):
                 else:
                     raise virt_vm.VMPAError(pa_type)
 
+            # Create serial ports.
+            for serial in params.objects("serials"):
+                self.serial_ports.append(serial)
+
             if (name is None and params is None and root_dir is None and
                     self.devices is not None):
                 self.update_system_dependent_devs()
@@ -2794,10 +2799,6 @@ class VM(virt_vm.BaseVM):
 
                 # Add this monitor to the list
                 self.monitors.append(monitor)
-
-            # Create serial ports.
-            for serial in params.objects("serials"):
-                self.serial_ports.append(serial)
 
             # Create virtio_ports (virtio_serialports and virtio_consoles)
             i = 0


### PR DESCRIPTION
Fix bug of assigning reg for multiple spapr-vty devices.

ID: 1412103