### PR TITLE
shared/cfg/guest-os: Remove case multi_disk from guest-os

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -58,23 +58,6 @@
         status_off:
             up-status = unknown
             down-status = unknown
-    multi_disk:
-        show_mount_cmd = mount|gawk '/mnt/{print $1}'
-        clean_cmd = "\rm -rf /mnt/*"
-        cmd_list = "copy_to_command copy_from_command"
-        file_system = "ext3 ext2"
-        mount_command = "mkdir /mnt/%s && mount /dev/%s /mnt/%s"
-        umount_command = "umount /dev/%s && rm -rf /mnt/%s"
-        list_volume_command = "cd /dev && \ls [vhs]d* |grep -v [0-9]$"
-        re_str = "[vhs]d[a-z]+"
-        format_command = "yes| mkfs -t %s /dev/%s"
-        copy_to_command = "\cp -rf /bin/ls /mnt/%s"
-        copy_from_command = "\cp -rf /mnt/%s/ls /tmp/ls"
-        compare_command = "cd /bin && md5sum ls > /tmp/ls.md5 && cd /tmp && md5sum -c ls.md5"
-        check_result_key_word = OK
-        max_disk..virtio_blk:
-            stg_image_num = 27
-            list_volume_command = "cd /dev && \ls vd*"
     usb_multi_disk:
         show_mount_cmd = mount|gawk '/mnt/{print $1}'
         clean_cmd = "\rm -rf /mnt/*"

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -250,7 +250,7 @@
         guest_port_remote_shell = 23
     vmstop:
         guest_path = C:\
-    multi_disk, usb_multi_disk:
+    usb_multi_disk:
         black_list += " E:"
         shell_port = 23
         shell_client = telnet


### PR DESCRIPTION
Remove case multi_disk in files Linux.cfg and Windows.cfg

ID: 1412576

Signed-off-by: Nini Gu <ngu@redhat.com>