### PR TITLE
Fix start ksmtuned  process hang issue

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -617,8 +617,13 @@ class KSMConfig(object):
 
         # Get original ksm loaded status
         default_ksm_loaded = default_status.pop()
+        if self.ksm_module and not default_ksm_loaded:
+            self.ksmctler.unload_ksm_module()
+            return
+
         # Remove pid of ksmtuned
-        if default_status.pop() != 0:
+        ksmtuned_pid = default_status.pop()
+        if ksmtuned_pid != 0:
             # ksmtuned used to run in host. Start the process
             # and don't need set up the configures.
             self.ksmctler.start_ksmtuned()
@@ -631,9 +636,6 @@ class KSMConfig(object):
         self.ksmctler.set_ksm_feature({"run": default_status[0],
                                        "pages_to_scan": default_status[1],
                                        "sleep_millisecs": default_status[2]})
-
-        if self.ksm_module and not default_ksm_loaded:
-            self.ksmctler.unload_ksm_module()
 
 
 class PrivateBridgeError(Exception):

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3176,13 +3176,13 @@ class KSMController(object):
     def start_ksmtuned(self):
         """Start ksmtuned service"""
         if self.get_ksmtuned_pid() == 0:
-            process.system("ksmtuned")
+            process.system("setsid ksmtuned >& /dev/null", shell=True)
 
     def stop_ksmtuned(self):
         """Stop ksmtuned service"""
         pid = self.get_ksmtuned_pid()
         if pid:
-            process.system("kill -1 %s" % pid)
+            os.kill(pid, signal.SIGTERM)
 
     def restart_ksmtuned(self):
         """Restart ksmtuned service"""


### PR DESCRIPTION
Meet block pipe caused deadlock when call wait() function in avocado.utils.process module. Will do funture debug to fix it. instead it with subprocess.check_call temporarily.
And fix bug in kill incorrect signal when kill ksmtuned daemon.

ID: 1347633