### PR TITLE
Empty soundcards params for ppc64le platform

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -34,6 +34,7 @@ variants:
         # Currently only supports standard VGA
         vga = std
         del rtc_drift
+        del soundcards
     - arm64-mmio:
         only aarch64
         auto_cpu_model = "no"


### PR DESCRIPTION
ID: 1414244

For ppc platform , no soundcards support for qemu, remove it