### PR TITLE
Remove fio_windows cfg set from Windows.cfg

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -78,7 +78,7 @@
             install_path = "C:\Program Files\JAM Software\HeavyLoad"
         x86_64:
             install_path = "C:\Program Files (x86)\JAM Software\HeavyLoad"
-    fio_windows, migrate_multi_host.virtio_blk_data_plane:
+    migrate_multi_host.virtio_blk_data_plane:
         bg_stress_test = fio_windows
         timeout = 300
         i386, i686:


### PR DESCRIPTION
it will cover the setup in case cfg file,
but {$install_path} still use the cfg in case, which will make the test failed
Signed-off-by: Suqin Huang <shuang@redhat.com>