### PR TITLE
RHEL.6.7:update cd_md5sum for latest RHEL6.7 ISO

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/6.7/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.7/i386.cfg
@@ -8,8 +8,8 @@
         initrd = images/rhel67-32/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         cdrom_cd1 = isos/linux/RHEL-6.7-i386-DVD.iso
-        md5sum_cd1 = 36a5edcf061111b6556f8fb6c6aedb7e
-        md5sum_1m_cd1 = a8bc221122a820bbf4371386e8a87bbf
+        md5sum_cd1 = 8463dc5780222e10ab960e58bcaabce5
+        md5sum_1m_cd1 = 0021efc52ff5cd3aa0469eb409f3ad45
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel67-32/ks.vfd

--- a/shared/cfg/guest-os/Linux/RHEL/6.7/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.7/x86_64.cfg
@@ -8,8 +8,8 @@
         initrd = images/rhel67-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         cdrom_cd1 = isos/linux/RHEL-6.7-x86_64-DVD.iso
-        md5sum_cd1 = 7dc7af6e0d91f3c988d54920a3693384
-        md5sum_1m_cd1 = fa14ee7b43769104999801e208e9e52a
+        md5sum_cd1 = a2bc9de743bfb0bfe1f14676a46a624b
+        md5sum_1m_cd1 = df186ef635541f7656a3e7fc7f5a52b8
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel67-64/ks.vfd


### PR DESCRIPTION
shared.cfg.guest-os.Linux.RHEL.6.7:
1.update cd_md5sum in x86_64.cfg
2.update cd_md5sum in i386.cfg

Signed-off-by:Aihua Liang <aliang@redhat.com>

ID:1411210