### PR TITLE
docs: Add note about bootstrap without 7za

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -36,6 +36,10 @@ After the package, a bootstrap process must be run. Choose your test backend
 
     $ avocado vt-bootstrap --vt-type qemu
 
+.. note:: If you don't intend to use ``JeOS`` and don't want to install the
+   ``7za`` you can use ``avocado vt-bootstrap --vt-type qemu --vt-guest-os
+   $OS_OF_YOUR_CHOICE`` which bypasses the ``7za`` check.
+
 The output should be similar to::
 
     12:02:10 INFO | qemu test config helper


### PR DESCRIPTION
The 7za is not hard-dependency, let's add a note how to bypass the 7za
check to the documentation.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>