### PR TITLE
Increase the maximum number of supported pci-bridge to 31

### DIFF
--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -776,7 +776,7 @@ fdc
         self.assertNotEqual(qdev2, qdev, "Other qdev matches this one:\n%s\n%s"
                             % (qdev, qdev2))
         # cmdline
-        exp = ("-machine pc -device HBA,id=hba1,addr=0a,bus=pci.0 -device dev "
+        exp = ("-machine pc -device HBA,id=hba1,addr=0x0a,bus=pci.0 -device dev "
                "-device dev -device dev")
         out = qdev.cmdline()
         self.assertEqual(out, exp, 'Corrupted qdev.cmdline() output:\n%s\n%s'

--- a/virttest/qemu_devices/qbuses.py
+++ b/virttest/qemu_devices/qbuses.py
@@ -632,9 +632,9 @@ class QPCIBus(QSparseBus):
         orig_addr = device.get_param('addr')
         if addr[1] or (isinstance(orig_addr, str) and
                        orig_addr.find('.') != -1):
-            device.set_param('addr', '%02x.%x' % (addr[0], addr[1]))
+            device.set_param('addr', '0x%02x.%x' % (addr[0], addr[1]))
         else:
-            device.set_param('addr', '%02x' % (addr[0]))
+            device.set_param('addr', '0x%02x' % (addr[0]))
 
     def _update_device_props(self, device, addr):
         """ Always set properties """
@@ -666,11 +666,11 @@ class QPCISwitchBus(QPCIBus):
         if addr not in self.__downstream_ports:
             bus_id = "%s.%s" % (self.busid, int(addr, 16))
             bus = QPCIBus(bus_id, 'PCIE', bus_id)
-            self.__downstream_ports[addr] = bus
+            self.__downstream_ports['0x%02x' % addr] = bus
             downstream = qdevices.QDevice(self.__downstream_type,
                                           {'id': bus_id,
                                            'bus': self.busid,
-                                           'addr': addr},
+                                           'addr': '0x%02x' % addr},
                                           aobject=self.aobject,
                                           parent_bus={'busid': '_PCI_CHASSIS'},
                                           child_bus=bus)
@@ -699,7 +699,7 @@ class QPCISwitchBus(QPCIBus):
         Instead of setting the addr this insert the device into the
         downstream port.
         """
-        self.__downstream_ports['%02x' % addr[0]].insert(device)
+        self.__downstream_ports['0x%02x' % addr[0]].insert(device)
 
 
 class QSCSIBus(QSparseBus):

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1763,9 +1763,9 @@ class DevContainer(object):
                 name, bus_type, 'xio3130-downstream', name)
             driver = 'x3130-upstream'
         else:
-            if driver == 'pci-bridge':  # addr 1-19, chasis_nr
+            if driver == 'pci-bridge':  # addr 1-32, chasis_nr
                 parent_bus.append({'busid': '_PCI_CHASSIS_NR'})
-                bus_length = 20
+                bus_length = 31
                 bus_first_port = 1
             elif driver == 'i82801b11-bridge':  # addr 1-19
                 bus_length = 20


### PR DESCRIPTION
In fact, maximun number of pci-bridge should to 32, but first port 0 in Q35 machine reserved by special use. 

ID: 1410315