### PR TITLE
avocado-vt: add erms for cpu model 'Penryn' and 'Nehalem'

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1143,20 +1143,27 @@ class VM(virt_vm.BaseVM):
 
         def add_cpu_flags(devices, cpu_model, flags=None, vendor_id=None,
                           family=None):
-            if devices.has_option('cpu'):
-                cmd = " -cpu '%s'" % cpu_model
-
-                if vendor_id:
-                    cmd += ",vendor=\"%s\"" % vendor_id
-                if flags:
-                    if not flags.startswith(","):
-                        cmd += ","
-                    cmd += "%s" % flags
-                if family is not None:
-                    cmd += ",family=%s" % family
-                return cmd
-            else:
+            if not devices.has_option('cpu'):
                 return ""
+
+            cmd = " -cpu '%s'" % cpu_model
+            if vendor_id:
+                cmd += ",vendor=\"%s\"" % vendor_id
+            if flags:
+                if not flags.startswith(","):
+                    cmd += ","
+                cmd += "%s" % flags
+            # CPU flag 'erms' is required by Win10 and Win2016 guest, if VM's
+            # CPU model is 'Penryn' or 'Nehalem'(see detail RHBZ#1252134), and
+            # it's harmless for other guest, so add it here.
+            if cpu_model in ['Penryn', 'Nehalem']:
+                recognize_flags = utils_misc.get_recognized_cpuid_flags(
+                     qemu_binary)
+                if not ('erms' in flags or 'erms' in recognize_flags):
+                    cmd += ',+erms'
+            if family:
+                cmd += ",family=%s" % family
+            return cmd
 
         def add_boot(devices, boot_order, boot_once, boot_menu, boot_strict):
             if params.get('machine_type', "").startswith("arm"):
@@ -1881,9 +1888,9 @@ class VM(virt_vm.BaseVM):
             cpu_model = params.get("default_cpu_model")
 
         if cpu_model:
-            vendor = params.get("cpu_model_vendor")
-            flags = params.get("cpu_model_flags")
-            family = params.get("cpu_family")
+            family = params.get("cpu_family", "")
+            flags = params.get("cpu_model_flags", "")
+            vendor = params.get("cpu_model_vendor", "")
             self.cpuinfo.model = cpu_model
             self.cpuinfo.vendor = vendor
             self.cpuinfo.flags = flags

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2132,6 +2132,22 @@ def get_support_machine_type(qemu_binary="/usr/libexec/qemu-kvm"):
     return (s, c)
 
 
+def get_recognized_cpuid_flags(qemu_binary="/usr/libexec/qemu-kvm"):
+    """
+    Get qemu recongnized CPUID flags
+
+    :param qemu_binary: qemu-kvm binary file path
+    :return: flags list
+    """
+    out = process.system_output("%s -cpu ?" % qemu_binary)
+    match = re.search("Recognized CPUID flags:(.*)", out, re.M | re.S)
+    try:
+        return filter(None, re.split('\s', match.group(1)))
+    except AttributeError:
+        pass
+    return []
+
+
 def get_host_cpu_models():
     """
     Get cpu model from host cpuinfo


### PR DESCRIPTION
'erms' flag is required by Win10 and Win2016 guest OS, if VM CPU model is 'Penryn' or 'Nehalem', and it's harmless for other guest OS, so add it with guest OS insensitive.

ID: 1419399
Signed-off-by: Xu Tian <xutian@redhat.com>