### PR TITLE
Support for ipv6 connection to Spice client/server

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -7,7 +7,7 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 46.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -15,7 +15,7 @@ Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-
 BuildRequires: python2-devel, python-setuptools
 BuildArch: noarch
 Requires: avocado == %{version}
-Requires: python, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect, git, python-netaddr
+Requires: python, autotest-framework, p7zip, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect, git, python-netaddr, python-netifaces
 
 Requires: python-imaging
 %if 0%{?el6}
@@ -53,6 +53,9 @@ Xunit output, among others.
 
 
 %changelog
+* Fri Feb 15 2017 Radek Duda <rduda@redhat.com> - 46.0-1
+- Added python-netifaces to requires
+
 * Tue Feb 14 2017 Cleber Rosa <cleber@redhat.com> - 46.0-0
 - New upstream release
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -4,6 +4,7 @@ autotest==0.16.2
 aexpect==1.0.0
 simplejson==3.8.0
 netaddr>=0.7.18
+netifaces>=0.10.5
 argparse==1.3.0; python_version < '2.7'
 logutils==0.3.3; python_version < '2.7'
 importlib==1.0.3; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ autotest>=0.16.2
 aexpect>=1.2.0
 simplejson>=3.5.3
 netaddr>=0.7.18
+netifaces>=0.10.5

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -995,17 +995,10 @@ class VM(virt_vm.BaseVM):
                 set_value("port=%s", "spice_port")
 
             set_value("password=%s", "spice_password", "disable-ticketing")
-            if optget("listening_addr") == "ipv4":
-                host_ip = utils_net.get_host_ip_address(self.params)
-                self.spice_options['listening_addr'] = "ipv4"
+            ip_ver = optget("listening_addr")
+            if ip_ver:
+                host_ip = utils_net.get_host_ip_address(self.params, ip_ver)
                 spice_opts.append("addr=%s" % host_ip)
-                # set_value("addr=%s", "listening_addr", )
-            elif optget("listening_addr") == "ipv6":
-                host_ip = utils_net.get_host_ip_address(self.params)
-                host_ip_ipv6 = utils_misc.convert_ipv4_to_ipv6(host_ip)
-                self.spice_options['listening_addr'] = "ipv6"
-                spice_opts.append("addr=%s" % host_ip_ipv6)
-
             set_yes_no_value(
                 "disable_copy_paste", yes_value="disable-copy-paste")
             set_value("addr=%s", "spice_addr")


### PR DESCRIPTION
Instead of using utils_net.get_host_ip_address(self.params) to translate ipv4 address to ipv6, real ipv6 address of utilized interface is used.
The ipv6 addresss of host interface cannot be obtained using get_ip_address_by_interface(ifname).
I added a parameter to function to choose from family address: get_ip_address_by_interface(ifname, ip_ver).

This PR is correction of https://github.com/avocado-framework/avocado-vt/pull/855 proposed by @xutian.

Signed-off-by: Radek Duda <rduda@redhat.com>