### PR TITLE
shared.cfg: Remove ancient workaround

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -15,7 +15,7 @@
         kernel_params += " nicdelay=60 "
         boot_path = images/pxeboot
         aarch64:
-            kernel_params += " efi-rtc=noprobe earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"
+            kernel_params += " earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"
         ppc64, ppc64le:
             kernel_params += " console=hvc0,38400 console=tty0"
             boot_path = ppc/ppc64


### PR DESCRIPTION
The efi-rtc=noprobe workaround to boot on arm was necessary years ago,
but is not necessary anymore. Let's remove it.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>