### PR TITLE
JeOS image: deprecate JeOS version 21

### DIFF
--- a/docs/source/DownloadableImages.rst
+++ b/docs/source/DownloadableImages.rst
@@ -42,11 +42,7 @@ make changes, remaster the iso and upload back to the main location.
 JeOS image
 ==========
 
-You can find the JeOS images currently here:
-
-https://assets-avocadoproject.rhcloud.com/static/jeos-21-64.qcow2.7z
-
-https://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS21
+You can find the JeOS images currently available here:
 
 https://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.7z
 

--- a/shared/downloads/jeos-21-64.ini
+++ b/shared/downloads/jeos-21-64.ini
@@ -1,6 +1,0 @@
-[jeos-21-64]
-title = JeOS 21 x86_64
-url = http://assets-avocadoproject.rhcloud.com/static/jeos-21-64.qcow2.7z
-sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS21
-destination = images/jeos-21-64.qcow2.7z
-destination_uncompressed = images/jeos-21-64.qcow2


### PR DESCRIPTION
As it was explained on the mailing list, we're dropping JeOS 21
to make room for JeOS 25 and also to switch to a new compression
format (xz).

For now, this only removes JeOS.21 from the list of available
downloads.

Reference: https://www.redhat.com/archives/avocado-devel/2017-February/msg00077.html
Reference: https://trello.com/c/hJiQaKPu/
Signed-off-by: Cleber Rosa <crosa@redhat.com>