### PR TITLE
qemu_vm: add params for add memory devices

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1810,8 +1810,8 @@ class DevContainer(object):
         pc-dimm devices.
         """
         devices = []
-        if not self.has_option("object"):
-            logging.warn("QOM does not support by your qemu")
+        if not self.has_device("pc-dimm"):
+            logging.warn("'PC-DIMM' does not support by your qemu")
             return devices
         mem = self.memory_object_define_by_params(params, name)
         if mem:


### PR DESCRIPTION
Reset vm memory size according host free memory size if 'automem' params is 'yes'(default is 'yes'). For
migration related test case 'automem' should be 'no' to avoid migration failed.
And add device check before add 'slots' and 'maxmem' option for memory devices.

ID: 1426892

Signed-off-by: Xu Tian <xutian@redhat.com>