### PR TITLE
avocado_vt: Cope with recent changes in Avocado

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -104,12 +104,39 @@ class VirtTest(test.Test):
         self.tmpdir = os.path.dirname(self.workdir)
         # Move self.params to self.avocado_params and initialize virttest
         # (cartesian_config) params
-        self.avocado_params = self.params
-        self.params = utils_params.Params(vt_params)
+        self.__params = utils_params.Params(vt_params)
         self.debugdir = self.logdir
         self.resultsdir = self.logdir
         self.timeout = vt_params.get("test_timeout", self.timeout)
         utils_misc.set_log_file_dir(self.logdir)
+
+    @property
+    def params(self):
+        """
+        Avocado-vt test params
+
+        During `avocado.Test.__init__` this reports the original params but
+        once the Avocado-vt params are set it reports those instead. This
+        is necessary to complete the `avocado.Test.__init__` phase
+        """
+        try:
+            return self.__params
+        except AttributeError:
+            return self.avocado_params
+
+    @params.setter
+    def params(self, value):
+        """
+        For compatibility with 36lts we need to support setter on params
+        """
+        self.__params = value
+
+    @property
+    def avocado_params(self):
+        """
+        Original Avocado (multiplexer/varianter) params
+        """
+        return super(VirtTest, self).params
 
     @property
     def datadir(self):

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -92,12 +92,9 @@ class VirtTest(test.Test):
         self.virtdir = os.path.join(self.bindir, 'shared')
 
         self.iteration = 0
-        self.outputdir = None
         self.resultsdir = None
-        self.logfile = None
         self.file_handler = None
         self.background_errors = Queue.Queue()
-        self.whiteboard = None
         super(VirtTest, self).__init__(methodName=methodName, name=name,
                                        params=params,
                                        base_logdir=base_logdir, job=job,


### PR DESCRIPTION
When the https://github.com/avocado-framework/avocado/pull/1817 is applied Avocado-vt won't be able to override the params as before. This patch set adjusts the VirtTest to be able to work with the new proposed way (including the params handling) while allowing to work with the current and even 36lts version.

This should only be applied if we decide to go with the https://github.com/avocado-framework/avocado/pull/1817 and could be simplified if we decide to skip the params protection (demonstrated in https://github.com/avocado-framework/avocado/pull/1809 ).

__This patch needs to be applied before merging any of the Avocado patches!__