### PR TITLE
Fixup: Changed topology miss from error to debug log

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -746,7 +746,7 @@ class VMXML(VMXMLBase):
         try:
             topology = self.cpu.topology
         except Exception:
-            logging.error("Can't find <cpu>/<topology> element")
+            logging.debug("<cpu>/<topology> xml element not found")
         return topology
 
     def get_disk_all(self):


### PR DESCRIPTION
xml topology miss in guest xml is not a error
hence reduced log level to debug.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>