### PR TITLE
selftest: Custom inspektor style check rules

### DIFF
--- a/selftests/checkall
+++ b/selftests/checkall
@@ -10,7 +10,7 @@ run_rc() {
 }
 run_rc 'inspekt --exclude=.git lint'
 run_rc 'inspekt --exclude=.git indent'
-run_rc 'inspekt --exclude=.git style'
+run_rc 'inspekt --exclude=.git style --disable E501,E265,W503,W601,E402,E722'
 run_rc 'selftests/run'
 exit ${GR}
 


### PR DESCRIPTION
1. Now we pass all the disable rules explicitly to inspektor.
2. Disable W503. It complain 'line break before binary operator',
but PEP8 do recommend to break after binary operator and it looks
really better. See more:
https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator

Signed-off-by: Yanbing Du <ydu@redhat.com>