### PR TITLE
Bumped latest aexpect version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2
-aexpect>=1.2.0
+aexpect>=1.3.1
 simplejson>=3.5.3
 netaddr>=0.7.18
 netifaces>=0.10.5


### PR DESCRIPTION
Bumped latest aexpect version in requirements.txt
to get "UnicodeDecodeError" fix.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
