### PR TITLE
get_ip_address_by_interface gives exceptions if a network interface is up without ip address configured

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3054,7 +3054,8 @@ def get_ip_address_by_interface(ifname, ip_ver="ipv4"):
         ver = netifaces.AF_INET
     try:
         addr = netifaces.ifaddresses(ifname).get(ver)
-        return [a['addr'] for a in addr if not a['addr'].startswith('fe80')][0]
+        if addr is not None:
+            return [a['addr'] for a in addr if not a['addr'].startswith('fe80')][0]
     except Exception, e:
         raise exceptions.TestError("Cannot get %s address form %s interface: %s"
                                    % (ip_ver, ifname, e))


### PR DESCRIPTION
The net_utils function get_ip_address_by_interface gives exceptions if a network interface is up without ip address configured
Signed-off-by: Sudeesh John <sudeesh@linux.vnet.ibm.com>