### PR TITLE
Guest OS Support: add Fedora 25 (x86_64)

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/25.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/25.x86_64.cfg
@@ -1,0 +1,26 @@
+- 25.x86_64:
+    image_name = images/f25-64
+    vm_arch_name = x86_64
+    os_variant = fedora25
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel_params = 'inst.repo=cdrom:/dev/disk/by-label/Fedora-S-dvd-x86_64-25'
+        kernel_params += ' nicdelay=60 console=tty0 console=ttyS0'
+        unattended_file = unattended/Fedora-25.ks
+        kernel = images/f25-64/vmlinuz
+        initrd = images/f25-64/initrd.img
+        syslog_server_proto = tcp
+        extra_cdrom_ks:
+            cdrom_unattended = images/f25-64/ks.iso
+            kernel_params += ' ks=cdrom'
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-dvd-x86_64-25-1.3.iso
+        md5sum_cd1 = 805d3030b77d537037ffb08753b55bd3
+        md5sum_1m_cd1 = a091132e84ad1a97fe828b1738905ed7
+    unattended_install.url:
+        url = http://dl.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/os
+        sha1sum_vmlinuz = 86c707ebfbe4e35f8edc28449e3835587a236de4
+        sha1sum_initrd = 2b301694ecfe51e8a4dba3d953796fe3f9318d76
+        # Installation works fine with mem=1024 on methods such as cdrom
+        # but fails ("No space left on device") with methods such as url.
+        mem = 2048

--- a/shared/downloads/fedora-25-x86_64.ini
+++ b/shared/downloads/fedora-25-x86_64.ini
@@ -1,0 +1,4 @@
+[fedora-25-x86_64]
+title = Fedora Server 25 x86_64 DVD
+url = http://dl.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/iso/Fedora-Server-dvd-x86_64-25-1.3.iso
+destination = isos/linux/Fedora-Server-dvd-x86_64-25-1.3.iso

--- a/shared/unattended/Fedora-25.ks
+++ b/shared/unattended/Fedora-25.ks
@@ -1,0 +1,45 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+autopart
+
+%packages --ignoremissing
+@standard
+@c-development
+@development-tools
+python
+%end
+
+%post
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+# if package groups were missing from main installation repo
+# try again from installed system
+dnf -y groupinstall c-development development-tools
+# include avocado: allows using this machine with remote runner
+dnf -y install python2-avocado
+ECHO 'Post set up finished'
+%end


### PR DESCRIPTION
This introduces the Fedora 25 (for the x86_64 arch).  This has
been tested with both "cdrom" and "url" methods, and with the
delivery of the "unattended file" (the kickstart file) with
"extra_cdrom_ks" and also the builtin HTTP server.

One particular difference in the kickstart file is that it
includes the installation of Avocado from the official repos.
This may open the way for other types of tests and uses for images
generated with this guest OS type.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#911):
* Added download definition file
* Removed unnecessary `serial` kernel parameter
* Limit the `mem` parameter overwrite to the `url` variant