### PR TITLE
Store host_ip as vm parameter

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -999,7 +999,7 @@ class VM(virt_vm.BaseVM):
             ip_ver = optget("listening_addr")
             if ip_ver:
                 host_ip = utils_net.get_host_ip_address(self.params, ip_ver)
-                spice_opts.append("addr=%s" % host_ip)
+                self.spice_options['spice_addr'] = host_ip
             set_yes_no_value(
                 "disable_copy_paste", yes_value="disable-copy-paste")
             set_value("addr=%s", "spice_addr")

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3448,7 +3448,7 @@ def check_listening_port_by_service(service, port, listen_addr='0.0.0.0',
     """
     Check TCP/IP listening by service
     """
-    cmd = "netstat -tunlp | grep -E '^tcp.*LISTEN.*%s.*'" % service
+    cmd = "netstat -tunlpW | grep -E '^tcp.*LISTEN.*%s.*'" % service
     find_netstat_cmd = "which netstat"
     output = ""
     find_str = listen_addr + ":" + port


### PR DESCRIPTION
Make host_ip variable accessible after vm creation if listening_addr specified.

Signed-off-by: Radek Duda <rduda@redhat.com>