### PR TITLE
Shifting from 7zip to xz

### DIFF
--- a/docs/source/DownloadableImages.rst
+++ b/docs/source/DownloadableImages.rst
@@ -44,7 +44,7 @@ JeOS image
 
 You can find the JeOS images currently available here:
 
-https://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.7z
+https://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.xz
 
 https://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23
 
@@ -72,9 +72,9 @@ command is similar to::
 
     $ qemu-img convert -f qcow2 -O qcow2 jeos-file-backup.qcow2 jeos-file.qcow2
 
-Then it'll compress it using 7zip, to save space and speed up downloads for
+Then it'll compress it using xz, to save space and speed up downloads for
 ``avocado-vt`` users. The command is similar to::
 
-    $ 7za a jeos-file.qcow2.7z jeos-file.qcow2
+    $ xz jeos-file.qcow2.xz jeos-file.qcow2
 
 As mentioned, the script is supposed to help you with the process.

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -37,8 +37,8 @@ After the package, a bootstrap process must be run. Choose your test backend
     $ avocado vt-bootstrap --vt-type qemu
 
 .. note:: If you don't intend to use ``JeOS`` and don't want to install the
-   ``7za`` you can use ``avocado vt-bootstrap --vt-type qemu --vt-guest-os
-   $OS_OF_YOUR_CHOICE`` which bypasses the ``7za`` check.
+   ``xz`` you can use ``avocado vt-bootstrap --vt-type qemu --vt-guest-os
+   $OS_OF_YOUR_CHOICE`` which bypasses the ``xz`` check.
 
 The output should be similar to::
 
@@ -47,7 +47,7 @@ The output should be similar to::
     12:02:10 INFO | 1 - Updating all test providers
     12:02:10 INFO |
     12:02:10 INFO | 2 - Checking the mandatory programs and headers
-    12:02:10 INFO | /bin/7za OK
+    12:02:10 INFO | /bin/xz OK
     12:02:10 INFO | /sbin/tcpdump OK
     ...
     12:02:11 INFO | /usr/include/asm/unistd.h OK

--- a/docs/source/InstallOptionalPackages.rst
+++ b/docs/source/InstallOptionalPackages.rst
@@ -33,11 +33,11 @@ Install the following packages:
     $ yum install nmap-ncat
 
 
-#. Install the p7zip file archiver so you can uncompress the JeOS [2] image.
+#. Install the xz file archiver so you can uncompress the JeOS [2] image.
 
 ::
 
-    $ yum install p7zip
+    $ yum install xz
 
 #. Install the autotest-framework package, to provide the needed autotest libs.
 
@@ -190,11 +190,11 @@ Install the following packages:
     $ apt-get install autotest
 
 
-#. Install the p7zip file archiver so you can uncompress the JeOS [2] image.
+#. Install the xz-utils file archiver so you can uncompress the JeOS [2] image.
 
 ::
 
-    $ apt-get install p7zip-full
+    $ apt-get install xz-utils
 
 
 #. Install tcpdump, necessary to determine guest IPs automatically

--- a/docs/source/MultiHostMigration.rst
+++ b/docs/source/MultiHostMigration.rst
@@ -96,7 +96,7 @@ to run the steps below manually.
     16:11:19 INFO | git commit ID is edc07c0c4346f9029930b062c573ff6f5433bc53 (no tag found)
     16:11:20 INFO |
     16:11:20 INFO | 2 - Checking the mandatory programs and headers
-    16:11:20 INFO | /usr/bin/7za
+    16:11:20 INFO | /usr/bin/xz
     16:11:20 INFO | /usr/sbin/tcpdump
     16:11:20 INFO | /usr/bin/nc
     16:11:20 INFO | /sbin/ip

--- a/scripts/package_jeos.py
+++ b/scripts/package_jeos.py
@@ -23,7 +23,7 @@ def package_jeos(img):
     Steps:
     1) Move /path/to/jeos.qcow2 to /path/to/jeos.qcow2.backup
     2) Sparsify the image, creating a new, trimmed down /path/to/jeos.qcow2
-    3) Compress the sparsified image with 7za
+    3) Compress the sparsified image with xz
 
     :param img: Path to a qcow2 image
     """
@@ -35,10 +35,9 @@ def package_jeos(img):
 
     process.system("%s convert -f qcow2 -O qcow2 -o compat=0.10 %s %s" % (qemu_img, backup, img))
     logging.info("Sparse file %s created successfully", img)
-
-    archiver = utils_misc.find_command('7za')
-    compressed_img = img + ".7z"
-    process.system("%s a %s %s" % (archiver, compressed_img, img))
+    compressed_img = img + ".xz"
+    archiver = utils_misc.find_command('xz')
+    process.system("%s -9 -e %s" % (archiver, img))
     logging.info("JeOS compressed file %s created successfuly",
                  compressed_img)
 

--- a/shared/downloads/jeos-23-64.ini
+++ b/shared/downloads/jeos-23-64.ini
@@ -1,6 +1,6 @@
 [jeos-23-64]
 title = JeOS 23 x86_64
-url = http://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.7z
+url = http://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.xz
 sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23
-destination = images/jeos-23-64.qcow2.7z
+destination = images/jeos-23-64.qcow2.xz
 destination_uncompressed = images/jeos-23-64.qcow2

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -422,6 +422,7 @@ def uncompress_asset(asset_info, force=False):
     if destination_uncompressed is not None:
         if uncompress_cmd is None:
             match = archive_re.match(destination)
+ rockstar full song
             if match:
                 if match.group(1) == 'gz':
                     uncompress_cmd = ('gzip -cd %s > %s' %

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -19,7 +19,7 @@ from . import utils_selinux
 from . import defaults
 from . import arch
 
-basic_program_requirements = ['7za', 'tcpdump', 'nc', 'ip', 'arping']
+basic_program_requirements = ['xz' 'tcpdump', 'nc', 'ip', 'arping']
 
 recommended_programs = {'qemu': [('qemu-kvm', 'kvm'), ('qemu-img',),
                                  ('qemu-io',)],
@@ -131,8 +131,8 @@ def verify_mandatory_programs(t_type, guest_os):
         try:
             logging.info('%s OK', utils_path.find_command(cmd))
         except utils_path.CmdNotFoundError:
-            if cmd == '7za' and guest_os != defaults.DEFAULT_GUEST_OS:
-                logging.warn("Command 7za (required to uncompress JeOS) "
+            if cmd == 'xz' and guest_os != defaults.DEFAULT_GUEST_OS:
+                logging.warn("Command xz (required to uncompress JeOS) "
                              "missing. You can still use avocado-vt with guest"
                              " OS's other than JeOS.")
                 continue
@@ -760,7 +760,7 @@ def bootstrap(options, interactive=False):
     :param interactive: Whether to ask for confirmation.
 
     :raise error.CmdError: If JeOS image failed to uncompress
-    :raise ValueError: If 7za was not found
+    :raise ValueError: If xz was not found
     """
     if interactive:
         log_cfg = utils_misc.VirtLoggingConfig()


### PR DESCRIPTION
7zip is only available in EPEL for on some archs, but xz is available in stock repos for EL.Hence shifting from 7zip for compression and decompression of JeOS images to xz.

Signed-off-by: Greeshma Gopinath <ggopinat@redhat.com>