### PR TITLE
fix set_block_job_speed function

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -968,7 +968,7 @@ class HumanMonitor(Monitor):
         if correct:
             cmd = self.correct(cmd)
         self.verify_supported_cmd(cmd)
-        cmd += " %s %sB" % (device, speed)
+        cmd += " %s %sB" % (device.split(" ")[0], speed)
         return self.cmd(cmd)
 
     def cancel_block_job(self, device, cmd="block_job_cancel", correct=True):


### PR DESCRIPTION
In qemu2.6,the para "device" is "drive_image1 (#block856)".But we
expect it as "drive_image1".So seperate the str and take the
first part.This modify is compatible with qemu1.5 or earlier version.