### PR TITLE
avocado_vt: Move runTest to test phase and improve exceptions

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -99,7 +99,7 @@ class VirtTest(test.Test):
                                        base_logdir=base_logdir, job=job,
                                        runner_queue=runner_queue)
         self.builddir = os.path.join(self.workdir, 'backends',
-                                     vt_params.get("vm_type"))
+                                     vt_params.get("vm_type", ""))
         self.tmpdir = os.path.dirname(self.workdir)
         # Move self.params to self.avocado_params and initialize virttest
         # (cartesian_config) params

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2281,7 +2281,7 @@ def _get_backend_dir(params):
     Get the appropriate backend directory. Example: backends/qemu.
     """
     return os.path.join(data_dir.get_root_dir(), 'backends',
-                        params.get("vm_type"))
+                        params.get("vm_type", ""))
 
 
 def get_qemu_binary(params):


### PR DESCRIPTION
Avocado now supports status CANCEL, which is basically what SKIP was
being used for in Avocado-vt. Let's move the test execution back to
"runTest" phase and use `self.$status` to map the Avocado-vt exceptions
to Avocado ones, which, unlike exceptions, should be stable.

Fixes: https://github.com/avocado-framework/avocado-vt/issues/934