### PR TITLE
virttest.utils_package: Add package manager module

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -385,7 +385,7 @@ def is_port_free(port, address):
     """
     try:
         s = socket.socket()
-        #s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if address == "localhost":
             s.bind(("localhost", port))
             free = True
@@ -912,7 +912,7 @@ def get_guest_service_status(session, service, service_former=None):
             output.count("Active: active") > 0):
         status = "active"
     elif (re.search(r"running", output.lower(), re.M) and
-            not re.search(r"not running", output.lower(), re.M)):
+          not re.search(r"not running", output.lower(), re.M)):
         status = "active"
 
     return status
@@ -1611,34 +1611,6 @@ def get_cpu_info(session=None):
     return cpu_info
 
 
-def yum_install(pkg_list, session=None, timeout=300):
-    """
-    Try to install packages on system
-
-    :param pkg_list: list of packages
-    :session: session Object
-    :return: True if all packages installed, False if any error
-    """
-    if not isinstance(pkg_list, list):
-        logging.error("Parameter exceptions.")
-        return False
-    yum_cmd = "rpm -q {0} || yum -y install {0}"
-    for pkg in pkg_list:
-        if session:
-            status = session.cmd_status(yum_cmd.format(pkg),
-                                        timeout=timeout)
-        else:
-            status = process.run(yum_cmd.format(pkg),
-                                 timeout=timeout,
-                                 ignore_status=False,
-                                 shell=True).exit_status
-        if status:
-            logging.error("Failed to install package: %s"
-                          % pkg)
-            return False
-    return True
-
-
 def add_identities_into_ssh_agent():
     """
     Adds RSA or DSA identities to the authentication agent
@@ -2018,16 +1990,16 @@ kvm_map_flags_aliases = {
     'ffxsr': 'fxsr_opt',
     'xd': 'nx',
     'i64': 'lm',
-           'psn': 'pn',
-           'clfsh': 'clflush',
-           'dts': 'ds',
-           'htt': 'ht',
-           'CMPXCHG8B': 'cx8',
-           'Page1GB': 'pdpe1gb',
-           'LahfSahf': 'lahf_lm',
-           'ExtApicSpace': 'extapic',
-           'AltMovCr8': 'cr8_legacy',
-           'cr8legacy': 'cr8_legacy'
+    'psn': 'pn',
+    'clfsh': 'clflush',
+    'dts': 'ds',
+    'htt': 'ht',
+    'CMPXCHG8B': 'cx8',
+    'Page1GB': 'pdpe1gb',
+    'LahfSahf': 'lahf_lm',
+    'ExtApicSpace': 'extapic',
+    'AltMovCr8': 'cr8_legacy',
+    'cr8legacy': 'cr8_legacy'
 }
 
 

--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -1,0 +1,213 @@
+"""
+Package utility for manage package operation on host
+"""
+import logging
+import aexpect
+
+from avocado.core import exceptions
+from avocado.utils import software_manager
+
+from . import utils_misc
+
+PACKAGE_MANAGERS = ['apt-get',
+                    'yum',
+                    'zypper',
+                    'dnf']
+
+
+class RemotePackageMgr(object):
+
+    """
+    The remote package manage class
+    """
+
+    def __init__(self, session, pkg):
+        """
+        :param session: session object
+        :param pkg: package name or list
+        """
+        if not isinstance(session, (aexpect.ShellSession, aexpect.Expect)):
+            raise exceptions.TestError("Parameters exception on session")
+        if not isinstance(pkg, list):
+            if not isinstance(pkg, str):
+                raise exceptions.TestError("pkg %s must be list or str" % pkg)
+            else:
+                self.pkg_list = [pkg, ]
+        else:
+            self.pkg_list = pkg
+        self.package_manager = None
+        self.cmd = None
+        self.query_cmd = None
+        self.install_cmd = None
+        self.remove_cmd = None
+        self.session = session
+
+        # Inspect and set package manager
+        for pkg_mgr in PACKAGE_MANAGERS:
+            cmd = 'which ' + pkg_mgr
+            if not self.session.cmd_status(cmd):
+                self.package_manager = pkg_mgr
+                break
+
+        if not self.package_manager:
+            raise exceptions.TestError("Package manager not in %s" %
+                                       PACKAGE_MANAGERS)
+        elif self.package_manager == 'apt-get':
+            self.query_cmd = "dpkg -s "
+            self.remove_cmd = "apt-get --purge remove -y "
+            self.install_cmd = "apt-get install -n "
+        else:
+            self.query_cmd = "rpm -q "
+            self.remove_cmd = self.package_manager + " remove -y "
+            self.install_cmd = self.package_manager + " install -y "
+
+    def is_installed(self, pkg_name):
+        """
+        Check the package installed status
+
+        :param pkg_name: package name
+        :return: True or False
+        """
+        cmd = self.query_cmd + pkg_name
+        return not self.session.cmd_status(cmd)
+
+    def operate(self, timeout, default_status):
+        """
+        Run command and return status
+
+        :param timeout: command timeout
+        :param default_status: package default installed status
+        :return: True of False
+        """
+        for pkg in self.pkg_list:
+            need = False
+            if '*' not in pkg:
+                if self.is_installed(pkg) == default_status:
+                    need = True
+            else:
+                need = True
+            if need:
+                cmd = self.cmd + pkg
+                if self.session.cmd_status(cmd, timeout):
+                    logging.error("Operate %s with %s failed", pkg, cmd)
+                    return False
+        return True
+
+    def install(self, timeout=300):
+        """
+        Use package manager install packages
+
+        :param timeout: install timeout
+        :return: if install succeed return True, else False
+        """
+        self.cmd = self.install_cmd
+        return self.operate(timeout, False)
+
+    def remove(self, timeout=300):
+        """
+        Use package manager remove packages
+
+        :param timeout: remove timeout
+        :return: if remove succeed return True, else False
+        """
+        self.cmd = self.remove_cmd
+        return self.operate(timeout, True)
+
+
+class LocalPackageMgr(software_manager.SoftwareManager):
+
+    """
+    Local package manage class
+    """
+
+    def __init__(self, pkg):
+        """
+        :param pkg: package name or list
+        """
+        if not isinstance(pkg, list):
+            if not isinstance(pkg, str):
+                raise exceptions.TestError("pkg %s must be list or str" % pkg)
+            else:
+                self.pkg_list = [pkg, ]
+        else:
+            self.pkg_list = pkg
+        super(LocalPackageMgr, self).__init__()
+        self.func = None
+
+    def operate(self, default_status):
+        """
+        Use package manager to operate packages
+
+        :param default_status: package default installed status
+        """
+        for pkg in self.pkg_list:
+            need = False
+            if '*' not in pkg:
+                if self.check_installed(pkg) == default_status:
+                    need = True
+            else:
+                need = True
+            if need:
+                if not self.func(pkg):
+                    logging.error("Operate %s on host failed", pkg)
+                    return False
+        return True
+
+    def install(self):
+        """
+        Use package manager install packages
+
+        :return: if install succeed return True, else False
+        """
+        self.func = super(LocalPackageMgr, self).__getattr__('install')
+        return self.operate(False)
+
+    def remove(self):
+        """
+        Use package manager remove packages
+
+        :return: if remove succeed return True, else False
+        """
+        self.func = super(LocalPackageMgr, self).__getattr__('remove')
+        return self.operate(True)
+
+
+def package_manager(session, pkg):
+    """
+    Package manager function
+
+    :param session: session object
+    :param pkg: pkg name or list
+    :return: package manager class object
+    """
+    if session:
+        mgr = RemotePackageMgr(session, pkg)
+    else:
+        mgr = LocalPackageMgr(pkg)
+    return mgr
+
+
+def package_install(pkg, session=None, timeout=300):
+    """
+    Try to install packages on system with package manager.
+
+    :param pkg: package name or list of packages
+    :param session: session Object
+    :param timeout: timeout for install with session
+    :return: True if all packages installed, False if any error
+    """
+    mgr = package_manager(session, pkg)
+    return utils_misc.wait_for(mgr.install, timeout)
+
+
+def package_remove(pkg, session=None, timeout=300):
+    """
+    Try to remove packages on system with package manager.
+
+    :param pkg: package name or list of packages
+    :param session: session Object
+    :param timeout: timeout for remove with session
+    :return: True if all packages removed, False if any error
+    """
+    mgr = package_manager(session, pkg)
+    return utils_misc.wait_for(mgr.remove, timeout)


### PR DESCRIPTION
Use LocalPackageMgr which is subclass from software_manager in
avocado to decide the package manager and install or remove
package on local host.

If remote session is given, use the RemotePackageMgr class
to find out the package manager on remote for install or remove
packages.

Signed-off-by: Wayne Sun <gsun@redhat.com>