### PR TITLE
virttest.utils_misc: Allow writing unicode in log_line

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -46,6 +46,7 @@ from .staging import utils_koji
 from .xml_utils import XMLTreeFile
 
 ARCH = platform.machine()
+ENCODING = os.environ.get("PYTHONENCODING", "utf-8")
 
 
 class UnsupportedCPU(exceptions.TestError):
@@ -476,7 +477,8 @@ def log_line(filename, line):
                 pass
             _open_log_files[base_file] = open(log_file, "w")
         timestr = time.strftime("%Y-%m-%d %H:%M:%S")
-        _open_log_files[base_file].write("%s: %s\n" % (timestr, line))
+        _open_log_files[base_file].write("%s: %s\n"
+                                         % (timestr, line.encode(ENCODING)))
         _open_log_files[base_file].flush()
     finally:
         _log_lock.release()


### PR DESCRIPTION
The function `utils_misc.log_line` does not respect the system encoding,
which works fine for ascii strings, but recently the serial console
started to write \xff which makes the writer to crash.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>