### PR TITLE
Guest OS Support: add JeOS 25 (x86_64)

### DIFF
--- a/shared/cfg/guest-os/Linux/JeOS/25.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/JeOS/25.x86_64.cfg
@@ -1,0 +1,27 @@
+- 25.x86_64:
+    image_name = images/jeos-25-64
+    vm_arch_name = x86_64
+    os_variant = fedora25
+    boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel_params = 'inst.repo=cdrom:/dev/disk/by-label/Fedora-S-dvd-x86_64-25'
+        kernel_params += ' nicdelay=60 console=tty0 console=ttyS0'
+        unattended_file = unattended/JeOS-25.ks
+        kernel = images/jeos-25-64/vmlinuz
+        initrd = images/jeos-25-64/initrd.img
+        syslog_server_proto = tcp
+        extra_cdrom_ks:
+            cdrom_unattended = images/jeos-25-64/ks.iso
+            kernel_params += ' ks=cdrom'
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-dvd-x86_64-25-1.3.iso
+        md5sum_cd1 = 805d3030b77d537037ffb08753b55bd3
+        md5sum_1m_cd1 = a091132e84ad1a97fe828b1738905ed7
+    unattended_install.url:
+        url = http://dl.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/os
+        sha1sum_vmlinuz = 86c707ebfbe4e35f8edc28449e3835587a236de4
+        sha1sum_initrd = 2b301694ecfe51e8a4dba3d953796fe3f9318d76
+        # Installation works fine with mem=1024 on methods such as cdrom
+        # but fails ("No space left on device") with methods such as url.
+        mem = 2048

--- a/shared/downloads/jeos-25-64.ini
+++ b/shared/downloads/jeos-25-64.ini
@@ -1,0 +1,6 @@
+[jeos-25-64]
+title = JeOS 25 x86_64
+url = http://assets-avocadoproject.rhcloud.com/static/jeos-25-64.qcow2.xz
+sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS25
+destination = images/jeos-25-64.qcow2.xz
+destination_uncompressed = images/jeos-25-64.qcow2

--- a/shared/unattended/JeOS-25.ks
+++ b/shared/unattended/JeOS-25.ks
@@ -1,0 +1,189 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+part / --fstype=ext4 --grow --asprimary --size=1
+
+%packages
+gpgme
+dmidecode
+ethtool
+tcpdump
+tar
+bzip2
+pciutils
+usbutils
+bind-utils
+net-tools
+rsync
+python
+-yum-utils
+-cryptsetup
+-dump
+-mlocate
+-stunnel
+-rng-tools
+-ntfs-3g
+-sos
+-jwhois
+-fedora-release-notes
+-pam_pkcs11
+-wireless-tools
+-rdist
+-mdadm
+-dmraid
+-ftp
+-system-config-network-tui
+-pam_krb5
+-nano
+-nc
+-PackageKit-yum-plugin
+-btrfs-progs
+-ypbind
+-yum-presto
+-microcode_ctl
+-finger
+-krb5-workstation
+-ntfsprogs
+-iptstate
+-fprintd-pam
+-irqbalance
+-dosfstools
+-mcelog
+-smartmontools
+-lftp
+-unzip
+-rsh
+-telnet
+-setuptool
+-bash-completion
+-pinfo
+-rdate
+-system-config-firewall-tui
+-system-config-firewall-base
+-nfs-utils
+-words
+-cifs-utils
+-prelink
+-wget
+-dos2unix
+-passwdqc
+-coolkey
+-symlinks
+-pm-utils
+-bridge-utils
+-zip
+-numactl
+-mtr
+-sssd
+-pcmciautils
+-tree
+-hunspell
+-irda-utils
+-time
+-man-pages
+-yum-langpacks
+-talk
+-wpa_supplicant
+-slang
+-authconfig
+-newt
+-newt-python
+-ntsysv
+-libnl3
+-tcp_wrappers
+-quota
+-libpipeline
+-man-db
+-groff
+-less
+-plymouth-core-libs
+-plymouth
+-plymouth-scripts
+-libgudev1
+-ModemManager
+-NetworkManager-glib
+-selinux-policy
+-selinux-policy-targeted
+-crontabs
+-cronie
+-cronie-anacron
+-cyrus-sasl
+-sendmail
+-netxen-firmware
+-linux-firmware
+-libdaemon
+-avahi-autoipd
+-libpcap
+-ppp
+-libsss_sudo
+-sudo
+-at
+-psacct
+-parted
+-passwd
+-tmpwatch
+-bc
+-acl
+-attr
+-traceroute
+-mailcap
+-quota-nls
+-mobile-broadband-provider-info
+-audit
+-e2fsprogs-libs
+-e2fsprogs
+-biosdevname
+-dbus-glib
+-libdrm
+-setserial
+-lsof
+-ed
+-cyrus-sasl-plain
+-dnsmasq
+-system-config-firewall-base
+-hesiod
+-libpciaccess
+-policycoreutils
+-m4
+-checkpolicy
+-procmail
+-libuser
+-polkit
+-rsyslog
+%end
+
+%post
+function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+sed -i -e "s,^GRUB_TIMEOUT=.*,GRUB_TIMEOUT=0," /etc/default/grub
+grub2-mkconfig > /etc/grub2.cfg
+dnf install -y hdparm ntpdate qemu-guest-agent
+dnf clean all
+mkdir -p /var/log/journal
+sed -i -e 's/\#SystemMaxUse=/SystemMaxUse=50M/g' /etc/systemd/journald.conf
+dd if=/dev/zero of=/fill-up-file bs=1M
+rm -f /fill-up-file
+ECHO 'Post set up finished'
+%end

--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -16,7 +16,7 @@ def get_default_guest_os_info():
     Gets the default asset and variant information
     TODO: Check for the ARCH and choose corresponding default asset
     """
-    return {'asset': 'jeos-23-64', 'variant': 'JeOS.23'}
+    return {'asset': 'jeos-25-64', 'variant': 'JeOS.25'}
 
 
 DEFAULT_GUEST_OS = get_default_guest_os_info()['variant']


### PR DESCRIPTION
This introduces JeOS 25, based on Fedora 25.  Differences from previous versions include an added Python 2 interpreter.