### PR TITLE
Add public config file for v2v

### DIFF
--- a/backends/v2v/cfg/convert_destination.cfg
+++ b/backends/v2v/cfg/convert_destination.cfg
@@ -1,0 +1,53 @@
+# Configurations of different conversion targets.
+# Please replace the example params with actual values.
+
+variants:
+    - dest_none:
+    - dest_libvirt:
+        output_mode = libvirt
+        target = libvirt
+        network = default
+        bridge = virbr0
+        pool_type = dir
+        pool_name = v2v_dir
+        pool_target = v2v_dir_pool
+        output_storage = ${pool_name}
+    - dest_rhev:
+        # Output source of ovirt engine, storage and network
+        output_mode = rhev
+        target = ovirt
+        network = OVIRT_NODE_NETWORK_V2V_EXAMPLE
+        bridge = OVIRT_NODE_BRIDGE_V2V_EXAMPLE
+        ovirt_engine_url = https://OVIRT_ENGINE_URL_V2V_EXAMPLE/api
+        ovirt_engine_user = OVIRT_ENGINE_USER_V2V_EXAMPLE
+        ovirt_engine_password = OVIRT_ENGINE_PASSWORD_V2V_EXAMPLE
+        # Libvirt SASL authencation(under VDSM control)
+        sasl_user = v2v_tester@ovirt
+        sasl_pwd = v2v_tester_pwd
+        remote_preprocess = yes
+        remote_node_user = root
+        remote_node_password = redhat
+        remote_user = ${remote_node_user}
+        remote_pwd = ${remote_node_password}
+        variants:
+            - NFS:
+                storage = NFS_EXPORT_STORAGE_V2V_EXAMPLE
+                export_name = NFS_EXPORT_NAME_V2V_EXAMPLE
+                storage_name = NFS_STORAGE_NAME_V2V_EXAMPLE
+                cluster_name = NFS_CLUSTER_NAME_V2V_EXAMPLE
+                ovirt_node_address = NFS_OVIRT_NODE_ADDRESS_V2V_EXAMPLE
+            - FC:
+                storage = FC_EXPORT_STORAGE_V2V_EXAMPLE
+                export_name = FC_EXPORT_NAME_V2V_EXAMPLE
+                storage_name = FC_STORAGE_NAME_V2V_EXAMPLE
+                cluster_name = FC_CLUSTER_NAME_V2V_EXAMPLE
+                ovirt_node_address = FC_OVIRT_NODE_ADDRESS_V2V_EXAMPLE
+            - ISCSI:
+                storage = ISCSI_EXPORT_STORAGE_V2V_EXAMPLE
+                export_name = ISCSI_EXPORT_NAME_V2V_EXAMPLE
+                storage_name = ISCSI_STORAGE_NAME_V2V_EXAMPLE
+                cluster_name = ISCSI_CLUSTER_NAME_V2V_EXAMPLE
+                ovirt_node_address = ISCSI_OVIRT_NODE_ADDRESS_V2V_EXAMPLE
+        output_storage = ${storage}
+        remote_node_address = ${ovirt_node_address}
+        remote_ip = ${remote_node_address}

--- a/backends/v2v/cfg/convert_source.cfg
+++ b/backends/v2v/cfg/convert_source.cfg
@@ -1,0 +1,27 @@
+# Input source of different hypervisors.
+# Please replace the example params with actual values.
+
+variants:
+    - source_none:
+    - source_kvm:
+        hypervisor = kvm
+    - source_xen:
+        hypervisor = xen
+        xen_hostname = XEN_HOSTNAME_V2V_EXAMPLE
+    - source_esx:
+        # ESX host and dc info
+        hypervisor = esx
+        vpx_password = VPX_PASSWORD_V2V_EXAMPLE
+        variants:
+            - esx_51:
+                vpx_hostname = VPX_51_HOSTNAME_V2V_EXAMPLE
+                vpx_dc = VPX_51_DC_V2V_EXAMPLE
+                esx_hostname = ESX_51_HOSTNAME_V2V_EXAMPLE
+            - esx_55:
+                vpx_hostname = VPX_55_HOSTNAME_V2V_EXAMPLE
+                vpx_dc = VPX_55_DC_V2V_EXAMPLE
+                esx_hostname = ESX_55_HOSTNAME_V2V_EXAMPLE
+            - esx_60:
+                vpx_hostname = VPX_60_HOSTNAME_V2V_EXAMPLE
+                vpx_dc = VPX_60_DC_V2V_EXAMPLE
+                esx_hostname = ESX_60_HOSTNAME_V2V_EXAMPLE

--- a/backends/v2v/cfg/tests-shared.cfg
+++ b/backends/v2v/cfg/tests-shared.cfg
@@ -15,6 +15,9 @@ include subtests.cfg
 include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg
+# Include configuration for v2v tests
+include convert_source.cfg
+include convert_destination.cfg
 
 # Modify/comment the following lines if you wish to modify the paths of the
 # image files, ISO files or qemu binaries.


### PR DESCRIPTION
These configurations including infomations of source hypervisors
and destinations are needed by almost every v2v cases. Therefore
organize and store them in public config files will be make future
case implementing job easier and cfg files lighter.