### PR TITLE
Calculating available memory from MemAvailable

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -526,7 +526,11 @@ def process(test, params, env, image_func, vm_func, vm_first=False):
         if (params.get("setup_ksm") == "yes" and
                 params.get("ksm_run", "1") == "1"):
             magnification = 1.2
-        free_mem = "%s KB" % memory.read_from_meminfo('MemFree')
+        # Test whether is MemAvailable already introduced
+        try:
+            free_mem = "%s KB" % memory.read_from_meminfo('MemAvailable')
+        except avocado_process.CmdError:
+            free_mem = "%s KB" % memory.read_from_meminfo('MemFree')
         free_mem = float(utils_misc.normalize_data_size(free_mem))
         provide_mem = free_mem * magnification
         # make memory size aligned to 256Mib


### PR DESCRIPTION
Signed-off-by: Radek Duda <rduda@redhat.com>

To create new VM machine, avocado-vt verifies available memory from `MemFree` in `proc/meminfo`. Sometimes, particularly after some completed avocado-vt test run, there is a lot of cached memory, which is generally available to occupy, but is not marked as `MemFree` in `/proc/meminfo`. This often leads to VM initiation with only 256 MB of RAM (`-m 256`).
To validate memory resources it is better to utilize `MemAvailable` from `/proc/meminfo/`,which is an estimate of how much memory is available for starting new applications, without swapping.
For more details see https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773