### PR TITLE
virttest/utils_test/__init__.py: Fix session.cmd issue on SLES guests

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -798,9 +798,10 @@ def run_autotest(vm, session, control_path, timeout,
         extract_cmd = "tar %s %s -C %s" % (options,
                                            basename,
                                            os.path.dirname(dest_dir))
+        extract_cmd += " & wait ${!}"
         output = session.cmd(extract_cmd, timeout=120)
         autotest_dirname = ""
-        for line in output.splitlines()[1:]:
+        for line in output.splitlines()[2:]:
             autotest_dirname = line.split("/")[0]
             break
         if autotest_dirname != os.path.basename(dest_dir):
@@ -1128,7 +1129,8 @@ def run_autotest(vm, session, control_path, timeout,
                 else:
                     verbose = ""
                 session.cmd_output(
-                    "python -x ./autotest-local %s control" % verbose,
+                    "python -x ./autotest-local %s control & wait ${!}" %
+                    verbose,
                     timeout=timeout,
                     print_func=logging.info)
         finally:


### PR DESCRIPTION
On SLES guests, session.cmd()/session.cmd_output might exit without any error WHILE the real cmd is still in progress in the guest; so add 'wait ${!}' for the issue code point.

ID: 1360676, 1361468

Signed-off-by: Nini Gu <ngu@redhat.com>