### PR TITLE
nfs: Skip ssh key remove fail when known_hosts not exist

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -247,8 +247,8 @@ class NFSClient(object):
     def __init__(self, params):
         self.nfs_client_ip = params.get("nfs_client_ip")
         # To Avoid host key verification failure
-        output = process.run("ssh-keygen -R %s" % self.nfs_client_ip)
-        if output.exit_status:
+        ret = process.run("ssh-keygen -R %s" % self.nfs_client_ip)
+        if ret.exit_status and "No such file or directory" not in ret.stderr:
             raise exceptions.TestFail("Failed to update host key: %s" %
                                       output.stderr)
         # Setup SSH connection


### PR DESCRIPTION
When use 'ssh-keygen -R hostname' to remove host key, if
known_hosts file not exist, command will return error with 'No
such file or directory'.

This happens when set in ssh_config with:

    UserKnownHostsFile=/dev/null

this should not fail the setup as no known hosts recorded when
ssh connect.

Signed-off-by: Wayne Sun <gsun@redhat.com>