### PR TITLE
qemu_vm: fix bug of the reboot function

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4004,6 +4004,10 @@ class VM(virt_vm.BaseVM):
                             return True
                     except Exception:
                         return False
+                elif not serial:
+                    net_session = self.login(nic_index=nic_index)
+                    net_session.close()
+                    return False
             except Exception:
                 return True
 


### PR DESCRIPTION
Commit 9ca0c3ea incorrectly removed some codes that is used for waiting
for guest accomplishing the shutdown operation in the case of using a
net session. This patch will bring them back.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1434307