### PR TITLE
virttest/nfs: Minor parameter fix for process.run

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -247,7 +247,8 @@ class NFSClient(object):
     def __init__(self, params):
         self.nfs_client_ip = params.get("nfs_client_ip")
         # To Avoid host key verification failure
-        ret = process.run("ssh-keygen -R %s" % self.nfs_client_ip)
+        ret = process.run("ssh-keygen -R %s" % self.nfs_client_ip,
+                          ignore_status=True)
         if ret.exit_status and "No such file or directory" not in ret.stderr:
             raise exceptions.TestFail("Failed to update host key: %s" %
                                       output.stderr)


### PR DESCRIPTION
'ignore_status' should be True in order to avoid of raising an exception
when the command execution fails.

Signed-off-by: Dan Zheng <dzheng@redhat.com>