### PR TITLE
shared/cfg/guest-os/Linux/SLES: Add SLES12.2 cfg file

### DIFF
--- a/shared/cfg/guest-os/Linux/SLES/12.2.x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/12.2.x86_64.cfg
@@ -1,0 +1,22 @@
+- 12.2.x86_64:
+    image_name = images/sles12sp2-64
+    vm_arch_name = x86_64
+    os_variant = sles12
+    unattended_install, svirt_install:
+        unattended_file = unattended/SLES-12.xml
+        cdrom_unattended = images/sles-12-2-64/autoyast.iso
+        kernel_params = "autoyast=device://sr1/autoinst.xml console=ttyS0,115200 console=tty0"
+        kernel = images/sles-12-2-64/linux
+        initrd = images/sles-12-2-64/initrd
+        boot_path = boot/x86_64/loader
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/SLE-12-SP2-Server-DVD-x86_64-GM-DVD1.iso
+        md5sum_cd1 = fe01223a08b2d293da2f940658af8168
+        md5sum_1m_cd1 = 7bf4ccf0ddc96f0e8f49734279a6836d
+    unattended_install.url, unattended_install.nfs:
+        kernel_params = "autoyast=device://sr0/autoinst.xml console=ttyS0,115200 console=tty0"
+
+    unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autoinst.xml console=ttyS0,115200 console=tty0"
+        floppies = "fl"
+        floppy_name = images/sles-12-2-64/autoyast.vfd


### PR DESCRIPTION
After the occurrence of SLES12 SP2, add its configuration file into guest-os

ID: 1436138

Signed-off-by: Nini Gu <ngu@redhat.com>