### PR TITLE
Added option to not specify spice_port

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -992,7 +992,8 @@ class VM(virt_vm.BaseVM):
                 else:
                     self.spice_options['spice_port'] = self.spice_port
                     spice_opts.append("port=%s" % self.spice_port)
-            else:
+            # spice_port = no: spice_port value is not present on qemu cmdline
+            elif optget("spice_port") != "no":
                 set_value("port=%s", "spice_port")
 
             set_value("password=%s", "spice_password", "disable-ticketing")


### PR DESCRIPTION
Signed-off-by: Radek Duda <rduda@redhat.com>

Some of our testcases does not require to specify `--spice port=foo` option.