### PR TITLE
share.deps: kill serialport server before install finished

### DIFF
--- a/shared/deps/finish/finish.bat
+++ b/shared/deps/finish/finish.bat
@@ -1,3 +1,5 @@
+taskkill /IM serialport.exe /F
+
 :check_net
 if [%2]==[] goto check_process
 
@@ -29,4 +31,3 @@ reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\Windows Error Reporting" /
 reg add "HKLM\SYSTEM\CurrentControlSet\Services\vds" /v Start /t REG_DWORD /d 3 /f
 
 for /L %%i in (1,1,3) do (echo Post set up finished> COM1)
-shutdown -t 0 -r -f


### PR DESCRIPTION
kill serailport.exe to release serialport to finished program
to write string to serialport.

Signed-off-by: Xu Tian <xutian@redhat.com>