### PR TITLE
shared/cfg/guest-os/Linux/SLES: Add SLES12.2 cfg file - ppc64le

### DIFF
--- a/shared/cfg/guest-os/Linux/SLES/12.2.ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/12.2.ppc64le.cfg
@@ -1,0 +1,16 @@
+- 12.2.ppc64le:
+    image_name = images/sles12sp2-ppc64le
+    vm_arch_name = ppc64le
+    os_variant = sles12
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        unattended_file = unattended/SLES-12.xml
+        cdrom_unattended = images/sles-12-2-ppc64le/autoyast.iso
+        kernel_params = "autoyast=device://sr1/autoinst.xml console=ttyS0,115200 console=tty0"
+        kernel = images/sles-12-2-ppc64le/linux
+        initrd = images/sles-12-2-ppc64le/initrd
+        boot_path = boot/ppc64le
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/SLE-12-SP2-Server-DVD-ppc64le-GM-DVD1.iso
+        md5sum_cd1 = 1cf874326f71e6e430d8e9dd563e1bea
+        md5sum_1m_cd1 = b3dc44c6d6d0eb0632369128f9acf0b1


### PR DESCRIPTION
After the occurrence of SLES12 SP2, add its ppc64le related configuration file into guest-os

ID: 1436138

Signed-off-by: Nini Gu <ngu@redhat.com>