### PR TITLE
utils_selinux: Handling exception if selinux not installed

### DIFF
--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -65,7 +65,11 @@ def get_status():
                     but the output is not expected.
     """
     cmd = 'getenforce'
-    result = process.run(cmd, ignore_status=True)
+    try:
+        result = process.run(cmd, ignore_status=True)
+    except OSError:
+        raise SeCmdError(cmd, "Command not available")
+
     if result.exit_status:
         raise SeCmdError(cmd, result.stderr)
 


### PR DESCRIPTION
get_status() breaks if selinux is not installed, it is handled and appropriate
exception is raised.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>