### PR TITLE
utils_test.get_time:Correct to match "PM" when get guest time with "PM" doesn't at the beginning

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -240,10 +240,10 @@ def get_time(session, time_command, time_filter_re, time_format):
                 msg = "Fail to get guest time offset. Command "
                 msg += "'%s', output: %s" % (time_command, output)
                 raise exceptions.TestError(msg)
-            if re.match('PM', guest_time):
+            if re.search('PM', guest_time):
                 hour = re.findall('\d+ (\d+):', guest_time)[0]
                 hour = str(int(hour) + 12)
-                guest_time = re.sub('\d+\s\d+:', "\d+\s%s:" % hour,
+                guest_time = re.sub('\s\d+:', " %s:" % hour,
                                     guest_time)[:-3]
             else:
                 guest_time = guest_time[:-3]


### PR DESCRIPTION
when get guest time with format "3/30/2017 3:28:47 PM", re.match can not match "PM" as it is not at the beginning of string.

id: 1437455
Signed-off-by: Yanan Fu <yfu@redhat.com>