### PR TITLE
utils_misc:correct "parm" to "param"

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2631,8 +2631,8 @@ def get_free_disk(session, mount):
     """
     Get FreeSpace for given mount point.
 
-    :parm session: shell Object.
-    :parm mount: mount point(eg. C:, /mnt)
+    :param session: shell Object.
+    :param mount: mount point(eg. C:, /mnt)
 
     :return string: freespace M-bytes
     """
@@ -2654,8 +2654,8 @@ def get_free_mem(session, os_type):
     """
     Get Free memory for given OS.
 
-    :parm session: shell Object.
-    :parm os_type: os type (eg. linux or windows)
+    :param session: shell Object.
+    :param os_type: os type (eg. linux or windows)
 
     :return string: freespace M-bytes
     """
@@ -2674,8 +2674,8 @@ def get_used_mem(session, os_type):
     """
     Get Used memory for given OS.
 
-    :parm session: shell Object.
-    :parm os_type: os type (eg. linux or windows)
+    :param session: shell Object.
+    :param os_type: os type (eg. linux or windows)
 
     :return string: usedspace M-bytes
     """


### PR DESCRIPTION
utils_misc:correct "parm" to "param"
virttest.utils_misc:
  correct "parm" to "param" in functions get_free_disk(),
get_free_mem() and get_used_mem()

Signed-off-by:Aihua Liang<aliang@redhat.com>

ID:1439602