### PR TITLE
Bootstrap: improve xz and other asset related checks and actions [v2]

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -7,7 +7,6 @@ import types
 import glob
 import ConfigParser
 import StringIO
-import commands
 import shutil
 
 from avocado.utils import process
@@ -444,7 +443,7 @@ def uncompress_asset(asset_info, force=False):
             os.chdir(os.path.dirname(destination_uncompressed))
             logging.debug('Uncompressing %s -> %s', destination,
                           destination_uncompressed)
-            commands.getstatusoutput(uncompress_cmd)
+            process.run(uncompress_cmd, shell=True)
             backup_file = destination_uncompressed + '.backup'
             if os.path.isfile(backup_file):
                 logging.debug('Copying %s -> %s', destination_uncompressed,

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -132,11 +132,6 @@ def verify_mandatory_programs(t_type, guest_os):
         try:
             LOG.debug('%s OK', utils_path.find_command(cmd))
         except utils_path.CmdNotFoundError:
-            if cmd == 'xz' and guest_os != defaults.DEFAULT_GUEST_OS:
-                LOG.warn("Command xz (required to uncompress JeOS) "
-                         "missing. You can still use avocado-vt with guest"
-                         " OS's other than JeOS.")
-                continue
             LOG.error("Required command %s is missing. You must "
                       "install it", cmd)
             failed_cmds.append(cmd)

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -754,9 +754,6 @@ def bootstrap(options, interactive=False):
 
     :param options: Command line options.
     :param interactive: Whether to ask for confirmation.
-
-    :raise error.CmdError: If JeOS image failed to uncompress
-    :raise ValueError: If xz was not found
     """
     if options.yes_to_all:
         interactive = False


### PR DESCRIPTION
This is a collection of a few improvements and fixes to the asset related part of the bootstrap module (and thus `avocado vt-bootstrap` user experience).

---

Changes from v1 (#957):
 * Enable shell on uncompress commands