### PR TITLE
asset: Adding try/except to avoid connection issues during download [v4]

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -494,9 +494,13 @@ def download_file(asset_info, interactive=False, force=False):
         else:
             answer = 'y'
         if answer == 'y':
-            download.url_download_interactive(url, destination,
-                                              "Downloading %s" % title)
-            had_to_download = True
+            try:
+                download.url_download_interactive(url, destination,
+                                                  "Downloading %s" % title)
+                had_to_download = True
+            except Exception, download_failure:
+                logging.error("Check your internet connection: %s", 
+                              download_failure)
         else:
             logging.warning("Missing file %s", destination)
     else:
@@ -519,8 +523,12 @@ def download_file(asset_info, interactive=False, force=False):
                 if answer == 'y':
                     logging.info("Updating image to the latest available...")
                     while not file_ok:
-                        download.url_download_interactive(url, destination,
-                                                          title)
+                        try:
+                            download.url_download_interactive(url, destination,
+                                                              title)
+                        except Exception, download_failure:
+                            logging.error("Check your internet connection: %s",
+                                          download_failure)
                         sha1_post_download = crypto.hash_file(destination,
                                                               algorithm='sha1')
                         had_to_download = True


### PR DESCRIPTION
When you are downloading the JEOS image and you lost the connection,
avocado chrashes with an error:

    6 - Verifying (and possibly downloading) guest image
    Verifying expected SHA1 sum from
    http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS25
    Expected SHA1 sum: 7f5a440f6eb83577d42f9f68987534b1076967d8
    File
    /home/jfaracco/Desktop/c4eb/git/virt-test/tests/data/avocado-vt/images/jeos-25-64.qcow2.xz
    not found
    Would you like to download it from
    http://assets-avocadoproject.rhcloud.com/static/jeos-25-64.qcow2.xz?
    (y/n) y
    Avocado crashed unexpectedly: <urlopen error [Errno -2] Name or service
    not known>
    You can find details in
    /var/tmp/avocado-traceback-2017-04-11_12:34:08-PF3PjA.log

Adding try/except will avoid this problem because urllib2 inside
url_download_interactive() will not throw any unexpected exception.

The try/except cannot be added inside the method
url_download_interactive() because it raises an exception if the file
content-length does not appear in the request header.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>