### PR TITLE
virttest.utils_test: update regex for getting ping loss ratio

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1222,14 +1222,9 @@ def get_loss_ratio(output):
     :param output: Ping output.
     """
     try:
-        return int(re.findall('(\d+)% packet loss', output)[0])
+        return int(re.findall('(\d+)%.*loss', output)[0])
     except IndexError:
-        pass
-    try:
-        return int(re.findall('Lost = (\d+)', output)[0])
-    except IndexError:
-        pass
-    logging.debug(output)
+        loggging.warn("Invaild output of ping command: %s" % output)
     return -1
 
 


### PR DESCRIPTION
output of ping command in windows is different with it output
in linux(output in win10 like:'.. Lost = 8 (80% loss)',
output in linux like:' 100% packet loss, time 8999ms'),so update
regex to made it works on both windows and linux.

ID: 1397690

Signed-off-by: Xu Tian <xutian@redhat.com>