### PR TITLE
qemu_vm: Remove thread check from function migrate

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3893,19 +3893,10 @@ class VM(virt_vm.BaseVM):
                                "but actual result is '%s'" % (key, state, s))
                         raise exceptions.TestError(msg)
 
-            threads_before_migrate = self.get_qemu_threads()
-
             logging.info("Migrating to %s", uri)
             self.monitor.migrate(uri)
             if not_wait_for_migration:
                 return clone
-
-            if self.params.get("enable_check_mig_thread", "no") == "yes":
-                threads_during_migrate = self.get_qemu_threads()
-                if not (len(threads_during_migrate) >
-                        len(threads_before_migrate)):
-                    raise virt_vm.VMMigrateFailedError("Cannot find new thread"
-                                                       " for migration.")
 
             if cancel_delay:
                 error_context.context("Do migrate_cancel after %d seconds" %


### PR DESCRIPTION
It is unreasonable to check whether a new thread is created for
doing migration in function `migrate` because the behavior is
implementation-dependent. Suggest to make this as an unittest for the
corresponding version of QEMU if do have the need.

ID: 1321505