### PR TITLE
virt_vm:fix issue of cannot connect to guests after v2v conversion

### DIFF
--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -554,7 +554,7 @@ class VMManager(virt_vm.BaseVM):
         except Exception, e:
             logging.error('Failed to create VM from template:\n%s' % str(e))
 
-    def get_address(self, index=0):
+    def get_address(self, index=0, *args):
         """
         Return the address of the guest through ovirt node tcpdump cache.
 

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -638,9 +638,11 @@ class BaseVM(object):
         """
         try:
             mac = self.virtnet[nic_index].mac
-            return mac
         except KeyError:
             raise VMMACAddressMissingError(nic_index)
+        if mac is None:
+            raise VMMACAddressMissingError(nic_index)
+        return mac
 
     def get_address(self, index=0, ip_version="ipv4"):
         """
@@ -705,7 +707,7 @@ class BaseVM(object):
         mac = _get_mac_addr(index)
         if 'mac' not in nic:
             if self.params.get("vm_type") in ["libvirt", "v2v"]:
-                nic.set_mac_address(index, mac)
+                self.virtnet.set_mac_address(index, mac)
                 self.virtnet[index] = nic
 
         if ip_version == "ipv4":


### PR DESCRIPTION
Raise exception that next procedure could catch and deal with
other than throw it out if get_mac_address returns None for mac
address.

set_mac_address method should be called with an object of
virttest.utils_net.VirtNet

update param list of function get_address() of ovirt.VMManager

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>