### PR TITLE
fix add SGA device failed issue

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1202,7 +1202,7 @@ class VM(virt_vm.BaseVM):
             return index
 
         def add_sga(devices):
-            if not devices.has_option("device"):
+            if not devices.has_device("sga"):
                 return ""
             else:
                 return " -device sga"


### PR DESCRIPTION
SGA (Serial Graphics Adapter) support in qemu as device, so
replace qcontainor.has_option with qcontainor.has_device to
avoid add 'sga' device failed.

ID: 1443432

Signed-off-by: Xu Tian <xutian@redhat.com>