### PR TITLE
rename skip exception

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -227,14 +227,14 @@ class VirtTest(test.Test):
             self.__status = "PASS"
         # This trick will give better reporting of virt tests being executed
         # into avocado (skips, warns and errors will display correctly)
-        except exceptions.TestSkipError:
+        except exceptions.TestSkip:
             raise   # This one has to be raised in setUp
         except:  # Old-style exceptions are not inherited from Exception()
             details = sys.exc_info()[1]
             self.__status = details
             if not hasattr(self, "cancel"):     # Old Avocado, skip here
                 if isinstance(self.__status, error.TestNAError):
-                    raise exceptions.TestSkipError(self.__status)
+                    raise exceptions.TestSkip(self.__status)
         finally:
             if env_lang:
                 os.environ['LANG'] = env_lang

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -132,7 +132,7 @@ def preprocess_vm(test, params, env, name):
                               (install_test, remove_test))
                 raise exceptions.TestError(error_msg)
             else:
-                raise exceptions.TestSkipError(error_msg)
+                raise exceptions.TestSkip(error_msg)
 
     remove_vm = False
     if params.get("force_remove_vm") == "yes":
@@ -575,18 +575,18 @@ def preprocess(test, params, env):
 
     # First, let's verify if this test does require root or not. If it
     # does and the test suite is running as a regular user, we shall just
-    # throw a TestSkipError exception, which will skip the test.
+    # throw a TestSkip exception, which will skip the test.
     if params.get('requires_root', 'no') == 'yes':
         utils_misc.verify_running_as_root()
 
-    # throw a TestSkipError exception if command requested by test is not
+    # throw a TestSkip exception if command requested by test is not
     # installed.
     if params.get("cmds_installed_host"):
         for cmd in params.get("cmds_installed_host").split():
             try:
                 path.find_command(cmd)
             except path.CmdNotFoundError, msg:
-                raise exceptions.TestSkipError(msg.message)
+                raise exceptions.TestSkip(msg.message)
 
     # enable network proxies setting in urllib2
     if params.get("network_proxies"):
@@ -696,7 +696,7 @@ def preprocess(test, params, env):
         else:
             warning_msg = "KVM module not loaded"
             if params.get("enable_kvm", "yes") == "yes":
-                raise exceptions.TestSkipError(warning_msg)
+                raise exceptions.TestSkip(warning_msg)
             logging.warning(warning_msg)
             kvm_version = "Unknown"
 

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -763,8 +763,8 @@ class VM(virt_vm.BaseVM):
             if machine_type in support_machine_type:
                 virt_install_cmd += add_machine_type(help_text, machine_type)
             else:
-                raise exceptions.TestSkipError("Unsupported machine type %s." %
-                                               (machine_type))
+                raise exceptions.TestSkip("Unsupported machine type %s." %
+                                          (machine_type))
 
         mem = params.get("mem")
         maxmemory = params.get("maxmemory", None)
@@ -864,10 +864,10 @@ class VM(virt_vm.BaseVM):
         # selectable OS variant
         if params.get("use_os_variant") == "yes":
             if not has_os_variant(os_text, params.get("os_variant")):
-                raise exceptions.TestSkipError("Unsupported OS variant: %s.\n"
-                                               "Supported variants: %s" %
-                                               (params.get('os_variant'),
-                                                os_text))
+                raise exceptions.TestSkip("Unsupported OS variant: %s.\n"
+                                          "Supported variants: %s" %
+                                          (params.get('os_variant'),
+                                           os_text))
             virt_install_cmd += add_os_variant(
                 help_text, params.get("os_variant"))
 
@@ -1700,17 +1700,17 @@ class VM(virt_vm.BaseVM):
                                      "Try using the "
                                      "unattended_install.cdrom.http_ks method "
                                      "instead." % details.result)
-                            raise exceptions.TestSkipError(e_msg)
+                            raise exceptions.TestSkip(e_msg)
                 if stderr.count('failed to launch bridge helper'):
                     if utils_selinux.is_enforcing():
-                        raise exceptions.TestSkipError("SELinux is enabled "
-                                                       "and preventing the "
-                                                       "bridge helper from "
-                                                       "accessing the bridge. "
-                                                       "Consider running as "
-                                                       "root or placing "
-                                                       "SELinux into "
-                                                       "permissive mode.")
+                        raise exceptions.TestSkip("SELinux is enabled "
+                                                  "and preventing the "
+                                                  "bridge helper from "
+                                                  "accessing the bridge. "
+                                                  "Consider running as "
+                                                  "root or placing "
+                                                  "SELinux into "
+                                                  "permissive mode.")
                 # some other problem happened, raise normally
                 raise
             # Wait for the domain to be created

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1024,8 +1024,8 @@ class DevContainer(object):
                 # similar to i440fx one (1 PCI bus, ..)
                 devices = machine_i440FX("-M %s" % machine_type)
             else:
-                raise exceptions.TestSkipError("Unsupported machine type %s." %
-                                               (machine_type))
+                raise exceptions.TestSkip("Unsupported machine type %s." %
+                                          (machine_type))
         else:
             devices = None
             for _ in self.__machine_types.splitlines()[1:]:
@@ -1080,8 +1080,8 @@ class DevContainer(object):
             return [usb]
 
         if not self.has_device(usb_type):
-            raise exceptions.TestSkipError("usb controller %s not available"
-                                           % usb_type)
+            raise exceptions.TestSkip("usb controller %s not available"
+                                      % usb_type)
 
         usb = qdevices.QDevice(usb_type, {}, usb_id, pci_bus,
                                qbuses.QUSBBus(max_ports, '%s.0' % usb_id, usb_type, usb_id))
@@ -1152,8 +1152,8 @@ class DevContainer(object):
         :return: QDev device
         """
         if not self.has_device(usb_type):
-            raise exceptions.TestSkipError("usb device %s not available"
-                                           % usb_type)
+            raise exceptions.TestSkip("usb device %s not available"
+                                      % usb_type)
         if self.has_option('device'):
             device = qdevices.QDevice(usb_type, aobject=usb_name)
             device.set_param('id', 'usb-%s' % usb_name)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2703,8 +2703,8 @@ class VM(virt_vm.BaseVM):
                 logging.debug(self.devices.str_short())
                 logging.debug(self.devices.str_bus_short())
                 qemu_command = self.devices.cmdline()
-            except exceptions.TestSkipError:
-                # TestSkipErrors should be kept as-is so we generate SKIP
+            except exceptions.TestSkip:
+                # TestSkips should be kept as-is so we generate SKIP
                 # results instead of bogus FAIL results
                 raise
             except Exception:
@@ -3339,9 +3339,9 @@ class VM(virt_vm.BaseVM):
         try:
             self.monitor.verify_supported_cmd(vcpu_add_cmd.split()[0])
         except qemu_monitor.MonitorNotSupportedCmdError:
-            raise exceptions.TestSkipError("%s monitor not support cmd '%s'" %
-                                           (self.monitor.protocol,
-                                            vcpu_add_cmd))
+            raise exceptions.TestSkip("%s monitor not support cmd '%s'" %
+                                      (self.monitor.protocol,
+                                       vcpu_add_cmd))
         try:
             # vcpu device based hotplug command contains arguments and with
             # convert=True, arguments will be filtered.

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2062,9 +2062,9 @@ def disable_smt(params=None):
         cmd = "ppc64_cpu --smt=off"
         if params:
             if (server_user.lower() != "root"):
-                raise exceptions.TestSkipError("Turning SMT off requires root "
-                                               "privileges(currently running "
-                                               "with user %s)" % server_user)
+                raise exceptions.TestSkip("Turning SMT off requires root "
+                                          "privileges(currently running "
+                                          "with user %s)" % server_user)
             cmd_output = server_session.cmd_status_output(cmd)
             server_session.close()
             if (cmd_output[0] != 0):

--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -414,11 +414,11 @@ class GuestFSModiDisk(object):
                 process.run(install_cmd)
                 import guestfs
             except Exception:
-                raise exceptions.TestSkipError('We need python-libguestfs (or '
-                                               'the equivalent for your '
-                                               'distro) for this particular '
-                                               'feature (modifying guest '
-                                               'files with libguestfs)')
+                raise exceptions.TestSkip('We need python-libguestfs (or '
+                                          'the equivalent for your '
+                                          'distro) for this particular '
+                                          'feature (modifying guest '
+                                          'files with libguestfs)')
 
         self.g = guestfs.GuestFS()
         self.disk = disk

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1942,7 +1942,7 @@ def set_cpu_status(cpu_num, enable=True):
     Set assigned cpu to be enable or disable
     """
     if cpu_num == 0:
-        raise exceptions.TestSkipError("The 0 cpu cannot be set!")
+        raise exceptions.TestSkip("The 0 cpu cannot be set!")
     cpu_status = get_cpu_status(cpu_num)
     if cpu_status == -1:
         return False
@@ -2594,12 +2594,12 @@ def verify_running_as_root():
     """
     Verifies whether we're running under UID 0 (root).
 
-    :raise: exceptions.TestSkipError
+    :raise: exceptions.TestSkip
     """
     if os.getuid() != 0:
-        raise exceptions.TestSkipError("This test requires root privileges "
-                                       "(currently running with user %s)" %
-                                       getpass.getuser())
+        raise exceptions.TestSkip("This test requires root privileges "
+                                  "(currently running with user %s)" %
+                                  getpass.getuser())
 
 
 def selinux_enforcing():
@@ -3818,7 +3818,7 @@ class SELinuxBoolean(object):
         result = process.run("setsebool %s %s" % (self.local_bool_var,
                                                   self.local_bool_value))
         if result.exit_status:
-            raise exceptions.TestSkipError(result.stderr.strip())
+            raise exceptions.TestSkip(result.stderr.strip())
 
         boolean_curr = self.get_sebool_local()
         logging.debug("To check local boolean value: %s", boolean_curr)
@@ -3841,7 +3841,7 @@ class SELinuxBoolean(object):
 
         result = process.run(set_boolean_cmd)
         if result.exit_status:
-            raise exceptions.TestSkipError(result.stderr.strip())
+            raise exceptions.TestSkip(result.stderr.strip())
 
         boolean_curr = self.get_sebool_remote()
         logging.debug("To check remote boolean value: %s", boolean_curr)

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -478,8 +478,8 @@ class Interface(object):
         Get ip network netmask
         """
         if not CTYPES_SUPPORT:
-            raise exceptions.TestSkipError("Getting the netmask requires "
-                                           "python > 2.4")
+            raise exceptions.TestSkip("Getting the netmask requires "
+                                      "python > 2.4")
         ifreq = struct.pack('16sH14s', self.name, socket.AF_INET, '\x00' * 14)
         try:
             res = fcntl.ioctl(sockfd, arch.SIOCGIFNETMASK, ifreq)
@@ -495,8 +495,8 @@ class Interface(object):
         Set netmask
         """
         if not CTYPES_SUPPORT:
-            raise exceptions.TestSkipError("Setting the netmask requires "
-                                           "python > 2.4")
+            raise exceptions.TestSkip("Setting the netmask requires "
+                                      "python > 2.4")
         netmask = ctypes.c_uint32(~((2 ** (32 - netmask)) - 1)).value
         nmbytes = socket.htonl(netmask)
         ifreq = struct.pack('16sH2si8s', self.name,
@@ -867,7 +867,7 @@ def ping(dest=None, count=None, interval=None, interface=None,
         else:
             if dest.upper().startswith("FE80"):
                 err_msg = "Using ipv6 linklocal must assigne interface"
-                raise exceptions.TestSkipError(err_msg)
+                raise exceptions.TestSkip(err_msg)
         if packetsize:
             command += " -s %s" % packetsize
         if ttl:
@@ -2144,13 +2144,13 @@ class IPv6Manager(propcan.PropCanBase):
         try:
             utils_path.find_command("ping6")
         except utils_path.CmdNotFoundError:
-            raise exceptions.TestSkipError("Can't find ping6 command")
+            raise exceptions.TestSkip("Can't find ping6 command")
         command = "ping6 -I %s %s -c %s" % (client_ifname, server_ipv6, count)
         result = process.run(command, ignore_status=True)
         if result.exit_status:
-            raise exceptions.TestSkipError("The '%s' destination is "
-                                           "unreachable: %s", server_ipv6,
-                                           result.stderr)
+            raise exceptions.TestSkip("The '%s' destination is "
+                                      "unreachable: %s", server_ipv6,
+                                      result.stderr)
         else:
             logging.info("The '%s' destination is connectivity!", server_ipv6)
 
@@ -2167,7 +2167,7 @@ class IPv6Manager(propcan.PropCanBase):
         try:
             utils_path.find_command("ip6tables")
         except utils_path.CmdNotFoundError:
-            raise exceptions.TestSkipError(test_skip_err)
+            raise exceptions.TestSkip(test_skip_err)
         # flush local ip6tables rules
         result = process.run(flush_cmd, ignore_status=True)
         if result.exit_status:
@@ -2178,7 +2178,7 @@ class IPv6Manager(propcan.PropCanBase):
 
         # check if ip6tables command exists on the remote
         if self.session.cmd_status(find_ip6tables_cmd):
-            raise exceptions.TestSkipError(test_skip_err)
+            raise exceptions.TestSkip(test_skip_err)
         # flush remote ip6tables rules
         if self.session.cmd_status(flush_cmd):
             raise exceptions.TestFail("%s on the remote host" % test_fail_err)
@@ -3496,12 +3496,12 @@ def check_listening_port_by_service(service, port, listen_addr='0.0.0.0',
             try:
                 utils_path.find_command("netstat")
             except utils_path.CmdNotFoundError, details:
-                raise exceptions.TestSkipError(details)
+                raise exceptions.TestSkip(details)
             output = process.system_output(cmd, shell=True)
         else:
             if not runner(find_netstat_cmd):
-                raise exceptions.TestSkipError("Missing netstat command on "
-                                               "remote")
+                raise exceptions.TestSkip("Missing netstat command on "
+                                          "remote")
             output = runner(cmd)
     except process.CmdError:
         logging.error("Failed to run command '%s'", cmd)
@@ -3550,14 +3550,14 @@ def block_specific_ip_by_time(ip_addr, block_time="1 seconds", runner=None):
             try:
                 utils_path.find_command("iptables")
             except utils_path.CmdNotFoundError, details:
-                raise exceptions.TestSkipError(details)
+                raise exceptions.TestSkip(details)
             output = local_runner(cmd, shell=True)
             logging.debug("List current iptables rules:\n%s",
                           local_runner(list_rules))
         else:
             if not runner(find_iptables):
-                raise exceptions.TestSkipError("Missing 'iptables' command on "
-                                               "remote")
+                raise exceptions.TestSkip("Missing 'iptables' command on "
+                                          "remote")
             output = runner(cmd)
             logging.debug("List current iptables rules:\n%s",
                           runner(list_rules))

--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -4,7 +4,7 @@ from threading import Lock
 from avocado.core import exceptions
 
 
-class ParamNotFound(exceptions.TestSkipError):
+class ParamNotFound(exceptions.TestSkip):
     pass
 
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1670,8 +1670,8 @@ class HostStress(object):
         try:
             path.find_command(self.stress_type)
         except path.CmdNotFoundError, detail:
-            raise exceptions.TestSkipError("Stress tool %s is missing: %s"
-                                           % (self.stress_type, str(detail)))
+            raise exceptions.TestSkip("Stress tool %s is missing: %s"
+                                      % (self.stress_type, str(detail)))
 
         args = [self.stress_type, '--args=%s' % self.stress_args,
                 '--verbose']

--- a/virttest/utils_test/libguestfs.py
+++ b/virttest/utils_test/libguestfs.py
@@ -385,11 +385,11 @@ class VirtTools(object):
         """
         result = lgf.virt_filesystems(self.oldvm.name, long_format=True)
         if result.exit_status:
-            raise exceptions.TestSkipError("Cannot get primary disk"
-                                           " filesystem information!")
+            raise exceptions.TestSkip("Cannot get primary disk"
+                                      " filesystem information!")
         fs_info = result.stdout.strip().splitlines()
         if len(fs_info) <= 1:
-            raise exceptions.TestSkipError("No disk filesystem information!")
+            raise exceptions.TestSkip("No disk filesystem information!")
         try:
             primary_disk_info = fs_info[1]
             fs_type = primary_disk_info.split()[2]

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -331,7 +331,7 @@ def get_all_cells():
     fc_result = virsh.freecell(options="--all", ignore_status=True)
     if fc_result.exit_status:
         if fc_result.stderr.count("NUMA not supported"):
-            raise exceptions.TestSkipError(fc_result.stderr.strip())
+            raise exceptions.TestSkip(fc_result.stderr.strip())
         else:
             raise exceptions.TestFail(fc_result.stderr.strip())
     output = fc_result.stdout.strip()
@@ -563,7 +563,7 @@ def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
     try:
         utils_path.find_command("gluster")
     except utils_path.CmdNotFoundError:
-        raise exceptions.TestSkipError("Missing command 'gluster'")
+        raise exceptions.TestSkip("Missing command 'gluster'")
     if not brick_path:
         tmpdir = data_dir.get_tmp_dir()
         brick_path = os.path.join(tmpdir, pool_name)
@@ -671,7 +671,7 @@ def define_pool(pool_name, pool_type, pool_target, cleanup_flag, **kwargs):
         extra = "--source-host %s --source-path %s --source-name %s" % \
                 (hostip, gluster_source_path, gluster_source_name)
     elif pool_type in ["scsi", "mpath", "rbd", "sheepdog"]:
-        raise exceptions.TestSkipError(
+        raise exceptions.TestSkip(
             "Pool type '%s' has not yet been supported in the test." %
             pool_type)
     else:
@@ -1393,7 +1393,7 @@ def check_result(result, expected_fails=[], skip_if=[], any_error=False):
     :param expected_fails: list of regex of expected stderr patterns. The check
                            will pass if any of these patterns matches.
     :param skip_if: list of regex of expected patterns. The check will raise a
-                    TestSkipError if any of these patterns matches.
+                    TestSkip if any of these patterns matches.
     :param any_error: Whether expect on any error message. Setting to True will
                       will override expected_fails
     """
@@ -1401,9 +1401,9 @@ def check_result(result, expected_fails=[], skip_if=[], any_error=False):
     if skip_if:
         for patt in skip_if:
             if re.search(patt, result.stderr):
-                raise exceptions.TestSkipError("Test skipped: found '%s' in test "
-                                               "result:\n%s" %
-                                               (patt, result.stderr))
+                raise exceptions.TestSkip("Test skipped: found '%s' in test "
+                                          "result:\n%s" %
+                                          (patt, result.stderr))
     if any_error:
         if result.exit_status:
             return
@@ -1666,7 +1666,7 @@ def create_disk_xml(params):
             if transport:
                 source_host[0].update({'transport': transport})
         else:
-            exceptions.TestSkipError("Unsupport disk type %s" % type_name)
+            exceptions.TestSkip("Unsupport disk type %s" % type_name)
         source_startupPolicy = params.get("source_startupPolicy")
         if source_startupPolicy:
             source_attrs['startupPolicy'] = source_startupPolicy
@@ -2119,8 +2119,8 @@ def set_domain_state(vm, vm_state):
         # Execute "pm-suspend-hybrid" command directly will get Timeout error,
         # so here execute it in background, and wait for 3s manually
         if session.cmd_status("which pm-suspend-hybrid"):
-            raise exceptions.TestSkipError("Cannot execute this test for domain"
-                                           " doesn't have pm-suspend-hybrid command!")
+            raise exceptions.TestSkip("Cannot execute this test for domain"
+                                      " doesn't have pm-suspend-hybrid command!")
         session.cmd("pm-suspend-hybrid &")
         time.sleep(3)
 
@@ -2497,7 +2497,7 @@ def create_scsi_disk(scsi_option, scsi_size="2048"):
     try:
         utils_path.find_command("lsscsi")
     except utils_path.CmdNotFoundError:
-        raise exceptions.TestSkipError("Missing command 'lsscsi'.")
+        raise exceptions.TestSkip("Missing command 'lsscsi'.")
 
     try:
         # Load scsi_debug kernel module.
@@ -3081,14 +3081,14 @@ def virsh_cmd_has_option(cmd, option, raise_skip=True):
     :param cmd: Virsh command name
     :param option: Virsh command option
     :raise_skip: Whether raise exception when option not find
-    :return: True/False or raise TestSkipError
+    :return: True/False or raise TestSkip
     """
     found = False
     if virsh.has_command_help_match(cmd, option):
         found = True
     msg = "command '%s' has option '%s': %s" % (cmd, option, str(found))
     if not found and raise_skip:
-        raise exceptions.TestSkipError(msg)
+        raise exceptions.TestSkip(msg)
     else:
         logging.debug(msg)
         return found

--- a/virttest/utils_test/qemu/migration.py
+++ b/virttest/utils_test/qemu/migration.py
@@ -702,9 +702,9 @@ class MultihostMigration(object):
                             if pause != "yes":
                                 start_work(mig_data)
                             else:
-                                raise exceptions.TestSkipError("Can't start "
-                                                               "work if vm is "
-                                                               "paused.")
+                                raise exceptions.TestSkip("Can't start "
+                                                          "work if vm is "
+                                                          "paused.")
 
                     # Starts VM and waits timeout before migration.
                     if pause == "yes" and mig_data.is_src():

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -282,7 +282,7 @@ class VMMigrateFailedError(VMMigrateError):
     pass
 
 
-class VMMigrateProtoUnknownError(exceptions.TestSkipError):
+class VMMigrateProtoUnknownError(exceptions.TestSkip):
 
     def __init__(self, protocol):
         self.protocol = protocol


### PR DESCRIPTION
To cover Avocado-VT in the ongoing change in Avocado, we need to rename the
skip exception from TestSkipError to TestSkip.

Signed-off-by: Amador Pahim <apahim@redhat.com>