### PR TITLE
fix avocado_params state report

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -165,7 +165,7 @@ class VirtTest(test.Test):
         reports the original params on `get_state` call.
         """
         state = super(VirtTest, self).get_state()
-        state["params"] = self.__dict__.get("avocado_params")
+        state["params"] = self.avocado_params
         return state
 
     def _start_logging(self):


### PR DESCRIPTION
avocado_params is now a property. This patch fixes the state['params']
attribution accordingly.

Fixes: https://github.com/avocado-framework/avocado/issues/1971