### PR TITLE
VT JobLock: adapt to Avocado's Pre/Post Job interface changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,14 @@ def get_data_files():
     return data_files
 
 
+def pre_post_plugin_type():
+    try:
+        from avocado.core.plugin_interfaces import JobPreTests as Pre
+        return 'avocado.plugins.result_events'
+    except ImportError:
+        return 'avocado.plugins.job.prepost'
+
+
 setup(name='avocado-plugins-vt',
       version=VERSION,
       description='Avocado Virt Test Compatibility Layer plugin',
@@ -103,8 +111,8 @@ setup(name='avocado-plugins-vt',
           'avocado.plugins.cli.cmd': [
               'vt-bootstrap = avocado_vt.plugins.vt_bootstrap:VTBootstrap',
               ],
-          'avocado.plugins.job.prepost': [
-              'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock'
+          pre_post_plugin_type(): [
+              'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock',
               ],
           },
       )


### PR DESCRIPTION
Avocado has changed the Pre/Post job interfaces.  Basically,
"JobPre" will really be run before the job, while "JobPreTests" will
be run as part of the job, but before the test execution.  The same
logic applies to "JobPost".

Signed-off-by: Cleber Rosa <crosa@redhat.com>