### PR TITLE
Fix venv support and add functional selftest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,14 @@ install:
     - rm -rf avocado-libs
 
 script:
+    # Create some fake binaries to make vt-bootstrap happy
+    - mkdir -p /tmp/dummy_bin
+    - touch /tmp/dummy_bin/arping
+    - touch /tmp/dummy_bin/tcpdump
+    - chmod 777 /tmp/dummy_bin/*
+    - export PATH="/tmp/dummy_bin:$PATH"
+    # Setup Avocado-vt for functional tests
+    - make install
+    - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-no-downloads --yes-to-all
+    # Run tests
     - make check

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -242,6 +242,7 @@ class VirtTest(test.Test):
             raise   # This one has to be raised in setUp
         except:  # Old-style exceptions are not inherited from Exception()
             details = sys.exc_info()[1]
+            stacktrace.log_exc_info(sys.exc_info(), 'avocado.test')
             self.__status = details
             if not hasattr(self, "cancel"):     # Old Avocado, skip here
                 if isinstance(self.__status, error.TestNAError):

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -1,0 +1,124 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from avocado.utils import process
+from avocado.utils import script
+from virttest import data_dir
+
+
+BASE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+BASE_DIR = os.path.abspath(BASE_DIR)
+
+TEST_STATUSES_PY = """from avocado.core import exceptions
+from autotest.client.shared import error
+import logging
+
+def run(test, params, env):
+    result_param = params.get("result_param")
+
+    if result_param == "autotest_skip":
+        raise error.TestNAError("my skip")
+    elif result_param == "autotest_fail":
+        raise error.TestFail("my fail")
+    elif result_param == "autotest_error":
+        raise error.TestError("my error")
+    elif result_param == "other exception":
+        raise Exception("asefsadf")
+    elif 'skip' in result_param:
+        raise exceptions.TestSkipError("Test Skip")
+    elif 'pass' in result_param:
+        logging.info("Test Pass")
+        pass
+    elif 'fail' in result_param:
+        raise exceptions.TestFail("Test Fail")
+    elif 'error' in result_param:
+        raise exceptions.TestError("Test Error")
+    else:
+        pass
+"""
+
+TEST_STATUSES_CFG = """variants:
+    - test_statuses:
+        type = test_statuses
+        start_vm = no
+        vms = ''
+        main_vm = ''
+        variants:
+            - skip:
+                result_param = 'skip'
+            - pass:
+                result_param = 'pass'
+            - fail:
+                result_param = 'fail'
+            - error:
+                result_param = 'error'
+            - autotest_skip:
+                result_param = 'autotest_skip'
+            - autotest_pass:
+                result_param = 'autotest_pass'
+            - autotest_fail:
+                result_param = 'autotest_fail'
+            - autotest_error:
+                result_param = 'autotest_error'
+            - other_exception:
+                result_param = "other exception"
+
+only test_statuses
+kvm_ver_cmd = /bin/true
+kvm_userspace_ver_cmd = /bin/true
+verify_host_dmesg = no
+"""
+
+
+class BasicTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        self.rm_files = []
+
+    def test_statuses(self):
+        os.chdir(BASE_DIR)
+        test_path = os.path.join(data_dir.get_test_providers_dir(),
+                                 "downloads", "io-github-autotest-qemu",
+                                 "generic", "tests", "test_statuses.py")
+        self.assertTrue(os.path.exists(os.path.dirname(test_path)),
+                        "The qemu providers dir does not exists, Avocado-vt "
+                        "is probably not configured properly.")
+        self.rm_files.append(test_path)
+        script.make_script(test_path, TEST_STATUSES_PY)
+        cfg = script.make_script(os.path.join(self.tmpdir,
+                                              "test_statuses.cfg"),
+                                 TEST_STATUSES_CFG)
+        result = process.run("avocado --show all run --vt-config %s "
+                             "--job-results-dir %s"
+                             % (cfg, self.tmpdir), ignore_status=True)
+        self.assertEqual(result.exit_status, 1, "Exit status is not 1:\n%s"
+                         % result)
+        status = json.load(open(os.path.join(self.tmpdir, "latest",
+                                             "results.json")))
+        act_statuses = [_["status"] for _ in status["tests"]]
+        statuses_master = ["SKIP", "PASS", "FAIL", "ERROR", "CANCEL", "PASS",
+                           "FAIL", "ERROR", "ERROR"]
+        statuses_36lts = ["SKIP", "PASS", "FAIL", "ERROR", "SKIP", "PASS",
+                          "FAIL", "ERROR", "ERROR"]
+        if not (act_statuses == statuses_master or
+                act_statuses == statuses_36lts):
+            self.fail("Test statuses does not match any of expected results:"
+                      "\nmaster: %s\n36lts: %s\nactual: %s\n\noutput:\n%s"
+                      % (statuses_master, statuses_36lts, act_statuses,
+                         result))
+
+    def tearDown(self):
+        for path in self.rm_files:
+            try:
+                os.unlink(path)
+            except IOError:
+                pass
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/run
+++ b/selftests/run
@@ -21,7 +21,7 @@ def test_suite():
     loader = unittest.TestLoader()
     selftests_dir = os.path.dirname(os.path.abspath(__file__))
     basedir = os.path.dirname(selftests_dir)
-    for section in (['unit', 'doc']):
+    for section in (['functional', 'unit', 'doc']):
         suite.addTests(loader.discover(start_dir=os.path.join(selftests_dir, section),
                                        top_level_dir=basedir))
     return suite

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 import os
+import sys
 import glob
 
 # pylint: disable=E0611
@@ -20,7 +21,7 @@ from setuptools import setup
 
 VERSION = open('VERSION', 'r').read().strip()
 
-VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
+VIRTUAL_ENV = hasattr(sys, 'real_prefix')
 
 
 def get_dir(system_path=None, virtual_path=None):
@@ -57,10 +58,7 @@ def get_data_files():
     data_files = [(get_dir(['etc', 'avocado', 'conf.d']),
                    ['etc/avocado/conf.d/vt.conf'])]
 
-    data_files += [(get_dir(['usr', 'share', 'avocado-plugins-vt',
-                             'test-providers.d']),
-                    glob.glob('test-providers.d/*'))]
-
+    data_files += add_files(["test-providers.d"])
     data_files_dirs = ['backends', 'shared']
 
     for data_file_dir in data_files_dirs:

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -11,21 +11,19 @@ import stat
 
 from avocado.core import data_dir
 
-_SYSTEM_WIDE_ROOT_PATH = '/usr/share/avocado-plugins-vt'
-if os.path.isdir(_SYSTEM_WIDE_ROOT_PATH):
-    _INSTALLED_SYSTEM_WIDE = len(os.listdir(os.path.join(_SYSTEM_WIDE_ROOT_PATH,
-                                                         'shared'))) > 0
+if hasattr(sys, 'real_prefix'):
+    # unlike default execution venv prefix does not contain /usr
+    _DEFAULT_SHARED_PATH = os.path.join(sys.prefix, "shared")
 else:
-    _INSTALLED_SYSTEM_WIDE = False
+    _DEFAULT_SHARED_PATH = os.path.join(sys.prefix, "share",
+                                        "avocado-plugins-vt",
+                                        "shared")
 
-if _INSTALLED_SYSTEM_WIDE:
-    # avocado-vt is installed
-    _ROOT_PATH = _SYSTEM_WIDE_ROOT_PATH
+if (os.path.isdir(_DEFAULT_SHARED_PATH) and
+        len(os.listdir(_DEFAULT_SHARED_PATH)) > 0):
+    _ROOT_PATH = os.path.dirname(_DEFAULT_SHARED_PATH)
 else:
-    # we're running from source code directories
-    virttest_init = sys.modules['virttest'].__file__
-    virttest_dir = os.path.realpath(os.path.dirname(virttest_init))
-    _ROOT_PATH = os.path.dirname(virttest_dir)
+    _ROOT_PATH = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
 ROOT_DIR = os.path.abspath(_ROOT_PATH)
 BASE_BACKEND_DIR = os.path.join(ROOT_DIR, 'backends')


### PR DESCRIPTION
The intention of this PR is to start functional testing of Avocado, but that requires deploying it in Travis which unveiled some issues with venv support:

```
$ virtualenv -p python venv
$ source venv/bin/activate
$ pip install avocado-framework aexpect netifaces simplejson netaddr
$ cd /home/medic/Work/Projekty/avocado/avocado-vt
$ make install
$ avocado vt-bootstrap
Failed to load plugin from module "avocado_vt.plugins.vt_list": ImportError('No module named autotest.client.shared',)
Failed to load plugin from module "avocado_vt.plugins.vt": ImportError('No module named autotest.client.shared',)
Failed to load plugin from module "avocado.plugins.yaml_to_mux": NameError("name 'Loader' is not defined",)
Running bootstrap for qemu

1 - Checking the mandatory programs and headers
/bin/xz OK
/sbin/tcpdump OK
/bin/nc OK
/sbin/ip OK
/sbin/arping OK
/bin/gcc OK
/usr/include/graphviz/types.h OK
/usr/include/linux/socket.h OK
/usr/include/linux/unistd.h OK
/usr/include/python3.5m/Python.h OK

2 - Checking the recommended programs
/bin/qemu-kvm OK
/bin/qemu-img OK
/bin/qemu-io OK

3 - Updating all test providers
Avocado crashed:
Traceback (most recent call last):
  File "/tmp/venv/bin/avocado", line 86, in <module>
    sys.exit(app.run())
  File "/tmp/venv/lib/python2.7/site-packages/avocado/core/app.py", line 90, in run
    return method(self.parser.args)
  File "/home/medic/Work/Projekty/avocado/avocado-vt/avocado_vt/plugins/vt_bootstrap.py", line 112, in run
    bootstrap.bootstrap(options=args, interactive=True)
  File "/home/medic/Work/Projekty/avocado/avocado-vt/virttest/bootstrap.py", line 789, in bootstrap
    dir_util.copy_tree(tp_base_dir, tp_local_dir)
  File "/usr/lib64/python2.7/distutils/dir_util.py", line 128, in copy_tree
    "cannot copy tree '%s': not a directory" % src
DistutilsFileError: cannot copy tree '/tmp/venv/test-providers.d': not a directory

Avocado crashed unexpectedly: cannot copy tree '/tmp/venv/test-providers.d': not a directory
You can find details in /tmp/venv/data/crashes/avocado-traceback-2017-05-06_09:30:01-Y8Z1TH.log
```

Basically the problem is that `test-providers.d` were not created directly in root as other files (eg. `shared`) but vt-bootstrap assumes them to be on the same location.

Anyway the functional test is a very basic test which reports several statuses and expects them to match.