### PR TITLE
Bootstrap: generate host os configuration [v3]

### DIFF
--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -72,6 +72,27 @@ class VTBootstrap(CLICmd):
                             default=False, help=("All interactive "
                                                  "questions will be "
                                                  "answered with yes (y)"))
+        parser.add_argument("--vt-host-distro-name", action="store",
+                            metavar="HOST_DISTRO_NAME",
+                            help=("The name of the distro to be used when "
+                                  "generating the host configuration entry"))
+        parser.add_argument("--vt-host-distro-version", action="store",
+                            metavar="HOST_DISTRO_VERSION",
+                            help=("The version of the distro to be used when "
+                                  "generating the host configuration entry"))
+        parser.add_argument("--vt-host-distro-release", action="store",
+                            metavar="HOST_DISTRO_RELEASE",
+                            help=("The release of the distro to be used when "
+                                  "generating the host configuration entry."))
+        parser.add_argument("--vt-host-distro-arch", action="store",
+                            metavar="HOST_DISTRO_ARCH",
+                            help=("The architecture of the distro to be used when "
+                                  "generating the host configuration entry."))
+        parser.add_argument("--vt-host-distro-compat",
+                            action="store_true", default=False,
+                            help=("Whether to generate host distro "
+                                  "configuration suitable for use with current"
+                                  " test provider configuration"))
 
     def run(self, args):
         args.vt_config = None

--- a/backends/libvirt/cfg/tests-shared.cfg
+++ b/backends/libvirt/cfg/tests-shared.cfg
@@ -12,6 +12,7 @@ connect_uri = default
 # Include the base config files.
 include base.cfg
 include subtests.cfg
+include host-os.cfg
 include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg

--- a/backends/qemu/cfg/tests-shared.cfg
+++ b/backends/qemu/cfg/tests-shared.cfg
@@ -12,6 +12,7 @@ connect_uri = default
 # Include the base config files.
 include base.cfg
 include subtests.cfg
+include host-os.cfg
 include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg


### PR DESCRIPTION
This introduces the generation of another file doing bootstrap time,
host-os.cfg.

This file contains the name, version and release of the host OS.  That
information comes, by default, from the Avocado distro detection, but
can be overriden by command line arguments.

This should allow for some tests in some providers, such as tp-qemu,
to properly enable or disable tests that should be available only
for some distros.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v2 (#1009):
 * Include `Host_arch_` prefix when compatibility mode is used
 * Dropped the `compat` parameter on utility functions

Changes from v1 (#1007):

 * Moved `host-os.cfg` to right after `subtests.cfg` (affects the full name of the variants, but it's cosmetic only).
 * Improved docstrings
 * Added distro architecture to the host OS variants definition
 * Dropped the `host_kernel_ver_str` variable

---

Some information on how to test this.  Before using this code, bootstrap avocado-vt in the usual way with the tp-qemu provider. 

Now, check for the list of `pxe_boot` tests:

```
$ avocado list pxe_boot
VT io-github-autotest-qemu.pxe_boot.default
VT io-github-autotest-qemu.pxe_boot.with_query_cpus
```

Now checkout this code, and run the vt-bootstrap again, this time setting the host config compatibility mode (and if you're not running RHEL 7, also set the distro name and version):

```
avocado vt-bootstrap --vt-host-distro-compat --vt-host-distro-name RHEL --vt-host-distro-version 7
```

Now list the `pxe_boot` tests available:

```
$ avocado list pxe_boot
VT io-github-autotest-qemu.pxe_boot.default
VT io-github-autotest-qemu.pxe_boot.ipxe
VT io-github-autotest-qemu.pxe_boot.with_query_cpus
```

Notice that the `ipxe` variant, which is configured in `tp-qemu` to only be available on RHEL 7, now shows up.
