### PR TITLE
VT JobLock: avoid iterating the test suite when one doesn't exist

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -124,9 +124,10 @@ class VTJobLock(Pre, Post):
 
     def pre_tests(self, job):
         try:
-            if any(test_factory[0] is VirtTest
-                   for test_factory in job.test_suite):
-                self._lock(job)
+            if job.test_suite is not None:
+                if any(test_factory[0] is VirtTest
+                       for test_factory in job.test_suite):
+                    self._lock(job)
         except Exception as detail:
             msg = "Failure trying to set Avocado-VT job lock: %s" % detail
             self.log.error(msg)


### PR DESCRIPTION
When the plugin "pre" phase is called, but the job has not created
a test suite, trying to iterate it will cause a failure such as:

   Failure trying to set Avocado-VT job lock: 'NoneType' object is not iterable
   Reproduced traceback from:
           /usr/lib/python2.7/site-packages/avocado_vt/plugins/vt_joblock.py:125
   TypeError: 'NoneType' object is not iterable

It's actually safe to skip the lock if there are no tests in the suite
(and thus no VT test).

This bug was actually revealed by the dispatcher calling the "JobPre",
but the fix is approapriate to any situation.

Signed-off-by: Cleber Rosa <crosa@redhat.com>