### PR TITLE
etc: Change default disk drive

### DIFF
--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -41,7 +41,7 @@ image_type = qcow2
 nic_model = virtio_net
 # Guest disk bus for main image. One of
 # ('ide', 'scsi', 'virtio_blk', 'virtio_scsi', 'lsi_scsi', 'ahci', 'usb2', 'xenblk')
-disk_bus = virtio_blk
+disk_bus = virtio_scsi
 # Enable qemu sandboxing (on/off)
 sandbox = on
 # Prevent qemu from loading sysconfdir/qemu.conf and sysconfdir/target-ARCH.conf at startup


### PR DESCRIPTION
Currently the default disk drive is `virtio_blk`, which used to be the
best option, but for quite a long while `virtio_scsi` is recommended as
more standardized way. Let's change our default to by default utilize
what's recommended.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>