### PR TITLE
vm_xml: get_agent_channel tracesback if channel device not available

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1038,15 +1038,18 @@ class VMXML(VMXMLBase):
         """
         Get all qemu guest agent channels
         """
-        channels = self.xmltreefile.findall("./devices/channel")
         ga_channels = []
-        for channel in channels:
-            target = channel.find('./target')
-            if target is not None:
-                name = target.get('name')
-                if name and name.startswith("org.qemu.guest_agent"):
-                    ga_channels.append(channel)
-        return ga_channels
+        try:
+            channels = self.xmltreefile.findall("./devices/channel")
+            for channel in channels:
+                target = channel.find('./target')
+                if target is not None:
+                    name = target.get('name')
+                    if name and name.startswith("org.qemu.guest_agent"):
+                        ga_channels.append(channel)
+            return ga_channels
+        except xcepts.LibvirtXMLError:
+            return ga_channels
 
     def set_agent_channel(self, src_path=None,
                           tgt_name='org.qemu.guest_agent.0',


### PR DESCRIPTION
Handle LibvirtXMLError if device is not available in guest xml

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>