### PR TITLE
Enable readonly attribute when attaching rbd disk with snapshot

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2375,6 +2375,7 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
                            'source_config_file': disk_src_config}
         if disk_snap_name:
             disk_params_src.update({'source_snap_name': disk_snap_name})
+            disk_params.update({'readonly': params.get("read_only", "no")})
     else:
         # use current source file with update params
         disk_params_src = {'source_file': blk_source}


### PR DESCRIPTION
since readonly attribute need be set explicitly

Signed-off-by: chunfuwen <chwen@redhat.com>