### PR TITLE
 bootstrap: Remove the --vt-host-distro-compat option

### DIFF
--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -88,11 +88,6 @@ class VTBootstrap(CLICmd):
                             metavar="HOST_DISTRO_ARCH",
                             help=("The architecture of the distro to be used when "
                                   "generating the host configuration entry."))
-        parser.add_argument("--vt-host-distro-compat",
-                            action="store_true", default=False,
-                            help=("Whether to generate host distro "
-                                  "configuration suitable for use with current"
-                                  " test provider configuration"))
 
     def run(self, args):
         args.vt_config = None


### PR DESCRIPTION
The --vt-host-distro-compat option was introduced to start fresh and
provide clean host configuration. There is one issue with that and that
is that cartesian_config does not behave correctly when clashes occur
and in the fresh version they are likely to happen. Let's keep what has
been working for years downstream and that is:

 * Host OS is prefixed with "Host_"
 * Major version is prefixed with "m"
 * Minor version is prefixed with "u"
 * Architecture is prefixed with "Host_arch_"

This should minimize the possible clashes as Fedora.25.0.x86_64 becomes
Host_fedora.m25.u0.Host_arch_x86_64.

Possible clashes are usually recognizable by multiple/no produced
variants. Without this fix one easy clash is to use:

    avocado run boot --vt-guest-os RHEL.7.devel --dry-run
    ...
     (1/4) io-github-autotest-qemu.boot: CANCEL (0.00 s)
     (2/4) io-github-autotest-qemu.boot: CANCEL (0.00 s)
     (3/4) io-github-autotest-qemu.boot: CANCEL (0.00 s)
     (4/4) io-github-autotest-qemu.boot: CANCEL (0.00 s)

where the "only x86_64" intended for guest architecture is consumed by
host architecture and avocado-vt then tries to run the boot test on all
architectures supported by the guest os (RHEL.7).

With this patch the command above works properly as the host
architecture is "Host_arch_x86_64".

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>