### PR TITLE
Config from `/etc/avocado/*` should not overwrite cartesian by default

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -75,8 +75,7 @@ class VirtTestOptionsProcess(object):
             'vt.common', 'type_specific_only', key_type=bool,
             default=False)
         self.options.vt_mem = settings.get_value(
-            'vt.common', 'mem', key_type=int,
-            default=1024)
+            'vt.common', 'mem', key_type=int, default=None)
         self.options.vt_nettype = settings.get_value(
             'vt.common', 'nettype', default=None)
         self.options.vt_netdst = settings.get_value(
@@ -390,7 +389,9 @@ class VirtTestOptionsProcess(object):
 
     def _process_mem(self):
         if not self.options.vt_config:
-            self.cartesian_parser.assign("mem", self.options.vt_mem)
+            mem = self.options.vt_mem
+            if mem is not None:
+                self.cartesian_parser.assign("mem", mem)
 
     def _process_tcpdump(self):
         """

--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -12,7 +12,10 @@ data_dir =
 # Enable only type specific tests. Shared tests will not be tested
 type_specific_only = False
 # RAM dedicated to the main VM
-mem = 1024
+# Usually defaults to 1024, as set in "base.cfg", but can be a different
+# value depending on the various other configuration files such as
+# configuration files under "guest-os" and test provider specific files
+mem =
 # Architecture under test
 arch =
 # Machine type under test

--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -5,6 +5,7 @@ backup_image_before_test = True
 restore_image_after_test = True
 # Keep guest running between tests (faster, but unsafe)
 keep_guest_running=False
+
 [vt.common]
 # Data dir path. If none specified, the default virt-test data dir will be used
 data_dir =
@@ -20,6 +21,7 @@ machine_type =
 nettype =
 # Bridge name to be used if you select bridge as a nettype
 netdst = virbr0
+
 [vt.qemu]
 # Path to a custom qemu binary to be tested
 qemu_bin =
@@ -50,9 +52,11 @@ defconfig = yes
 # Use MALLOC_PERTURB_ env variable set to 1 to help catch memory allocation problems on qemu
 # (yes/no)
 malloc_perturb = yes
+
 [vt.libvirt]
 # Test connect URI for libvirt (qemu:///system', 'lxc:///')
 connect_uri = qemu:///session
+
 [vt.debug]
 # Don't clean up tmp files or VM processes at the end of a virt-test execution
 no_cleanup = False


### PR DESCRIPTION
The current handling of configuration values from `/etc/avocado/*` overwrite whatever is set in the cartesian configuration by default.  Let's change that behavior, so that, by default, no value is set and nothing is overriden.  If users set the value in the Avocado config file, than it will overwrite whatever is set in the cartesian config.