### PR TITLE
Bootstrap improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ script:
     - export PATH="/tmp/dummy_bin:$PATH"
     # Setup Avocado-vt for functional tests
     - make install
-    - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --yes-to-all
+    - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
     # Run tests
     - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ script:
     - export PATH="/tmp/dummy_bin:$PATH"
     # Setup Avocado-vt for functional tests
     - make install
-    - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-no-downloads --yes-to-all
+    - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --yes-to-all
     # Run tests
     - make check

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -56,6 +56,11 @@ class VTBootstrap(CLICmd):
         parser.add_argument("--vt-no-downloads", action="store_true",
                             default=False,
                             help="Do not attempt any download")
+        parser.add_argument("--vt-skip-verify-download-assets",
+                            action='store_true', default=False,
+                            help=("Skip the bootstrap phase that verifies "
+                                  "and possibly downloads assets files "
+                                  "(usually a JeOS image)"))
         parser.add_argument("--vt-update-config", action="store_true",
                             default=False, help=("Forces configuration "
                                                  "updates (all manual "

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -90,9 +90,6 @@ class VTBootstrap(CLICmd):
                                   "generating the host configuration entry."))
 
     def run(self, args):
-        args.vt_config = None
-        args.vt_keep_image = False
-
         # Enable root logger as some Avocado-vt libraries use that
         handler = logging.StreamHandler()
         handler.setLevel(logging.DEBUG)

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -55,7 +55,7 @@ class VTBootstrap(CLICmd):
                             help="Define default contexts of directory.")
         parser.add_argument("--vt-no-downloads", action="store_true",
                             default=False,
-                            help="Do not attempt to download JeOS images")
+                            help="Do not attempt any download")
         parser.add_argument("--vt-update-config", action="store_true",
                             default=False, help=("Forces configuration "
                                                  "updates (all manual "

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -91,33 +91,7 @@ class VTBootstrap(CLICmd):
 
     def run(self, args):
         args.vt_config = None
-        args.vt_verbose = True
-        args.vt_log_level = 'debug'
-        args.vt_console_level = 'debug'
-        args.vt_arch = None
-        args.vt_machine_type = None
         args.vt_keep_image = False
-        args.vt_keep_guest_running = False
-        args.vt_keep_image_between_tests = False
-        args.vt_mem = 1024
-        args.vt_no_filter = ''
-        args.vt_qemu_bin = None
-        args.vt_dst_qemu_bin = None
-        args.vt_nettype = 'user'
-        args.vt_only_type_specific = False
-        args.vt_tests = ''
-        args.vt_connect_uri = 'qemu:///system'
-        args.vt_accel = 'kvm'
-        args.vt_monitor = 'human'
-        args.vt_smp = 1
-        args.vt_image_type = 'qcow2'
-        args.vt_nic_model = 'virtio_net'
-        args.vt_disk_bus = 'virtio_blk'
-        args.vt_vhost = 'off'
-        args.vt_malloc_perturb = 'yes'
-        args.vt_qemu_sandbox = 'on'
-        args.show_job_log = False
-        args.test_lister = True
 
         # Enable root logger as some Avocado-vt libraries use that
         handler = logging.StreamHandler()

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -333,6 +333,19 @@ def download_test_provider(provider, update=False):
             os.chdir(original_dir)
 
 
+def test_providers_not_downloaded():
+    """
+    Return the list of test providers that have not being downloaded
+    """
+    result = []
+    for provider in get_test_provider_names():
+        download_dst = data_dir.get_test_provider_dir(provider)
+        repo_downloaded = os.path.isdir(os.path.join(download_dst, '.git'))
+        if not repo_downloaded:
+            result.append(provider)
+    return result
+
+
 def download_all_test_providers(update=False):
     """
     Download all available test providers.

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -904,11 +904,7 @@ def bootstrap(options, interactive=False):
         create_guest_os_cfg(options.vt_type)
     create_host_os_cfg(options)
 
-    if not options.vt_config:
-        restore_image = not (options.vt_no_downloads or options.vt_keep_image)
-    else:
-        restore_image = False
-
+    restore_image = not options.vt_no_downloads
     if restore_image:
         LOG.info("")
         step += 1

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -918,8 +918,7 @@ def bootstrap(options, interactive=False):
         create_guest_os_cfg(options.vt_type)
     create_host_os_cfg(options)
 
-    restore_image = not options.vt_no_downloads
-    if restore_image:
+    if not (options.vt_no_downloads or options.vt_skip_verify_download_assets):
         LOG.info("")
         step += 1
         LOG.info("%s - Verifying (and possibly downloading) guest image",
@@ -929,7 +928,7 @@ def bootstrap(options, interactive=False):
                 os_asset = os_info['asset']
                 try:
                     asset.download_asset(os_asset, interactive=interactive,
-                                         restore_image=restore_image)
+                                         restore_image=True)
                 except AssertionError:
                     pass    # Not all files are managed via asset
 

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -840,13 +840,25 @@ def bootstrap(options, interactive=False):
 
     LOG.info("")
     step += 1
-    LOG.info("%d - Updating all test providers", step)
-    # First update the test-providers-ini from base to data dir
+    LOG.info("%d - Updating test providers repo configuration from local copy", step)
     tp_base_dir = data_dir.get_base_test_providers_dir()
     tp_local_dir = data_dir.get_test_providers_dir()
     dir_util.copy_tree(tp_base_dir, tp_local_dir)
-    # Now try to download/update the providers (if necessary)
-    asset.download_all_test_providers(options.vt_update_providers)
+
+    not_downloaded = asset.test_providers_not_downloaded()
+    if not_downloaded:
+        action = "Downloading"
+    else:
+        action = "Updating"
+    if not options.vt_no_downloads:
+        LOG.info("")
+        step += 1
+        LOG.info("%d - %s the test providers from remote repos", step, action)
+        asset.download_all_test_providers(options.vt_update_providers)
+    else:
+        if not_downloaded:
+            LOG.warn("The following test providers have not been downloaded: %s",
+                     ", ".join(not_downloaded))
 
     LOG.info("")
     step += 1

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -941,8 +941,8 @@ def bootstrap(options, interactive=False):
             else:
                 LOG.debug("Module %s loaded", module)
 
-    online_docs_url = 'http://avocado-vt.readthedocs.org/'
     LOG.info("")
-    step += 1
-    LOG.info("%d - If you wish, you may take a look at the online docs for "
-             "more info: %s", step, online_docs_url)
+    LOG.info("VT-BOOTSTRAP FINISHED")
+    LOG.debug("You may take a look at the following online docs for more info:")
+    LOG.debug(" - http://avocado-vt.readthedocs.org/")
+    LOG.debug(" - http://avocado-framework.readthedocs.org/")

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -865,7 +865,9 @@ def bootstrap(options, interactive=False):
 
     base_backend_dir = data_dir.get_base_backend_dir()
     local_backend_dir = data_dir.get_local_backend_dir()
-    LOG.info("Syncing backend dirs %s -> %s", base_backend_dir,
+    LOG.info("")
+    step += 1
+    LOG.info("%d - Syncing backend dirs %s -> %s", step, base_backend_dir,
              local_backend_dir)
     dir_util.copy_tree(base_backend_dir, local_backend_dir)
 


### PR DESCRIPTION
This is a collection of (hopeful) improvements to the bootstrap process.

Included are:
 * cleanups to options processing
 * reorganization of some phases
 * one change in behavior: `--vt-no-downloads` won't attempt *any* downloads (including test providers)
 * a new option `-vt-skip-verify-download-assets` will skip the phase about downloads asset files (usually JeOS images)