### PR TITLE
Bootstrap: allow extra repos with guest OS configurations

### DIFF
--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -68,6 +68,13 @@ class VTBootstrap(CLICmd):
                                                  "will be lost). "
                                                  "Requires --vt-type "
                                                  "to be set"))
+        parser.add_argument("--vt-extra-guest-os",
+                            action="append", metavar="PATH", default=[],
+                            help=("Adds extra guest OS configuration from "
+                                  "external repos.  PATH is location to a "
+                                  "guest-os directory, with the same directory"
+                                  " structure as the one provided by "
+                                  "Avocado-VT.  Can be given multiple times."))
         parser.add_argument("--vt-update-providers", action="store_true",
                             default=False, help=("Forces test "
                                                  "providers to be "


### PR DESCRIPTION
Besides the configuration that ships with Avocado-VT itself, there may
be extra guest OS configuration that needs to be merged into the
resulting `guest-os.cfg` during bootstrap time.

This adds supports for that, by means of a `--vt-extra-guest-os`
command line option.

Signed-off-by: Cleber Rosa <crosa@redhat.com>