### PR TITLE
avocado-plugins-vt.spec: replace aexpect with python-aexpect

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -7,7 +7,7 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 51.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -15,7 +15,7 @@ Source0: https://github.com/avocado-framework/%{modulename}/archive/%{commit}/%{
 BuildRequires: python2-devel, python-setuptools
 BuildArch: noarch
 Requires: avocado >= 36.4
-Requires: python, autotest-framework, xz, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, aexpect, git, python-netaddr, python-netifaces, python-simplejson
+Requires: python, autotest-framework, xz, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, python-aexpect, git, python-netaddr, python-netifaces, python-simplejson
 
 Requires: python-imaging
 %if 0%{?el6}
@@ -53,6 +53,9 @@ Xunit output, among others.
 
 
 %changelog
+* Wed Jun 14 2017 Cleber Rosa <cleber@redhat.com> - 51.0-1
+- Replace aexpect dependency with python-aexpect
+
 * Mon Jun 12 2017 Cleber Rosa <cleber@redhat.com> - 51.0-0
 - New upstream release
 


### PR DESCRIPTION
python-aexpect files are already present on EPEL7 and Fedora.  Also,
the previous requirement was now causing conflicts with the
installation of python-aexpect from Avocado's own repo.

Signed-off-by: Cleber Rosa <crosa@redhat.com>