### PR TITLE
Fixup: error verification in host dmesg

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1188,8 +1188,12 @@ def postprocess(test, params, env):
         raise virt_vm.VMError("Failures occurred while postprocess:%s" % err)
     if params.get("verify_host_dmesg", "yes") == "yes":
         dmesg_log_file = params.get("host_dmesg_logfile", "host_dmesg.log")
+        level = params.get("host_dmesg_level", 3)
+        ignore_result = params.get("host_dmesg_ignore", "no") == "yes"
         dmesg_log_file = utils_misc.get_path(test.debugdir, dmesg_log_file)
-        utils_misc.verify_host_dmesg(dmesg_log_file=dmesg_log_file)
+        utils_misc.verify_host_dmesg(dmesg_log_file=dmesg_log_file,
+                                     ignore_result=ignore_result,
+                                     level_check=level)
 
 
 def postprocess_on_error(test, params, env):


### PR DESCRIPTION
Added host_dmesg_level, host_dmesg_ignore params
which would help testers to define the log level needs
to be asserted and whether test need to fail if messages
present in given log level, by default it fails the tests
for log level 3(emerg,alert,crit)

Supported Log level:
1 - emerg
2 - emerg,alert
3 - emerg,alert,crit
4 - emerg,alert,crit,err
5 - emerg,alert,crit,err,warn

Config usage:
verify_host_dmesg = yes(by default)
host_dmesg_level = 3(by default)
host_dmesg_ignore = False(by default)

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>