### PR TITLE
Bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ script:
     - export PATH="/tmp/dummy_bin:$PATH"
     # Setup Avocado-vt for functional tests
     - make install
-    - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
+    - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-skip-assets --yes-to-all
     # Run tests
     - make check

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -55,12 +55,13 @@ class VTBootstrap(CLICmd):
                             help="Define default contexts of directory.")
         parser.add_argument("--vt-no-downloads", action="store_true",
                             default=False,
-                            help="Do not attempt any download")
-        parser.add_argument("--vt-skip-verify-download-assets",
-                            action='store_true', default=False,
-                            help=("Skip the bootstrap phase that verifies "
-                                  "and possibly downloads assets files "
-                                  "(usually a JeOS image)"))
+                            help="[obsoleted] Do not attempt to check/"
+                            "download asset files (JeOS)")
+        parser.add_argument("--vt-skip-assets", action="store_true",
+                            dest="vt_no_downloads", help="Skip processing"
+                            " asset files (download/check JeOS)")
+        parser.add_argument("--vt-skip-providers", action="store_true",
+                            help="Skip downloading/updating test providers.")
         parser.add_argument("--vt-update-config", action="store_true",
                             default=False, help=("Forces configuration "
                                                  "updates (all manual "

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -850,6 +850,7 @@ def bootstrap(options, interactive=False):
         action = "Downloading"
     else:
         action = "Updating"
+
     if not options.vt_skip_providers:
         LOG.info("")
         step += 1
@@ -955,7 +956,6 @@ def bootstrap(options, interactive=False):
                 LOG.debug("Module %s loaded", module)
 
     LOG.info("")
-    LOG.info("VT-BOOTSTRAP FINISHED")
-    LOG.debug("You may take a look at the following online docs for more info:")
-    LOG.debug(" - http://avocado-vt.readthedocs.org/")
-    LOG.debug(" - http://avocado-framework.readthedocs.org/")
+    LOG.info("vt-bootstrap finished")
+    LOG.debug("You may take a look at the following online docs for more "
+              "info: http://avocado-vt.readthedocs.org/")

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -850,7 +850,7 @@ def bootstrap(options, interactive=False):
         action = "Downloading"
     else:
         action = "Updating"
-    if not options.vt_no_downloads:
+    if not options.vt_skip_providers:
         LOG.info("")
         step += 1
         LOG.info("%d - %s the test providers from remote repos", step, action)
@@ -918,7 +918,7 @@ def bootstrap(options, interactive=False):
         create_guest_os_cfg(options.vt_type)
     create_host_os_cfg(options)
 
-    if not (options.vt_no_downloads or options.vt_skip_verify_download_assets):
+    if not options.vt_no_downloads:
         LOG.info("")
         step += 1
         LOG.info("%s - Verifying (and possibly downloading) guest image",


### PR DESCRIPTION
This is a reaction to https://github.com/avocado-framework/avocado-vt/pull/1029 it removes the newly introduced option, reverts the `--vt-no-downloads` behavior and adds 2 new options to allow similar handling. Last it decreases the ad banner at the vt-bootstrap end.