### PR TITLE
Clearing the targetcli configuration

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -347,6 +347,9 @@ class _IscsiComm(object):
             restart_iscsid()
         if self.export_flag:
             self.delete_target()
+        cmd = "targetcli clearconfig confirm=true"
+        if process.system(cmd, shell=True) != 0:
+            logging.error("targetcli configuration unable to clear")
 
 
 class IscsiTGT(_IscsiComm):


### PR DESCRIPTION
while running regression running test case clear the iscsi devices, but still i found the configuration issues for next test case, so i clear the targetcli configuration. so i added the code.
Signed-off-by: prudhvi <mprudhvi@linux.vnet.ibm.com>