### PR TITLE
utils_test: fix a typo in update_boot_option() to succeed grubby --remove-args

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -97,8 +97,8 @@ def update_boot_option(vm, args_removed=None, args_added=None,
     msg = "Update guest kernel option. "
     cmd = "grubby --update-kernel=`grubby --default-kernel` "
     if args_removed is not None:
-        msg += " remove args: %s." % args_removed
-        cmd += '--remove-args="%s." ' % args_removed
+        msg += " remove args: %s" % args_removed
+        cmd += '--remove-args="%s" ' % args_removed
     if args_added is not None:
         msg += " add args: %s" % args_added
         cmd += '--args="%s"' % args_added


### PR DESCRIPTION
typo fix to succeed grubby --remove-args

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>