### PR TITLE
Respect empty parameters for Spice protocol

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2069,7 +2069,9 @@ class VM(virt_vm.BaseVM):
 
                 for skey in spice_keys:
                     value = params.get(skey, None)
-                    if value:
+                    if value is not None:
+                        # parameter can be defined as empty string in Cartesian
+                        # config.  Example: spice_password =
                         self.spice_options[skey] = value
 
                 cmd += add_spice()


### PR DESCRIPTION
    Cartesian config can have empty parameters:

        param =

    There are a few test-cases where Spice params are initialized to
    empty value. In batch test runs such parameters are skipped. This
    commit fix this.

    Note. Avocado-VT uses the same VM objects in batch tests. Which is a
    part of cause of such behaviour. More info:

    https://www.redhat.com/archives/avocado-devel/2017-February/msg00000.html

Signed-off-by: Andrei Stepanov <astepano@redhat.com>