### PR TITLE
guest-os: replace live_snapshot.with_installation with with_installat…

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -6,7 +6,7 @@
     block_hotplug:
         modprobe_module = acpiphp
         no block_scsi
-    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, live_snapshot.with_installation:
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         kernel_params = "ks=cdrom"
         # The below config breaks RHEL6 x86, so it's commented out until we figure out a decent
         # solution that works across the board.

--- a/shared/cfg/guest-os/Linux/RHEL/7.2.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2.cfg
@@ -2,7 +2,7 @@
     no setup
     image_name = images/rhel72
     os_variant = rhel7
-    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, live_snapshot.with_installation:
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/7.2/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2/x86_64.cfg
@@ -2,11 +2,11 @@
     grub_file = /boot/grub2/grub.cfg
     vm_arch_name = x86_64
     image_name += -64
-    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, live_snapshot.with_installation:
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         cdrom_unattended = images/rhel72-64/ks.iso
         kernel = images/rhel72-64/vmlinuz
         initrd = images/rhel72-64/initrd.img
-    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install, live_snapshot.with_installation:
+    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         cdrom_cd1 = isos/linux/RHEL7.2-Server-x86_64.iso
         md5sum_cd1 = 51e013512f489203a923a716b408fbdf
         md5sum_1m_cd1 = fae5710b17bb03f1de8e1f8b44df51c7

--- a/shared/cfg/guest-os/Linux/RHEL/7.3.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3.cfg
@@ -2,7 +2,7 @@
     no setup
     image_name = images/rhel73
     os_variant = rhel7
-    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, live_snapshot.with_installation:
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
     nic_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/x86_64.cfg
@@ -2,11 +2,11 @@
     grub_file = /boot/grub2/grub.cfg
     vm_arch_name = x86_64
     image_name += -64
-    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, live_snapshot.with_installation:
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         cdrom_unattended = images/rhel73-64/ks.iso
         kernel = images/rhel73-64/vmlinuz
         initrd = images/rhel73-64/initrd.img
-    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install, live_snapshot.with_installation:
+    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         cdrom_cd1 = isos/linux/RHEL7.3-Server-x86_64.iso
         md5sum_cd1 = 34a65dbdfb8d9bb19b3a03d278df2a99
         md5sum_1m_cd1 = 723133b2618219539ff2e27a2b868832

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -45,7 +45,7 @@
     cdrom_check_cdrom_pattern = "\d\s+(\w).*CD-ROM"
     cdrom_test_cmd = "dir %s:\"
     cdrom_info_cmd = "wmic cdrom list full"
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
         timeout = 7200
         finish_program = deps/finish/finish.bat
         # process need to check after post install

--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -2,7 +2,7 @@
     maxmem = 3G
     vm_arch_name = i686
     image_name += -32
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
         unattended_file = unattended/win10-32-autounattend.xml
         cdrom_cd1 = isos/windows/en_windows_10_enterprise_x86_dvd_6851156.iso
         md5sum_cd1 = 68162933e551e55779504dacdfb0c5ae

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -4,7 +4,7 @@
     vm_arch_name = x86_64
     install:
         passwd = 1q2w3eP
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
         cdrom_cd1 = isos/windows/en_windows_10_enterprise_x64_dvd_6851151.iso
         md5sum_cd1 = a67722adfaf209c72eacb3ab910ee65e
         md5sum_1m_cd1 = 0e246b56b7b63f0526c3367eb160ff7d

--- a/shared/cfg/guest-os/Windows/Win2008/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/i386.cfg
@@ -20,7 +20,7 @@
                 steps = steps/Win2008-32.steps
             setup:
                 steps = steps/Win2008-32-rss.steps
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/Windows2008-x86.iso
                 md5sum_cd1 = 0bfca49f0164de0a8eba236ced47007d
                 md5sum_1m_cd1 = 07d7f5006393f74dc76e6e2e943e2440
@@ -37,7 +37,7 @@
                     cdrom_unattended = "images/win2008-sp1-32/autounattend.iso"
         - sp2:
             image_name += -sp2-32
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/en_windows_server_2008_datacenter_enterprise_standard_sp2_x86_dvd_342333.iso
                 md5sum_cd1 = b9201aeb6eef04a3c573d036a8780bdf
                 md5sum_1m_cd1 = b7a9d42e55ea1e85105a3a6ad4da8e04

--- a/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
@@ -25,7 +25,7 @@
                 passwd = 1q2w3eP
             setup:
                 steps = steps/Win2008-64-rss.steps
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/Windows2008-x64.iso
                 md5sum_cd1 = 27c58cdb3d620f28c36333a5552f271c
                 md5sum_1m_cd1 = efdcc11d485a1ef9afa739cb8e0ca766
@@ -43,7 +43,7 @@
 
         - sp2:
             image_name += -sp2-64
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/en_windows_server_2008_datacenter_enterprise_standard_sp2_x64_dvd_342336.iso
                 md5sum_cd1 = e94943ef484035b3288d8db69599a6b5
                 md5sum_1m_cd1 = ee55506823d0efffb5532ddd88a8e47b
@@ -64,7 +64,7 @@
         - r2:
             maxmem = 32G
             image_name += -r2-64
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/en_windows_server_2008_r2_standard_enterprise_datacenter_and_web_x64_dvd_x15-59754.iso
                 md5sum_cd1 = 0207ef392c60efdda92071b0559ca0f9
                 md5sum_1m_cd1 = a5a22ce25008bd7109f6d830d627e3ed

--- a/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
@@ -30,7 +30,7 @@
         - @r1:
         - r2:
             image_name += r2
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
                 cdrom_cd1 = isos/windows/en_windows_server_2012_r2_x64_dvd_2707946.iso
                 md5sum_cd1 = 0e7c09aab20dec3cd7eab236dab90e78
                 md5sum_1m_cd1 = fab118cfa7f66d3606c38dc1330a769e

--- a/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
@@ -4,7 +4,7 @@
     image_name += -64
     install:
         passwd = 1q2w3eP
-    unattended_install.cdrom, whql.support_vm_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+    unattended_install.cdrom, whql.support_vm_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
         cdrom_cd1 = isos/ISO/Win2016/en_windows_server_2016_x64_dvd_9327751.iso
         md5sum_cd1 = 91d7b2ebcff099b3557570af7a8a5cd6
         md5sum_1m_cd1 = 5f297f2178a618c166d1116475ed6368

--- a/shared/cfg/guest-os/Windows/Win7/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/i386.cfg
@@ -2,7 +2,7 @@
     maxmem = 3G
     vm_arch_name = i686
     image_name += -32
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
         cdrom_cd1 = isos/windows/en_windows_7_ultimate_x86_dvd_x15-65921.iso
         md5sum_cd1 = d0b8b407e8a3d4b75ee9c10147266b89
         md5sum_1m_cd1 = 2b0c2c22b1ae95065db08686bf83af93
@@ -38,7 +38,7 @@
         - sp0:
         - sp1:
             image_name += -sp1
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/en_windows_7_ultimate_n_with_sp1_x86_dvd_u_677597.iso
                 md5sum_cd1 = 8d9c55270d91a25663517dbef9968c80
                 md5sum_1m_cd1 = 65b2d563769a07982a4fb0c26eaed910

--- a/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
@@ -12,7 +12,7 @@
         steps = steps/Win7-64-rss.steps
     sysprep:
         unattended_file = unattended/win7-64-autounattend.xml
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
         cdrom_cd1 = isos/windows/en_windows_7_ultimate_x64_dvd_x15-65922.iso
         md5sum_cd1 = f43d22e4fb07bf617d573acd8785c028
         md5sum_1m_cd1 = b44d8cf99dbed2a5cb02765db8dfd48f
@@ -50,7 +50,7 @@
         - sp0:
         - sp1:
             image_name += -sp1
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/en_windows_7_ultimate_with_sp1_x64_dvd_u_677332.iso
                 md5sum_cd1 = c9f7ecb768acb82daacf5030e14b271e
                 md5sum_1m_cd1 = 0b45ee07fc26d8cbc7d08daed9be1a22

--- a/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -2,7 +2,7 @@
     maxmem = 3G
     vm_arch_name = i686
     image_name += -32
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
         cdrom_cd1 = isos/windows/en_windows_8_enterprise_x86_dvd_917587.iso
         md5sum_cd1 = ad055cae50cef987586c51cc6cc3c62e
         md5sum_1m_cd1 = 92e5522e0ceff8c703d5fdca620c841f
@@ -37,7 +37,7 @@
         - @0:
         - 1:
             image_name += .1
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
                 cdrom_cd1 = isos/windows/en_windows_8_1_enterprise_x86_dvd_2972289.iso
                 md5sum_cd1 = bf620a67b5dda1e18e9ce17d25711201
                 md5sum_1m_cd1 = 0dddab9c979407e871c007424c7f75a3

--- a/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
@@ -10,7 +10,7 @@
         steps = steps/Win8-64.steps
     setup:
         steps = steps/Win8-64-rss.steps
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
         cdrom_cd1 = isos/windows/en_windows_8_enterprise_x64_dvd_917522.iso
         md5sum_cd1 = 27aa354b8088527ffcd32007b51b25bf
         md5sum_1m_cd1 = 06f8883a669f55f27e98938e71e90d67
@@ -45,7 +45,7 @@
         - @0:
         - 1:
             image_name += .1
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, live_snapshot.with_installation, check_block_size.4096_512, check_block_size.512_512:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
                 cdrom_cd1 = isos/windows/en_windows_8_1_enterprise_x64_dvd_2971902.iso
                 md5sum_cd1 = 8e194185fcce4ea737f274ee9005ddf0
                 md5sum_1m_cd1 = ec868109e725742b83363908405d21f3


### PR DESCRIPTION
To make it a common configuration for all test cases that need to test other qemu function during installation.

Signed-off-by: Qianqian Zhu <qizhu@redhat.com>