### PR TITLE
Fix params sequence of secret_set_value

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -3607,7 +3607,7 @@ def secret_get_value(uuid, options=None, **dargs):
     return command(cmd, **dargs)
 
 
-def secret_set_value(uuid, password, encode=False, options=None, **dargs):
+def secret_set_value(uuid, password, options=None, encode=False, **dargs):
     """
     Set a secret value
 


### PR DESCRIPTION
Some existing cases will use virsh.secret_set_value() as follow:
 result = virsh.secret_set_value(uuid, secret_string, options, debug=True)
So avocado-vt PR#1036 will cause case failure because an new param 'encode'
inserted before 'options'.

Sign-offed by: Yi Sun(yisun@redhat.com)