### PR TITLE
error_context: assigning ctx.contexts with index if it is empty errors

### DIFF
--- a/virttest/error_context.py
+++ b/virttest/error_context.py
@@ -74,7 +74,10 @@ def context(s="", log=None):
     :param log: A logging function to pass the context message to.  If None, no
             function will be called.
     """
-    ctx.contexts[-1] = s
+    if ctx.contexts:
+        ctx.contexts[-1] = s
+    else:
+        ctx.contexts.append(s)
     if s and log:
         log("Context: %s" % get_context())
 


### PR DESCRIPTION
Handle list ctx.contexts to assign with index if the list is not empty and append instead
if it is empty.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>