### PR TITLE
test_setup: request_devs() function doesn't have error_context decorator

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1543,6 +1543,7 @@ class PciAssignable(object):
                         return False
             return True
 
+    @error_context.context_aware
     def request_devs(self, devices=None):
         """
         Implement setup process: unbind the PCI device and then bind it


### PR DESCRIPTION
request_devs() function doesn't have error_context decorator which causes
traceback in error_context as "IndexError: list assignment index out of range"

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>