### PR TITLE
Add sg3_utils package to RHEL-7-devel.ks file

### DIFF
--- a/shared/unattended/RHEL-7-devel.ks
+++ b/shared/unattended/RHEL-7-devel.ks
@@ -55,6 +55,7 @@ SDL
 totem
 dmidecode
 alsa-utils
+sg3_utils
 -gnome-initial-setup
 %end
 


### PR DESCRIPTION
Adding the sg3_utils package installs the sginfo command which is required by
the type_specific.io-github-autotest-qemu.physical_resources_check test for
RHEL guests