### PR TITLE
virttest.qemu_vm: Add windows guest max memory limit.

### DIFF
--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -1,5 +1,4 @@
 - i386:
-    maxmem = 3G
     vm_arch_name = i686
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
@@ -37,3 +36,5 @@
         uninstall_balloon_service = "%s:\Balloon\w10\x86\blnsvr.exe -u"
         status_balloon_service = "%s:\Balloon\w10\x86\blnsvr.exe status"
         run_balloon_service = "%s:\Balloon\w10\x86\blnsvr.exe -r"
+    balloon_check, balloon_stop_continue, balloon_stress, balloon_hotplug, balloon_in_use, balloon_service, balloon_illegal, balloon_boot_in_pause, systemtap_tracing.balloon_event, driver_load_stress.with_balloon, win_virtio_driver_update_test.with_balloon:
+        vm_mem_limit = 3G

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -1,5 +1,4 @@
 - x86_64:
-    maxmem = 2T
     image_name += -64
     vm_arch_name = x86_64
     install:

--- a/shared/cfg/guest-os/Windows/Win2003/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win2003/i386.cfg
@@ -1,5 +1,4 @@
 - i386:
-    maxmem = 4G
     vm_arch_name = i686
     image_name += -32
     install:

--- a/shared/cfg/guest-os/Windows/Win2003/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2003/x86_64.cfg
@@ -1,5 +1,4 @@
 - x86_64:
-    maxmem = 32G
     image_name += -64
     vm_arch_name = x86_64
     install:

--- a/shared/cfg/guest-os/Windows/Win2008/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/i386.cfg
@@ -1,5 +1,4 @@
 - i386:
-    maxmem = 4G
     vm_arch_name = i686
     sysprep:
         unattended_file = unattended/win2008-32-autounattend.xml

--- a/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
@@ -1,5 +1,4 @@
 - x86_64:
-    maxmem = 32G
     vm_arch_name = x86_64
     sysprep:
         unattended_file = unattended/win2008-64-autounattend.xml
@@ -62,7 +61,6 @@
                     cdrom_unattended = "images/win2008-sp2-64/autounattend.iso"
 
         - r2:
-            maxmem = 32G
             image_name += -r2-64
             unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/en_windows_server_2008_r2_standard_enterprise_datacenter_and_web_x64_dvd_x15-59754.iso

--- a/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
@@ -1,5 +1,4 @@
 - x86_64:
-    maxmem = 2T
     vm_arch_name = x86_64
     image_name += -64
     install:

--- a/shared/cfg/guest-os/Windows/Win7/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/i386.cfg
@@ -1,5 +1,4 @@
 - i386:
-    maxmem = 3G
     vm_arch_name = i686
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
@@ -34,6 +33,8 @@
         uninstall_balloon_service = "%s:\Balloon\w7\x86\blnsvr.exe -u"
         status_balloon_service = "%s:\Balloon\w7\x86\blnsvr.exe status"
         run_balloon_service = "%s:\Balloon\w7\x86\blnsvr.exe -r"
+    balloon_check, balloon_stop_continue, balloon_stress, balloon_hotplug, balloon_in_use, balloon_service, balloon_illegal, balloon_boot_in_pause, systemtap_tracing.balloon_event, driver_load_stress.with_balloon, win_virtio_driver_update_test.with_balloon:
+        vm_mem_limit = 3G
     variants:
         - sp0:
         - sp1:

--- a/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
@@ -1,5 +1,4 @@
 - x86_64:
-    maxmem = 192G
     image_name += -64
     vm_arch_name = x86_64
     install:

--- a/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -1,5 +1,4 @@
 - i386:
-    maxmem = 3G
     vm_arch_name = i686
     image_name += -32
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size.4096_512, check_block_size.512_512:
@@ -33,6 +32,8 @@
         uninstall_balloon_service = "%s:\Balloon\w8\x86\blnsvr.exe -u"
         status_balloon_service = "%s:\Balloon\w8\x86\blnsvr.exe status"
         run_balloon_service = "%s:\Balloon\w8\x86\blnsvr.exe -r"
+    balloon_check, balloon_stop_continue, balloon_stress, balloon_hotplug, balloon_in_use, balloon_service, balloon_illegal, balloon_boot_in_pause, systemtap_tracing.balloon_event, driver_load_stress.with_balloon, win_virtio_driver_update_test.with_balloon:
+        vm_mem_limit = 3G
     variants:
         - @0:
         - 1:

--- a/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
@@ -1,5 +1,4 @@
 - x86_64:
-    maxmem = 512G
     image_name += -64
     vm_arch_name = x86_64
     install:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -894,7 +894,7 @@ class VM(virt_vm.BaseVM):
 
         def add_memorys(devices, params):
             """
-            Add memory controler by params
+            Add memory controller by params
 
             :param devices: VM devices container
             """
@@ -903,10 +903,19 @@ class VM(virt_vm.BaseVM):
             mem_params = params.object_params("mem")
             mem_params.setdefault("automem", "no")
             automem = mem_params["automem"] == "yes"
+
+            normalize_data_size = utils_misc.normalize_data_size
+            mem_size_m = "%sM" % mem_params["mem"]
+            mem_size_m = float(normalize_data_size(mem_size_m))
+            if mem_params.get("vm_mem_limit"):
+                max_mem_size_m = params.get("vm_mem_limit")
+                max_mem_size_m = float(normalize_data_size(max_mem_size_m))
+                if mem_size_m >= max_mem_size_m:
+                    logging.debug("Guest max memory is limited to %s"
+                                  % max_mem_size_m)
+                    mem_size_m = max_mem_size_m
+                    params["mem"] = str(int(max_mem_size_m))
             if automem:
-                normalize_data_size = utils_misc.normalize_data_size
-                mem_size_m = "%sM" % mem_params["mem"]
-                mem_size_m = float(normalize_data_size(mem_size_m))
                 usable_mem_m = utils_misc.get_usable_memory_size(align=1024)
                 if mem_size_m >= usable_mem_m:
                     logging.debug("Host no enough free memory, reset guest"


### PR DESCRIPTION
There are max memory limit for windows 32bit guests,
the memory can not be recognized which out of the limit.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1442987