### PR TITLE
Add sg3_utils package to Fedora and RHEL kickstart files

### DIFF
--- a/shared/unattended/Fedora-10.ks
+++ b/shared/unattended/Fedora-10.ks
@@ -21,6 +21,7 @@ poweroff
 @development-libs
 @development-tools
 ntpdate
+sg3_utils
 
 %post
 function ECHO { for TTY in ttyS0 hvc0; do echo "$*" > /dev/$TTY; done }

--- a/shared/unattended/Fedora-11.ks
+++ b/shared/unattended/Fedora-11.ks
@@ -21,6 +21,7 @@ autopart
 @development-libs
 @development-tools
 ntpdate
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-12.ks
+++ b/shared/unattended/Fedora-12.ks
@@ -21,6 +21,7 @@ autopart
 @development-libs
 @development-tools
 ntpdate
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-13.ks
+++ b/shared/unattended/Fedora-13.ks
@@ -21,6 +21,7 @@ autopart
 @development-libs
 @development-tools
 ntpdate
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-14.ks
+++ b/shared/unattended/Fedora-14.ks
@@ -22,6 +22,7 @@ autopart
 @development-tools
 ntpdate
 dmidecode
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-15.ks
+++ b/shared/unattended/Fedora-15.ks
@@ -23,6 +23,7 @@ autopart
 @development-tools
 ntpdate
 dmidecode
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-16.ks
+++ b/shared/unattended/Fedora-16.ks
@@ -21,6 +21,7 @@ autopart
 @base
 @development-libs
 @development-tools
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-17.ks
+++ b/shared/unattended/Fedora-17.ks
@@ -22,6 +22,7 @@ autopart
 @development-libs
 @development-tools
 dmidecode
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-18.ks
+++ b/shared/unattended/Fedora-18.ks
@@ -22,6 +22,7 @@ autopart
 @development-libs
 @development-tools
 dmidecode
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-19.ks
+++ b/shared/unattended/Fedora-19.ks
@@ -21,6 +21,7 @@ autopart
 @standard
 @development-tools
 dmidecode
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-20.ks
+++ b/shared/unattended/Fedora-20.ks
@@ -20,6 +20,7 @@ autopart
 %packages
 @standard
 @development-tools
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-21.ks
+++ b/shared/unattended/Fedora-21.ks
@@ -21,6 +21,7 @@ autopart
 %packages
 @standard
 @development-tools
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-22.ks
+++ b/shared/unattended/Fedora-22.ks
@@ -20,6 +20,7 @@ autopart
 
 %packages
 @standard
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-23.ks
+++ b/shared/unattended/Fedora-23.ks
@@ -21,6 +21,7 @@ autopart
 %packages
 @standard
 python
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-25.ks
+++ b/shared/unattended/Fedora-25.ks
@@ -22,6 +22,7 @@ autopart
 @c-development
 @development-tools
 python
+sg3_utils
 %end
 
 %post

--- a/shared/unattended/Fedora-8.ks
+++ b/shared/unattended/Fedora-8.ks
@@ -21,6 +21,7 @@ autopart
 @development-libs
 @development-tools
 ntpdate
+sg3_utils
 
 %post
 function ECHO { for TTY in ttyS0 hvc0; do echo "$*" > /dev/$TTY; done }

--- a/shared/unattended/Fedora-9.ks
+++ b/shared/unattended/Fedora-9.ks
@@ -21,6 +21,7 @@ autopart
 @development-libs
 @development-tools
 ntpdate
+sg3_utils
 
 %post
 function ECHO { for TTY in ttyS0 hvc0; do echo "$*" > /dev/$TTY; done }

--- a/shared/unattended/RHEL-3-series.ks
+++ b/shared/unattended/RHEL-3-series.ks
@@ -25,6 +25,7 @@ patch
 make
 nc
 ntp
+sg3_utils
 redhat-lsb
 
 %post

--- a/shared/unattended/RHEL-4-series.ks
+++ b/shared/unattended/RHEL-4-series.ks
@@ -26,6 +26,7 @@ patch
 make
 nc
 ntp
+sg3_utils
 redhat-lsb
 
 %post

--- a/shared/unattended/RHEL-6-spice.ks
+++ b/shared/unattended/RHEL-6-spice.ks
@@ -49,6 +49,7 @@ spice-vdagent
 usbredir
 SDL
 totem
+sg3_utils
 %end
 
 %post


### PR DESCRIPTION
Adding the sg3_utils package installs the sginfo command which is required by
the type_specific.io-github-autotest-qemu.physical_resources_check test for
RHEL guests

This is a follow-up commit to https://github.com/avocado-framework/avocado-vt/pull/1055

After discussing with @clebergnu on Friday, he suggested that we update all Fedora and RHEL kickstart files so users can expect a consistent experience when running Avocado-VT with these guests.

@luckyh Could you kindly review and merge ?

Thanks.