### PR TITLE
RPM: also satisfy avocado requirement with EPEL package

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -7,14 +7,14 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 51.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
 Source0: https://github.com/avocado-framework/%{modulename}/archive/%{commit}/%{modulename}-%{version}-%{shortcommit}.tar.gz
 BuildRequires: python2-devel, python-setuptools
 BuildArch: noarch
-Requires: avocado >= 36.4
+Requires: python-avocado >= 51.0
 Requires: python, autotest-framework, xz, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, python-aexpect, git, python-netaddr, python-netifaces, python-simplejson
 
 Requires: python-imaging
@@ -53,6 +53,9 @@ Xunit output, among others.
 
 
 %changelog
+* Mon Jul 10 2017 Cleber Rosa <cleber@redhat.com> - 51.0-2
+- Satisfy avocado requirement with EPEL package
+
 * Wed Jun 14 2017 Cleber Rosa <cleber@redhat.com> - 51.0-1
 - Replace aexpect dependency with python-aexpect
 


### PR DESCRIPTION
With the introduction of python-avocado packages on EPEL 7, the
general installation workflow of Avocado + Avocado-VT broke.  The
reason is that for the installation of Avocado itself from Avocado's
own repo, EPEL is necessary.  Then, given that 51.0 is the latest
major release on both Avocado's repo and EPEL, the package from EPEL
gets installed.

When comes the time to install avocado-plugins-vt, the requirement for
"avocado >= 36.4" can not be satisfied, because it's only present in
Avocado's version of the "python-avocado" RPM.

If RPM supported boolean operators on all versions that we need, we
could do a:

  Requires: (avocado >= 36.4 or python-avocado >= xx.y)

But unfortunately that is only present in RPM >= 4.13.  The solution
proposed here is to switch the package name that is required.  The
consequence is that new packages will *not* work with Avocado's 36.x
LTS series.  I think this is a minor issue now that LTS 52.x is out
and should be favored instead anyway.

If EPEL and Avocado's repo are enable, this is the resulting
installation (package name / version / repo):

avocado-plugins-vt.noarch   51.0-2.el7.centos      avocado
python2-avocado             51.0-1.el7             epel

If Avocado's LTS repo is enabled, this would be the resulting
installation:

avocado-plugins-vt.noarch   51.0-2.el7.centos      avocado
python-avocado.noarch       52.0-1.el7.centos      avocado-lts

This will of course change when new versions get pushed to those
repos.  I have the feeling the right thing to do is to separate the
Avocado and Avocado-VT's repo in the near future to allow for more
precise and straightforward selection versions.

Signed-off-by: Cleber Rosa <crosa@redhat.com>