### PR TITLE
virttest.utils_misc: fix support machine type parsing for RHEL ARM

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2034,7 +2034,7 @@ def get_support_machine_type(qemu_binary="/usr/libexec/qemu-kvm"):
     """
     o = process.system_output("%s -M ?" % qemu_binary)
     s = re.findall("(\S*)\s*RHEL[-\s]", o)
-    c = re.findall("(RHEL.*PC)", o)
+    c = re.findall("(RHEL.*)", o)
     return (s, c)
 
 


### PR DESCRIPTION
A sample of ARM machines supported by RHEL is listed below. Apparently
the ARM machine type description is not ended with "PC", which is x86
specific. So get_support_machine_type() parsing returns a incorrect
result. This patch fixes the regular expression by removing "PC", to
make it work on ARM platform.

  * virt-rhel7.4.0       RHEL 7.4.0 ARM Virtual Machine (default)
  * virt-rhel7.3.0       RHEL 7.3.0 ARM Virtual Machine
  * none                 empty machine

Signed-off-by: Wei Huang <wei@redhat.com>