### PR TITLE
Fix HMP parsing of 'info block' on QEMU >= 1.5

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -503,7 +503,7 @@ class Monitor:
                 continue
             if not line.startswith(' '):   # new block device
                 line = line.split(':', 1)
-                name = line[0].strip()
+                name = line[0].split(' ', 1)[0]  # disregard extra info such as #(blockNNN)
                 line = line[1][1:]
                 blocks[name] = {}
                 if line == "[not inserted]":


### PR DESCRIPTION
'info block- can generate output such as:

drive_image1 (#block188): /path/to/image.qcow2 (qcow2)
    Cache mode:       writeback

When parsing those lines, the device name was including the extra
information (' (#block188)' in this example), which makes matches
against the information present on qtree fail.

This doesn't happen when a QMP monitor is used, though, so it only
affects tests running with HMP and with QEMU >= 1.5.0.

Signed-off-by: Cleber Rosa <crosa@redhat.com>