### PR TITLE
Windows.cfg: Add "rtc_base=2006-6-17" to test "-rtc base=2006-6-17"

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -138,6 +138,8 @@
             time_command = "echo TIME: %date% %time%"
             time_filter_re = "(?<=TIME: \w\w\w ).{19}(?=\.\d\d)"
             time_format = "%m/%d/%Y %H:%M:%S"
+    timedrift..base_date, timerdevice..base_date:
+        rtc_base = 2006-06-17
     time_manage:
         alive_test_cmd = systeminfo
         time_command = "echo TIME: %date% %time%"


### PR DESCRIPTION
In Windows.cfg, "-rtc base=localtime" is default for windows guest.

In order to test "-rtc base=2006-6-17", add "rtc_base=2006-6-17" for
case "timedrift.with_pvclock.shared_ntp_date.ntp.with_stop.base_date".

id: 1468138, 1468139

Signed-off-by: Huiqing Ding <huding@redhat.com>