### PR TITLE
Increase memory assigned to guest when installing using URL

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64.cfg
@@ -15,3 +15,6 @@
         cdrom_cd1 = isos/linux/RHEL-7.2-Server-ppc64.iso
         md5sum_cd1 = d4e597629de04a848c124d3589472372
         md5sum_1m_cd1 = 8c3e5a70edb328f58887c99fc4c4654b
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64le.cfg
@@ -15,3 +15,6 @@
         cdrom_cd1 = isos/linux/RHEL-7.2-Server-ppc64le.iso
         md5sum_cd1 = 7fd0c4d9a034463bcdfdbc69cff3a69d
         md5sum_1m_cd1 = ad122d234b83bf34c55e7df405bd8f22
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.2/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2/x86_64.cfg
@@ -13,3 +13,6 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel72-64/ks.vfd
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/aarch64.cfg
@@ -11,3 +11,6 @@
         cdrom_cd1 = isos/linux/RHEL-7.3-Server-aarch64.iso
         md5sum_cd1 = 341e225661ff926c22e04bac2edc6c18
         md5sum_1m_cd1 = c3c4dd7857a0b42ba8c86af8047c6480
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64.cfg
@@ -15,3 +15,6 @@
         cdrom_cd1 = isos/linux/RHEL-7.3-Server-ppc64.iso
         md5sum_cd1 = 0b295c908491ebf6644082d809e0d63e
         md5sum_1m_cd1 = e11b57d9b3e8e531b82f3936d256d4b6
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64le.cfg
@@ -15,3 +15,6 @@
         cdrom_cd1 = isos/linux/RHEL-7.3-Server-ppc64le.iso
         md5sum_cd1 = c0542bb27a3d8d87cf04f9f96955f545
         md5sum_1m_cd1 = 650e9b36fcdda852aaf01259d4996183
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/x86_64.cfg
@@ -13,3 +13,6 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel73-64/ks.vfd
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096   

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/aarch64.cfg
@@ -9,3 +9,6 @@
         initrd = images/rhel7-aarch64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         cdrom_cd1 = isos/linux/RHEL-7-devel-aarch64.iso
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64.cfg
@@ -16,3 +16,6 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel7-ppc64/ks.vfd
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/ppc64le.cfg
@@ -16,3 +16,6 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel7-ppc64le/ks.vfd
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/x86_64.cfg
@@ -11,3 +11,6 @@
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel7-64/ks.vfd
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096


### PR DESCRIPTION
Setting memory parameter to 4096 for RHEL 7.2, 7.3 and 7.devel guests
when running unattended_install.url test as installing RHEL over http
fails with memory set to 1024.