### PR TITLE
libvirt_vm: Enablement to boot guest with Numa nodes pinned with Hugepage

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -148,6 +148,26 @@ mem = 1024
 # Pattern for check memory size inside guest
 mem_chk_re_str = ([0-9]+)
 
+# To configure guest backed by hugepages, set it to "yes"
+# hugepage = "no"
+
+# To have guest numa nodes backed by hugepages, but numa = "yes" and hugepage =
+# "yes" is pre-requisite
+# hugepage_pin = "no"
+
+# specific guest numa node number can be configured to be backed by hugepage,
+# numa = "yes" and hugepage = "yes" is pre-requisite
+# hugepage_pinned_numa = "0"
+
+# Instructs hypervisor to disable shared pages (memory merge, KSM) for
+# this domain, hugepage = "yes" is pre-requisite
+# hp_nosharepages = "no"
+
+# memory pages belonging to the domain will be locked in host's memory
+# and the host will not be allowed to swap them out, hugepage = "yes" is
+# pre-requisite
+# hp_locked = "no"
+
 # Host networking restart command line for PCI assign cases
 # net_restart_cmd = /etc/init.d/network restart
 


### PR DESCRIPTION
This patch enables option to pin hugepage to back Numa using virt-install
and start the guest, unattended_install can be used to boot guest with Numa
pinned with hugepage by setting param "hugepage_pin = "yes" in cfg. But for
using this option guest should have Numa nodes(numa = "yes") and backed
by hugepage(hugepage = "yes")

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>