### PR TITLE
Added guest dmesg verification during postprocess

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -901,6 +901,10 @@ def postprocess(test, params, env):
     """
     error_context.context("postprocessing")
     err = ""
+    if params.get("verify_guest_dmesg", "yes") == "yes" and params.get("start_vm", "no") == "yes":
+        guest_dmesg_log_file = params.get("guest_dmesg_logfile", "guest_dmesg.log")
+        guest_dmesg_log_file = utils_misc.get_path(test.debugdir, guest_dmesg_log_file)
+        virt_vm.verify_dmesg(dmesg_log_file=guest_dmesg_log_file)
 
     # Postprocess all VMs and images
     try:


### PR DESCRIPTION
Added guest dmesg verification during postprocess

Config usage:
    verify_guest_dmesg = yes(by default)
    guest_dmesg_level = 3(by default)
    guest_dmesg_ignore = False(by default)

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>