### PR TITLE
libvirt_vm: Enablement to pin guest numa with host numa

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -143,6 +143,23 @@ smp = 1
 #vcpu_threads = 1
 #vcpu_sockets = 1
 
+# configure guest numa nodes, it can be set to "yes"
+# numa = "no"
+
+# configure number of numa nodes in guest but numa = "yes" is pre-requisite
+# numa_nodes = 2
+
+# To have guest numa pinned with host numa but numa = "yes" is pre-requisite
+# numa_pin = "no"
+
+# numa memory mode is either 'interleave', 'strict', or 'preferred',
+# defaults to 'strict', numa = "yes" and numa_pin = "yes" is pre-requisite
+# numa_pin_mode = "strict"
+
+# To pin the guest numa with specific host numa, host numa node number
+# can be configured, numa = "yes" and numa_pin = "yes" is pre-requisite
+# pin_to_host_numa_node = 1
+
 # Memory for each VM
 mem = 1024
 # Pattern for check memory size inside guest


### PR DESCRIPTION
This patch will enable virt-install to pin guest numa with host numa
using unattended_install if param numa_pin = "yes" is set, it also have
a pre-requisite to have guest numa enabled by setting numa = "yes". The
patch checks if host numa nodes are available online to pin.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>