### PR TITLE
Added support for additional args for virt-install

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -515,6 +515,10 @@ install_virtio = no
 # Default value, overridden by other cfgs
 cmds_installed_host = ""
 
+# Additional user defined commandline args for virt-install commandline
+# Default is empty, can be modified and used it in install/import test configs
+virtinstall_extra_args = ""
+
 # Add the parameter decide if setup host env in the test case in a loop
 # For some special tests we only setup host in the first and last case as
 # SRIOV related tests. The meaning of this flag is as following:

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1100,6 +1100,10 @@ class VM(virt_vm.BaseVM):
                                              sec_label=sec_label,
                                              sec_relabel=sec_relabel)
 
+        virtinstall_extra_args = params.get("virtinstall_extra_args", "")
+        if virtinstall_extra_args:
+            virt_install_cmd += " %s" % virtinstall_extra_args
+
         return virt_install_cmd
 
     def get_serial_console_filename(self, name):


### PR DESCRIPTION
Added support for user defined additional args to
virt-install command line, will be usefull for new
features to test till proper method to add
commandline and flexible negative cases.

Usage:
define additional commadline args(string) in this
param "virtinstall_extra_args"

E:g:- virtinstall_extra_args = "--controller type=usb,model=nec-xhci"

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>