### PR TITLE
virt_vm: fix migration timeout limit

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -502,7 +502,7 @@ class BaseVM(object):
     LOGIN_TIMEOUT = 10
     LOGIN_WAIT_TIMEOUT = 240
     COPY_FILES_TIMEOUT = 600
-    MIGRATE_TIMEOUT = 3600
+    MIGRATE_TIMEOUT = 2000
     REBOOT_TIMEOUT = 240
 
     def __init__(self, name, params):


### PR DESCRIPTION
Upstream qemu recently changed the migration max downtime from 3600 to
2000 (see qemu commit 87c9cc1c). This caused an error if test script
calls save_to_file() defined in qemu_vm.py because MIGRATE_TIMEOUT is
passed to self.monitor.migrate_set_downtime(). The error reads
"Parameter 'downtime_limit' expects an integer in the range of 0 to
2000 seconds".

This patch addresses the problem by changing the downtime limit to 2000.

Signed-off-by: Wei Huang <wei@redhat.com>