### PR TITLE
Increase memory assigned to guest when installing using URL v2

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/7.0.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0.cfg
@@ -5,6 +5,9 @@
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096
     nic_hotplug:
         modprobe_module =
     block_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/7.1.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.1.cfg
@@ -5,6 +5,9 @@
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096
     nic_hotplug:
         modprobe_module =
     block_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/7.2.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2.cfg
@@ -5,6 +5,9 @@
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096
     nic_hotplug:
         modprobe_module =
     block_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/7.3.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3.cfg
@@ -5,6 +5,9 @@
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096
     nic_hotplug:
         modprobe_module =
     block_hotplug:

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel.cfg
@@ -5,6 +5,9 @@
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
         unattended_file = unattended/RHEL-7-devel.ks
         syslog_server_proto = udp
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 4096
     nic_hotplug:
         modprobe_module =
     block_hotplug:


### PR DESCRIPTION
Setting memory parameter to 4096 for RHEL 7.0, 7.1, 7.2, 7.3 and 7.devel
guests when running unattended_install.url test as installing RHEL over
http fails with memory set to 1024.