### PR TITLE
nfs: Cleanup new created export dir

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -152,7 +152,8 @@ class Nfs(object):
         self.mount_src = params.get("nfs_mount_src")
         self.nfs_setup = False
         path.find_command("mount")
-        self.mk_mount_dir = False
+        self.rm_mount_dir = False
+        self.rm_export_dir = False
         self.unexportfs_in_clean = False
         distro_details = distro.detect()
 
@@ -211,6 +212,7 @@ class Nfs(object):
 
             if not os.path.isdir(self.export_dir):
                 os.makedirs(self.export_dir)
+                self.rm_export_dir = True
             self.exportfs.export()
             self.unexportfs_in_clean = not self.exportfs.already_exported
 
@@ -222,7 +224,7 @@ class Nfs(object):
 
         if not os.path.isdir(self.mount_dir):
             os.makedirs(self.mount_dir)
-            self.mk_mount_dir = True
+            self.rm_mount_dir = True
         self.mount()
 
     def cleanup(self):
@@ -235,7 +237,9 @@ class Nfs(object):
         self.umount()
         if self.nfs_setup and self.unexportfs_in_clean:
             self.exportfs.reset_export()
-        if self.mk_mount_dir and os.path.isdir(self.mount_dir):
+            if self.rm_export_dir and os.path.isdir(self.export_dir):
+                utils_misc.safe_rmdir(self.export_dir)
+        if self.rm_mount_dir and os.path.isdir(self.mount_dir):
             utils_misc.safe_rmdir(self.mount_dir)
 
 

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -478,6 +478,8 @@ def setup_or_cleanup_nfs(is_setup, mount_dir="nfs-mount", is_mount=False,
         if restore_selinux:
             utils_selinux.set_status(restore_selinux)
         _nfs.unexportfs_in_clean = True
+        _nfs.rm_mount_dir = True
+        _nfs.rm_export_dir = True
         _nfs.cleanup()
     return result
 


### PR DESCRIPTION
Add option to support clean up new created dir in nfs module.
Enable cleanup both new created export and mount dir in libvirt
nfs setup and clean function.

Signed-off-by: Wayne Sun <gsun@redhat.com>