### PR TITLE
Change the disk Offline status check format

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2791,7 +2791,8 @@ def format_windows_disk(session, did, mountpoint=None, size=None,
             logging.debug("Detail for 'Disk%s'" % did)
             details = session.cmd_output(detail_cmd)
 
-            if re.search("Status.*Offline", details, re.I | re.M):
+            pattern = "DISK %s.*Offline" % did
+            if re.search(pattern, details, re.I | re.M):
                 online_cmd = 'echo online disk>> disk'
                 online_cmd = ' '.join([cmd_header, online_cmd, cmd_footer])
                 logging.info("Online 'Disk%s'" % did)


### PR DESCRIPTION
Due to different disk return format on win2008-32/64 and others,
change the disk status(Offline)re.search format.

id: 1472063

Signed-off-by: peixiu <phou@redhat.com>