### PR TITLE
libvirt_vm: Fixup virt-install takes conflicting memory unit with --memory and --cpu

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -842,7 +842,9 @@ class VM(virt_vm.BaseVM):
             # Number of numa nodes required can be set in param
             numa_nodes = int(params.get("numa_nodes", 2))
             numa_vcpus = int(smp)
-            numa_memory = int(mem)
+            # virt-install takes --memory in MiB but --cpu cell adds numa
+            # memory in KiB by default
+            numa_memory = int(mem) * 1024
             if vcpu_max_cpus:
                 numa_vcpus = int(vcpu_max_cpus)
             if maxmemory:


### PR DESCRIPTION
virt-install takes MiB as default memory unit for --memory option and
in KiB as default memory unit for --cpu option while adding numa nodes.
Due to this behavior virt-install boots guest with memory value in --memory
but with KiB due to libvirt issue.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>