### PR TITLE
guest-hw.cfg:change rng backend to /dev/urandom

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -346,7 +346,7 @@ variants:
              - rng_random:
                  backend_rng0 = rng-random
                  backend_type = passthrough
-                 filename_passthrough = /dev/random
+                 filename_passthrough = /dev/urandom
              - rng_egd:
                  backend_rng0 = rng-egd
                  backend_type = chardev


### PR DESCRIPTION
guest-hw.cfg:change rng backend to /dev/urandom 

RNG backend /dev/random has bad performance,especially generate random
numbers continuously.So change backend to /dev/urandom.

Signed-off-by: lijin <lijin@redhat.com>

ID:1477573