### PR TITLE
virttest.utils_test.__init__.py: correct a typo

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1235,7 +1235,7 @@ def get_loss_ratio(output):
     try:
         return int(re.findall('(\d+)%.*loss', output)[0])
     except IndexError:
-        loggging.warn("Invaild output of ping command: %s" % output)
+        logging.warn("Invaild output of ping command: %s" % output)
     return -1
 
 


### PR DESCRIPTION
ID: 1477485
Correct a typo.
Signed-off-by: Zhengtong <zhengtli@redhat.com>