### PR TITLE
Add net-tools package to Fedora and RHEL kickstart files

### DIFF
--- a/shared/unattended/Fedora-16.ks
+++ b/shared/unattended/Fedora-16.ks
@@ -22,6 +22,7 @@ autopart
 @development-libs
 @development-tools
 sg3_utils
+net-tools
 %end
 
 %post

--- a/shared/unattended/Fedora-17.ks
+++ b/shared/unattended/Fedora-17.ks
@@ -22,6 +22,7 @@ autopart
 @development-libs
 @development-tools
 dmidecode
+net-tools
 sg3_utils
 %end
 

--- a/shared/unattended/Fedora-18.ks
+++ b/shared/unattended/Fedora-18.ks
@@ -22,6 +22,7 @@ autopart
 @development-libs
 @development-tools
 dmidecode
+net-tools
 sg3_utils
 %end
 

--- a/shared/unattended/Fedora-19.ks
+++ b/shared/unattended/Fedora-19.ks
@@ -21,6 +21,7 @@ autopart
 @standard
 @development-tools
 dmidecode
+net-tools
 sg3_utils
 %end
 

--- a/shared/unattended/Fedora-20.ks
+++ b/shared/unattended/Fedora-20.ks
@@ -21,6 +21,7 @@ autopart
 @standard
 @development-tools
 sg3_utils
+net-tools
 %end
 
 %post

--- a/shared/unattended/Fedora-21.ks
+++ b/shared/unattended/Fedora-21.ks
@@ -22,6 +22,7 @@ autopart
 @standard
 @development-tools
 sg3_utils
+net-tools
 %end
 
 %post

--- a/shared/unattended/Fedora-22.ks
+++ b/shared/unattended/Fedora-22.ks
@@ -20,6 +20,7 @@ autopart
 
 %packages
 @standard
+net-tools
 sg3_utils
 %end
 

--- a/shared/unattended/Fedora-23.ks
+++ b/shared/unattended/Fedora-23.ks
@@ -21,6 +21,7 @@ autopart
 %packages
 @standard
 python
+net-tools
 sg3_utils
 %end
 

--- a/shared/unattended/Fedora-25.ks
+++ b/shared/unattended/Fedora-25.ks
@@ -22,6 +22,7 @@ autopart
 @c-development
 @development-tools
 python
+net-tools
 sg3_utils
 %end
 

--- a/shared/unattended/RHEL-6-series.ks
+++ b/shared/unattended/RHEL-6-series.ks
@@ -43,6 +43,7 @@ patch
 make
 git
 nc
+net-tools
 NetworkManager
 ntpdate
 redhat-lsb

--- a/shared/unattended/RHEL-6-spice.ks
+++ b/shared/unattended/RHEL-6-spice.ks
@@ -33,6 +33,7 @@ KVM_TEST_LOGGING
 gnome-utils
 python-imaging
 python-six
+net-tools
 NetworkManager
 ntpdate
 watchdog

--- a/shared/unattended/RHEL-6.3.ks
+++ b/shared/unattended/RHEL-6.3.ks
@@ -32,6 +32,7 @@ KVM_TEST_LOGGING
 @Smart Card Support
 NetworkManager
 ntpdate
+net-tools
 watchdog
 coreutils
 usbutils

--- a/shared/unattended/RHEL-7-devel.ks
+++ b/shared/unattended/RHEL-7-devel.ks
@@ -33,6 +33,7 @@ gnome-utils
 python-imaging
 python-six
 pyparsing
+net-tools
 NetworkManager
 ntpdate
 dconf

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -33,6 +33,7 @@ patch
 make
 git
 nc
+net-tools
 NetworkManager
 ntpdate
 redhat-lsb


### PR DESCRIPTION
Adding the net-tools package installs the ifconfig command which is required by the io-github-autotest-qemu.jumbo test for Fedora and RHEL hosts.