### PR TITLE
Set nettype = bridge in /etc/avocado/conf.d/vt.conf

### DIFF
--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -21,7 +21,7 @@ arch =
 # Machine type under test
 machine_type =
 # Nettype (bridge, user, none)
-nettype =
+nettype = bridge
 # Bridge name to be used if you select bridge as a nettype
 netdst = virbr0
 


### PR DESCRIPTION
Setting nettype = bridge is a requirement for the following avocado tests:

- io-github-autotest-qemu.jumbo
- io-github-autotest-qemu.mac_change.defalut_ctrl_mac_addr.down_change
- io-github-autotest-qemu.mac_change.defalut_ctrl_mac_addr.up_change
- io-github-autotest-qemu.netstress_kill_guest.load
- type_specific.io-github-autotest-qemu.nic_hotplug.vhost_nic.nic_virtio
- io-github-autotest-qemu.vlan.vlan_connective_test
- io-github-autotest-qemu.vlan.vlan_scalability_test