### PR TITLE
avocado_vt: Improve the nettype detection

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -154,15 +154,14 @@ class VirtTestOptionsProcess(object):
         nettype_setting = 'config vt.qemu.nettype'
         if not self.options.vt_config:
             # Let's select reasonable defaults depending on vt_type
-            if self.options.vt_type == 'qemu':
-                self.options.vt_nettype = (self.options.vt_nettype if
-                                           self.options.vt_nettype else 'user')
-            elif self.options.vt_type == 'spice':
-                self.options.vt_nettype = (self.options.vt_nettype if
-                                           self.options.vt_nettype else 'none')
-            else:
-                self.options.vt_nettype = (self.options.vt_nettype if
-                                           self.options.vt_nettype else 'bridge')
+            if not self.options.vt_nettype:
+                if self.options.vt_type == 'qemu':
+                    self.options.vt_nettype = ("bridge" if os.getuid() == 0
+                                               else "user")
+                elif self.options.vt_type == 'spice':
+                    self.options.vt_nettype = "none"
+                else:
+                    self.options.vt_nettype = "bridge"
 
             if self.options.vt_nettype not in SUPPORTED_NET_TYPES:
                 raise ValueError("Invalid %s '%s'. "


### PR DESCRIPTION
Currently when nettype is not set in config it's set according to
provider. For qemu it's always "user". This commit changes the default
(only for qemu) to either "bridge" (when running as root) or "user"
(otherwise). This should give better user experience.

Note the default for spice or other providers hasn't changed, only
slight simplification was made.

@KarMez-Redhat @clebergnu would this work for you?