### PR TITLE
travis: Update to inspektor 0.4.0

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,5 +1,5 @@
 Sphinx==1.3b1
-inspektor==0.2.2
+inspektor==0.4.0
 autotest==0.16.2
 aexpect==1.0.0
 simplejson==3.8.0

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -8,9 +8,9 @@ run_rc() {
     fi
     echo ""
 }
-run_rc 'inspekt --exclude=.git lint'
-run_rc 'inspekt --exclude=.git indent'
-run_rc 'inspekt --exclude=.git style --disable E501,E265,W503,W601,E402,E722'
+run_rc 'inspekt lint --exclude=.git'
+run_rc 'inspekt indent --exclude=.git'
+run_rc 'inspekt style --disable E501,E265,W503,W601,E402,E722 --exclude=.git'
 run_rc 'selftests/run'
 exit ${GR}
 


### PR DESCRIPTION
Inspektor 0.4.0 brings a number of updates, including
porting to the cliff command line application framework,
which makes inspekt commands to look more natural in
terms of arguments.  Let's update and reflect that
in the CI scripts.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>