### PR TITLE
virttest.qbuses: support to specify the port of usb device on the bus

### DIFF
--- a/virttest/qemu_devices/qbuses.py
+++ b/virttest/qemu_devices/qbuses.py
@@ -443,7 +443,7 @@ class QUSBBus(QSparseBus):
     """
 
     def __init__(self, length, busid, bus_type, aobject=None,
-                 port_prefix=None):
+                 port_prefix=""):
         """
         Bus type have to be generalized and parsed from original bus type:
         (usb-ehci == ehci, ich9-usb-uhci1 == uhci, ...)
@@ -483,6 +483,9 @@ class QUSBBus(QSparseBus):
         value = device.get_param('port')
         if value is None:
             addr = [None]
+        # this part allows to speicfy the port of usb devices on the root bus
+        elif not self.__port_prefix:
+            addr = [int(value)]
         else:
             addr = [int(value[len(self.__port_prefix) + 1:])]
         return addr


### PR DESCRIPTION
The param port_prefix is initialized with value None.
It will not work, if set usb devices up by specifying usb device port
on the bus. Because it will always return False or try to get len of
a None object.

id: 1480109

Signed-off-by: Haotong Chen <hachen@redhat.com>