### PR TITLE
guest-os.Linux.cfg: Remove "-no-kvm-pit-reinjection" option for ARM

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -20,7 +20,7 @@
     cdrom_test_cmd = "dd if=%s of=/dev/null bs=1 count=1"
     cdrom_info_cmd = "cat /proc/sys/dev/cdrom/info"
     timedrift, timerdevice..boot_test:
-        !ppc64, ppc64le:
+        !ppc64, ppc64le, aarch64:
             extra_params += " -no-kvm-pit-reinjection"
         time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
         time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"


### PR DESCRIPTION
qemu option "-no-kvm-pit-reinjection"  is unsupported in arm, remove it.

id: 1480178
Signed-off-by: Yanan Fu <yfu@redhat.com>