### PR TITLE
Selftests: cartesian config lint [v4]

### DIFF
--- a/selftests/unit/test_cartesian_config_lint.py
+++ b/selftests/unit/test_cartesian_config_lint.py
@@ -1,0 +1,103 @@
+import glob
+import os
+import re
+import sys
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from virttest import cartesian_config
+
+
+BASEDIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+RHELDIR = os.path.join(BASEDIR, 'shared', 'cfg', 'guest-os', 'Linux', 'RHEL')
+UNATTENDEDDIR = os.path.join(BASEDIR, 'shared', 'unattended')
+
+
+class CartesianCfgLint(unittest.TestCase):
+
+    @staticmethod
+    def get_cfg_as_dict(path, drop_only=True, drop_conditional_assigment=True):
+        """
+        Gets a single config file as dict
+
+        By putting the content of file within a "variants:" context.
+
+        Optionally (default) also drops all instances of "only" statements,
+        and optional assigments, ie:
+
+        section_name:
+           foo = bar
+
+        since the files are evaluated individually and that can lead to an
+        empty results.
+        """
+        lines = open(path).readlines()
+        if drop_only:
+            lines = [l for l in lines
+                     if not re.match('^\s*only\s+', l)]
+        if drop_conditional_assigment:
+            lines = [l for l in lines
+                     if not re.match('^\s*[a-zA-Z0-9_]+([\s,])?.*\:$', l)]
+        lines.insert(0, "variants:")
+        content = "\n".join(lines)
+        parser = cartesian_config.Parser()
+        parser.parse_string(content)
+        dicts = [d for d in parser.get_dicts()]
+        len_dicts = (len(dicts))
+        assert len_dicts == 1
+        return dicts[0]
+
+    @unittest.skipIf(not os.path.isdir(RHELDIR),
+                     "Could not find RHEL configuration dir")
+    def test_rhel_iso_names(self):
+        arch_map = {'i386': '32',
+                    'x86_64': '64',
+                    'ppc64': 'ppc64',
+                    'ppc64le': 'ppc64le',
+                    'aarch64': 'aarch64'}
+
+        for major in (5, 6, 7):
+            minors = set([ver.split(".")[1] for ver in
+                          glob.glob(os.path.join(RHELDIR, "%s.*" % major))])
+            for minor in minors:
+                if minor == 'devel':
+                    continue
+                generic_cfg = "%s.%s.cfg" % (major, minor)
+                generic_cfg_path = os.path.join(RHELDIR, generic_cfg)
+                config_dict = self.get_cfg_as_dict(generic_cfg_path)
+                self.assertEqual(config_dict['shortname'],
+                                 "%s.%s" % (major, minor))
+                self.assertEqual(config_dict['image_name'],
+                                 'images/rhel%s%s' % (major, minor))
+                for arch, alt in arch_map.items():
+                    arch_cfg = "%s.%s/%s.cfg" % (major, minor, arch)
+                    arch_cfg_path = os.path.join(RHELDIR, arch_cfg)
+                    if not os.path.exists(arch_cfg_path):
+                        continue
+                    config_dict = self.get_cfg_as_dict(arch_cfg_path)
+                    if 'cdrom_unattended' in config_dict:
+                        self.assertEqual(config_dict['cdrom_unattended'],
+                                         'images/rhel%s%s-%s/ks.iso' % (major, minor, alt))
+                    if 'kernel' in config_dict:
+                        self.assertEqual(config_dict['kernel'],
+                                         'images/rhel%s%s-%s/vmlinuz' % (major, minor, alt))
+                    if 'initrd' in config_dict:
+                        self.assertEqual(config_dict['initrd'],
+                                         'images/rhel%s%s-%s/initrd.img' % (major, minor, alt))
+                    if 'cdrom_cd1' in config_dict:
+                        self.assertEqual(config_dict['cdrom_cd1'],
+                                         'isos/linux/RHEL-%s.%s-%s-DVD.iso' % (major, minor, arch))
+
+    @unittest.skipIf(not os.path.isdir(UNATTENDEDDIR),
+                     "Could not find unattended configuration dir")
+    def test_unattended_kickstart_password_123456(self):
+        """
+        Tests if passwords in unattended installs are set to 123456
+        """
+        rootpw_regex = re.compile(r'^rootpw\s+(--plaintext\s+)?123456\s?$',
+                                  re.MULTILINE)
+        for ks in glob.glob(os.path.join(UNATTENDEDDIR, '*.ks')):
+            self.assertIsNotNone(rootpw_regex.search(open(ks).read()))

--- a/shared/cfg/guest-os/Linux/RHEL/5.11/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/5.11/i386.cfg
@@ -7,7 +7,7 @@
         kernel = images/rhel511-32/vmlinuz
         initrd = images/rhel511-32/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL-5.10-i386-DVD.iso
+        cdrom_cd1 = isos/linux/RHEL-5.11-i386-DVD.iso
         md5sum_cd1 = 710ff3450986f9055c5c120002b10108
         md5sum_1m_cd1 = c04cdfbd58c2fa624da4901d7a6d5db5
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/6.4/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.4/ppc64.cfg
@@ -12,7 +12,7 @@
         initrd = images/rhel64-ppc64/initrd.img
     unattended_install.cdrom, svirt_install:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL6.4-20130130.0-Server-ppc64-DVD1.iso
+        cdrom_cd1 = isos/linux/RHEL-6.4-ppc64-DVD.iso
         md5sum_cd1 = d15a615f0e19e32de821f2c07dab9596
         md5sum_1m_cd1 = c3e7569996c60c1284df5928639a1932
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/6.9/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.9/i386.cfg
@@ -11,7 +11,7 @@
         perf:
             unattended_file = unattended/RHEL-6-perf-series.ks
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL-6.9-Server-i386-DVD.iso
+        cdrom_cd1 = isos/linux/RHEL-6.9-i386-DVD.iso
         md5sum_cd1 = 2e27376cc5e3a195eaf3d863ba53168a
         md5sum_1m_cd1 = 059c6e9660f64f1f76afd952aa4c256b
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/6.9/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.9/ppc64.cfg
@@ -12,6 +12,6 @@
         initrd = images/rhel69-ppc64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-6.9-Server-ppc64-DVD.iso
+        cdrom_cd1 = isos/linux/RHEL-6.9-ppc64-DVD.iso
         md5sum_cd1 = bc6153125d8d3d9d87c5ed30fae128a3
         md5sum_1m_cd1 = 13ec77e05d297c742fc64cc4bb845310

--- a/shared/cfg/guest-os/Linux/RHEL/6.9/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.9/x86_64.cfg
@@ -11,7 +11,7 @@
         perf:
             unattended_file = unattended/RHEL-6-perf-series.ks
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL-6.9-Server-x86_64-DVD.iso
+        cdrom_cd1 = isos/linux/RHEL-6.9-x86_64-DVD.iso
         md5sum_cd1 = 57e29b68d92e1fc2f294e85baa29c5af
         md5sum_1m_cd1 = d2dbb40cfa136c8bace140c9ed8422b3
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0/ppc64.cfg
@@ -12,7 +12,7 @@
         initrd = images/rhel70-ppc64/initrd.img
     unattended_install.cdrom:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-7.0-Server-ppc64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.0-ppc64-DVD.iso
         md5sum_cd1 = e12636ae7460395dd317a63b0ddaf77e
         md5sum_1m_cd1 = 80306c0106fde0dc8a06d71ba24564a3
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/7.0/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.0/x86_64.cfg
@@ -7,7 +7,7 @@
         kernel = images/rhel70-64/vmlinuz
         initrd = images/rhel70-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL7.0-Server-x86_64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.0-x86_64-DVD.iso
         md5sum_cd1 = 08961a5cb32d2cdf72026bec43876b7f
         md5sum_1m_cd1 = e1ffd40aa14c8048e423160e5d4cf49b
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/7.1/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.1/ppc64.cfg
@@ -12,6 +12,6 @@
         initrd = images/rhel71-ppc64/initrd.img
     unattended_install.cdrom:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-7.1-Server-ppc64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.1-ppc64-DVD.iso
         md5sum_cd1 = de9a9179ae5a8ccbdcfe595c4d8502e1
         md5sum_1m_cd1 = 91ac1a82438f3df123d5150de7ab43ed

--- a/shared/cfg/guest-os/Linux/RHEL/7.1/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.1/ppc64le.cfg
@@ -12,6 +12,6 @@
         initrd = images/rhel71-ppc64le/initrd.img
     unattended_install.cdrom:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-7.1-Server-ppc64le.iso
+        cdrom_cd1 = isos/linux/RHEL-7.1-ppc64le-DVD.iso
         md5sum_cd1 = 6332d939bc0dcf47b51a98e72c382f36
         md5sum_1m_cd1 = 147f70aeda36b27b5951437fa469b5ce

--- a/shared/cfg/guest-os/Linux/RHEL/7.1/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.1/x86_64.cfg
@@ -7,7 +7,7 @@
         kernel = images/rhel71-64/vmlinuz
         initrd = images/rhel71-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL7.1-Server-x86_64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.1-x86_64-DVD.iso
         md5sum_cd1 = 370662c78e36528bbaf3f2b901c29d6f
         md5sum_1m_cd1 = b30118881200053a47bb1601fd16781c
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64.cfg
@@ -12,6 +12,6 @@
         initrd = images/rhel72-ppc64/initrd.img
     unattended_install.cdrom:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-7.2-Server-ppc64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.2-ppc64-DVD.iso
         md5sum_cd1 = d4e597629de04a848c124d3589472372
         md5sum_1m_cd1 = 8c3e5a70edb328f58887c99fc4c4654b

--- a/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2/ppc64le.cfg
@@ -12,6 +12,6 @@
         initrd = images/rhel72-ppc64le/initrd.img
     unattended_install.cdrom:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-7.2-Server-ppc64le.iso
+        cdrom_cd1 = isos/linux/RHEL-7.2-ppc64le-DVD.iso
         md5sum_cd1 = 7fd0c4d9a034463bcdfdbc69cff3a69d
         md5sum_1m_cd1 = ad122d234b83bf34c55e7df405bd8f22

--- a/shared/cfg/guest-os/Linux/RHEL/7.2/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.2/x86_64.cfg
@@ -7,7 +7,7 @@
         kernel = images/rhel72-64/vmlinuz
         initrd = images/rhel72-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
-        cdrom_cd1 = isos/linux/RHEL7.2-Server-x86_64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.2-x86_64-DVD.iso
         md5sum_cd1 = 51e013512f489203a923a716b408fbdf
         md5sum_1m_cd1 = fae5710b17bb03f1de8e1f8b44df51c7
     unattended_install..floppy_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/aarch64.cfg
@@ -8,6 +8,6 @@
         kernel = images/rhel73-aarch64/vmlinuz
         initrd = images/rhel73-aarch64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL-7.3-Server-aarch64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.3-aarch64-DVD.iso
         md5sum_cd1 = 341e225661ff926c22e04bac2edc6c18
         md5sum_1m_cd1 = c3c4dd7857a0b42ba8c86af8047c6480

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64.cfg
@@ -12,6 +12,6 @@
         initrd = images/rhel73-ppc64/initrd.img
     unattended_install.cdrom:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-7.3-Server-ppc64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.3-ppc64-DVD.iso
         md5sum_cd1 = 0b295c908491ebf6644082d809e0d63e
         md5sum_1m_cd1 = e11b57d9b3e8e531b82f3936d256d4b6

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/ppc64le.cfg
@@ -12,6 +12,6 @@
         initrd = images/rhel73-ppc64le/initrd.img
     unattended_install.cdrom:
         boot_path = ppc/ppc64
-        cdrom_cd1 = isos/linux/RHEL-7.3-Server-ppc64le.iso
+        cdrom_cd1 = isos/linux/RHEL-7.3-ppc64le-DVD.iso
         md5sum_cd1 = c0542bb27a3d8d87cf04f9f96955f545
         md5sum_1m_cd1 = 650e9b36fcdda852aaf01259d4996183

--- a/shared/cfg/guest-os/Linux/RHEL/7.3/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.3/x86_64.cfg
@@ -7,7 +7,7 @@
         kernel = images/rhel73-64/vmlinuz
         initrd = images/rhel73-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
-        cdrom_cd1 = isos/linux/RHEL7.3-Server-x86_64.iso
+        cdrom_cd1 = isos/linux/RHEL-7.3-x86_64-DVD.iso
         md5sum_cd1 = 34a65dbdfb8d9bb19b3a03d278df2a99
         md5sum_1m_cd1 = 723133b2618219539ff2e27a2b868832
     unattended_install..floppy_ks:


### PR DESCRIPTION
This introduces a series of checks, initially limited to:
  * unattended files (the default root password on kickstart files)
  * RHEL configuration files, making sure things such as image names,
    ISO files adhere to a standard

The idea is to make sure configuration is predictable, and to increase
the coverage where it makes sense.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v3 (#1109):
 * Fix ISO names for RHEL 5.11 (i386) and 6.9 (i386, x86_64 and ppc64) 

Changes from v2 (1062):
 * Fix typo (s/withing/within)

Changes from v1 (#1031):
 * Added aarch64 coverage
 * Rebased