### PR TITLE
utils_misc.py: add support for guest disk mount

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -45,6 +45,7 @@ from . import data_dir
 from . import error_context
 from . import cartesian_config
 from . import utils_selinux
+from . import utils_disk
 from .staging import utils_koji
 from .xml_utils import XMLTreeFile
 
@@ -1073,19 +1074,7 @@ def umount(src, mount_point, fstype, verbose=False, fstype_mtab=None):
     :param fstype_mtab: file system type in mtab could be different
     :type fstype_mtab: str
     """
-    if fstype_mtab is None:
-        fstype_mtab = fstype
-
-    if is_mounted(src, mount_point, fstype, None, verbose, fstype_mtab):
-        umount_cmd = "umount %s" % mount_point
-        try:
-            process.system(umount_cmd, verbose=verbose)
-            return True
-        except process.CmdError:
-            return False
-    else:
-        logging.debug("%s is not mounted under %s", src, mount_point)
-        return True
+    return utils_disk.umount(src, mount_point, fstype, verbose)
 
 
 def mount(src, mount_point, fstype, perm=None, verbose=False, fstype_mtab=None):
@@ -1099,22 +1088,7 @@ def mount(src, mount_point, fstype, perm=None, verbose=False, fstype_mtab=None):
     :param fstype_mtab: file system type in mtab could be different
     :type fstype_mtab: str
     """
-    if perm is None:
-        perm = "rw"
-    if fstype_mtab is None:
-        fstype_mtab = fstype
-
-    if is_mounted(src, mount_point, fstype, perm, verbose, fstype_mtab):
-        logging.debug("%s is already mounted in %s with %s",
-                      src, mount_point, perm)
-        return True
-    mount_cmd = "mount -t %s %s %s -o %s" % (fstype, src, mount_point, perm)
-    try:
-        process.system(mount_cmd, verbose=verbose)
-    except process.CmdError:
-        return False
-    return wait_for(lambda: is_mounted(src, mount_point, fstype, perm, verbose, fstype_mtab),
-                    timeout=5)
+    return utils_disk.mount(src, mount_point, fstype, perm, verbose)
 
 
 def is_mounted(src, mount_point, fstype, perm=None, verbose=False,
@@ -1137,32 +1111,7 @@ def is_mounted(src, mount_point, fstype, perm=None, verbose=False,
     :return: if the src is mounted as expect
     :rtype: Boolean
     """
-    if perm is None:
-        perm = ""
-    if fstype_mtab is None:
-        fstype_mtab = fstype
-
-    # Version 4 nfs displays 'nfs4' in mtab
-    if fstype == "nfs":
-        fstype_mtab = "nfs\d?"
-
-    mount_point = os.path.realpath(mount_point)
-    if fstype not in ['nfs', 'smbfs', 'glusterfs', 'hugetlbfs']:
-        if src:
-            src = os.path.realpath(src)
-        else:
-            # Allow no passed src(None or "")
-            src = ""
-    mount_string = "%s %s .*%s %s" % (src, mount_point, fstype_mtab, perm)
-    logging.debug("Searching '%s' in mtab...", mount_string)
-    if verbose:
-        logging.debug("/etc/mtab contents:\n%s", file("/etc/mtab").read())
-    if re.findall(mount_string.strip(), file("/etc/mtab").read()):
-        logging.debug("%s is mounted.", src)
-        return True
-    else:
-        logging.debug("%s is not mounted.", src)
-        return False
+    return utils_disk.is_mount(src, mount_point, fstype, perm, verbose)
 
 
 def install_host_kernel(job, params):


### PR DESCRIPTION
1. Add guest support for mount function in utils_disk
2. Import utils_disk directly in utils_misc for same function, it should be removed, but just keep it for existed import.
id: 1490235
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>