### PR TITLE
Update avocado-plugins-vt.spec

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -16,6 +16,12 @@ BuildRequires: python2-devel, python-setuptools
 BuildArch: noarch
 Requires: python-avocado >= 51.0
 Requires: python, autotest-framework, xz, tcpdump, iproute, iputils, gcc, glibc-headers, python-devel, nc, python-aexpect, git, python-netaddr, python-netifaces, python-simplejson
+Requires: attr
+%if 0%{?rhel}
+Requires: policycoreutils-python
+%else
+Requires: policycoreutils-python-utils
+%endif
 
 Requires: python-imaging
 %if 0%{?el6}


### PR DESCRIPTION
These new dependencies are needed to satisfy the need for getfattr,
semanage, and wget commands during avocado `vt-bootstrap` and `run`
subcommands.

Fixes https://github.com/avocado-framework/avocado-vt/issues/1119

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>