### PR TITLE
Update CI scripts to use inspektor 0.4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,13 @@ python:
 sudo: false
 
 install:
-    - pip install "Sphinx==1.3b1"   # autotest requires Sphinx during install
+    - pip install Sphinx==1.3b1
     - pip install -r requirements-travis.txt
     - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then AVOCADO_BRANCH=36lts; else AVOCADO_BRANCH=master; fi; git clone --depth 1 --branch $AVOCADO_BRANCH https://github.com/avocado-framework/avocado.git avocado-libs    # avocado-46+ does not supports python-2.6
     - cd avocado-libs
-    - pip install -r requirements-travis.txt
-    - python setup.py install
+    - pip install -e .
     - cd ..
-    - rm -rf avocado-libs
+    - pip install -e .
 
 script:
     # Create some fake binaries to make vt-bootstrap happy
@@ -23,7 +22,8 @@ script:
     - chmod 777 /tmp/dummy_bin/*
     - export PATH="/tmp/dummy_bin:$PATH"
     # Setup Avocado-vt for functional tests
-    - make install
     - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
     # Run tests
-    - make check
+    - inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E1003 --exclude avocado-libs --no-license-check
+    # Cleanup avocado libs
+    - rm -rf avocado-libs

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ requirements:
 	- pip install -r requirements.txt
 
 check:
-	selftests/checkall
+	inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E1003 --no-license-check
+
 clean:
 	$(PYTHON) setup.py clean
 	$(MAKE) -f $(CURDIR)/debian/rules clean || true

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -240,7 +240,7 @@ class VirtTest(test.Test):
         # into avocado (skips, warns and errors will display correctly)
         except exceptions.TestSkipError:
             raise   # This one has to be raised in setUp
-        except:  # Old-style exceptions are not inherited from Exception()
+        except:  # nopep8 Old-style exceptions are not inherited from Exception()
             details = sys.exc_info()[1]
             stacktrace.log_exc_info(sys.exc_info(), 'avocado.test')
             self.__status = details
@@ -260,16 +260,15 @@ class VirtTest(test.Test):
         The actual testing happens inside setUp stage, this only
         reports the correct results
         """
-        if self.__status == "PASS":
-            pass
-        elif isinstance(self.__status, error.TestNAError):
-            self.cancel(self.__status)
-        elif isinstance(self.__status, error.TestWarn):
-            self.log.warn(details)
-        elif isinstance(self.__status, error.TestFail):
-            self.fail(self.__status)
-        else:
-            raise self.__status
+        if self.__status != "PASS":
+            if isinstance(self.__status, error.TestNAError):
+                self.cancel(str(self.__status))
+            elif isinstance(self.__status, error.TestWarn):
+                self.log.warn(str(self.__status))
+            elif isinstance(self.__status, error.TestFail):
+                self.fail(str(self.__status))
+            else:
+                raise self.__status  # pylint: disable=E0702
 
     def _runTest(self):
         params = self.params

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,7 @@
 Sphinx==1.3b1
 inspektor==0.4.5
 autotest==0.16.2
-aexpect==1.0.0
+aexpect==1.4.0
 simplejson==3.8.0
 netaddr>=0.7.18
 netifaces>=0.10.5

--- a/scripts/cd_hash.py
+++ b/scripts/cd_hash.py
@@ -10,9 +10,9 @@ import sys
 import logging
 import optparse
 
-from virttest.utils_misc import LoggingConfig
-
 from avocado.utils import crypto
+
+from logging_config import LoggingConfig
 
 
 if __name__ == "__main__":

--- a/scripts/download_manager.py
+++ b/scripts/download_manager.py
@@ -29,9 +29,10 @@ if os.path.isdir(os.path.join(basedir, 'virttest')):
     sys.path.append(basedir)
 
 from virttest import asset
-from virttest.utils_misc import LoggingConfig
 
 from avocado.core.output import TERM_SUPPORT
+
+from logging_config import LoggingConfig
 
 
 def download_assets():

--- a/scripts/logging_config.py
+++ b/scripts/logging_config.py
@@ -1,0 +1,93 @@
+import logging
+import os
+import sys
+
+
+class AllowBelowSeverity(logging.Filter):
+
+    """
+    Allows only records less severe than a given level (the opposite of what
+    the normal logging level filtering does.
+    """
+
+    def __init__(self, level):
+        self.level = level
+
+    def filter(self, record):
+        return record.levelno < self.level
+
+
+class LoggingConfig(object):
+    global_level = logging.DEBUG
+    stdout_level = logging.INFO
+    stderr_level = logging.ERROR
+
+    file_formatter = logging.Formatter(
+        fmt='%(asctime)s %(levelname)-5.5s|%(module)10.10s:%(lineno)4.4d| '
+            '%(message)s',
+        datefmt='%m/%d %H:%M:%S')
+
+    console_formatter = logging.Formatter(
+        fmt='%(asctime)s %(levelname)-5.5s| %(message)s',
+        datefmt='%H:%M:%S')
+
+    def __init__(self, use_console=True, set_fmt=True):
+        self.logger = logging.getLogger()
+        self.global_level = logging.DEBUG
+        self.use_console = use_console
+        self.set_fmt = set_fmt
+
+    def add_stream_handler(self, stream, level=logging.DEBUG):
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(level)
+        if self.set_fmt:
+            handler.setFormatter(self.console_formatter)
+        self.logger.addHandler(handler)
+        return handler
+
+    def add_console_handlers(self):
+        stdout_handler = self.add_stream_handler(sys.stdout,
+                                                 level=self.stdout_level)
+        # only pass records *below* STDERR_LEVEL to stdout, to avoid
+        # duplication
+        stdout_handler.addFilter(AllowBelowSeverity(self.stderr_level))
+
+        self.add_stream_handler(sys.stderr, self.stderr_level)
+
+    def add_file_handler(self, file_path, level=logging.DEBUG, log_dir=None):
+        if log_dir:
+            file_path = os.path.join(log_dir, file_path)
+        handler = logging.FileHandler(file_path)
+        handler.setLevel(level)
+        if self.set_fmt:
+            handler.setFormatter(self.file_formatter)
+        self.logger.addHandler(handler)
+        return handler
+
+    def _add_file_handlers_for_all_levels(self, log_dir, log_name):
+        for level in (logging.DEBUG, logging.INFO, logging.WARNING,
+                      logging.ERROR):
+            file_name = '%s.%s' % (log_name, logging.getLevelName(level))
+            self.add_file_handler(file_name, level=level, log_dir=log_dir)
+
+    def add_debug_file_handlers(self, log_dir, log_name=None):
+        raise NotImplementedError
+
+    def _clear_all_handlers(self):
+        for handler in list(self.logger.handlers):
+            self.logger.removeHandler(handler)
+            # Attempt to close the handler. If it's already closed a KeyError
+            # will be generated. http://bugs.python.org/issue8581
+            try:
+                handler.close()
+            except KeyError:
+                pass
+
+    def configure_logging(self, use_console=True, verbose=False):
+        self._clear_all_handlers()  # see comment at top of file
+        self.logger.setLevel(self.global_level)
+
+        if verbose:
+            self.stdout_level = logging.DEBUG
+        if use_console:
+            self.add_console_handlers()

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -256,7 +256,7 @@ class NFSClient(object):
                           ignore_status=True)
         if ret.exit_status and "No such file or directory" not in ret.stderr:
             raise exceptions.TestFail("Failed to update host key: %s" %
-                                      output.stderr)
+                                      ret.stderr)
         # Setup SSH connection
         self.ssh_obj = SSHConnection(params)
         ssh_timeout = int(params.get("ssh_timeout", 10))

--- a/virttest/utils_hotplug.py
+++ b/virttest/utils_hotplug.py
@@ -72,7 +72,7 @@ def hotplug_supported(vm_name, mtype):
                                                  debug=False)
         try:
             result = json.loads(json_result.stdout)
-        except:
+        except Exception:
             # Failure to parse json output and default support to False
             # TODO: Handle for failure cases
             return supported

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1118,6 +1118,11 @@ class Bridge(object):
         return bridge_stp
 
 
+# Global variable for OpenVSwitch
+__ovs = None
+__bridge = Bridge()
+
+
 def __init_openvswitch(func):
     """
     Decorator used for late init of __ovs variable.
@@ -1135,11 +1140,6 @@ def __init_openvswitch(func):
 
         return func(*args, **kargs)
     return wrap_init
-
-
-# Global variable for OpenVSwitch
-__ovs = None
-__bridge = Bridge()
 
 
 def if_nametoindex(ifname):


### PR DESCRIPTION
The latest version of inspektor won't ignore all E messages and brings other improvements across the board. Fix the problems found by static analysis and update CI scripts to use the latest version.

At the moment, this still needs some testing, as some of the bugs were in some critical places, but not on commonly used code paths.