### PR TITLE
shared.cfg.machines: Change the default pci bus for q35 and arm64-pci

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -61,6 +61,11 @@ variants:
         # Currently no USB support
         usbs =
         usb_devices =
+        # Use root port instead of default pcie.0
+        pci_controllers = root_port
+        type_root_port = pcie-root-port
+        pci_bus_root_port = pci.0
+        pci_bus = root_port
     - s390-virtio:
         only s390x
         auto_cpu_model = "no"

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3593,6 +3593,16 @@ class VM(virt_vm.BaseVM):
                 device_add_cmd += ",mq=on"
             if 'vectors' in nic:
                 device_add_cmd += ",vectors=%s" % nic.vectors
+        bus = nic.get("pci_bus")
+        if bus is not None:
+            # Bus is aobject, not the actual bus id
+            buses = self.devices.get_buses({"aobject": bus})
+            if len(buses) == 1:
+                device_add_cmd += ",bus=%s" % buses[0].busid
+            else:
+                logging.warning("Ignoring pci_bus %s on %s because did not "
+                                "found correct candidate: %s", bus,
+                                nic_index_or_name, buses)
         device_add_cmd += nic.get('nic_extra_params', '')
         if 'romfile' in nic:
             device_add_cmd += ",romfile=%s" % nic.romfile

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2418,7 +2418,7 @@ class QemuIface(VirtIface):
                  'tapfd_ids', 'netdev_id', 'tftp',
                  'romfile', 'nic_extra_params',
                  'netdev_extra_params', 'queues', 'vhostfds',
-                 'vectors']
+                 'vectors', 'pci_bus']
 
 
 class VMNet(list):


### PR DESCRIPTION
This probably controversial PR is inspired by running `nic_hotplug.additional.nic_virtio` test, which does not work on q35, nor on arm64-pci, because when no bus is specified on hotplug, first PCI-like bus is used, which does not supports hotplug.

The first patch changes the arm64-pci definition to add use by default a custom `root_port`, which is recommended here https://libvirt.org/pci-hotplug.html with note that unlike on q35 the pci_bridge is most probably not necessary.

The second patch changes the default pci bus from the Q35's main-system-bus to the first added root_port. This might require some changes in config where legacy devices are added (images, nics and other devices that use `vm._get_pci_bus` should be fine), but overall it should use for other devices the recommended setup.

The last patch adds support to `vm.activate_nic` to reflect `pci_bus` parameter, which is necessary as that way nic-hotplug respects the chosen pci bus. With this patch devices on arm64-pci and q35 are going to end in the first root_port. There is no change on i440fx as it's main bus is undefined.

Tested on x86+q35 x86+i440fx and aarch64+arm64-pci.