### PR TITLE
Revert "libvirt_xml: Fix pylint E1003"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ script:
     # Setup Avocado-vt for functional tests
     - AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
     # Run tests
-    - inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011 --exclude avocado-libs --no-license-check
+    - inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E1003 --exclude avocado-libs --no-license-check
     # Cleanup avocado libs
     - rm -rf avocado-libs

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ requirements:
 	- pip install -r requirements.txt
 
 check:
-	inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011 --no-license-check
+	inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E1003 --no-license-check
 
 clean:
 	$(PYTHON) setup.py clean

--- a/virttest/libvirt_xml/devices/address.py
+++ b/virttest/libvirt_xml/devices/address.py
@@ -16,9 +16,9 @@ class Address(base.TypedDeviceBase):
         # Blindly accept any/all attributes as simple dictionary
         accessors.XMLElementDict('attrs', self, parent_xpath='/',
                                  tag_name='address')
-        super(Address, self).__init__(device_tag='address',
-                                      type_name=type_name,
-                                      virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(device_tag='address',
+                                             type_name=type_name,
+                                             virsh_instance=virsh_instance)
 
     @classmethod
     def new_from_dict(cls, attributes, virsh_instance=base.base.virsh):

--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -203,7 +203,7 @@ class Disk(base.TypedDeviceBase):
                                    tag_name='config', attribute='file')
             accessors.XMLAttribute('snapshot_name', self, parent_xpath='/',
                                    tag_name='snapshot', attribute='name')
-            super(Disk.DiskSource, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<source/>'
 
         @staticmethod
@@ -283,7 +283,7 @@ class Disk(base.TypedDeviceBase):
                 else:
                     accessors.XMLElementInt(slot, self, parent_xpath='/',
                                             tag_name=slot)
-            super(Disk.IOTune, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<iotune/>'
 
     class Encryption(base.base.LibvirtXMLBase):
@@ -306,7 +306,7 @@ class Disk(base.TypedDeviceBase):
                                    tag_name='encryption', attribute='format')
             accessors.XMLElementDict('secret', self, parent_xpath='/',
                                      tag_name='secret')
-            super(Disk.Encryption, self).__init__(
+            super(self.__class__, self).__init__(
                 virsh_instance=virsh_instance)
             self.xml = '<encryption/>'
 
@@ -338,5 +338,5 @@ class Disk(base.TypedDeviceBase):
                                    tag_name='secret', attribute='uuid')
             accessors.XMLAttribute('secret_usage', self, parent_xpath='/',
                                    tag_name='secret', attribute='usage')
-            super(Disk.Auth, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = u"<auth/>"

--- a/virttest/libvirt_xml/devices/hostdev.py
+++ b/virttest/libvirt_xml/devices/hostdev.py
@@ -26,9 +26,9 @@ class Hostdev(base.TypedDeviceBase):
         accessors.XMLAttribute('boot_order', self, parent_xpath='/',
                                tag_name='boot', attribute='order')
 
-        super(Hostdev, self).__init__(device_tag='hostdev',
-                                      type_name=type_name,
-                                      virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(device_tag='hostdev',
+                                             type_name=type_name,
+                                             virsh_instance=virsh_instance)
 
     def new_source(self, **dargs):
         new_one = self.Source(virsh_instance=self.virsh)
@@ -62,7 +62,7 @@ class Hostdev(base.TypedDeviceBase):
                                          'virsh_instance': virsh_instance})
             accessors.XMLAttribute('adapter_name', self, parent_xpath='/',
                                    tag_name='adapter', attribute='name')
-            super(Hostdev.Source, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<source/>'
 
         def new_untyped_address(self, **dargs):
@@ -91,6 +91,6 @@ class Hostdev(base.TypedDeviceBase):
                                        tag_name='address', attribute='target')
                 accessors.XMLAttribute('unit', self, parent_xpath='/',
                                        tag_name='address', attribute='unit')
-                super(Hostdev.Source.UntypedAddress, self).__init__(
+                super(self.__class__, self).__init__(
                     "address", virsh_instance=virsh_instance)
                 self.xml = "<address/>"

--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -141,7 +141,7 @@ class Interface(base.TypedDeviceBase):
                                      tag_name="inbound")
             accessors.XMLElementDict("outbound", self, parent_xpath="/",
                                      tag_name="outbound")
-            super(Interface.Bandwidth, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<bandwidth/>'
 
     class Driver(base.base.LibvirtXMLBase):
@@ -167,7 +167,7 @@ class Interface(base.TypedDeviceBase):
                                      tag_name="host")
             accessors.XMLElementDict("driver_guest", self, parent_xpath="/",
                                      tag_name="guest")
-            super(Interface.Driver, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<driver/>'
 
     class Filterref(base.base.LibvirtXMLBase):
@@ -196,7 +196,7 @@ class Interface(base.TypedDeviceBase):
                                      parent_xpath='/',
                                      marshal_from=self.marshal_from_parameter,
                                      marshal_to=self.marshal_to_parameter)
-            super(Interface.Filterref, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<filterref/>'
 
         @staticmethod

--- a/virttest/libvirt_xml/devices/memory.py
+++ b/virttest/libvirt_xml/devices/memory.py
@@ -60,7 +60,7 @@ class Memory(base.UntypedDeviceBase):
             accessors.XMLElementInt('node',
                                     self, parent_xpath='/',
                                     tag_name='node')
-            super(Memory.Target, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<target/>'
 
     class Source(base.base.LibvirtXMLBase):
@@ -90,7 +90,7 @@ class Memory(base.UntypedDeviceBase):
             accessors.XMLElementText('nodemask',
                                      self, parent_xpath='/',
                                      tag_name='nodemask')
-            super(Memory.Source, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<source/>'
 
     def new_mem_address(self, type_name='dimm', **dargs):

--- a/virttest/libvirt_xml/devices/rng.py
+++ b/virttest/libvirt_xml/devices/rng.py
@@ -71,7 +71,7 @@ class Rng(base.UntypedDeviceBase):
                                    parent_xpath='/',
                                    tag_name='protocol',
                                    attribute='type')
-            super(Rng.Backend, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<backend/>'
 
         @staticmethod

--- a/virttest/libvirt_xml/nwfilter_protocols/ah.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ah.py
@@ -120,5 +120,5 @@ class Ah(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='ah', attribute='ipsetflags')
 
-            super(Ah.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<ah/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/ah_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ah_ipv6.py
@@ -123,5 +123,5 @@ class Ah_ipv6(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='ah-ipv6', attribute='ipsetflags')
 
-            super(Ah_ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<ah-ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/all.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/all.py
@@ -121,5 +121,5 @@ class All(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='all', attribute='ipsetflags')
 
-            super(All.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<all/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/all_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/all_ipv6.py
@@ -122,5 +122,5 @@ class All_ipv6(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='all-ipv6', attribute='ipsetflags')
 
-            super(All_ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<all-ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/arp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/arp.py
@@ -110,5 +110,5 @@ class Arp(base.TypedDeviceBase):
             accessors.XMLAttribute('gratuitous', self, parent_xpath='/',
                                    tag_name='arp', attribute='gratuitous')
 
-            super(Arp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<arp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/esp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/esp.py
@@ -120,5 +120,5 @@ class Esp(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='esp', attribute='ipsetflags')
 
-            super(Esp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<esp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/esp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/esp_ipv6.py
@@ -122,5 +122,5 @@ class Esp_ipv6(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='esp-ipv6', attribute='ipsetflags')
 
-            super(Esp_ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<esp-ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/icmp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/icmp.py
@@ -127,5 +127,5 @@ class Icmp(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='icmp', attribute='ipsetflags')
 
-            super(Icmp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<icmp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/icmpv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/icmpv6.py
@@ -115,5 +115,5 @@ class Icmpv6(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='icmpv6', attribute='ipsetflags')
 
-            super(Icmpv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<icmpv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/igmp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/igmp.py
@@ -117,5 +117,5 @@ class Igmp(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='igmp', attribute='ipsetflags')
 
-            super(Igmp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<igmp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/ip.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ip.py
@@ -115,5 +115,5 @@ class Ip(base.TypedDeviceBase):
             accessors.XMLAttribute('comment', self, parent_xpath='/',
                                    tag_name='ip', attribute='comment')
 
-            super(Ip.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<ip/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ipv6.py
@@ -113,5 +113,5 @@ class Ipv6(base.TypedDeviceBase):
             accessors.XMLAttribute('comment', self, parent_xpath='/',
                                    tag_name='ipv6', attribute='comment')
 
-            super(Ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/mac.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/mac.py
@@ -86,5 +86,5 @@ class Mac(base.TypedDeviceBase):
             accessors.XMLAttribute('comment', self, parent_xpath='/',
                                    tag_name='mac', attribute='comment')
 
-            super(Mac.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<mac/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/rarp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/rarp.py
@@ -109,5 +109,5 @@ class Rarp(base.TypedDeviceBase):
             accessors.XMLAttribute('gratuitous', self, parent_xpath='/',
                                    tag_name='rarp', attribute='gratuitous')
 
-            super(Rarp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<rarp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/sctp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/sctp.py
@@ -125,5 +125,5 @@ class Sctp(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='sctp', attribute='ipsetflags')
 
-            super(Sctp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<sctp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/sctp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/sctp_ipv6.py
@@ -128,5 +128,5 @@ class Sctp_ipv6(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='sctp-ipv6', attribute='ipsetflags')
 
-            super(Sctp_ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<sctp-ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/stp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/stp.py
@@ -152,5 +152,5 @@ class Stp(base.TypedDeviceBase):
             accessors.XMLAttribute('comment', self, parent_xpath='/',
                                    tag_name='stp', attribute='comment')
 
-            super(Stp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<stp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/tcp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/tcp.py
@@ -127,5 +127,5 @@ class Tcp(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='tcp', attribute='ipsetflags')
 
-            super(Tcp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<tcp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/tcp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/tcp_ipv6.py
@@ -130,5 +130,5 @@ class Tcp_ipv6(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='tcp-ipv6', attribute='ipsetflags')
 
-            super(Tcp_ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<tcp-ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/udp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udp.py
@@ -124,5 +124,5 @@ class Udp(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='udp', attribute='ipsetflags')
 
-            super(Udp.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<udp/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/udp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udp_ipv6.py
@@ -127,5 +127,5 @@ class Udp_ipv6(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='udp-ipv6', attribute='ipsetflags')
 
-            super(Udp_ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<udp-ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/udplite.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udplite.py
@@ -121,5 +121,5 @@ class Udplite(base.TypedDeviceBase):
             accessors.XMLAttribute('ipsetflags', self, parent_xpath='/',
                                    tag_name='udplite', attribute='ipsetflags')
 
-            super(Udplite.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<udplite/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/udplite_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udplite_ipv6.py
@@ -139,5 +139,5 @@ class Udplite_ipv6(base.TypedDeviceBase):
                                    tag_name='udplite-ipv6',
                                    attribute='ipsetflags')
 
-            super(Udplite_ipv6.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<udplite-ipv6/>'

--- a/virttest/libvirt_xml/nwfilter_protocols/vlan.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/vlan.py
@@ -89,5 +89,5 @@ class Vlan(base.TypedDeviceBase):
             accessors.XMLAttribute('comment', self, parent_xpath='/',
                                    tag_name='vlan', attribute='comment')
 
-            super(Vlan.Attr, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<vlan/>'

--- a/virttest/libvirt_xml/snapshot_xml.py
+++ b/virttest/libvirt_xml/snapshot_xml.py
@@ -137,5 +137,5 @@ class SnapshotXML(SnapshotXMLBase):
             """
             accessors.XMLAttribute('disk_name', self, parent_xpath='/',
                                    tag_name='disk', attribute='name')
-            super(SnapshotXML.SnapDiskXML, self).__init__(virsh_instance=virsh_instance)
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = u"<disk></disk>"

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1838,7 +1838,7 @@ class VMCPUTuneXML(base.LibvirtXMLBase):
                         'emulator_quota'):
                 accessors.XMLElementInt(slot, self, parent_xpath='/',
                                         tag_name=slot)
-        super(VMCPUTuneXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<cputune/>'
 
     @staticmethod
@@ -1952,7 +1952,7 @@ class VMOSXML(base.LibvirtXMLBase):
                                  tag_name='dtb')
         accessors.XMLElementText('init', self, parent_xpath='/',
                                  tag_name='init')
-        super(VMOSXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<os/>'
 
     @staticmethod
@@ -1993,7 +1993,7 @@ class VMPMXML(base.LibvirtXMLBase):
                                tag_name='suspend-to-disk', attribute='enabled')
         accessors.XMLAttribute('mem_enabled', self, parent_xpath='/',
                                tag_name='suspend-to-mem', attribute='enabled')
-        super(VMPMXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<pm/>'
 
 
@@ -2048,7 +2048,7 @@ class VMFeaturesXML(base.LibvirtXMLBase):
                                attribute='state')
         accessors.AllForbidden(property_name="feature_list",
                                libvirtxml=self)
-        super(VMFeaturesXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<features/>'
 
     def get_feature_list(self):
@@ -2111,7 +2111,7 @@ class VMVCPUSXML(base.LibvirtXMLBase):
         accessors.XMLElementList('vcpu', self, parent_xpath="/",
                                  marshal_from=self.marshal_from_vcpu,
                                  marshal_to=self.marshal_to_vcpu)
-        super(VMVCPUSXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<vcpus/>'
 
     @staticmethod
@@ -2153,7 +2153,7 @@ class VMHugepagesXML(VMXML):
                                  parent_xpath="/",
                                  marshal_from=self.marshal_from_page,
                                  marshal_to=self.marshal_to_page)
-        super(VMHugepagesXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<hugepages/>'
 
     # Sub-element of hugepages
@@ -2240,7 +2240,7 @@ class VMMemBackingXML(VMXML):
         for slot in ('nosharepages', 'locked'):
             accessors.XMLElementBool(slot, self, parent_xpath='/',
                                      tag_name=slot)
-        super(VMMemBackingXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<memoryBacking/>'
 
 
@@ -2320,7 +2320,7 @@ class VMIothreadidsXML(VMXML):
         accessors.XMLElementList('iothread', self, parent_xpath='/',
                                  marshal_from=self.marshal_from_iothreads,
                                  marshal_to=self.marshal_to_iothreads)
-        super(VMIothreadidsXML, self).__init__(virsh_instance=virsh_instance)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
         self.xml = '<iothreadids/>'
 
     @staticmethod


### PR DESCRIPTION
This reverts commit f1e87c1178975fa04d214374c216647626672f2f.

The super will fail with imp.load_module as load_module will
reload the class and got TypeError with: obj must be an
instance or subtype of type.

This problem exist for a long time and in commit 0bb4f7a4b33
fixed it with using self.__class__, E1003 also been disabled
in other classes, so revert to disable E1003 check and avoid
the problem.

Signed-off-by: Wayne Sun <gsun@redhat.com>