### PR TITLE
shared.cfg.guest-os: switch virtio-win rng cases back to netcat

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -264,9 +264,6 @@
         copy_from_command = copy %s\notepad.exe c:\ /y
         compare_command = fc /b c:\windows\system32\notepad.exe c:\notepad.exe
         check_result_key_word = no difference
-    virtio_rng:
-        shell_client = telnet
-        shell_port = 23
     floppy_test:
         format_floppy_cmd = echo n|format A: /Q /V:test_floppy
         source_file = C:\Windows\System32\cmd.exe


### PR DESCRIPTION
Due to telnet does not work well on Win10 and Win2016,
switch virtio-win rng cases back to netcat

id: 1438136
Signed-off-by: Haotong Chen <hachen@redhat.com>