### PR TITLE
virttest/virsh.py: Add virsh command "domrename"

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -4354,3 +4354,17 @@ def iothreadpin(name, thread_id, cpuset, options=None, **dargs):
         cmd += " %s" % options
 
     return command(cmd, **dargs)
+
+
+def domrename(domain, new_name, options="", **dargs):
+    """
+    Rename an inactive domain.
+
+    :param domain:domain name, id or uuid.
+    :param new_name:new domain name.
+    :param options:extra param.
+    :param dargs: standardized virsh function API keywords
+    :return: result from command
+    """
+    cmd = "domrename %s %s %s" % (domain, new_name, options)
+    return command(cmd, **dargs)


### PR DESCRIPTION
domrename <domain> <new-name>. This command changes current inactive
domain name to the new name specified in the second argument.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>