### PR TITLE
libvirt_storage: minor fix of multiple exceptions in one line

### DIFF
--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -173,7 +173,7 @@ class StoragePool(object):
         """
         try:
             return self.list_pools()[name]['State']
-        except process.CmdError, KeyError:
+        except (process.CmdError, KeyError) as e:
             return None
 
     def pool_autostart(self, name):
@@ -184,7 +184,7 @@ class StoragePool(object):
         """
         try:
             return self.list_pools()[name]['Autostart']
-        except process.CmdError, KeyError:
+        except (process.CmdError, KeyError) as e:
             return None
 
     def pool_info(self, name):


### PR DESCRIPTION
when with multiple exceptions in one line, "as" shall be used.
the old way that separating the exceptions from the variable
with a comma is now deprecated.

Signed-off-by: Yan Li <yannli@redhat.com>