### PR TITLE
qcontainer: fix duplicated device hotplug in simple_hotplug

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -609,8 +609,6 @@ class DevContainer(object):
         except DeviceError, exc:
             raise DeviceHotplugError(device, 'According to qemu_device: %s'
                                      % exc, self, ver_out)
-        out = device.hotplug(monitor)
-
         return out, ver_out
 
     def simple_unplug(self, device, monitor):


### PR DESCRIPTION
Device 'virtio_serial_pci' will be hotplugged two times in simple_hotplug function. This error affects the devices which can be catched by 'info qtree'.

id: 1491577
Signed-off-by: Sitong Liu <siliu@redhat.com>