### PR TITLE
Fix installation of Win10/Win2016 fail issue 

### DIFF
--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -11,24 +11,11 @@
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win10-32/autounattend.iso"
-            virtio_storage_path = 'A:\i386\Win8'
-            virtio_network_path = 'A:\i386\Win8'
-            virtio_scsi_path = 'A:\i386\Win8'
-            extra_cdrom_ks:
-                virtio_storage_path = 'G:\viostor\w8\x86'
-                virtio_network_path = 'G:\NetKVM\w8\x86'
-                virtio_scsi_path = 'G:\vioscsi\w8\x86'
-                virtio_qxl_installer_path = E:\\install_driver.bat G:\\qxl\\Win8\\x86
-                virtio_balloon_installer_path = E:\\install_driver.bat G:\\Balloon\\w8\\x86
-                cd_format = ide
-                q35:
-                    cd_format = ahci
     sysprep:
         unattended_file = unattended/win10-32-autounattend.xml
     balloon_service:

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -10,26 +10,13 @@
         unattended_file = unattended/win10-64-autounattend.xml
         floppies = "fl"
         floppy_name = images/win10-64/answer.vfd
-        virtio_storage_path = 'A:\amd64\Win8'
-        virtio_network_path = 'A:\amd64\Win8'
-        virtio_scsi_path = 'A:\amd64\Win8'
-        #virtio_network_installer_path = 'F:\RHEV-Network32.msi'
         extra_cdrom_ks:
-            virtio_storage_path = 'G:\viostor\w8\amd64'
-            virtio_network_path = 'G:\NetKVM\w8\amd64'
-            virtio_scsi_path = 'G:\vioscsi\w8\amd64'
-            virtio_qxl_installer_path = E:\\install_driver.bat G:\\qxl\\Win8\\amd64
-            virtio_balloon_installer_path = E:\\install_driver.bat G:\\Balloon\\w8\\amd64
-            cd_format = ide
-            q35:
-                cd_format = ahci
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win10-64/autounattend.iso"
     sysprep:
         unattended_file = unattended/win10-64-autounattend.xml

--- a/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
@@ -13,11 +13,10 @@
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
-            cdroms = "cd1 winutils unattended virtio"
+            cdroms = "cd1 winutils unattended"
             drive_index_cd1 = 1
             drive_index_winutils = 2
             drive_index_unattended = 3
-            drive_index_virtio = 4
             cdrom_unattended = "images/win2016-64/autounattend.iso"
     sysprep:
         unattended_file = win2016-64-autounattend.xml


### PR DESCRIPTION
Remove cdrom "virtio" and its related params from cfgs under Win10
and Win2016. Reasons as bellow:

1.cdrom "virtio" is defined but no virtio_iso_path given in upstream,
which will cause installation of win10/win2016 fail.

2.i440fx only support 4 ide units. If we install Win10/Win2016 guest
with virtio_iso_path defined manually, 5 ide disks/cdroms will be
created, so start vm failed.

3.no "virtio" defined for other windows' cfgs in upstream, like Win2012,
so i think it's better to keep uniform among windows.

Signed-off-by: Aihua Liang <aliang@redhat.com>

Bug id:1491991