### PR TITLE
Update cfg file to disable ovmf on s390x platform since it's not supp…

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -361,7 +361,7 @@ variants:
 variants:
     - @default_bios:
     - ovmf:
-        no i386 ppc64 ppc64le
+        no i386 ppc64 ppc64le s390x
         no Win2003 WinXP WinVista
         # Please update this based on your test env
         ovmf_path = /usr/share/OVMF


### PR DESCRIPTION
Update cfg file to disable ovmf on s390x platform since it's not supported.

Signed-off-by: Qunfang Zhang qzhang@redhat.com
ID: 1493897