### PR TITLE
virttest.qemu_vm: Avoid failures when no pcic are available

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1320,7 +1320,7 @@ class VM(virt_vm.BaseVM):
                 try:
                     idx = random.randint(0, (len(devices) - 1))
                     return {"aobject": devices[idx].get_qid()}
-                except IndexError:
+                except (IndexError, ValueError):
                     pass
             return {'aobject': params.get('pci_bus', 'pci.0')}
 


### PR DESCRIPTION
The function _get_pci_bus expects the q35 machine to always have
x3130-upstream available, which might not be True. In that case the
ValueError might be emitted. Let's proceed with `pci.0` in such case.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>