### PR TITLE
QEMU userspace version logging: attempt to better detect the version

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -722,12 +722,14 @@ def preprocess(test, params, env):
             kvm_userspace_version = "Unknown"
     else:
         qemu_path = utils_misc.get_qemu_binary(params)
-        version_output = avocado_process.system_output("%s -help" % qemu_path,
+        version_output = avocado_process.system_output("%s -version" % qemu_path,
                                                        verbose=False)
         version_line = version_output.split('\n')[0]
-        matches = re.findall("[Vv]ersion .*?,", version_line)
+        regex = r"QEMU emulator version\s([0-9]+\.[0-9]+\.[0-9]+)\s?\((.*)\)"
+        matches = re.match(regex, version_line)
         if matches:
-            kvm_userspace_version = " ".join(matches[0].split()[1:]).strip(",")
+            kvm_userspace_version = "%s (%s)" % (matches.groups[0],
+                                                 matches.groups[1])
         else:
             kvm_userspace_version = "Unknown"
 


### PR DESCRIPTION
The regex being used can doesn't match with the QEMU versions I've
tried.  Maybe it's time to updated to match newer QEMU syntax.

This was tested with the following output from QEMU:

 * 'QEMU emulator version 2.9.0(qemu-kvm-rhev-2.9.0-16.el7_4.8)'
 * 'QEMU emulator version 2.10.50 (v2.10.0-594-gf75637badd)'

Signed-off-by: Cleber Rosa <crosa@redhat.com>