### PR TITLE
Empty vm.spice_options before its another population

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -939,7 +939,7 @@ class VM(virt_vm.BaseVM):
             """
             processes spice parameters on rhel5 host.
 
-            :param spice_options - dict with spice keys/values
+            :param spice_params - string containing spice parameters
             :param port_range - tuple with port range, default: (3000, 3199)
             """
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2464,6 +2464,20 @@ class VM(virt_vm.BaseVM):
                 qdev = qdevices.QGlobal(vga_type, pro, val)
                 self.devices.insert(qdev)
 
+    @property
+    def spice_port(self):
+        logging.warning("'VM.spice_port' will be removed by the end of "
+                        "the year 2017, please use 'self.spice_options."
+                        "get(\"spice_port\")' instead")
+        return self.spice_options.get("spice_port")
+
+    @property
+    def spice_tls_port(self):
+        logging.warning("'VM.spice_tls_port' will be removed by the end of "
+                        "the year 2017, please use 'self.spice_options."
+                        "get(\"spice_tls_port\")' instead")
+        return self.spice_options.get("spice_tls_port")
+
     @error_context.context_aware
     def create(self, name=None, params=None, root_dir=None,
                timeout=120, migration_mode=None,
@@ -2707,8 +2721,6 @@ class VM(virt_vm.BaseVM):
             try:
                 self.devices, self.spice_options = self.make_create_command()
                 self.update_vga_global_default(params, migration_mode)
-                self.spice_port = self.spice_options.get("spice_port")
-                self.spice_tls_port = self.spice_options.get("spice_tls_port")
                 logging.debug(self.devices.str_short())
                 logging.debug(self.devices.str_bus_short())
                 qemu_command = self.devices.cmdline()


### PR DESCRIPTION
This is an update of previous PR https://github.com/avocado-framework/avocado-vt/pull/1144.

In `vm.spice_options` are preserved outdated `params` from previous testcase. This is 
because `vm` instance is not recreated when another test run from job suite is performed.

example:
TC 1 `params`:
> spice_port = no
> spice_port_closed = no
> spice_seamless_migration = on
> spice_secure_channels = 
> spice_ssl = yes
> spice_tls_ciphers = DEFAULT
> spice_tls_port = blabla


qemu-kvm spice cmd:

    -spice disable-ticketing,tls-port=blabla,x509-dir=/tmp/spice_x509d,seamless-migration=on


`params` for following TC_2 in the same job:

> spice_addr = 127.0.0.1
> spice_port = generate
> spice_port_closed = no
> spice_seamless_migration = on

(notice `spice_tls_port = blabla` is not in `params`)

qemu-kvm spice cmd:

    -spice port=3000,disable-ticketing,addr=127.0.0.1,tls-port=blabla,x509-dir=/tmp/spice_x509d,seamless-migration=on

`tls-port=blabla` makes this 2. TC to fail.

- To correct this behaviour, instead of `self.spice_options` was used local variable `spice_options`, which is recreated on `vm.make_create_command()` and assigned to `vm` instance only by `vm.create()` command.

- Another problem presents dynamically generated `spice_port` value (`spice_*port = generate` parameter must be set) while `keep_guest_running == True` option. After first test case finishes, `vm` is not restarted, but newly created `vm.spice*_port` reports different spice port, then virtual machine is actually listening on. For following test case - this might cause fake test FAIL. To workaround this problem, `vm.is_alive()` test was removed from `if optget("spice*_port") == "generate"` condition, so that `vm.needs_restart(..)` always returns `True`. This recreates vm instance with proper `spice*_port`. As a trade-off we loose functionality of `keep_guest_running` option for SPICE tests while `spice_port == "generate"`. Nevertheless we, as SPICE QE team, do not use this option. This way we prevent to create unrestarted VM with changed parameters. 

- Final thing is to drop `vm.spice*_port` option in favour of `vm.spice_options["spice*_port"]`. There is no reason to store this value twice now. Thus `vm.spice-*port` temporary properties were created.

Deeper analysis can be found here: https://www.redhat.com/archives/avocado-devel/2017-February/msg00010.html

Signed-off-by: Radek Duda <rduda@redhat.com>