### PR TITLE
qemu_vm: docstring correction for `add_spice_rhel5`

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -939,7 +939,7 @@ class VM(virt_vm.BaseVM):
             """
             processes spice parameters on rhel5 host.
 
-            :param spice_options - dict with spice keys/values
+            :param spice_params - dict with spice keys/values
             :param port_range - tuple with port range, default: (3000, 3199)
             """
 


### PR DESCRIPTION
I have noticed wrong param in docstring of `add_spice_rhel5` function and corrected it.

Signed-off-by: Radek Duda <rduda@redhat.com>