### PR TITLE
QEMU userspace version logging: attempt to better detect the version [v2]

### DIFF
--- a/selftests/unit/test_env_process.py
+++ b/selftests/unit/test_env_process.py
@@ -1,0 +1,29 @@
+import re
+import sys
+
+if sys.version_info[:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from virttest.env_process import QEMU_VERSION_RE
+
+
+class QEMUVersion(unittest.TestCase):
+
+    def test_regex(self):
+        versions_expected = {
+            'QEMU emulator version 2.9.0(qemu-kvm-rhev-2.9.0-16.el7_4.8)': (
+                '2.9.0', 'qemu-kvm-rhev-2.9.0-16.el7_4.8'),
+            'QEMU emulator version 2.10.50 (v2.10.0-594-gf75637badd)': (
+                '2.10.50', 'v2.10.0-594-gf75637badd'),
+            'QEMU emulator version 2.7.1(qemu-2.7.1-7.fc25), Copyright (c) '
+            '2003-2016 Fabrice Bellard and the QEMU Project developers': (
+                '2.7.1', 'qemu-2.7.1-7.fc25'),
+            'QEMU PC emulator version 0.12.1 (qemu-kvm-0.12.1.2-2.503.el6_9.3),'
+            ' Copyright (c) 2003-2008 Fabrice Bellard': (
+                '0.12.1', 'qemu-kvm-0.12.1.2-2.503.el6_9.3')
+        }
+        for version, expected in versions_expected.items():
+            match = re.match(QEMU_VERSION_RE, version)
+            self.assertEqual(match.groups(), expected)

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -51,6 +51,11 @@ kernel_modified = False
 kernel_cmdline = None
 
 
+#: QEMU version regex.  Attempts to extract the simple and extended version
+#: information from the output produced by `qemu -version`
+QEMU_VERSION_RE = r"QEMU (?:PC )?emulator version\s([0-9]+\.[0-9]+\.[0-9]+)\s?\((.*?)\)"
+
+
 def preprocess_image(test, params, image_name, vm_process_status=None):
     """
     Preprocess a single QEMU image according to the instructions in params.
@@ -722,12 +727,12 @@ def preprocess(test, params, env):
             kvm_userspace_version = "Unknown"
     else:
         qemu_path = utils_misc.get_qemu_binary(params)
-        version_output = avocado_process.system_output("%s -help" % qemu_path,
+        version_output = avocado_process.system_output("%s -version" % qemu_path,
                                                        verbose=False)
         version_line = version_output.split('\n')[0]
-        matches = re.findall("[Vv]ersion .*?,", version_line)
+        matches = re.match(QEMU_VERSION_RE, version_line)
         if matches:
-            kvm_userspace_version = " ".join(matches[0].split()[1:]).strip(",")
+            kvm_userspace_version = "%s (%s)" % matches.groups()
         else:
             kvm_userspace_version = "Unknown"
 


### PR DESCRIPTION
The regex being used can doesn't match with the QEMU versions I've
tried.  Let's update the regex, and test it, to match various QEMU
versions syntax.

---

Changes from v1 (#1167):
 * More flexible regex to account for optional "PC" and optional parentheses (say in "Copyright (c)")
 * Made the regex available at module level
 * Added tests
 * Fixed incorrect syntax (`matches.groups[0]`)