### PR TITLE
virttest.qemu_devices: Add QPCIEBus to extend pcie bus support.

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -5,13 +5,9 @@ variants:
     - rtl8139:
         no ppc64 ppc64le
         nic_model = rtl8139
-        q35:
-            nic_pci_bus = pci_bridge
     - e1000:
         no ppc64 ppc64le
         nic_model = e1000
-        q35:
-            nic_pci_bus = pci_bridge
     - e1000-82540em:
         no ppc64 ppc64le
         nic_model = e1000-82540em
@@ -24,7 +20,6 @@ variants:
     - e1000e:
         only q35
         nic_model = e1000e
-        nic_pci_bus = pcie_switch
     - virtio_net:
         nic_model = virtio
         # Assign the queue number of nic device
@@ -36,8 +31,6 @@ variants:
         # following lines to enable the vhost support ( only available
         # for tap )
         #netdev_extra_params = ",vhost=on"
-        q35:
-            nic_pci_bus = pcie_switch
         enable_msix_vectors = yes
         whql.submission.device.net:
             test_device = VirtIO Ethernet Adapter$
@@ -82,8 +75,6 @@ variants:
         i440fx:
             cd_format=ide
         q35:
-            disk_pci_bus = pcie_switch
-            cdrom_pci_bus = ${disk_pci_bus}
             cd_format=ahci
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
@@ -99,9 +90,6 @@ variants:
         cd_format=scsi-cd
         scsi_hba=virtio-scsi-pci
         libvirt_controller=virtio-scsi
-        q35:
-            disk_pci_bus = pcie_switch
-            cdrom_pci_bus = ${disk_pci_bus}
     - spapr_vscsi:
         drive_format=scsi-hd
         cd_format=scsi-cd
@@ -342,8 +330,6 @@ variants:
         virtio_rngs += " rng0"
         #max-bytes_virtio-rng-pci =
         #period_virtio-rng-pci =
-        q35:
-            rng_pci_bus = pcie_switch
         variants:
              - rng_random:
                  backend_rng0 = rng-random

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -20,11 +20,8 @@ variants:
         # RHEL.5, RHEL.6 guest unsupport attach pcie device to downstream
         # port of pcie-switch, see RHBZ#1380285
         no WinXP Win2000 Win2003 RHEL.5 RHEL.6
-        pci_controllers = root_port pcie_switch dmi2pci_bridge pci_bridge
+        pci_controllers = dmi2pci_bridge pci_bridge
         pci_bus = pci.0
-        type_root_port = ioh3420
-        type_pcie_switch = x3130
-        pci_bus_pcie_switch = root_port
         type_dmi2pci_bridge = i82801b11-bridge
         type_pci_bridge = pci-bridge
         pci_bus_pci_bridge = dmi2pci_bridge

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -765,6 +765,11 @@ class DevContainer(object):
         :param params: VM params
         :return: List of added devices (including default buses)
         """
+        if self.has_device("pcie-root-port"):
+            root_port_type = "pcie-root-port"
+        else:
+            root_port_type = "ioh3420"
+
         def machine_q35(cmd=False):
             """
             Q35 + ICH9
@@ -774,7 +779,7 @@ class DevContainer(object):
             logging.warn('Using Q35 machine which is not yet fully tested on '
                          'avocado-vt. False errors might occur.')
             devices = []
-            bus = (qbuses.QPCIBus('pcie.0', 'PCIE', 'pci.0'),
+            bus = (qbuses.QPCIEBus('pcie.0', 'PCIE', root_port_type, 'pci.0'),
                    qbuses.QStrictCustomBus(None, [['chassis'], [256]], '_PCI_CHASSIS',
                                            first_port=[1]),
                    qbuses.QStrictCustomBus(None, [['chassis_nr'], [256]],
@@ -1756,9 +1761,9 @@ class DevContainer(object):
         :warning: x3130-upstream device creates only x3130-upstream device
                   and you are responsible for creating the downstream ports.
         """
-        driver = params.get('type', 'ioh3420')
+        driver = params.get('type', 'pcie-root-port')
         pcic_params = {"id": name}
-        if driver in ('ioh3420', 'x3130-upstream', 'x3130'):
+        if driver in ('pcie-root-port', 'ioh3420', 'x3130-upstream', 'x3130'):
             bus_type = 'PCIE'
         else:
             bus_type = 'PCI'

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1311,9 +1311,8 @@ class VM(virt_vm.BaseVM):
             """
             if dtype and "%s_pci_bus" % dtype in params:
                 return {"aobject": params["%s_pci_bus" % dtype]}
-
-            if params.get("machine_type") == "q35":
-                pcic = pcie and "x3130-upstream" or "pci-bridge"
+            if params.get("machine_type") == "q35" and not pcie:
+                pcic = "pci-bridge"
                 devices = [
                     d for d in devices if isinstance(
                         d, QDevice) and d.get_param("driver") == pcic]
@@ -1335,7 +1334,7 @@ class VM(virt_vm.BaseVM):
                 """
                 Function used to sort pcic list
                 """
-                order_pcics = ['ioh3420', 'x3130-upstream',
+                order_pcics = ['pcie-root-port', 'ioh3420', 'x3130-upstream',
                                'x3130', 'i82801b11-bridge',
                                'pci-bridge']
                 try:
@@ -1346,9 +1345,6 @@ class VM(virt_vm.BaseVM):
             pcics = []
             for pcic in params.objects("pci_controllers"):
                 dev = devices.pcic_by_params(pcic, params.object_params(pcic))
-                slot = len([_ for _ in pcics if _.get_param('driver') == 'ioh3420'])
-                if dev.get_param('driver') == 'ioh3420':
-                    dev.set_param('slot', hex(slot))
                 pcics.append(dev)
             pcics.sort(key=sort_key, reverse=False)
             map(devices.insert, pcics)


### PR DESCRIPTION
1. qbuses.py: class QPCIEBus: Add individual pcie-root-port for each
virtio device.

2. qcontainer.py: Modify q35 bus type from QPCIBus to QPCIEBus. Use
"pcie-root-port" as default root port type for new qemu version.

3. qemu_vm.py:
  _get_pci_bus: Use pcie.0 as default bus instead of "x3130-upstream".
  add_pci_controllers: Add "pcie-root-port" to order list. Remove slot
  assignment part, which will be unified to qbuses.QPCIEBus.

4. guest-hw.cfg: Remove all q35 related device default bus
specifications, which are unified to qbuses.QPCIEBus.

5. machines.cfg: q35: Remove default pci controller root_port and
pcie_switch, which is not default need in the new topology.

id: 1490226

Signed-off-by: Qianqian Zhu <qizhu@redhat.com>