### PR TITLE
Collect usefull information in system report

### DIFF
--- a/shared/scripts/rh_perf_log_guestinfo_script.sh
+++ b/shared/scripts/rh_perf_log_guestinfo_script.sh
@@ -11,3 +11,11 @@ call cat /proc/cmdline
 call cat /sys/devices/system/clocksource/clocksource0/current_clocksource
 
 call "grep flags /proc/cpuinfo |head -n 1"
+
+call sestatus
+
+call cat /proc/sys/kernel/watchdog
+
+call cat /proc/sys/kernel/nmi_watchdog
+
+call tuned-adm active

--- a/shared/scripts/rh_perf_log_hostinfo_script.sh
+++ b/shared/scripts/rh_perf_log_hostinfo_script.sh
@@ -20,6 +20,20 @@ call "cat /proc/meminfo  |grep HugePages_Total"
 
 call cat /sys/kernel/debug/sched_features
 
+call cat /sys/kernel/mm/ksm/run
+
+call sestatus
+
+call cat /proc/sys/kernel/watchdog
+
+call cat /proc/sys/kernel/nmi_watchdog
+
+call tuned-adm active
+
+call tc qdisc show
+
+call ifconfig
+
 bridges=`brctl show|grep -v "bridge.*name.*bridge.*id"|awk {'print $1'}`
 ports=`brctl show|grep -v "bridge.*name.*bridge.*id"|awk {'print $4'}`
 
@@ -31,6 +45,7 @@ done
 for i in $ports;do
     call ethtool -k $i
     call ethtool -i $i
+    call ethtool -c $i
 done
 
 echo "=========================== Test steps ================================="


### PR DESCRIPTION
Add selinux/watchdog/tuning profile/qdisc/coalescing parameters information in system report.
    
Signed-off-by: Wenli Quan <wquan@redhat.com>

ID: 1502520
