### PR TITLE
utilize setup_hugepages from env_process for hugepage backed vm bringup 

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -741,6 +741,10 @@ def preprocess(test, params, env):
 
     libvirtd_inst = utils_libvirtd.Libvirtd()
 
+    # If guest is configured to be backed by hugepages, setup hugepages in host
+    if params.get("hugepage") == "yes":
+        params["setup_hugepages"] = "yes"
+
     if params.get("setup_hugepages") == "yes":
         h = test_setup.HugePageConfig(params)
         suggest_mem = h.setup()

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -420,12 +420,6 @@ class VM(virt_vm.BaseVM):
                         logging.warning("hugepages option not supported by "
                                         "virt-install")
                     else:
-                        # checks whether host supports Hugepage and calculate
-                        # target hugepages required for the VM, set the
-                        # calculated hugepages in host nr_hugepages for
-                        # guest to use it
-                        hp = test_setup.HugePageConfig(params)
-                        hp.set_hugepages()
                         cmd += ",hugepages=yes"
                 return cmd
             else:
@@ -883,6 +877,8 @@ class VM(virt_vm.BaseVM):
 
         mem = params.get("mem")
         maxmemory = params.get("maxmemory", None)
+
+        # hugepage setup in host will be taken care in env_process
         hugepage = params.get("hugepage", "no") == "yes"
         if mem:
             virt_install_cmd += add_mem(help_text, mem, maxmemory, hugepage)


### PR DESCRIPTION
For bringing up hugepage backed VM from virt-install, hugepages have to be configured in host. setup_hugepages from env_process can be reused for configuring hugepages in host to avoid redundancy and cleanup issues.

Signed-off-by: Balamuruhan S \<bala24@linux.vnet.ibm.com\>