### PR TITLE
q35/arm64-pci: Put devices into root-ports

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -35,11 +35,10 @@ variants:
         vga = std
         del rtc_drift
         del soundcards
-    - arm64-mmio:
+    - arm64:
         only aarch64
         auto_cpu_model = "no"
         cpu_model = host
-        machine_type = arm64-mmio:virt
         # No support for VGA yet
         vga = none
         vir_domain_undefine_nvram = yes
@@ -48,19 +47,13 @@ variants:
         # Currently no USB support
         usbs =
         usb_devices =
-    - arm64-pci:
-        only aarch64
-        auto_cpu_model = "no"
-        cpu_model = host
-        machine_type = arm64-pci:virt
-        # No support for VGA yet
-        vga = none
-        vir_domain_undefine_nvram = yes
-        inactivity_watcher = none
-        take_regular_screendumps = no
-        # Currently no USB support
-        usbs =
-        usb_devices =
+        variants:
+            - arm64-mmio:
+                # Use mmio devices (legacy)
+                machine_type = arm64-mmio:virt
+            - arm64-pci:
+                # Put pci devices directly into pcie.0
+                machine_type = arm64-pci:virt
     - s390-virtio:
         only s390x
         auto_cpu_model = "no"

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -908,7 +908,8 @@ class DevContainer(object):
                 # Don't add pci-representation
                 return devices
             # And this is the pcie bus
-            bus = (qbuses.QPCIBus('pcie.0', 'PCIE', 'pci.0'),
+            pcie = qbuses.QPCIEWithRootPorts('pcie.0', 'PCIE', 'pci.0')
+            bus = (pcie,
                    qbuses.QStrictCustomBus(None, [['chassis'], [256]],
                                            '_PCI_CHASSIS', first_port=[1]),
                    qbuses.QStrictCustomBus(None, [['chassis_nr'], [256]],
@@ -918,6 +919,10 @@ class DevContainer(object):
             devices.append(qdevices.QStringDevice('gpex-root',
                                                   {'addr': 0, 'driver': 'gpex-root'},
                                                   parent_bus={'aobject': 'pci.0'}))
+            if self.has_device("pcie-root-port"):
+                # skip ports 0x0 - gpex
+                for addr in xrange(1, 31):
+                    devices.append(pcie.add_root_port(hex(addr)))
             return devices
 
         def machine_s390_virtio(cmd=False):

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -843,7 +843,7 @@ class DevContainer(object):
                                )
             return devices
 
-        def machine_arm64_mmio(cmd=False):
+        def machine_arm64(cmd=False, bus="pci"):
             """
             aarch64 (arm64) doesn't support PCI bus, only MMIO transports.
             Also it requires pflash for EFI boot.
@@ -892,56 +892,9 @@ class DevContainer(object):
             devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
                                                   child_bus=bus,
                                                   aobject="virtio-mmio-bus"))
-            return devices
-
-        def machine_arm64_pci(cmd=False):
-            """
-            Experimental support for pci-based aarch64
-            :param cmd: If set uses "-M $cmd" to force this machine type
-            :return: List of added devices (including default buses)
-            """
-            def get_aavmf_vars(params):
-                """
-                Naive implementation of obtaining the main (first) image name
-                """
-                try:
-                    first_image = params.objects('images')[0]
-                    name = params.object_params(first_image).get('image_name')
-                    return os.path.join(data_dir.DATA_DIR,
-                                        name + "_AAVMF_VARS.fd")
-                except IndexError:
-                    raise DeviceError("Unable to map main image name to "
-                                      "AAVMF variables file.")
-            logging.warn('Support for aarch64 is highly experimental!')
-            devices = []
-            devices.append(qdevices.QStringDevice('machine', cmdline=cmd))
-            # EFI pflash
-            aavmf_code = ("-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,"
-                          "if=pflash,format=raw,unit=0,readonly=on")
-            devices.append(qdevices.QStringDevice('AAVMF_CODE',
-                                                  cmdline=aavmf_code))
-            aavmf_vars = get_aavmf_vars(params)
-            if not os.path.exists(aavmf_vars):
-                logging.warn("AAVMF variables file '%s' doesn't exist, "
-                             "recreating it from the template (this should "
-                             "only happen when you install the machine as "
-                             "there is no default boot in EFI!)", aavmf_vars)
-                shutil.copy2('/usr/share/AAVMF/AAVMF_VARS.fd', aavmf_vars)
-            aavmf_vars = ("-drive file=%s,if=pflash,format=raw,unit=1"
-                          % aavmf_vars)
-            devices.append(qdevices.QStringDevice('AAVMF_VARS',
-                                                  cmdline=aavmf_vars))
-            # Add virtio-bus
-            # TODO: Currently this uses QNoAddrCustomBus and does not
-            # set the device's properties. This means that the qemu qtree
-            # and autotest's representations are completelly different and
-            # can't be used.
-            bus = qbuses.QNoAddrCustomBus('bus', [['addr'], [32]],
-                                          'virtio-mmio-bus', 'virtio-bus',
-                                          'virtio-mmio-bus')
-            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
-                                                  child_bus=bus,
-                                                  aobject="virtio-mmio-bus"))
+            if bus == "mmio":
+                # Don't add pci-representation
+                return devices
             # And this is the pcie bus
             bus = (qbuses.QPCIBus('pcie.0', 'PCIE', 'pci.0'),
                    qbuses.QStrictCustomBus(None, [['chassis'], [256]],
@@ -1010,9 +963,9 @@ class DevContainer(object):
                 if 'q35' in machine_type:   # Q35 + ICH9
                     devices = machine_q35(cmd)
                 elif arm_machine == 'arm64-pci':
-                    devices = machine_arm64_pci(cmd)
+                    devices = machine_arm64(cmd, bus="pci")
                 elif arm_machine == 'arm64-mmio':
-                    devices = machine_arm64_mmio(cmd)
+                    devices = machine_arm64(cmd, bus="mmio")
                 elif machine_type.startswith("s390"):
                     devices = machine_s390_virtio(cmd)
                 elif 'isapc' not in machine_type:   # i440FX

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3601,6 +3601,16 @@ class VM(virt_vm.BaseVM):
                 device_add_cmd += ",mq=on"
             if 'vectors' in nic:
                 device_add_cmd += ",vectors=%s" % nic.vectors
+        bus = nic.get("pci_bus")
+        if bus is not None:
+            # Bus is aobject, not the actual bus id
+            buses = self.devices.get_buses({"aobject": bus})
+            if len(buses) == 1:
+                device_add_cmd += ",bus=%s" % buses[0].busid
+            else:
+                logging.warning("Ignoring pci_bus %s on %s because did not "
+                                "found correct candidate: %s", bus,
+                                nic_index_or_name, buses)
         device_add_cmd += nic.get('nic_extra_params', '')
         if 'romfile' in nic:
             device_add_cmd += ",romfile=%s" % nic.romfile

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1815,8 +1815,9 @@ class VM(virt_vm.BaseVM):
                     net_params["guest_port%d" % i] = guest_port
 
                 # TODO: Is every NIC a PCI device?
-                devices.insert(StrDev("NET-%s" % nettype, cmdline=cmd,
-                                      params=net_params, cmdline_nd=cmd_nd))
+                devices.insert(StrDev("NET-%s" % nettype, aobject=netdev_id,
+                                      cmdline=cmd, params=net_params,
+                                      cmdline_nd=cmd_nd))
             else:
                 device_driver = nic_params.get("device_driver", "pci-assign")
                 pci_id = vm.pa_pci_ids[iov]
@@ -3605,11 +3606,17 @@ class VM(virt_vm.BaseVM):
         if bus is not None:
             # Bus is aobject, not the actual bus id
             buses = self.devices.get_buses({"aobject": bus})
-            if len(buses) == 1:
-                device_add_cmd += ",bus=%s" % buses[0].busid
+            qdev_type = "NET-%s" % nic.nettype
+            for bus in buses:
+                # Add device into internal representation to get the expected
+                # bus id
+                dev = qdevices.QBaseDevice(qdev_type, aobject=nic.nic_name)
+                if isinstance(bus.insert(dev), list):
+                    device_add_cmd += ",bus=%s" % dev.get_param("bus")
+                    break
             else:
-                logging.warning("Ignoring pci_bus %s on %s because did not "
-                                "found correct candidate: %s", bus,
+                logging.warning("Ignoring pci_bus %s on %s because did "
+                                "not found correct candidate: %s", bus,
                                 nic_index_or_name, buses)
         device_add_cmd += nic.get('nic_extra_params', '')
         if 'romfile' in nic:
@@ -3658,6 +3665,24 @@ class VM(virt_vm.BaseVM):
                                             "guest, please check whether the "
                                             "hotplug module was loaded in "
                                             "guest")
+
+        bus = nic.get("pci_bus")
+        if bus is not None:
+            # Bus is aobject, not the actual bus id
+            buses = self.devices.get_buses({"aobject": bus})
+            aobject = nic.nic_name
+            for bus in buses:
+                for device in bus:
+                    if getattr(device, "aobject", None) == aobject:
+                        # Remove the device from internal representation
+                        if bus.remove(device):
+                            break
+                else:
+                    continue
+                break
+            else:
+                logging.warning("Unable to find nic %s in pci_buses %s.",
+                                nic_index_or_name, buses)
 
     @error_context.context_aware
     def deactivate_netdev(self, nic_index_or_name):

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2436,7 +2436,7 @@ class QemuIface(VirtIface):
                  'tapfd_ids', 'netdev_id', 'tftp',
                  'romfile', 'nic_extra_params',
                  'netdev_extra_params', 'queues', 'vhostfds',
-                 'vectors']
+                 'vectors', 'pci_bus']
 
 
 class VMNet(list):


### PR DESCRIPTION
**DON'T MERGE - q35 works well, arm does not boot on my machine, investigating...**

This patch set fixes some little issues and then adds a support for new PCI bus representation, which allows to plug devices into root-ports rather then directly into the PCIE bus and makes q35-based and arm64-pci-based machines to use this representation instead of the stock one.

This can be controversial, so I'm open to suggestions and eventually even to allow to call this a different name (eg. arm64-pci-hp) in order to let it stabilize before breaking all the existing tests, anyway for the purposes of this PR I enable this always when root-port is a supported device.

This supersedes the https://github.com/avocado-framework/avocado-vt/pull/1127 which treated this incorrectly.

**DON'T MERGE - q35 works well, arm does not boot on my machine, investigating...**

_I noticed the boot disk discovery fails when too many root ports are added. BZ is available here https://bugzilla.redhat.com/show_bug.cgi?id=1499513 so hopefully we'll know more soon._