### PR TITLE
libvirt_vm:rule out rescue kernel when set debug kernel to default

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1435,7 +1435,7 @@ class VM(virt_vm.BaseVM):
                 index = -1
                 logging.info("Setting debug kernel as default")
                 for i in range(len(kernel_list)):
-                    if "debug" in kernel_list[i]:
+                    if "debug" in kernel_list[i] and 'rescue' not in kernel_list[i].lower():
                         index = i
                         break
                 if index == -1:


### PR DESCRIPTION
Add condition to rule out rescue kernel in case to be set as
default kernel when it shoud be debug kernel to be set as default.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>