### PR TITLE
libvirt: initialize param selinux_status_bak to avoid key error

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -462,6 +462,7 @@ def setup_or_cleanup_nfs(is_setup, mount_dir="nfs-mount", is_mount=False,
         mount_dir = os.path.join(tmpdir, mount_dir)
     result["export_dir"] = export_dir
     result["mount_dir"] = mount_dir
+    result["selinux_status_bak"] = None
     if not ubuntu:
         result["selinux_status_bak"] = utils_selinux.get_status()
 


### PR DESCRIPTION
param selinux_status_bak is not initialized for ubuntu and breaks with keyerror
in set_vm_disk() where this param is retrieved as res['selinux_status_bak']

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>