### PR TITLE
docs: Fix foo.cfg syntax error in DefiningNewGuests.rst

### DIFF
--- a/docs/source/WritingTests/DefiningNewGuests.rst
+++ b/docs/source/WritingTests/DefiningNewGuests.rst
@@ -21,7 +21,7 @@ You can add, say, foo.cfg to that dir with the content:
 
 ::
 
-    FooLinux:
+    - FooLinux:
         image_name = images/foo-linux
 
 Which would make it possible to specify this custom guest using
@@ -79,7 +79,7 @@ You can add, say, foo.cfg to that dir with the content:
 
 ::
 
-    FooWindows:
+    - FooWindows:
         image_name = images/foo-windows
 
 Which would make it possible to specify this custom guest using


### PR DESCRIPTION
This fixes a syntax error in foo.cfg example of DefiningNewGuests.rst.

Fixes https://github.com/avocado-framework/avocado-vt/issues/1189

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>