### PR TITLE
virttest: Two fixes to avoid Avocado hangs

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -257,7 +257,10 @@ class Monitor:
         # dependency by creating fake VM object which only contains `vm.name`,
         # which is in reality the only information required by Monitor object
         # at this time.
-        return VM(self.vm.name), self.name, self.filename, False
+        # Always ignore errors during unpickle as exceptions during "__init__"
+        # would cause the whole unpickle operation to fail, leaving us without
+        # any representation whatsoever.
+        return VM(self.vm.name), self.name, self.filename, True
 
     def _close_sock(self):
         try:

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -889,7 +889,10 @@ class BaseVM(object):
         """
         Verify guest dmesg
         """
-        session = self.wait_for_login()
+        if len(self.virtnet) > 0:
+            session = self.wait_for_login()
+        else:
+            session = self.wait_for_serial_login()
         level = self.params.get("guest_dmesg_level", 3)
         ignore_result = self.params.get("guest_dmesg_ignore", "no") == "yes"
         utils_misc.verify_dmesg(dmesg_log_file=dmesg_log_file,


### PR DESCRIPTION
Recently my CI hanged, because of unfinished qemu processes caused by `dmesg` check without `nic` interface. The first commit fixes the hang, the second commit uses serial console to access the machine when no nics are attached.