### PR TITLE
shared.cfg.guest-os: switch multi_disk cases to use netcat

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -252,8 +252,6 @@
         guest_path = C:\
     multi_disk, usb_multi_disk:
         black_list += " E:"
-        shell_port = 23
-        shell_client = telnet
         post_cmd = del c:\cmd.exe; true
         file_system = "ntfs fat32"
         cmd_list = "copy_to_command copy_from_command"


### PR DESCRIPTION
Due to telnet does not work well on Win10 and Win2016,
switch multi_disk cases to use netcat.

id: 1503414
Signed-off-by: Haotong Chen <hachen@redhat.com>