### PR TITLE
shared: Add RHEL.7.devel on s390x

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -20,7 +20,7 @@
     cdrom_test_cmd = "dd if=%s of=/dev/null bs=1 count=1"
     cdrom_info_cmd = "cat /proc/sys/dev/cdrom/info"
     timedrift, timerdevice..boot_test:
-        !ppc64, ppc64le, aarch64:
+        i386, x86_64:
             extra_params += " -no-kvm-pit-reinjection"
         time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
         time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"

--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -20,3 +20,5 @@
             boot_path = ppc/ppc64
         x86_64, i386:
             kernel_params += " console=ttyS0,115200 console=tty0"
+        s390x:
+            kernel_params += " console=ttysclp0 debug ignore_loglevel"

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/s390x.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/s390x.cfg
@@ -1,0 +1,12 @@
+- s390x:
+    grub_file = /boot/grub/grub.conf
+    vm_arch_name = s390x
+    image_name += -s390x
+    boot_path = images
+    install_timeout = 14400
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_unattended = images/rhel7-s390x/ks.iso
+        kernel = images/rhel7-s390x/kernel.img
+        initrd = images/rhel7-s390x/initrd.img
+    unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_cd1 = isos/linux/RHEL-7-devel-s390x.iso

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -70,3 +70,5 @@ variants:
         # Currently no USB support
         usbs =
         usb_devices =
+        # The main disc is usually /dev/dasda device
+        indirect_image_blacklist = "/dev/dasda[\d]*"

--- a/shared/unattended/RHEL-7-devel.ks
+++ b/shared/unattended/RHEL-7-devel.ks
@@ -61,7 +61,9 @@ sg3_utils
 %end
 
 %post
-function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
 ECHO "OS install is completed"
 ECHO "remove rhgb quiet by grubby"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -49,7 +49,9 @@ prelink
 %end
 
 %post
-function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
 ECHO "OS install is completed"
 ECHO "remove rhgb quiet by grubby"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1389,7 +1389,7 @@ class DevContainer(object):
             elif scsi_hba == 'virtio-scsi-device':
                 addr_spec = [256, 16384]
                 pci_bus = {'type': 'virtio-bus'}
-            if scsi_hba in ('spapr-vscsi', "virtio-scsi-ccw"):
+            elif scsi_hba in ('spapr-vscsi', "virtio-scsi-ccw"):
                 addr_spec = [8, 16384]
                 pci_bus = None
             _, bus, dev_parent = define_hbas('SCSI', scsi_hba, bus, unit, port,

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1384,12 +1384,13 @@ class DevContainer(object):
             addr_spec = None
             if scsi_hba == 'lsi53c895a':
                 addr_spec = [8, 16384]
-            elif scsi_hba == 'virtio-scsi-pci':
+            elif scsi_hba.startswith("virtio"):
                 addr_spec = [256, 16384]
-            elif scsi_hba == 'virtio-scsi-device':
-                addr_spec = [256, 16384]
-                pci_bus = {'type': 'virtio-bus'}
-            elif scsi_hba in ('spapr-vscsi', "virtio-scsi-ccw"):
+                if scsi_hba == 'virtio-scsi-device':
+                    pci_bus = {'type': 'virtio-bus'}
+                elif scsi_hba == 'virtio-scsi-ccw':
+                    pci_bus = None
+            elif scsi_hba == 'spapr-vscsi':
                 addr_spec = [8, 16384]
                 pci_bus = None
             _, bus, dev_parent = define_hbas('SCSI', scsi_hba, bus, unit, port,


### PR DESCRIPTION
This adds the s390x variant of RHEL.7.devel.

If you are checking this on RHEL 7, note that you need kernel with KVM support enabled and you must use `nettype=user` because of https://bugzilla.redhat.com/show_bug.cgi?id=1505330

Also note that running this test from z/vm guest might result in many timeouts so it's advised to run directly from lpar.