### PR TITLE
Clear the targetcli configuration before use it

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -558,6 +558,10 @@ class IscsiLIO(_IscsiComm):
         :param params: parameters dict for LIO backend of iSCSI
         """
         super(IscsiLIO, self).__init__(params, root_dir)
+        # clear the targetcli configuration before using it
+        cmd = "targetcli clearconfig confirm=true"
+        if process.system(cmd, shell=True) != 0:
+            logging.error("targetcli configuration unable to clear")
 
     def get_target_id(self):
         """


### PR DESCRIPTION
it is better to clear targetcli configuration before use it, otherwise i seen few errors like "AttributeError: 'NoneType' object has no attribute 'export_flag'"
Signed-off-by: prudhvi <mprudhvi@linux.vnet.ibm.com>