### PR TITLE
Fixup: Available hugepage from buddyinfo for ppc64

### DIFF
--- a/virttest/staging/utils_memory.py
+++ b/virttest/staging/utils_memory.py
@@ -274,3 +274,12 @@ def get_buddy_info(chunk_sizes, nodes="all", zones="all"):
             buddyinfo_dict[chunk_size] += int(chunk_info)
 
     return buddyinfo_dict
+
+
+def getpagesize():
+    """
+    Get system page size
+
+    :return: pagesize in kB
+    """
+    return os.sysconf('SC_PAGE_SIZE') / 1024

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -399,9 +399,12 @@ class HugePageConfig(object):
             hugepage_allocated = open(self.kernel_hp_file, "r")
             available_hugepages = int(hugepage_allocated.read().strip())
             hugepage_allocated.close()
-            chunk_bottom = int(math.log(self.hugepage_size / 4, 2))
-            chunk_info = utils_memory.get_buddy_info(">=%s" % chunk_bottom,
-                                                     zones="DMA32 Normal")
+            chunk_bottom = int(math.log(self.hugepage_size / utils_memory.getpagesize(), 2))
+            if ARCH == 'ppc64le':
+                chunk_info = utils_memory.get_buddy_info(">=%s" % chunk_bottom)
+            else:
+                chunk_info = utils_memory.get_buddy_info(">=%s" % chunk_bottom,
+                                                         zones="DMA32 Normal")
             for size in chunk_info:
                 available_hugepages += int(chunk_info[size] * math.pow(2,
                                                                        int(int(size) - chunk_bottom)))


### PR DESCRIPTION
1. Calculation of available hugepages from buddyinfo
is arch dependant(,due to the different page_size),
it was hardcoded for x86, this patch tries to make
it generic by adding getpagesize method.

2. Additionaly powerpc does not have different buddy
regions added support for same.


Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>