### PR TITLE
qemu_virtio_port: add pattern to match exit status in GuestWorker

### DIFF
--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -415,7 +415,7 @@ class GuestWorker(object):
         Default state: No data on port or in port buffer. Read mode = blocking.
         """
         # Check if python is still alive
-        match, tmp = self._cmd("is_alive()", 10)
+        match, tmp = self._cmd("is_alive()", 10, ("^PASS: Guest is ok no thread alive",))
         if match is not 0:
             logging.error("Python died/is stuck/have remaining threads")
             logging.debug(tmp)
@@ -451,7 +451,7 @@ class GuestWorker(object):
             self.vm.verify_kernel_crash()
         # Quit worker
         if self.session and self.vm and self.vm.is_alive():
-            match, tmp = self._cmd("guest_exit()", 10)
+            match, tmp = self._cmd("guest_exit()", 10, ("^PASS: virtio_guest finished",))
             self.session.close()
             # On windows it dies with the connection
             if match is not 0 and self.os_linux:


### PR DESCRIPTION
GuestWorker is a process in guest,  receiving commands and printing results on screen, these results will be got by session. Since there are several commands operated in sequence, session might get several results together and host will be confused with common pattern `("^PASS:", "^FAIL:")`.

I saw a relevant issue in my work, so suggest to import this patch to framework. Thanks.
Signed-off-by: Sitong Liu <siliu@redhat.com>