### PR TITLE
qemu_vm: Fix bug of migration with qemu 2.10

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2924,14 +2924,8 @@ class VM(virt_vm.BaseVM):
             if params.get("paused_after_start_vm") != "yes":
                 # start guest
                 if self.monitor.verify_status("paused"):
-                    try:
+                    if not migration_mode:
                         self.monitor.cmd("cont")
-                    except qemu_monitor.QMPCmdError, e:
-                        if ((e.data['class'] == "MigrationExpected") and
-                                (migration_mode is not None)):
-                            logging.debug("Migration did not start yet...")
-                        else:
-                            raise e
 
             # Update mac and IP info for assigned device
             # NeedFix: Can we find another way to get guest ip?


### PR DESCRIPTION
Qemu 2.10 introduced image file locking feature which would cause
the following automation error during migration.

    QMPCmdError: QMP command 'cont' failed (arguments: None, error message: {u'class': u'GenericError', u'desc': u'Failed to get "write" lock'})

This patch will fix this problem by not sending `cont` to the
destination before migration started.

Signed-off-by: Xu Han <xuhan@redhat.com>