### PR TITLE
Modify check_vfs_count to include the total no.of PF interfaces rather than fixed values.

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1305,10 +1305,9 @@ class PciAssignable(object):
         """
         Check VFs count number according to the parameter driver_options.
         """
-        # Network card 82576 has two network interfaces and each can be
-        # virtualized up to 7 virtual functions, therefore we multiply
-        # two for the value of driver_option 'max_vfs'.
-        expected_count = int((re.findall("(\d+)", self.driver_option)[0])) * 2
+        # The VF count should be multiplied with the total no.of PF's
+        # present, rather than fixed number of network interfaces.
+        expected_count = int((re.findall("(\d+)", self.driver_option)[0])) * len(self.get_pf_ids())
         return (self.get_vfs_count() == expected_count)
 
     def is_binded_to_stub(self, full_id):


### PR DESCRIPTION
The function should fetch the total no.of PF devices in the host, and multiply the same with the VF's to get the total number of VF's.
Multiplying with a fixed number of PF's will error out if there is mismatch in number of
network interfaces.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>