### PR TITLE
virttest: Two fixes required for pci_devices test to work again

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1339,7 +1339,8 @@ class VM(virt_vm.BaseVM):
             for pcic in params.objects("pci_controllers"):
                 dev = devices.pcic_by_params(pcic, params.object_params(pcic))
                 pcics.append(dev)
-            pcics.sort(key=sort_key, reverse=False)
+            if params.get("pci_controllers_autosort", "yes") == "yes":
+                pcics.sort(key=sort_key, reverse=False)
             map(devices.insert, pcics)
         # End of command line option wrappers
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1637,7 +1637,8 @@ class VM(virt_vm.BaseVM):
             usbs = ("oldusb",)  # Old qemu, add only one controller '-usb'
         for usb_name in usbs:
             usb_params = params.object_params(usb_name)
-            for dev in devices.usbc_by_params(usb_name, usb_params):
+            parent_bus = _get_pci_bus(devices, usb_params, "usbc", True)
+            for dev in devices.usbc_by_params(usb_name, usb_params, parent_bus):
                 devices.insert(dev)
 
         for iothread in params.get("iothreads", "").split():


### PR DESCRIPTION
The `pci_devices` test does not work anymore because of multiple changes in pci controllers handing. This PR contains 2 fixes required in virttest in order to be able to make that test to work again. Please see the details in each commit.