### PR TITLE
etc: Add note about WinXP not working with virtio_scsi

### DIFF
--- a/etc/avocado/conf.d/vt.conf
+++ b/etc/avocado/conf.d/vt.conf
@@ -46,6 +46,8 @@ image_type = qcow2
 nic_model = virtio_net
 # Guest disk bus for main image. One of
 # ('ide', 'scsi', 'virtio_blk', 'virtio_scsi', 'lsi_scsi', 'ahci', 'usb2', 'xenblk')
+# Note: Older qemu versions and/or operating systems might not support
+#       "virtio_scsi" (WinXP) Please use virtio_blk" or "ide" instead.
 disk_bus = virtio_scsi
 # Enable qemu sandboxing (on/off)
 sandbox = on


### PR DESCRIPTION
A while ago we changed the default disk backend to "virtio_scsi", which
is not supported on WinXP (and ancient qemu versions). Let's include a
note in config to help our users.

Addresses comment from https://github.com/avocado-framework/avocado-vt/commit/e010cf166aa67f883ba7b0d2658f425ef4e53c42