### PR TITLE
Fedora 26/27 AArch64 guest support

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/26.aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/26.aarch64.cfg
@@ -1,0 +1,24 @@
+- 26.aarch64:
+    image_name = images/f26-aarch64
+    vm_arch_name = aarch64
+    os_variant = fedora26
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel_params = 'nicdelay=60 console=ttyAMA0 console=ttyS0 serial'
+        unattended_file = unattended/Fedora-25.ks
+        kernel = images/f26-aarch64/vmlinuz
+        initrd = images/f26-aarch64/initrd.img
+        syslog_server_proto = tcp
+        extra_cdrom_ks:
+            cdrom_unattended = images/f26-aarch64/ks.iso
+            kernel_params += ' ks=cdrom:/ks.cfg'
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-dvd-aarch64-26-1.5.iso
+        md5sum_cd1 = 6bd8b4fea6872cde08d2105f6f87128e
+        md5sum_1m_cd1 = 34552e3747fcfcbfd250665698edcb21
+    unattended_install.url:
+        url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/26/Server/aarch64/os/
+        kernel_params += ' inst.repo=${url}'
+        sha1sum_vmlinuz = 76736a88e41fc83b7f0962cc3a72fbddd1c61a3f
+        sha1sum_initrd = 39f485b4ee63d03fe9ef7c9448c8e453616a352c
+        mem = 2048

--- a/shared/cfg/guest-os/Linux/Fedora/27.aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/27.aarch64.cfg
@@ -1,0 +1,24 @@
+- 27.aarch64:
+    image_name = images/f27-aarch64
+    vm_arch_name = aarch64
+    os_variant = fedora27
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel_params = 'nicdelay=60 console=ttyAMA0 console=ttyS0 serial'
+        unattended_file = unattended/Fedora-25.ks
+        kernel = images/f27-aarch64/vmlinuz
+        initrd = images/f27-aarch64/initrd.img
+        syslog_server_proto = tcp
+        extra_cdrom_ks:
+            cdrom_unattended = images/f27-aarch64/ks.iso
+	    kernel_params += ' ks=cdrom:/ks.cfg'
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/Fedora-Server-dvd-aarch64-27-1.6.iso
+        md5sum_cd1 = 1a9cb7c3feeb5a6d5c4319dd9b60aa93
+        md5sum_1m_cd1 = 061c5f6acec56e5b7defd632de673349
+    unattended_install.url:
+        url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/27/Server/aarch64/os/
+        kernel_params += ' inst.repo=${url}'
+        sha1sum_vmlinuz = 76736a88e41fc83b7f0962cc3a72fbddd1c61a3f
+        sha1sum_initrd = 39f485b4ee63d03fe9ef7c9448c8e453616a352c
+        mem = 2048


### PR DESCRIPTION
These two commits add AArch64 guest config files for both Fedora 26 and Fedora 27. Both URL and CDROM unattended installation passed with these config files.