### PR TITLE
qemu_storage: Support '-U' for QemuImg

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -283,7 +283,7 @@ def postprocess_image(test, params, image_name, vm_process_status=None):
             logging.debug("Guest is still running, skip the image check.")
             check_image_flag = False
         else:
-            image_info_output = image.info()
+            image_info_output = image.info(force_share=True)
             image_info = {}
             if image_info_output is not None:
                 for image_info_item in image_info_output.splitlines():
@@ -304,10 +304,10 @@ def postprocess_image(test, params, image_name, vm_process_status=None):
     if check_image_flag:
         try:
             if clone_master is None:
-                image.check_image(params, base_dir)
+                image.check_image(params, base_dir, force_share=True)
             elif clone_master == "yes":
                 if image_name in params.get("master_images_clone").split():
-                    image.check_image(params, base_dir)
+                    image.check_image(params, base_dir, force_share=True)
             # Allow test to overwrite any pre-testing  automatic backup
             # with a new backup. i.e. assume pre-existing image/backup
             # would not be usable after this test succeeds. The best


### PR DESCRIPTION
QEMU commit 244a566 introduced the image locking feature which brought
a new option '-U' to the qemu-img command as the result. This patch
adds the support to pass the new option to qemu-img when user needs
to do so.
