### PR TITLE
utils_env: Fix a stuck issue

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -356,8 +356,7 @@ class Env(UserDict.IterableUserDict):
                                          output_func=_tcpdump_handler,
                                          output_params=(self, "tcpdump.log"))
 
-        if not utils_misc.wait_for(lambda: self._tcpdump.is_alive(),
-                                   1.0, 0.1, 0.1):
+        if not self._tcpdump.is_alive():
             logging.warn("Could not start tcpdump")
             logging.warn("Status: %s", self._tcpdump.get_status())
             msg = utils_misc.format_str_for_message(self._tcpdump.get_output())


### PR DESCRIPTION
On some (buggy?) system when `_start_tcpdump()` is being executed,
the job emits "Could not start tcpdump" and then will stuck at
this point since it is waiting for a file lock held by another
process. This is caused by the wrong result given by the following
check: it returns `None` because time has already expired before
invoking the callback function (btw, we should consider about the
time resolution of `wait_for` when we use it next time).

```python
  utils_misc.wait_for(lambda: self._tcpdump.is_alive(),
                      1.0, 0.1, 0.1)
```

The fix removes `wait_for` from the check because `_tcpdump.is_alive`
is already safe enough.

Signed-off-by: Xu Han <xuhan@redhat.com>