### PR TITLE
qemu_vm: update for minimum guest memory

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -909,6 +909,9 @@ class VM(virt_vm.BaseVM):
             # if not provided, use automem
             else:
                 usable_mem_m = utils_misc.get_usable_memory_size(align=512)
+                if not usable_mem_m:
+                    raise exceptions.TestError("Insufficient memory to"
+                                               " start a VM.")
                 logging.info("Auto set guest memory size to %s MB" %
                              usable_mem_m)
                 mem_size_m = usable_mem_m

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -908,7 +908,7 @@ class VM(virt_vm.BaseVM):
                 mem_size_m = float(normalize_data_size(mem_size_m))
             # if not provided, use automem
             else:
-                usable_mem_m = utils_misc.get_usable_memory_size(align=1024)
+                usable_mem_m = utils_misc.get_usable_memory_size(align=512)
                 logging.info("Auto set guest memory size to %s MB" %
                              usable_mem_m)
                 mem_size_m = usable_mem_m

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -191,7 +191,7 @@ def get_usable_memory_size(align=None):
     usable_mem = memory.read_from_meminfo('MemFree')
     usable_mem = float(normalize_data_size("%s KB" % usable_mem))
     if align:
-        usable_mem = math.ceil(usable_mem / align) * align
+        usable_mem = math.floor(usable_mem / align) * align
     return usable_mem
 
 


### PR DESCRIPTION
Using vm_mem_minimum can specify minimum guest memory.
If params["mem"] is provided, it will use this value.
Otherwise, it will use an auto calculated usable mem.
All these two should be within the range between
vm_mem_limit and vm_mem_minimum, if these max and min
values are provided.

id: 1514381
Signed-off-by: Haotong Chen <hachen@redhat.com>