### PR TITLE
Fix the 'except' syntax error

### DIFF
--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -173,7 +173,7 @@ class StoragePool(object):
         """
         try:
             return self.list_pools()[name]['State']
-        except process.CmdError, KeyError:
+        except (process.CmdError, KeyError):
             return None
 
     def pool_autostart(self, name):
@@ -184,7 +184,7 @@ class StoragePool(object):
         """
         try:
             return self.list_pools()[name]['Autostart']
-        except process.CmdError, KeyError:
+        except (process.CmdError, KeyError):
             return None
 
     def pool_info(self, name):


### PR DESCRIPTION

_2:07:40 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-55.0-py2.7.egg/virttest/libvirt_storage.py", line 175, in pool_state
02:07:40 ERROR|     return self.list_pools()[name]['State']
02:07:40 ERROR| KeyError: 'virsh_pool_acl_test'_
-----------------------------------------------------------------------------------------------------------------------
above error occurred while running the test case. 
even though we mention KeyError exception it is not handled because syntax is wrong, when we want to handle multiple exceptions open braces are () mandatory in syntax. 

Signed-off-by: prudhvi <mprudhvi@linux.vnet.ibm.com>