### PR TITLE
virttest: Change the q35's ICH9-LPC device name

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -787,8 +787,8 @@ class DevContainer(object):
                                                   aobject="pci.0"))
             devices.append(qdevices.QStringDevice('mch', {'addr': 0, 'driver': 'mch'},
                                                   parent_bus={'aobject': 'pci.0'}))
-            devices.append(qdevices.QStringDevice('ICH9 LPC', {'addr': '1f.0',
-                                                               'driver': 'ICH9 LPC'},
+            devices.append(qdevices.QStringDevice('ICH9-LPC', {'addr': '1f.0',
+                                                               'driver': 'ICH9-LPC'},
                                                   parent_bus={'aobject': 'pci.0'}))
             devices.append(qdevices.QStringDevice('ICH9 SMB', {'addr': '1f.3',
                                                                'driver': 'ICH9 SMB'},


### PR DESCRIPTION
The ICH9-LPC device which is present on q35 machines is named "ICH9-LPC"
and not "ICH9 LPC" which makes the pci_device to fail.

I'm not certain whether the name changed but I tried qemu-2.7.1 with all
q35 machine types as well as qemu-2.10.92 and tried to grep qemu sources
and couldn't get to the point where it was changed so I think changing
it to the current name should work in most cases, but let me know if you
identify really old qemu with the other name so we can add some
heuristic. Anyway I don't think it's necessary as q35 is probably tested
on the later qemu versions so it should be fine.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>