### PR TITLE
This patch clears the targetcli configuration.

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -347,6 +347,11 @@ class _IscsiComm(object):
             restart_iscsid()
         if self.export_flag:
             self.delete_target()
+        # clear the targetcli configuration
+        if path.find_command("targetcli"):
+            cmd = "targetcli clearconfig confirm=true"
+            if process.system(cmd, shell=True) != 0:
+                logging.error("targetcli configuration unable to clear")
 
 
 class IscsiTGT(_IscsiComm):


### PR DESCRIPTION
iscsi: clear iscsi targetcli configuration on cleanup

"AttributeError: 'NoneType' object has no attribute 'export_flag'" as the
iscsi target configuration is not cleared,
this patch handles it by clearing during cleanup.
This fix also reduces the test execution time for forthcoming cases.


Signed-off-by: prudhvi <mprudhvi@linux.vnet.ibm.com>