### PR TITLE
 Add param "bus" to device "scsi-*"

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1287,9 +1287,10 @@ class DevContainer(object):
             if qbus == qbuses.QAHCIBus and unit is not None:
                 bus += ".%d" % unit
             # If bus was not set, don't set it, unless the device is
-            # a spapr-vscsi device.
-            elif _bus is None and 'spapr_vscsi' not in _hba:
-                bus = None
+            # a spapr-vscsi/virtio-scsi-pci device.
+            elif _bus is None:
+                if not ('virtio_scsi_pci' in _hba or 'spapr_vscsi' in _hba):
+                    bus = None
             return devices, bus, {'type': qtype, 'atype': atype}
 
         #
@@ -1511,6 +1512,8 @@ class DevContainer(object):
             devices[-1].set_param('removable', removable, bool)
             if strict_mode:
                 devices[-1].set_param('channel', 0)
+            if bus:
+                devices[-1].set_param('bus', bus)
         elif fmt == 'virtio':
             devices[-1].set_param('driver', 'virtio-blk-pci')
             devices[-1].set_param("scsi", scsi, bool)


### PR DESCRIPTION
In qemu cmdline, when create device "scsi-hd", no bus defined.
So add the param.

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1507185