### PR TITLE
virttest: Allow booting guests without serial

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2344,7 +2344,8 @@ class VM(virt_vm.BaseVM):
         try:
             tmp_serial = self.serial_ports[0]
         except IndexError:
-            raise virt_vm.VMConfigMissingError(self.name, "serial")
+            logging.warning("No serial ports defined!")
+            return
         log_name = "serial-%s-%s.log" % (tmp_serial, self.name)
         self.serial_console_log = os.path.join(utils_misc.get_log_file_dir(),
                                                log_name)


### PR DESCRIPTION
The valgrind_memalign test requires to boot machine without serial
ports and I believe it might not be the only test. Let's just log
information about no serial ports being available and proceed rather
than failing the test.

Reproducer "avocado run boot --vt-extra-params serials=''"

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>