### PR TITLE
Add JeOS.27 with multiple architectures

### DIFF
--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -46,7 +46,8 @@ class VTBootstrap(CLICmd):
                             default='qemu')
         parser.add_argument("--vt-guest-os", action="store",
                             default=None,
-                            help=("Select the guest OS to be used. "
+                            help=("Select the guest OS to be used  "
+                                  "optionally followed by guest arch. "
                                   "If -c is provided, this will be "
                                   "ignored. Default: %s" %
                                   defaults.DEFAULT_GUEST_OS))

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -45,12 +45,12 @@ class VTBootstrap(CLICmd):
                                   ", ".join(SUPPORTED_TEST_TYPES)),
                             default='qemu')
         parser.add_argument("--vt-guest-os", action="store",
-                            default=None,
+                            default="%s.%s" % (defaults.DEFAULT_GUEST_OS,
+                                               defaults.ARCH),
                             help=("Select the guest OS to be used  "
                                   "optionally followed by guest arch. "
                                   "If -c is provided, this will be "
-                                  "ignored. Default: %s" %
-                                  defaults.DEFAULT_GUEST_OS))
+                                  "ignored. Default: %(default)s"))
         parser.add_argument("--vt-selinux-setup", action="store_true",
                             default=False,
                             help="Define default contexts of directory.")

--- a/shared/cfg/guest-os/Linux/JeOS/27.cfg
+++ b/shared/cfg/guest-os/Linux/JeOS/27.cfg
@@ -1,0 +1,58 @@
+- 27:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64:
+            vm_arch_name = ppc64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    image_name = images/jeos-27-${vm_arch_name}
+    os_variant = fedora27
+    boot_path = "images/pxeboot"
+    # Currently we only support unattended_install.url.extra_cdrom_ks
+    no unattended_install..floppy_ks, unattended_install..cdrom, svirt_install
+    unattended_install.url.extra_cdrom_ks:
+        # Use secondary as default url, because it's common to most variants
+        url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/27/Server/${vm_arch_name}/os/
+        kernel = images/jeos-27-${vm_arch_name}/vmlinuz
+        initrd = images/jeos-27-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/JeOS-25.ks
+        aarch64:
+            kernel_params += "console=ttyAMA0 console=ttyS0 serial"
+            sha1sum_vmlinuz = 0727385709ac2fcb4a4e58b93b085a567ab2e321
+            sha1sum_initrd = 8885b55a0e8442215b2e1c6d34ba9c33075e1ad2
+            unattended_file = unattended/JeOS-25.aarch64.ks
+        ppc64:
+            kernel_params += "console=hvc0 serial"
+            sha1sum_vmlinuz = c42b4d80a4897ee610d16398541cd74803a7d85e
+            sha1sum_initrd = 964a3803e1a8e3289692de5f0a23b62275d530c0
+            boot_path = ppc/ppc64
+            unattended_file = unattended/JeOS-25.ppc64.ks
+        ppc64le:
+            kernel_params += "console=hvc0 serial"
+            sha1sum_vmlinuz = 846e7229c0df898115be37f32f7e7a36d4ef564e
+            sha1sum_initrd = dcbf67ea6e4f83a127ca33f38c465b5b888744ea
+            boot_path = ppc/ppc64
+            unattended_file = unattended/JeOS-25.ppc64.ks
+        s390x:
+            kernel_params += "console=ttysclp0 serial"
+            sha1sum_vmlinuz = e29f67caf031eaede7636ec6d1ca663223c545b8
+            sha1sum_initrd = 04a48e10034434a7521a84221859dcb951428c78
+            boot_path = images
+            kernel = images/jeos-27-s390x/kernel.img
+        x86_64:
+            kernel_params += "console=tty0 console=ttyS0"
+            url = http://dl.fedoraproject.org/pub/fedora/linux/releases/27/Server/${vm_arch_name}/os
+            sha1sum_vmlinuz = ee1edf674d7a8bff17c97dca012a9fb396414e81
+            sha1sum_initrd = 298bd038864bf105fea1b12f3da0ed8ec2d4acb0
+        syslog_server_proto = tcp
+        cdrom_unattended = images/jeos-27-${vm_arch_name}/ks.iso
+        kernel_params += " ks=cdrom nicdelay=60 inst.repo=${url}"
+        # Installation works fine with mem=1024 on methods such as cdrom
+        # but fails ("No space left on device") with methods such as url.
+        mem = 2048

--- a/shared/downloads/jeos-27-64.ini
+++ b/shared/downloads/jeos-27-64.ini
@@ -1,0 +1,6 @@
+[jeos-27-64]
+title = JeOS 27 x86_64
+url = http://avocado-project.org/data/assets/jeos/27/jeos-27-64.qcow2.xz
+sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_64
+destination = images/jeos-27-64.qcow2.xz
+destination_uncompressed = images/jeos-27-64.qcow2

--- a/shared/downloads/jeos-27-aarch64.ini
+++ b/shared/downloads/jeos-27-aarch64.ini
@@ -1,0 +1,6 @@
+[jeos-27-aarch64]
+title = JeOS 27 aarch64
+url = http://avocado-project.org/data/assets/jeos/27/jeos-27-aarch64.qcow2.xz
+sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_AARCH64
+destination = images/jeos-27-aarch64.qcow2.xz
+destination_uncompressed = images/jeos-27-aarch64.qcow2

--- a/shared/downloads/jeos-27-ppc64.ini
+++ b/shared/downloads/jeos-27-ppc64.ini
@@ -1,0 +1,6 @@
+[jeos-27-ppc64]
+title = JeOS 27 ppc64
+url = http://avocado-project.org/data/assets/jeos/27/jeos-27-ppc64.qcow2.xz
+sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_PPC64
+destination = images/jeos-27-ppc64.qcow2.xz
+destination_uncompressed = images/jeos-27-ppc64.qcow2

--- a/shared/downloads/jeos-27-ppc64le.ini
+++ b/shared/downloads/jeos-27-ppc64le.ini
@@ -1,0 +1,6 @@
+[jeos-27-ppc64le]
+title = JeOS 27 ppc64le
+url = http://avocado-project.org/data/assets/jeos/27/jeos-27-ppc64le.qcow2.xz
+sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_PPC64LE
+destination = images/jeos-27-ppc64le.qcow2.xz
+destination_uncompressed = images/jeos-27-ppc64le.qcow2

--- a/shared/downloads/jeos-27-s390x.ini
+++ b/shared/downloads/jeos-27-s390x.ini
@@ -1,0 +1,6 @@
+[jeos-27-s390x]
+title = JeOS 27 s390x
+url = http://avocado-project.org/data/assets/jeos/27/jeos-27-s390x.qcow2.xz
+sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_S390X
+destination = images/jeos-27-s390x.qcow2.xz
+destination_uncompressed = images/jeos-27-s390x.qcow2

--- a/shared/unattended/JeOS-25.aarch64.ks
+++ b/shared/unattended/JeOS-25.aarch64.ks
@@ -1,0 +1,192 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+part /boot/efi --size=200 --ondisk=sda --fstype=efi
+part / --fstype=ext4 --grow --asprimary --size=1
+
+%packages --ignoremissing
+gpgme
+dmidecode
+ethtool
+tcpdump
+tar
+bzip2
+pciutils
+usbutils
+bind-utils
+net-tools
+rsync
+python
+-yum-utils
+-cryptsetup
+-dump
+-mlocate
+-stunnel
+-rng-tools
+-ntfs-3g
+-sos
+-jwhois
+-fedora-release-notes
+-pam_pkcs11
+-wireless-tools
+-rdist
+-mdadm
+-dmraid
+-ftp
+-system-config-network-tui
+-pam_krb5
+-nano
+-nc
+-PackageKit-yum-plugin
+-btrfs-progs
+-ypbind
+-yum-presto
+-microcode_ctl
+-finger
+-krb5-workstation
+-ntfsprogs
+-iptstate
+-fprintd-pam
+-irqbalance
+-dosfstools
+-mcelog
+-smartmontools
+-lftp
+-unzip
+-rsh
+-telnet
+-setuptool
+-bash-completion
+-pinfo
+-rdate
+-system-config-firewall-tui
+-system-config-firewall-base
+-nfs-utils
+-words
+-cifs-utils
+-prelink
+-wget
+-dos2unix
+-passwdqc
+-coolkey
+-symlinks
+-pm-utils
+-bridge-utils
+-zip
+-numactl
+-mtr
+-sssd
+-pcmciautils
+-tree
+-hunspell
+-irda-utils
+-time
+-man-pages
+-yum-langpacks
+-talk
+-wpa_supplicant
+-slang
+-authconfig
+-newt
+-newt-python
+-ntsysv
+-libnl3
+-tcp_wrappers
+-quota
+-libpipeline
+-man-db
+-groff
+-less
+-plymouth-core-libs
+-plymouth
+-plymouth-scripts
+-libgudev1
+-ModemManager
+-NetworkManager-glib
+-selinux-policy
+-selinux-policy-targeted
+-crontabs
+-cronie
+-cronie-anacron
+-cyrus-sasl
+-sendmail
+-netxen-firmware
+-linux-firmware
+-libdaemon
+-avahi-autoipd
+-libpcap
+-ppp
+-libsss_sudo
+-sudo
+-at
+-psacct
+-parted
+-passwd
+-tmpwatch
+-bc
+-acl
+-attr
+-traceroute
+-mailcap
+-quota-nls
+-mobile-broadband-provider-info
+-audit
+-e2fsprogs-libs
+-e2fsprogs
+-biosdevname
+-dbus-glib
+-libdrm
+-setserial
+-lsof
+-ed
+-cyrus-sasl-plain
+-dnsmasq
+-system-config-firewall-base
+-hesiod
+-libpciaccess
+-policycoreutils
+-m4
+-checkpolicy
+-procmail
+-libuser
+-polkit
+-rsyslog
+%end
+
+%post
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+sed -i -e "s,^GRUB_TIMEOUT=.*,GRUB_TIMEOUT=0," /etc/default/grub
+grub2-mkconfig > /etc/grub2.cfg
+dnf install -y hdparm ntpdate qemu-guest-agent
+dnf clean all
+mkdir -p /var/log/journal
+sed -i -e 's/\#SystemMaxUse=/SystemMaxUse=50M/g' /etc/systemd/journald.conf
+dd if=/dev/zero of=/fill-up-file bs=1M
+rm -f /fill-up-file
+ECHO 'Post set up finished'
+%end

--- a/shared/unattended/JeOS-25.ks
+++ b/shared/unattended/JeOS-25.ks
@@ -18,7 +18,7 @@ KVM_TEST_LOGGING
 clearpart --all --initlabel
 part / --fstype=ext4 --grow --asprimary --size=1
 
-%packages
+%packages --ignoremissing
 gpgme
 dmidecode
 ethtool

--- a/shared/unattended/JeOS-25.ks
+++ b/shared/unattended/JeOS-25.ks
@@ -168,7 +168,9 @@ python
 %end
 
 %post
-function ECHO { for TTY in `cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
 ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient

--- a/shared/unattended/JeOS-25.ppc64.ks
+++ b/shared/unattended/JeOS-25.ppc64.ks
@@ -1,0 +1,192 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+part prepboot --fstype "PPC PReP Boot" --size=10 --ondisk=sda
+part / --fstype=ext4 --grow --asprimary --size=1
+
+%packages --ignoremissing
+gpgme
+dmidecode
+ethtool
+tcpdump
+tar
+bzip2
+pciutils
+usbutils
+bind-utils
+net-tools
+rsync
+python
+-yum-utils
+-cryptsetup
+-dump
+-mlocate
+-stunnel
+-rng-tools
+-ntfs-3g
+-sos
+-jwhois
+-fedora-release-notes
+-pam_pkcs11
+-wireless-tools
+-rdist
+-mdadm
+-dmraid
+-ftp
+-system-config-network-tui
+-pam_krb5
+-nano
+-nc
+-PackageKit-yum-plugin
+-btrfs-progs
+-ypbind
+-yum-presto
+-microcode_ctl
+-finger
+-krb5-workstation
+-ntfsprogs
+-iptstate
+-fprintd-pam
+-irqbalance
+-dosfstools
+-mcelog
+-smartmontools
+-lftp
+-unzip
+-rsh
+-telnet
+-setuptool
+-bash-completion
+-pinfo
+-rdate
+-system-config-firewall-tui
+-system-config-firewall-base
+-nfs-utils
+-words
+-cifs-utils
+-prelink
+-wget
+-dos2unix
+-passwdqc
+-coolkey
+-symlinks
+-pm-utils
+-bridge-utils
+-zip
+-numactl
+-mtr
+-sssd
+-pcmciautils
+-tree
+-hunspell
+-irda-utils
+-time
+-man-pages
+-yum-langpacks
+-talk
+-wpa_supplicant
+-slang
+-authconfig
+-newt
+-newt-python
+-ntsysv
+-libnl3
+-tcp_wrappers
+-quota
+-libpipeline
+-man-db
+-groff
+-less
+-plymouth-core-libs
+-plymouth
+-plymouth-scripts
+-libgudev1
+-ModemManager
+-NetworkManager-glib
+-selinux-policy
+-selinux-policy-targeted
+-crontabs
+-cronie
+-cronie-anacron
+-cyrus-sasl
+-sendmail
+-netxen-firmware
+-linux-firmware
+-libdaemon
+-avahi-autoipd
+-libpcap
+-ppp
+-libsss_sudo
+-sudo
+-at
+-psacct
+-parted
+-passwd
+-tmpwatch
+-bc
+-acl
+-attr
+-traceroute
+-mailcap
+-quota-nls
+-mobile-broadband-provider-info
+-audit
+-e2fsprogs-libs
+-e2fsprogs
+-biosdevname
+-dbus-glib
+-libdrm
+-setserial
+-lsof
+-ed
+-cyrus-sasl-plain
+-dnsmasq
+-system-config-firewall-base
+-hesiod
+-libpciaccess
+-policycoreutils
+-m4
+-checkpolicy
+-procmail
+-libuser
+-polkit
+-rsyslog
+%end
+
+%post
+# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+sed -i -e "s,^GRUB_TIMEOUT=.*,GRUB_TIMEOUT=0," /etc/default/grub
+grub2-mkconfig > /etc/grub2.cfg
+dnf install -y hdparm ntpdate qemu-guest-agent
+dnf clean all
+mkdir -p /var/log/journal
+sed -i -e 's/\#SystemMaxUse=/SystemMaxUse=50M/g' /etc/systemd/journald.conf
+dd if=/dev/zero of=/fill-up-file bs=1M
+rm -f /fill-up-file
+ECHO 'Post set up finished'
+%end


### PR DESCRIPTION
This PR improves a bit the old JeOS.25 kickstart to be multi-arch friendly and then adds JeOS.27 (based on the old ks) in all variants. The ks is simplified to only work with `url` installation as users are not expected to usually install it, but they should download it during vt-bootstrap.

As a consequence of multi-arch support the default value of guest-os changed in the last commit to avoid usually unwanted questions to download all variants of this guest-os.