### PR TITLE
qemu_vm: fixed destination vm process handling issue

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3990,7 +3990,7 @@ class VM(virt_vm.BaseVM):
             # If we're doing remote migration and it's completed successfully,
             # self points to a dead VM object
             if not not_wait_for_migration:
-                if self.is_alive():
+                if self.is_alive() and self.is_paused():
                     self.monitor.cmd("cont")
                 clone.destroy(gracefully=False)
                 if env:


### PR DESCRIPTION
During migration, destination vms were not closed if error
occurs and  not_wait_for_migration=False. This patch fixed it.

id: 1510286
Signed-off-by: Haotong Chen <hachen@redhat.com>