### PR TITLE
distinguish ide from scsi in /proc/scsi/scsi

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -471,7 +471,10 @@ class QtreeDisksContainer(object):
         scsis = set()
         for scsi in _scsis:
             # Ignore IDE disks
-            if scsi[5] != 'CD-ROM':
+            # In "/proc/scsi/scsi",device info for ide/scsi almost the same,
+            # except ide.vendor="ATA" and scsi.vendor="QEMU", so use the field
+            # to distiguish scsi from ide.
+            if scsi[5] != 'CD-ROM' and scsi[4] == 'QEMU':
                 # Qemu encode LUNs with scsi's with 'flat space addressing'
                 # method if LUNs > 255, decode LUNs when LUN ID - 16384 > 255.
                 lun_id = int(scsi[3])


### PR DESCRIPTION
qemu_qtree:identifier 'vendor' add for scsi
device in check_guests_proc_scsi()

Signed-off-by: Aihua Liang <aliang@redhat.com>

bug id:1520718