### PR TITLE
utils_env: Support various ip sniffers

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -664,10 +664,10 @@ def preprocess(test, params, env):
                 params[name_tag] = os.path.join(image_nfs.mount_dir,
                                                 image_name_only)
 
-    # Start tcpdump if it isn't already running
+    # Start ip address sniffer if it isn't already running
     # The fact it has to be started here is so that the test params
     # have to be honored.
-    env.start_tcpdump(params)
+    env.start_ip_sniffer(params)
 
     # Add migrate_vms to vms
     migrate_vms = params.objects("migrate_vms")
@@ -1040,8 +1040,8 @@ def postprocess(test, params, env):
                 vm.name)
             vm.destroy()
 
-    # Terminate the tcpdump thread
-    env.stop_tcpdump()
+    # Terminate the ip sniffer thread
+    env.stop_ip_sniffer()
 
     # Kill all aexpect tail threads
     aexpect.kill_tail_threads()


### PR DESCRIPTION
Make the framework support various ip sniffers, and add the support of
tshark (wireshark).

The reason to do so is because tcpdump till now (the current latest
version is 4.9.2) has some problem to deal with the bootp/dhcp packet:
it will not show the 'vendor extensions/options' field when a packet
has the 'sname' or 'file' field, and that would forbid `address_cache`
being updated properly. So let us use tshark to workaround this issue.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1516187