### PR TITLE
qemu_vm: added check host component version functionality

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -717,27 +717,15 @@ def preprocess(test, params, env):
             env["cpu_model"] = utils_misc.get_qemu_best_cpu_model(params)
         params["cpu_model"] = env.get("cpu_model")
 
-    kvm_ver_cmd = params.get("kvm_ver_cmd", "")
-
-    if kvm_ver_cmd:
-        try:
-            kvm_version = avocado_process.system_output(
-                    kvm_ver_cmd, shell=True).strip()
-        except avocado_process.CmdError:
-            kvm_version = "Unknown"
+    # Get the KVM kernel module version and write it as a keyval
+    if os.path.exists("/dev/kvm"):
+        kvm_version = os.uname()[2]
     else:
-        # Get the KVM kernel module version and write it as a keyval
-        if os.path.exists("/dev/kvm"):
-            try:
-                kvm_version = open("/sys/module/kvm/version").read().strip()
-            except Exception:
-                kvm_version = os.uname()[2]
-        else:
-            warning_msg = "KVM module not loaded"
-            if params.get("enable_kvm", "yes") == "yes":
-                raise exceptions.TestSkipError(warning_msg)
-            logging.warning(warning_msg)
-            kvm_version = "Unknown"
+        warning_msg = "KVM module not loaded"
+        if params.get("enable_kvm", "yes") == "yes":
+            raise exceptions.TestSkipError(warning_msg)
+        logging.warning(warning_msg)
+        kvm_version = "Unknown"
 
     logging.debug("KVM version: %s" % kvm_version)
     test.write_test_keyval({"kvm_version": kvm_version})

--- a/virttest/utils_numeric.py
+++ b/virttest/utils_numeric.py
@@ -1,3 +1,4 @@
+import re
 import math
 
 
@@ -10,3 +11,41 @@ def align_factor(value, factor=1024):
     :return: factored value
     """
     return int(math.ceil(float(value) / factor) * factor)
+
+
+class Interval(object):
+
+    """A class for a mathematical interval like object."""
+
+    def __init__(self, interval, data_type):
+        interval_re = r"(\[|\()(.*?)\s*,\s*(.*?)(\]|\))"
+        match = re.match(interval_re, interval)
+        if match is None:
+            raise ValueError("Invaild string representation of an interval.")
+
+        self.opening, lower, upper, self.closing = match.groups()
+        if not (lower or upper):
+            raise ValueError("Invaild interval.")
+
+        self.lower_bound = data_type(lower) if lower else None
+        self.upper_bound = data_type(upper) if upper else None
+        if lower and upper and (self.lower_bound > self.upper_bound):
+            raise ValueError("Invaild interval.")
+
+    def __repr__(self):
+        return '<interval %s%s, %s%s>' % (self.opening,
+                                          self.lower_bound,
+                                          self.upper_bound,
+                                          self.closing)
+
+    def __contains__(self, data):
+        if self.lower_bound and data < self.lower_bound:
+            return False
+        if self.upper_bound and data > self.upper_bound:
+            return False
+        if self.lower_bound and data == self.lower_bound:
+            return (self.opening == '[')
+        if self.upper_bound and data == self.upper_bound:
+            return (self.closing == ']')
+        return True
+


### PR DESCRIPTION
It enabled using required_kernel and required_qemu to ensure
the test runs only on certain versions.

id: 1519710
Signed-off-by: Haotong Chen <hachen@redhat.com>