### PR TITLE
Add virt-install param support for cpu sub options

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -143,6 +143,16 @@ smp = 1
 #vcpu_threads = 1
 #vcpu_sockets = 1
 
+# Configure cpu mode and model
+# possible values: host-model, host-passthrough, custom, default:''
+# virt_cpu_mode = ''
+# possible values: power8, core2duo etc, default:''
+# virt_cpu_model = ''
+# possible values: minimum, exact, strict, default:''
+# virt_cpu_match = ''
+# possible values: True or False, default: False
+# virt_cpu_vendor = False
+
 # configure guest numa nodes, it can be set to "yes"
 # numa = "no"
 


### PR DESCRIPTION
Add virt-install param support for cpu's suboptions
mode, model, vendor, match.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>