### PR TITLE
Add encryption and auth xml in disk source xml

### DIFF
--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -187,8 +187,8 @@ class Disk(base.TypedDeviceBase):
         hosts: list of dictionaries describing network host properties
         """
 
-        __slots__ = ('attrs', 'seclabels', 'hosts', 'config_file',
-                     'snapshot_name',)
+        __slots__ = ('attrs', 'seclabels', 'hosts', 'encryption', 'auth',
+                     'config_file', 'snapshot_name',)
 
         def __init__(self, virsh_instance=base.base.virsh):
             accessors.XMLElementDict('attrs', self, parent_xpath='/',
@@ -199,6 +199,14 @@ class Disk(base.TypedDeviceBase):
             accessors.XMLElementList('hosts', self, parent_xpath='/',
                                      marshal_from=self.marshal_from_host,
                                      marshal_to=self.marshal_to_host)
+            accessors.XMLElementNest('encryption', self, parent_xpath='/',
+                                     tag_name='encryption', subclass=Disk.Encryption,
+                                     subclass_dargs={
+                                         'virsh_instance': virsh_instance})
+            accessors.XMLElementNest('auth', self, parent_xpath='/',
+                                     tag_name='auth', subclass=Disk.Auth,
+                                     subclass_dargs={
+                                         'virsh_instance': virsh_instance})
             accessors.XMLAttribute('config_file', self, parent_xpath='/',
                                    tag_name='config', attribute='file')
             accessors.XMLAttribute('snapshot_name', self, parent_xpath='/',


### PR DESCRIPTION
After libvirt commit 37537a7c64b43be2eebf8b0cea7c6d445e214806,
<encryption> and <auth> elements can be put into disk->source xml.
So add them in class DiskSource.

Signed-off-by: Yi Sun <yisun@redhat.com>