### PR TITLE
Support various ip sniffers [v2]

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -664,10 +664,10 @@ def preprocess(test, params, env):
                 params[name_tag] = os.path.join(image_nfs.mount_dir,
                                                 image_name_only)
 
-    # Start tcpdump if it isn't already running
+    # Start ip sniffing if it isn't already running
     # The fact it has to be started here is so that the test params
     # have to be honored.
-    env.start_tcpdump(params)
+    env.start_ip_sniffing(params)
 
     # Add migrate_vms to vms
     migrate_vms = params.objects("migrate_vms")
@@ -1040,8 +1040,8 @@ def postprocess(test, params, env):
                 vm.name)
             vm.destroy()
 
-    # Terminate the tcpdump thread
-    env.stop_tcpdump()
+    # Terminate the ip sniffer thread
+    env.stop_ip_sniffing()
 
     # Kill all aexpect tail threads
     aexpect.kill_tail_threads()

--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -1,0 +1,272 @@
+"""
+IP sniffing facilities
+"""
+
+import threading
+import logging
+import re
+
+import aexpect
+from avocado.utils import path as utils_path
+
+from remote import handle_prompts
+from utils_misc import log_line
+from utils_misc import format_str_for_message
+
+
+class AddrCache(object):
+
+    """
+    Address cache implementation.
+    """
+
+    def __init__(self):
+        """Initializes the address cache."""
+        self._data = {}
+        self._lock = threading.RLock()
+
+    def __repr__(self):
+        return repr(self._data)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _format_hwaddr(hwaddr):
+        return hwaddr.lower()
+
+    def __setitem__(self, hwaddr, ipaddr):
+        hwaddr = self._format_hwaddr(hwaddr)
+        with self._lock:
+            if self._data.get(hwaddr) == ipaddr:
+                return
+            self._data[hwaddr] = ipaddr
+        logging.debug("Updated HWADDR (%s)<->(%s) IP pair "
+                      "into address cache", hwaddr, ipaddr)
+
+    def __getitem__(self, hwaddr):
+        hwaddr = self._format_hwaddr(hwaddr)
+        ipaddr = None
+        with self._lock:
+            ipaddr = self._data.get(hwaddr)
+        return ipaddr
+
+    def __delitem__(self, hwaddr):
+        hwaddr = self._format_hwaddr(hwaddr)
+        with self._lock:
+            del self._data[hwaddr]
+        logging.debug("Dropped the address cache of HWADDR (%s)", hwaddr)
+
+    def get(self, hwaddr):
+        """
+        Get the ip address of the given hardware address.
+
+        :param hwaddr: Hardware address.
+        """
+        return self.__getitem__(hwaddr)
+
+    def drop(self, hwaddr):
+        """
+        Drop the cache of the given hardware address.
+
+        :param hwaddr: Hardware address.
+        """
+        return self.__delitem__(hwaddr)
+
+    def update(self, cache):
+        """
+        Update the address cache with the address pairs from other,
+        overwriting existing hardware address.
+
+        :param cache: AddrCache object, dict object or iterable
+                      key/value pairs.
+        """
+        if self == cache:
+            return
+        if isinstance(cache, AddrCache):
+            _cache = cache
+            with _cache._lock:
+                cache = _cache._data.copy()
+        if hasattr(cache, "iteritems"):
+            cache = cache.iteritems()
+        for hwaddr, ipaddr in cache:
+            self[hwaddr] = ipaddr
+
+    def clear(self):
+        """Clear all the address caches."""
+        with self._lock:
+            self._data.clear()
+        logging.debug("Clean out all the address caches")
+
+
+class Sniffer(object):
+
+    """
+    Virtual base class of the ip sniffer abstraction.
+
+    The `_output_handler(self, line)` method must be
+    provided by the subclasses.
+    """
+
+    #: Sniffer's command name
+    command = ""
+    #: Sniffer's options
+    options = ""
+
+    def __init__(self, addr_cache, log_file, remote_opts=None):
+        """
+        Initializes the sniffer.
+
+        :param addr_cache: Address cache to be updated.
+        :param log_file: Log file name.
+        :param remote_opts: Options of remote host session, is a tuple built
+                            up by `(address, port, username, password,
+                            prompt)`. If provided, launches the sniffer on
+                            remote host, otherwise on local host.
+        """
+        self._cache = addr_cache
+        self._logfile = log_file
+        self._remote_opts = remote_opts
+        self._process = None
+
+    @classmethod
+    def _is_supported_remote(cls, session):
+        return session.cmd_status("which %s" % cls.command) == 0
+
+    @classmethod
+    def is_supported(cls, session=None):
+        """
+        Check if host supports the sniffer.
+
+        :param session: Remote host session. If provided, performs the
+                        check on remote host, otherwise on local host.
+        """
+        if session:
+            return cls._is_supported_remote(session)
+        try:
+            utils_path.find_command(cls.command)
+            return True
+        except utils_path.CmdNotFoundError:
+            return False
+
+    def _output_handler(self, line):
+        raise NotImplementedError
+
+    def _output_logger_handler(self, line):
+        try:
+            log_line(self._logfile, line)
+        except Exception as e:
+            logging.warn("Can't log ip sniffer output: '%s'", e)
+        self._output_handler(line)
+
+    def _start_remote(self):
+        address, port, username, password, prompt = self._remote_opts
+        cmd = "%s %s" % (self.command, self.options)
+        logging.debug("Run '%s' on host '%s'", cmd, address)
+        login_cmd = ("ssh -o UserKnownHostsFile=/dev/null "
+                     "-o StrictHostKeyChecking=no "
+                     "-o PreferredAuthentications=password -p %s %s@%s" %
+                     (port, username, address))
+
+        self._process = aexpect.ShellSession(
+            login_cmd,
+            output_func=self._output_logger_handler)
+        handle_prompts(self._process, username, password, prompt)
+        self._process.sendline(cmd)
+
+    def _start(self):
+        cmd = "%s %s" % (self.command, self.options)
+        if self._remote_opts:
+            self._start_remote()
+        else:
+            self._process = aexpect.run_tail(
+                command=cmd,
+                output_func=self._output_logger_handler)
+
+        if not self._process.is_alive():
+            logging.warn("Could not start ip sniffer (%s)", self.command)
+            logging.warn("Status: %s", self._process.get_status())
+            msg = format_str_for_message(self._process.get_output())
+            logging.warn("Output: %s", msg)
+
+    def is_alive(self):
+        """Check if the sniffer is alive."""
+        if not self._process:
+            return False
+        return self._process.is_alive()
+
+    def start(self):
+        """Start sniffing."""
+        if self.is_alive():
+            return
+        self.stop()
+        self._start()
+
+    def stop(self):
+        """Stop sniffing."""
+        if self._process:
+            self._process.close()
+            self._process = None
+
+    def __del__(self):
+        self.stop()
+
+
+class TcpdumpSniffer(Sniffer):
+
+    """
+    Tcpdump sniffer class.
+    """
+
+    command = "tcpdump"
+    options = "-tnpvvvi any 'port 68 or port 546'"
+
+    def __init__(self, addr_cache, log_file, remote_opts=None):
+        super(TcpdumpSniffer, self).__init__(addr_cache, log_file, remote_opts)
+        self._context = {}
+
+    def _output_handler(self, line):
+        # BootP/DHCP (RFC 951/2131)
+        matches = re.search(r"^IP\s", line)
+        if matches:
+            # Clear context upon receiving a new packet
+            self._context.clear()
+            return
+
+        matches = re.search(r"Your.IP\s+(\S+)", line, re.I)
+        if matches:
+            self._context["ip"] = matches.group(1)
+            return
+
+        matches = re.search(r"Client.Ethernet.Address\s+(\S+)", line, re.I)
+        if matches:
+            self._context["mac"] = matches.group(1)
+            return
+
+        if re.search(r"DHCP.Message.*:\s+ACK", line, re.I):
+            mac = self._context.get("mac")
+            ip = self._context.get("ip")
+            if mac and ip:
+                self._cache[mac] = ip
+            return
+
+        # DHCPv6 (RFC 3315)
+        if re.search("dhcp6 reply", line, re.I):
+            regex = "IA_ADDR (.*) pltime.*client-ID.*?([0-9a-fA-F]{12})\)"
+            matches = re.search(regex, line, re.I)
+            if matches:
+                info = matches.groups()
+                mac = ":".join(re.findall("..", info[1]))
+                ip = info[0].lower()
+                self._cache["%s_6" % mac] = ip
+            return
+
+
+#: All the defined sniffers
+Sniffers = (TcpdumpSniffer,)

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3422,7 +3422,6 @@ def update_mac_ip_address(vm, timeout=240):
         if not addr_map:
             logging.warn("No VM's NIC got IP address")
             return
-        logging.debug("Update address_cache: %s", addr_map)
         vm.address_cache.update(addr_map)
     except Exception, e:
         logging.warn("Error occur when update VM address cache: %s", str(e))

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -706,9 +706,7 @@ class BaseVM(object):
         devs = set([nic.netdst]) if nic.has_key('netdst') else set()
         if not utils_net.verify_ip_address_ownership(ip_addr, [mac],
                                                      devs=devs):
-            logging.debug("Clean up outdated address info, "
-                          "MAC: %s, IP: %s" % (mac, ip_addr))
-            self.address_cache.pop(mac_pattern % mac)
+            self.address_cache.drop(mac_pattern % mac)
 
             nic_params = self.params.object_params(nic.nic_name)
             pci_assignable = nic_params.get("pci_assignable") != "no"
@@ -824,14 +822,6 @@ class BaseVM(object):
             self.virtnet.generate_mac_address(nic_name)
         # mac of '' or invaid format results in not setting a mac
         if nic.has_key('ip') and nic.has_key('mac'):
-            if not self.address_cache.has_key(nic.mac):
-                logging.debug("(address cache) Adding static "
-                              "cache entry: %s ---> %s" % (nic.mac, nic.ip))
-            else:
-                logging.debug("(address cache) Updating static "
-                              "cache entry from: %s ---> %s"
-                              " to: %s ---> %s" % (nic.mac,
-                                                   self.address_cache[nic.mac], nic.mac, nic.ip))
             self.address_cache[nic.mac] = nic.ip
         return nic
 
@@ -844,7 +834,7 @@ class BaseVM(object):
         self.free_mac_address(nic_index_or_name)
         try:
             del self.virtnet[nic_index_or_name]
-            del self.address_cache[nic_mac]
+            self.address_cache.drop(nic_mac)
         except IndexError:
             pass  # continue to not exist
         except KeyError:


### PR DESCRIPTION
Make the framework support various ip sniffers, and add the support of
tshark (wireshark).

The reason to do so is because tcpdump till now (the current latest
version is 4.9.2) has some problem to deal with the bootp/dhcp packet:
it will not show the 'vendor extensions/options' field when a packet
has the 'sname' or 'file' field, and that would forbid address_cache
being updated properly. So let us use tshark to workaround this issue.

---

Changes from v1 (https://github.com/avocado-framework/avocado-vt/pull/1249):

* Restructure ip sniffing facilities with OOP

Signed-off-by: Xu Han xuhan@redhat.com

ID: 1516187