### PR TITLE
Fixup: To run compat mode(power8) guest power9 host

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -29,6 +29,13 @@ variants:
         only ppc64, ppc64le
         machine_type = pseries
         # Currently only supports standard VGA
+        # Make sure below param is set 'yes' to run a
+        # power8(compat mode) on power9 host
+        # power9_compat = "no"
+        # Ref: https://github.com/torvalds/linux/commit/6d6ab940dc8b1c84fc86195c0f15a82ef282c8a3
+        # Make sure below param is set 'yes' to restore(enable)
+        # SMT after test
+        # restore_smt = "no"
         vga = std
         del rtc_drift
         del soundcards

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2042,12 +2042,13 @@ class StraceQemu(object):
         self._compress_log()
 
 
-def disable_smt(params=None):
+def switch_smt(state="off", params=None):
     """
-    Checks whether smt is on, if so disables it in PowerPC system
+    Checks whether smt is on/off, if so disables/enable it in PowerPC system
     This function is used in env_process and in libvirt.py to check
-    & disable smt in Power8 for local and remote machine respectively.
+    & disable smt in Powerpc for local and remote machine respectively.
 
+    :param state: 'off' or 'on' default: off
     :param params: Test params dict for remote machine login details
     """
     smt_output = ""
@@ -2068,27 +2069,30 @@ def disable_smt(params=None):
                                            % cmd_output[1])
     else:
         smt_output = process.system_output(cmd, shell=True).strip()
-    if (smt_output != "SMT is off"):
-        cmd = "ppc64_cpu --smt=off"
+    if (state == "off" and smt_output != "SMT is off") or (state == "on" and smt_output == "SMT is off"):
+        cmd = "ppc64_cpu --smt=%s" % state
         if params:
             if (server_user.lower() != "root"):
-                raise exceptions.TestSkipError("Turning SMT off requires root "
+                raise exceptions.TestSkipError("Turning SMT %s requires root "
                                                "privileges(currently running "
-                                               "with user %s)" % server_user)
+                                               "with user %s)" % (state,
+                                                                  server_user))
             cmd_output = server_session.cmd_status_output(cmd)
             server_session.close()
             if (cmd_output[0] != 0):
-                raise exceptions.TestSetupFail("VM cant be started :%s"
-                                               % cmd_output[1])
+                raise exceptions.TestSetupFail("Unable to turn %s SMT :%s"
+                                               % (state, cmd_output[1]))
             else:
-                logging.debug("SMT turned off successfully in remote server")
+                logging.debug("SMT turned %s successfully in remote server",
+                              state)
         else:
             try:
                 utils_misc.verify_running_as_root()
                 process.run(cmd, verbose=True, shell=True)
-                logging.debug("SMT turned off successfully")
+                logging.debug("SMT turned %s successfully", state)
             except process.CmdError, info:
-                raise exceptions.TestSetupFail("VM can not be started :%s" % info)
+                raise exceptions.TestSetupFail("Unable to turn %s SMT :%s" %
+                                               (state, info))
 
 
 class LibvirtdDebugLog(object):

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1294,7 +1294,7 @@ class MigrationTest(object):
                 if (cmd_output[0] == 0):
                     cmd_output = cmd_output[1].strip().upper()
                     if "POWER8" in cmd_output:
-                        test_setup.disable_smt(params=params)
+                        test_setup.switch_smt(state="off", params=params)
                 else:
                     raise exceptions.TestError("Failed to get cpuinfo of remote "
                                                "server", cmd_output[1])


### PR DESCRIPTION
This patch address this kernel commit
torvalds/linux@6d6ab94
and make sure prerequisite is set to run
power8(compat mode) guest on current power9 hardware.

disable and enable(restore) smt can be controlled by
two params, power9_compat, restore_smt.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>