### PR TITLE
Add interval for package install to avoid no exit status issues

### DIFF
--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -82,7 +82,7 @@ class RemotePackageMgr(object):
         cmd = self.query_cmd + pkg_name
         return not self.session.cmd_status(cmd)
 
-    def operate(self, timeout, default_status):
+    def operate(self, timeout, default_status, internal_timeout=2):
         """
         Run command and return status
 
@@ -99,7 +99,7 @@ class RemotePackageMgr(object):
                 need = True
             if need:
                 cmd = self.cmd + pkg
-                if self.session.cmd_status(cmd, timeout):
+                if self.session.cmd_status(cmd, timeout, internal_timeout):
                     # Try to clean the repo db and re-try installation
                     if not self.clean():
                         logging.error("Package %s was broken", self.package_manager)


### PR DESCRIPTION
Error get from test:
ShellStatusError: Could not get exit status of command: 'yum install -y omping' (output: u'Loaded plugins: product-id, search-disabled-repos, subscription-manager\nThis system is not registered with an entitlement server. You can use subscription-manager to register.\nResolving Dependencies\n--&gt; Running transaction check\n---&gt; Package omping.x86_64 0:0.0.4-6.el7 will be installed\n--&gt; Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package       Arch          Version              Repository               Size\n================================================================================\nInstalling:\n omping        x86_64        0.0.4-6.el7          HighAvailability         37 k\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal download size: 37 k\nInstalled size: 66 k\nDownloading packages:\nomping-0.0.4-6.el7.x86_64.rpm                              |  37 kB   00:00     \nRunning transaction check\nRunning transaction test\nTransaction test succeeded\nRunning transaction\nWarning: RPMDB altered outside of yum.\n')&#10;

Seems do not finish the install and then get the status, add interval can resolve this issue