### PR TITLE
shared: Always set gic-version on arm64

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -37,6 +37,8 @@ variants:
         auto_cpu_model = "no"
         cpu_model = host
         machine_type = arm64-mmio:virt
+        # TODO: Change to "gic-version=max" when supported
+        machine_type_extra_params = gic-version=host
         # No support for VGA yet
         vga = none
         vir_domain_undefine_nvram = yes
@@ -49,7 +51,9 @@ variants:
         only aarch64
         auto_cpu_model = "no"
         cpu_model = host
+        # TODO: Change to "gic-version=max" when supported
         machine_type = arm64-pci:virt
+        machine_type_extra_params = gic-version=host
         # No support for VGA yet
         vga = none
         vir_domain_undefine_nvram = yes


### PR DESCRIPTION
The default gic-version set by qemu is always gicv2, which does not work
on gicv3 machines. Let's use "gic-version=host" by default to at least
match the gic version, but later when "gic-version=max" is supported we
should start using that.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>