### PR TITLE
Assets: update location for ISO and other images location

### DIFF
--- a/docs/source/DownloadableImages.rst
+++ b/docs/source/DownloadableImages.rst
@@ -30,7 +30,7 @@ Winutils ISO
 
 The windows utils file can be currently found at:
 
-http://assets-avocadoproject.rhcloud.com/static/winutils.iso
+http://avocado-project.org/data/assets/winutils.iso
 
 How to update `winutils.iso`
 ----------------------------
@@ -44,14 +44,12 @@ JeOS image
 
 You can find the JeOS images currently available here:
 
-https://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.xz
+http://avocado-project.org/data/assets/jeos-23-64.qcow2.xz
 
-https://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23_XZ
+http://avocado-project.org/data/assets/SHA1SUM_JEOS23_XZ
 
-Unfortunately the host `assets-avocadoproject.rhcloud.com` is configured
-in such a way that exploring that base directory won't give you a file
-listing, and you have to provide the exact urls of what you're looking
-for.
+You can browse through http://avocado-project.org/data/assets/jeos/ and find
+other JeOS versions available.
 
 How to update JeOS
 ------------------

--- a/docs/source/Networking.rst
+++ b/docs/source/Networking.rst
@@ -59,7 +59,7 @@ test windows. First, download the iso. :doc:`The get started documentation <GetS
 can help you out with downloading if you like it, but the direct download
 link is here:
 
-http://assets-avocadoproject.rhcloud.com/static/winutils.iso
+http://avocado-project.org/data/assets/winutils.iso
 
 You need to put all its contents on a folder and create a new iso. Let's say you
 want to download the iso to ``/home/kermit/Downloads/winutils.iso``.

--- a/shared/downloads/jeos-23-64.ini
+++ b/shared/downloads/jeos-23-64.ini
@@ -1,6 +1,6 @@
 [jeos-23-64]
 title = JeOS 23 x86_64
-url = http://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.xz
-sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23_XZ
+url = http://avocado-project.org/data/assets/jeos-23-64.qcow2.xz
+sha1_url = http://avocado-project.org/data/assets/SHA1SUM_JEOS23_XZ
 destination = images/jeos-23-64.qcow2.xz
 destination_uncompressed = images/jeos-23-64.qcow2

--- a/shared/downloads/jeos-25-64.ini
+++ b/shared/downloads/jeos-25-64.ini
@@ -1,6 +1,6 @@
 [jeos-25-64]
 title = JeOS 25 x86_64
-url = http://assets-avocadoproject.rhcloud.com/static/jeos-25-64.qcow2.xz
-sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS25
+url = http://avocado-project.org/data/assets/jeos-25-64.qcow2.xz
+sha1_url = http://avocado-project.org/data/assets/SHA1SUM_JEOS25
 destination = images/jeos-25-64.qcow2.xz
 destination_uncompressed = images/jeos-25-64.qcow2

--- a/shared/downloads/winutils.ini
+++ b/shared/downloads/winutils.ini
@@ -1,5 +1,5 @@
 [winutils]
 title = Windows Utils ISO
-url = http://assets-avocadoproject.rhcloud.com/static/winutils.iso
-sha1_url = http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_WINUTILS
+url = http://avocado-project.org/data/assets/winutils.iso
+sha1_url = http://avocado-project.org/data/assets/SHA1SUM_WINUTILS
 destination = isos/windows/winutils.iso


### PR DESCRIPTION
We've got a new server, and the asset repo is already there.  Let's
use that new server in the documentation and download definition
files.

Signed-off-by: Cleber Rosa <crosa@redhat.com>