### PR TITLE
Set default value for param scsi_hba

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1572,7 +1572,7 @@ class DevContainer(object):
         """
         shared_dir = os.path.join(data_dir.get_data_dir(), "shared")
         drive_format = image_params.get("drive_format")
-        scsi_hba = image_params.get("scsi_hba")
+        scsi_hba = image_params.get("scsi_hba", "virtio-scsi-pci")
         if drive_format == "virtio":    # translate virtio to ccw/device
             machine_type = image_params.get("machine_type")
             if "s390" in machine_type:      # s390


### PR DESCRIPTION
When launching VM with scsi devices on some platforms, the following
error would be emitted if param scsi_hba is not set.
```
  DeviceError: Failed to insert device:
  ...
      driver = virtio-scsi-pci
      ...
  ParentBus({'aobject': 'pci.0'}): No matching bus
```
The patch fixes this error by setting the default value of param
scsi_hba to virtio-scsi-pci since virtio-scsi-pci does be the
default option of the images_define_by_variables function.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1515543