### PR TITLE
s390x: modify the directory of kernel.img for s390x

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -22,3 +22,4 @@
             kernel_params += " console=ttyS0,115200 console=tty0"
         s390x:
             kernel_params += " console=ttysclp0 debug ignore_loglevel"
+            boot_path = images


### PR DESCRIPTION
ID: 1528540
The default directory of kernel.img for s390x is different from
that of other platforms, this patch add the additional configurations
to let installation job find the *.img files

Signed-off-by: Zhengtong Liu <zhengtli@redhat.com>