### PR TITLE
virsh.memtune_get: return -1 if got "unlimited"

### DIFF
--- a/virttest/libvirt_xml/devices/serial.py
+++ b/virttest/libvirt_xml/devices/serial.py
@@ -10,7 +10,8 @@ from virttest.libvirt_xml.devices.character import CharacterBase
 
 class Serial(CharacterBase):
 
-    __slots__ = ('protocol_type', 'target_port', 'target_type', 'sources')
+    __slots__ = ('protocol_type', 'target_port', 'target_type',
+                 'target_model', 'sources')
 
     def __init__(self, type_name='pty', virsh_instance=base.virsh):
         # Additional attribute for protocol type (raw, telnet, telnets, tls)
@@ -20,6 +21,8 @@ class Serial(CharacterBase):
                                tag_name='target', attribute='port')
         accessors.XMLAttribute('target_type', self, parent_xpath='/',
                                tag_name='target', attribute='type')
+        accessors.XMLAttribute('target_model', self, parent_xpath='/target',
+                               tag_name='model', attribute='name')
         accessors.XMLElementList('sources', self, parent_xpath='/',
                                  marshal_from=self.marshal_from_sources,
                                  marshal_to=self.marshal_to_sources)

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2524,7 +2524,7 @@ def memtune_get(name, key):
     memtune_output = memtune_list(name)
     memtune_value = re.findall(r"%s\s*:\s+(\S+)" % key, str(memtune_output))
     if memtune_value:
-        return int(memtune_value[0])
+        return int(memtune_value[0] if memtune_value[0] != "unlimited" else -1)
     else:
         return -1
 


### PR DESCRIPTION
memtune_get() require return one integar. If there is no limit for one
memtune type, "virsh memtune" will output "unlimited", so change return
value to -1 in this case.

Signed-off-by: czhang0 <47047802@qq.com>