### PR TITLE
virsh.memtune_get: return -1 if got "unlimited"

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2524,7 +2524,7 @@ def memtune_get(name, key):
     memtune_output = memtune_list(name)
     memtune_value = re.findall(r"%s\s*:\s+(\S+)" % key, str(memtune_output))
     if memtune_value:
-        return int(memtune_value[0])
+        return int(memtune_value[0] if memtune_value[0] != "unlimited" else -1)
     else:
         return -1
 


### PR DESCRIPTION
memtune_get() require return one integar. If there is no limit for one
memtune type, "virsh memtune" will output "unlimited", so change return
value to -1 in this case.

Signed-off-by: czhang0 <47047802@qq.com>