### PR TITLE
utils_net: remove the serial session close after serial login

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3418,7 +3418,6 @@ def update_mac_ip_address(vm, timeout=240):
     try:
         session = vm.wait_for_serial_login(timeout=timeout)
         addr_map = get_guest_address_map(session)
-        session.close()
         if not addr_map:
             logging.warn("No VM's NIC got IP address")
             return


### PR DESCRIPTION
When login vm via serial, the serial session will be closed after
get mac ip map, then serial output cann't be logged. So the session
close is too early and remove it.

ID: 1485780
Signed-off-by: yama <yama@redhat.com>