### PR TITLE
RFC: Improvement of test setup development

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -607,6 +607,8 @@ def preprocess(test, params, env):
 
     global _setuper_mgr
     _setuper_mgr = test_setup.SetuperMgr(test, params, env)
+    if params.get("setup_ksm") == "yes":
+        _setuper_mgr.register(test_setup.KSMSetuper)
     _setuper_mgr.do_setup()
 
     # enable network proxies setting in urllib2
@@ -772,10 +774,6 @@ def preprocess(test, params, env):
     if params.get("setup_thp") == "yes":
         thp = test_setup.TransparentHugePageConfig(test, params)
         thp.setup()
-
-    if params.get("setup_ksm") == "yes":
-        ksm = test_setup.KSMConfig(params, env)
-        ksm.setup(env)
 
     if params.get("setup_egd") == "yes":
         egd = test_setup.EGDConfig(params, env)
@@ -1114,14 +1112,6 @@ def postprocess(test, params, env):
             thp.cleanup()
         except Exception, details:
             err += "\nTHP cleanup: %s" % str(details).replace('\\n', '\n  ')
-            logging.error(details)
-
-    if params.get("setup_ksm") == "yes":
-        try:
-            ksm = test_setup.KSMConfig(params, env)
-            ksm.cleanup(env)
-        except Exception, details:
-            err += "\nKSM cleanup: %s" % str(details).replace('\\n', '\n  ')
             logging.error(details)
 
     if params.get("setup_egd") == "yes" and params.get("kill_vm") == "yes":

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -48,6 +48,8 @@ _screendump_thread_termination_event = None
 _vm_register_thread = None
 _vm_register_thread_termination_event = None
 
+_setuper_mgr = None
+
 kernel_modified = False
 kernel_cmdline = None
 
@@ -602,6 +604,10 @@ def preprocess(test, params, env):
                 path.find_command(cmd)
             except path.CmdNotFoundError, msg:
                 raise exceptions.TestSkipError(msg.message)
+
+    global _setuper_mgr
+    _setuper_mgr = test_setup.SetuperMgr(test, params, env)
+    _setuper_mgr.do_setup()
 
     # enable network proxies setting in urllib2
     if params.get("network_proxies"):
@@ -1241,6 +1247,9 @@ def postprocess(test, params, env):
                                     level_check=level)
         except exceptions.TestFail as details:
             err += "\nHost dmesg verification failed: %s" % details
+
+    global _setuper_mgr
+    err += "\n".join(_setuper_mgr.do_cleanup())
 
     if err:
         raise RuntimeError("Failures occurred while postprocess:\n%s" % err)

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -640,12 +640,13 @@ class HugePageConfig(object):
             logging.debug("Hugepage memory successfully deallocated")
 
 
-class KSMConfig(object):
+class KSMSetuper(Setuper):
 
-    def __init__(self, params, env):
+    def __init__(self, test, params, env):
         """
         :param params: Dict like object containing parameters for the test.
         """
+        super(KSMSetuper, self).__init__(test, params, env)
         self.pages_to_scan = params.get("ksm_pages_to_scan")
         self.sleep_ms = params.get("ksm_sleep_ms")
         self.run = params.get("ksm_run", "1")
@@ -687,17 +688,17 @@ class KSMConfig(object):
         self.default_status.append(int(self.ksmtuned_process))
         self.default_status.append(self.ksm_module_loaded)
 
-    def setup(self, env):
+    def setup(self):
         if self.disable_ksmtuned:
             self.ksmctler.stop_ksmtuned()
 
-        env.data["KSM_default_config"] = self.default_status
+        self.env.data["KSM_default_config"] = self.default_status
         self.ksmctler.set_ksm_feature({"run": self.run,
                                        "pages_to_scan": self.pages_to_scan,
                                        "sleep_millisecs": self.sleep_ms})
 
-    def cleanup(self, env):
-        default_status = env.data.get("KSM_default_config")
+    def cleanup(self):
+        default_status = self.env.data.get("KSM_default_config")
 
         # Get original ksm loaded status
         default_ksm_loaded = default_status.pop()


### PR DESCRIPTION
Currently, the problem of test setup development is, without using `env`, it is hard to keep a persistent context for the `setup` and `cleanup` method of the same setuper instance, that makes the code buggy.

To solve this problem, we can introduce a manager which is alive through whole test phases for the setupers. The manager can register setupers, do all the setup procedures at the beginning of the test and do all the cleanup procedures at the end of the test.