### PR TITLE
Fixup: add default transfer_timeout to avoid test failure

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -504,7 +504,7 @@ def run_file_transfer(test, params, env):
     login_timeout = int(params.get("login_timeout", 360))
     session = vm.wait_for_login(timeout=login_timeout)
     error_context.context("Login to guest", logging.info)
-    transfer_timeout = int(params.get("transfer_timeout"))
+    transfer_timeout = int(params.get("transfer_timeout", 1000))
     clean_cmd = params.get("clean_cmd", "rm -f")
     filesize = int(params.get("filesize", 4000))
     count = int(filesize / 10) or 1


### PR DESCRIPTION
transfer_timeout does not have a default value set in
any of global config, so if not set explicitly will
lead to below error, as it got typecasted
to int while accessing.

 TypeError: int() argument must be a string or a number, not 'NoneType'

This patch avoids it by setting the default value.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>