### PR TITLE
Support various ip sniffers [v3]

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -674,10 +674,10 @@ def preprocess(test, params, env):
                 params[name_tag] = os.path.join(image_nfs.mount_dir,
                                                 image_name_only)
 
-    # Start tcpdump if it isn't already running
+    # Start ip sniffing if it isn't already running
     # The fact it has to be started here is so that the test params
     # have to be honored.
-    env.start_tcpdump(params)
+    env.start_ip_sniffing(params)
 
     # Add migrate_vms to vms
     migrate_vms = params.objects("migrate_vms")
@@ -1054,8 +1054,8 @@ def postprocess(test, params, env):
                 vm.name)
             vm.destroy()
 
-    # Terminate the tcpdump thread
-    env.stop_tcpdump()
+    # Terminate the ip sniffer thread
+    env.stop_ip_sniffing()
 
     # Kill all aexpect tail threads
     aexpect.kill_tail_threads()

--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -1,0 +1,274 @@
+"""
+IP sniffing facilities
+"""
+
+import threading
+import logging
+import re
+
+import aexpect
+from avocado.utils import path as utils_path
+
+from remote import handle_prompts
+from utils_misc import log_line
+
+
+class AddrCache(object):
+
+    """
+    Address cache implementation.
+    """
+
+    def __init__(self):
+        """Initializes the address cache."""
+        self._data = {}
+        self._lock = threading.RLock()
+
+    def __repr__(self):
+        return repr(self._data)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _format_hwaddr(hwaddr):
+        return hwaddr.lower()
+
+    def __setitem__(self, hwaddr, ipaddr):
+        hwaddr = self._format_hwaddr(hwaddr)
+        with self._lock:
+            if self._data.get(hwaddr) == ipaddr:
+                return
+            self._data[hwaddr] = ipaddr
+        logging.debug("Updated HWADDR (%s)<->(%s) IP pair "
+                      "into address cache", hwaddr, ipaddr)
+
+    def __getitem__(self, hwaddr):
+        hwaddr = self._format_hwaddr(hwaddr)
+        ipaddr = None
+        with self._lock:
+            ipaddr = self._data.get(hwaddr)
+        return ipaddr
+
+    def __delitem__(self, hwaddr):
+        hwaddr = self._format_hwaddr(hwaddr)
+        with self._lock:
+            del self._data[hwaddr]
+        logging.debug("Dropped the address cache of HWADDR (%s)", hwaddr)
+
+    def get(self, hwaddr):
+        """
+        Get the ip address of the given hardware address.
+
+        :param hwaddr: Hardware address.
+        """
+        return self.__getitem__(hwaddr)
+
+    def drop(self, hwaddr):
+        """
+        Drop the cache of the given hardware address.
+
+        :param hwaddr: Hardware address.
+        """
+        return self.__delitem__(hwaddr)
+
+    def update(self, cache):
+        """
+        Update the address cache with the address pairs from other,
+        overwriting existing hardware address.
+
+        :param cache: AddrCache object, dict object or iterable
+                      key/value pairs.
+        """
+        if self == cache:
+            return
+        if isinstance(cache, AddrCache):
+            _cache = cache
+            with _cache._lock:
+                cache = _cache._data.copy()
+        if hasattr(cache, "iteritems"):
+            cache = cache.iteritems()
+        for hwaddr, ipaddr in cache:
+            self[hwaddr] = ipaddr
+
+    def clear(self):
+        """Clear all the address caches."""
+        with self._lock:
+            self._data.clear()
+        logging.debug("Clean out all the address caches")
+
+
+class Sniffer(object):
+
+    """
+    Virtual base class of the ip sniffer abstraction.
+
+    The `_output_handler(self, line)` method must be
+    provided by the subclasses.
+    """
+
+    #: Sniffer's command name
+    command = ""
+    #: Sniffer's options
+    options = ""
+
+    def __init__(self, addr_cache, log_file, remote_opts=None):
+        """
+        Initializes the sniffer.
+
+        :param addr_cache: Address cache to be updated.
+        :param log_file: Log file name.
+        :param remote_opts: Options of remote host session, is a tuple built
+                            up by `(address, port, username, password,
+                            prompt)`. If provided, launches the sniffer on
+                            remote host, otherwise on local host.
+        """
+        self._cache = addr_cache
+        self._logfile = log_file
+        self._remote_opts = remote_opts
+        self._process = None
+
+    @classmethod
+    def _is_supported_remote(cls, session):
+        return session.cmd_status("which %s" % cls.command) == 0
+
+    @classmethod
+    def is_supported(cls, session=None):
+        """
+        Check if host supports the sniffer.
+
+        :param session: Remote host session. If provided, performs the
+                        check on remote host, otherwise on local host.
+        """
+        if session:
+            return cls._is_supported_remote(session)
+        try:
+            utils_path.find_command(cls.command)
+            return True
+        except utils_path.CmdNotFoundError:
+            return False
+
+    def _output_handler(self, line):
+        raise NotImplementedError
+
+    def _output_logger_handler(self, line):
+        try:
+            log_line(self._logfile, line)
+        except Exception as e:
+            logging.warn("Can't log ip sniffer output: '%s'", e)
+        if self._output_handler(line):
+            return
+        # We can check whether the process is terminated unexpectedly
+        # here since the terminated status is a line of the output
+        if re.match("\(Process terminated with status", line):
+            status = self._process.get_status()
+            if status != 0:
+                logging.error("IP sniffer (%s) terminated unexpectedly! "
+                              "please check the log to get the details "
+                              "(status: %s)", self.command, status)
+
+    def _start_remote(self):
+        address, port, username, password, prompt = self._remote_opts
+        cmd = "%s %s" % (self.command, self.options)
+        logging.debug("Run '%s' on host '%s'", cmd, address)
+        login_cmd = ("ssh -o UserKnownHostsFile=/dev/null "
+                     "-o StrictHostKeyChecking=no "
+                     "-o PreferredAuthentications=password -p %s %s@%s" %
+                     (port, username, address))
+
+        self._process = aexpect.ShellSession(
+            login_cmd,
+            output_func=self._output_logger_handler)
+        handle_prompts(self._process, username, password, prompt)
+        self._process.sendline(cmd)
+
+    def _start(self):
+        cmd = "%s %s" % (self.command, self.options)
+        if self._remote_opts:
+            self._start_remote()
+        else:
+            self._process = aexpect.run_tail(
+                command=cmd,
+                output_func=self._output_logger_handler)
+
+    def is_alive(self):
+        """Check if the sniffer is alive."""
+        if not self._process:
+            return False
+        return self._process.is_alive()
+
+    def start(self):
+        """Start sniffing."""
+        if self.is_alive():
+            return
+        self.stop()
+        self._start()
+
+    def stop(self):
+        """Stop sniffing."""
+        if self._process:
+            self._process.close()
+            self._process = None
+
+    def __del__(self):
+        self.stop()
+
+
+class TcpdumpSniffer(Sniffer):
+
+    """
+    Tcpdump sniffer class.
+    """
+
+    command = "tcpdump"
+    options = "-tnpvvvi any 'port 68 or port 546'"
+
+    def __init__(self, addr_cache, log_file, remote_opts=None):
+        super(TcpdumpSniffer, self).__init__(addr_cache, log_file, remote_opts)
+        self._context = {}
+
+    def _output_handler(self, line):
+        # BootP/DHCP (RFC 951/2131)
+        matches = re.search(r"^IP\s", line)
+        if matches:
+            # Clear context upon receiving new packets
+            self._context.clear()
+            return True
+
+        matches = re.search(r"Your.IP\s+(\S+)", line, re.I)
+        if matches:
+            self._context["ip"] = matches.group(1)
+            return True
+
+        matches = re.search(r"Client.Ethernet.Address\s+(\S+)", line, re.I)
+        if matches:
+            self._context["mac"] = matches.group(1)
+            return True
+
+        if re.search(r"DHCP.Message.*:\s+ACK", line, re.I):
+            mac = self._context.get("mac")
+            ip = self._context.get("ip")
+            if mac and ip:
+                self._cache[mac] = ip
+            return True
+
+        # DHCPv6 (RFC 3315)
+        if re.search("dhcp6 reply", line, re.I):
+            regex = "IA_ADDR (.*) pltime.*client-ID.*?([0-9a-fA-F]{12})\)"
+            matches = re.search(regex, line, re.I)
+            if matches:
+                info = matches.groups()
+                mac = ":".join(re.findall("..", info[1]))
+                ip = info[0].lower()
+                self._cache["%s_6" % mac] = ip
+            return True
+
+
+#: All the defined sniffers
+Sniffers = (TcpdumpSniffer,)

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -2,16 +2,12 @@ import cPickle
 import UserDict
 import os
 import logging
-import re
 import threading
 
-import aexpect
 from avocado.core import exceptions
-from avocado.utils import path as utils_path
-from avocado.utils import process
 
-import utils_misc
 import virt_vm
+import ip_sniffing
 import remote
 
 ENV_VERSION = 1
@@ -47,81 +43,6 @@ def lock_safe(function):
     return wrapper
 
 
-@lock_safe
-def _update_address_cache(env, line):
-    """
-    Update mac <-> ip releation ship dict when we got a dhcpack packet.
-    """
-    address_cache = env["address_cache"]
-    matches = re.search(r"Your.IP\s+(\S+)", line, re.I)
-    if matches:
-        ip = matches.group(1)
-        if ip != address_cache.get("last_seen_ip"):
-            address_cache["last_seen_ip"] = ip
-        return
-
-    matches = re.search(r"Client.Ethernet.Address\s+(\S+)", line, re.I)
-    if matches:
-        mac = matches.group(1).lower()
-        if mac != address_cache.get("last_seen_mac"):
-            address_cache["last_seen_mac"] = mac
-        return
-
-    if re.search(r"DHCP.Message.*:\s+ACK", line, re.I):
-        if (address_cache.get('last_seen_mac') and
-                address_cache.get('last_seen_ip')):
-            mac = address_cache['last_seen_mac']
-            ip = address_cache['last_seen_ip']
-            if address_cache.get(mac) != ip:
-                address_cache[mac] = ip
-                logging.info("Update MAC(%s)<->(%s)IP" % (mac, ip) +
-                             " pair into address_cache")
-            address_cache["last_seen_mac"] = None
-            address_cache["last_seen_ip"] = None
-        return
-
-    # ipv6 address cache:
-    mac_ipv6_reg = r"client-ID.*?([0-9a-fA-F]{12})\).*IA_ADDR (.*) pltime"
-    if re.search("dhcp6 (request|renew|confirm)", line, re.IGNORECASE):
-        matches = re.search(mac_ipv6_reg, line, re.I)
-        if matches:
-            ipinfo = matches.groups()
-            mac_address = ":".join(re.findall("..", ipinfo[0])).lower()
-            request_ip = ipinfo[1].lower()
-            logging.debug("(address cache) DHCPV6 lease OK: %s --> %s",
-                          mac_address, request_ip)
-            env["address_cache"]["%s_6" % mac_address] = request_ip
-        return
-
-    if re.search("dhcp6 (reply|advertise)", line, re.IGNORECASE):
-        ipv6_mac_reg = "IA_ADDR (.*) pltime.*client-ID.*?([0-9a-fA-F]{12})\)"
-        matches = re.search(ipv6_mac_reg, line, re.I)
-        if matches:
-            ipinfo = matches.groups()
-            mac_address = ":".join(re.findall("..", ipinfo[1])).lower()
-            allocate_ip = ipinfo[0].lower()
-            logging.debug("(address cache) DHCPV6 lease OK: %s --> %s",
-                          mac_address, allocate_ip)
-            env["address_cache"]["%s_6" % mac_address] = allocate_ip
-        return
-
-
-def _tcpdump_handler(env, filename, line):
-    """
-    Helper for handler tcpdump output.
-
-    :params address_cache: address cache path.
-    :params filename: Log file name for tcpdump message.
-    :params line: Tcpdump output message.
-    """
-    try:
-        utils_misc.log_line(filename, line)
-    except Exception, reason:
-        logging.warn("Can't log tcpdump output, '%s'", reason)
-
-    _update_address_cache(env, line)
-
-
 class Env(UserDict.IterableUserDict):
 
     """
@@ -142,8 +63,7 @@ class Env(UserDict.IterableUserDict):
         UserDict.IterableUserDict.__init__(self)
         empty = {"version": version}
         self._filename = filename
-        self._tcpdump = None
-        self._params = None
+        self._sniffer = None
         self.save_lock = threading.RLock()
         if filename:
             try:
@@ -204,7 +124,7 @@ class Env(UserDict.IterableUserDict):
         """
         Destroy all objects registered in this Env object.
         """
-        self.stop_tcpdump()
+        self.stop_ip_sniffing()
         for key in self.data:
             try:
                 if key.startswith("vm__"):
@@ -314,69 +234,43 @@ class Env(UserDict.IterableUserDict):
         """
         return self.data.get("lvmdev__%s" % name)
 
-    def _start_tcpdump(self):
+    def start_ip_sniffing(self, params):
+        """
+        Start ip sniffing.
 
-        cmd_template = "%s -npvvvi any 'port 68 or port 546'"
-        if self._params.get("remote_preprocess") == "yes":
-            client = self._params.get('remote_shell_client', 'ssh')
-            port = self._params.get('remote_shell_port', '22')
-            prompt = self._params.get('remote_shell_prompt', '#')
-            address = self._params.get('remote_node_address')
-            username = self._params.get('remote_node_user')
-            password = self._params.get('remote_node_password')
-            rsession = None
-            try:
-                rsession = remote.remote_login(client, address,
-                                               port, username,
-                                               password, prompt)
-                tcpdump_bin = rsession.cmd_output("which tcpdump")
-                rsession.close()
-            except process.CmdError:
-                rsession.close()
-                raise exceptions.TestError("Can't find tcpdump binary!")
+        :param params: Params object.
+        """
+        self.data.setdefault("address_cache", ip_sniffing.AddrCache())
+        sniffers = ip_sniffing.Sniffers
 
-            cmd = cmd_template % tcpdump_bin.strip()
-            logging.debug("Run '%s' on host '%s'", cmd, address)
-            login_cmd = ("ssh -o UserKnownHostsFile=/dev/null "
-                         "-o StrictHostKeyChecking=no "
-                         "-o PreferredAuthentications=password -p %s %s@%s" %
-                         (port, username, address))
+        if not self._sniffer:
+            remote_pp = params.get("remote_preprocess") == "yes"
+            remote_opts = None
+            session = None
+            if remote_pp:
+                client = params.get('remote_shell_client', 'ssh')
+                remote_opts = (params.get['remote_node_address'],
+                               params.get('remote_shell_port', '22'),
+                               params['remote_node_user'],
+                               params['remote_node_password'],
+                               params.get('remote_shell_prompt', '#'))
+                session = remote.remote_login(client, *remote_opts)
+            for s_cls in sniffers:
+                if s_cls.is_supported(session):
+                    self._sniffer = s_cls(self.data["address_cache"],
+                                          "ip-sniffer.log",
+                                          remote_opts)
+                    break
+            if session:
+                session.close()
 
-            self._tcpdump = aexpect.ShellSession(
-                login_cmd,
-                output_func=_update_address_cache,
-                output_params=(self,))
+        if not self._sniffer:
+            raise exceptions.TestError("Can't find any supported ip sniffer! "
+                                       "%s" % [s.command for s in sniffers])
 
-            remote.handle_prompts(self._tcpdump, username, password, prompt)
-            self._tcpdump.sendline(cmd)
+        self._sniffer.start()
 
-        else:
-            cmd = cmd_template % utils_path.find_command("tcpdump")
-            self._tcpdump = aexpect.Tail(command=cmd,
-                                         output_func=_tcpdump_handler,
-                                         output_params=(self, "tcpdump.log"))
-
-        if not self._tcpdump.is_alive():
-            logging.warn("Could not start tcpdump")
-            logging.warn("Status: %s", self._tcpdump.get_status())
-            msg = utils_misc.format_str_for_message(self._tcpdump.get_output())
-            logging.warn("Output: %s", msg)
-
-    def start_tcpdump(self, params):
-        self._params = params
-
-        if "address_cache" not in self.data:
-            self.data["address_cache"] = {}
-
-        if self._tcpdump is None:
-            self._start_tcpdump()
-        else:
-            if not self._tcpdump.is_alive():
-                del self._tcpdump
-                self._start_tcpdump()
-
-    def stop_tcpdump(self):
-        if self._tcpdump is not None:
-            self._tcpdump.close()
-            del self._tcpdump
-            self._tcpdump = None
+    def stop_ip_sniffing(self):
+        """Stop ip sniffing."""
+        if self._sniffer:
+            self._sniffer.stop()

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3422,7 +3422,6 @@ def update_mac_ip_address(vm, timeout=240):
         if not addr_map:
             logging.warn("No VM's NIC got IP address")
             return
-        logging.debug("Update address_cache: %s", addr_map)
         vm.address_cache.update(addr_map)
     except Exception, e:
         logging.warn("Error occur when update VM address cache: %s", str(e))

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -706,9 +706,7 @@ class BaseVM(object):
         devs = set([nic.netdst]) if nic.has_key('netdst') else set()
         if not utils_net.verify_ip_address_ownership(ip_addr, [mac],
                                                      devs=devs):
-            logging.debug("Clean up outdated address info, "
-                          "MAC: %s, IP: %s" % (mac, ip_addr))
-            self.address_cache.pop(mac_pattern % mac)
+            self.address_cache.drop(mac_pattern % mac)
 
             nic_params = self.params.object_params(nic.nic_name)
             pci_assignable = nic_params.get("pci_assignable") != "no"
@@ -824,14 +822,6 @@ class BaseVM(object):
             self.virtnet.generate_mac_address(nic_name)
         # mac of '' or invaid format results in not setting a mac
         if nic.has_key('ip') and nic.has_key('mac'):
-            if not self.address_cache.has_key(nic.mac):
-                logging.debug("(address cache) Adding static "
-                              "cache entry: %s ---> %s" % (nic.mac, nic.ip))
-            else:
-                logging.debug("(address cache) Updating static "
-                              "cache entry from: %s ---> %s"
-                              " to: %s ---> %s" % (nic.mac,
-                                                   self.address_cache[nic.mac], nic.mac, nic.ip))
             self.address_cache[nic.mac] = nic.ip
         return nic
 
@@ -844,7 +834,7 @@ class BaseVM(object):
         self.free_mac_address(nic_index_or_name)
         try:
             del self.virtnet[nic_index_or_name]
-            del self.address_cache[nic_mac]
+            self.address_cache.drop(nic_mac)
         except IndexError:
             pass  # continue to not exist
         except KeyError:


### PR DESCRIPTION
Make the framework support various ip sniffers, and add the support of
tshark (wireshark).

The reason to do so is because tcpdump till now (the current latest
version is 4.9.2) has some problem to deal with the bootp/dhcp packet:
it will not show the 'vendor extensions/options' field when a packet
has the 'sname' or 'file' field, and that would forbid address_cache
being updated properly. So let us use tshark to workaround this issue.

---
Changes from v2 (https://github.com/avocado-framework/avocado-vt/pull/1256):

* Give warning when using tshark with ipv6 env, since it is not supported yet
* Improve accuracy of the detection about unexpected termination of the process
* Fix argument order issue of tshark

Changes from v1 (https://github.com/avocado-framework/avocado-vt/pull/1249):

* Restructure ip sniffing facilities with OOP

Signed-off-by: Xu Han xuhan@redhat.com

ID: 1516187