### PR TITLE
Fix ci check

### DIFF
--- a/virttest/lvsb_base.py
+++ b/virttest/lvsb_base.py
@@ -293,7 +293,7 @@ class SandboxCommandBase(SandboxBase):
         self._name = state.pop('name')
         super(SandboxCommandBase, self).__setstate__(state)
 
-    def __get_name__(self):
+    def _get_name(self):
         """
         Represent a unique sandbox name generated from class and identifier
         """
@@ -309,15 +309,15 @@ class SandboxCommandBase(SandboxBase):
         return self._name
 
     @staticmethod
-    def __set_name__(value):
+    def _set_name(value):
         del value  # not used
         raise SandboxException("Name is read-only")
 
     @staticmethod
-    def __del_name__():
+    def _del_name():
         raise SandboxException("Name is read-only")
 
-    name = property(__get_name__, __set_name__, __del_name__)
+    name = property(_get_name, _set_name, _del_name)
 
     @staticmethod
     def flaten_options(options):


### PR DESCRIPTION
The SandboxCommandBase class now has a name conflict of method
`__set_name__`, it is treated as a special method from python 3.6,
let's rename it and its related methods since they are just
"normal" methods.

Reference:
  https://docs.python.org/3/reference/datamodel.html#object.__set_name__

Signed-off-by: Xu Han <xuhan@redhat.com>
  