### PR TITLE
s390x: fix the virtio rng device name for s390x platform

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -881,6 +881,10 @@ class VM(virt_vm.BaseVM):
                 dev.set_param("id", dev_id)
 
             dev_type = "virtio-rng-pci"
+            machine_type = self.params.get("machine_type", "pc")
+            if "s390" in machine_type:
+                dev_type = "virtio-rng-ccw"
+                parent_bus = None
             if devices.has_device(dev_type):
                 rng_pci = QDevice(dev_type, parent_bus=parent_bus)
                 set_dev_params(rng_pci, rng_params, None, dev_type)


### PR DESCRIPTION
ID: 1532138
On s390x platform, the name of virtio rng name is virtio-rng-ccw instead
of virtio-rng-pci. this patch fixed the name bug on s390x

Signed-off-by: Zhengtong Liu <zhengtli@redhat.com>