### PR TITLE
virsh: migrate_postcopy() API for triggering postcopy migration

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1410,6 +1410,18 @@ def domain_exists(name, **dargs):
         return False
 
 
+def migrate_postcopy(name, **dargs):
+    """
+    Trigger postcopy migration
+
+    :param name: VM name
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    cmd = "migrate-postcopy %s" % name
+    return command(cmd, **dargs)
+
+
 def migrate(name="", dest_uri="", option="", extra="", **dargs):
     """
     Migrate a guest to another host.


### PR DESCRIPTION
when migration is enabled with --postcopy (without --postcopy-after-precopy)
in virsh command line, postcopy logic is enabled but doesn't actually start
to perform postcopy unless migrate-postcopy command is sent from virsh. This
migrate_postcopy() can be used to serve the purpose.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>