### PR TITLE
docs: Update contact informations

### DIFF
--- a/docs/source/contributing/ContactInfo.rst
+++ b/docs/source/contributing/ContactInfo.rst
@@ -2,5 +2,8 @@
 Contact information
 ===================
 
-- `Virt-test-devel mailing list (new mailing list hosted by red hat) <http://www.redhat.com/mailman/listinfo/virt-test-devel>`_
-- `IRC channel: irc.oftc.net #virt-test <irc://irc.oftc.net/#virt-test>`_
+Currently there is no dedicated Avocado-vt communication channel,
+but you can use main Avocado-framework channels to reach us:
+
+- `Avocado mailing list (hosted by red hat) <http://www.redhat.com/mailman/listinfo/avocado-devel>`_
+- `IRC channel: irc.oftc.net #avocado <irc://irc.oftc.net/#avocado>`_


### PR DESCRIPTION
The virt-test-devel does not exist anymore and the irc channel is
dormant.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>