### PR TITLE
Makefile: adjust to the configuration file path change in Avocado

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,11 @@ clean:
 	find . -name '*.pyc' -delete
 
 link:
-	ln -sf ../../../../$(DIRNAME)/etc/avocado/conf.d/vt.conf ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/
-	ln -sf ../../../../$(DIRNAME)/etc/avocado/conf.d/vt_joblock.conf ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/
+	ln -sf ../../../../../$(DIRNAME)/etc/avocado/conf.d/vt.conf ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/
+	ln -sf ../../../../../$(DIRNAME)/etc/avocado/conf.d/vt_joblock.conf ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/
 	$(PYTHON) setup.py develop --user
 
 unlink:
 	$(PYTHON) setup.py develop --uninstall --user
-	test -L ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/vt.conf && rm -f ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/vt.conf || true
+	test -L ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt.conf && rm -f ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt.conf || true
+	test -L ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt_joblock.conf && rm -f ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt_joblock.conf || true


### PR DESCRIPTION
When run from the source tree, Avocado-VT's configuration files
must now be linked to a different directory.

While at it, let's also clean up the `vt_joblock.conf` file, which
was missing from the unlink target.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

**Note**: this change depends on https://github.com/avocado-framework/avocado/pull/2402