### PR TITLE
RFC: Improvement of test setup development [v2]

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -48,6 +48,8 @@ _screendump_thread_termination_event = None
 _vm_register_thread = None
 _vm_register_thread_termination_event = None
 
+_setup_manager = test_setup.SetupManager()
+
 kernel_modified = False
 kernel_cmdline = None
 
@@ -602,6 +604,9 @@ def preprocess(test, params, env):
                 path.find_command(cmd)
             except path.CmdNotFoundError, msg:
                 raise exceptions.TestSkipError(msg.message)
+
+    _setup_manager.initialize(test, params, env)
+    _setup_manager.do_setup()
 
     # enable network proxies setting in urllib2
     if params.get("network_proxies"):
@@ -1241,6 +1246,8 @@ def postprocess(test, params, env):
                                     level_check=level)
         except exceptions.TestFail as details:
             err += "\nHost dmesg verification failed: %s" % details
+
+    err += "\n".join(_setup_manager.do_cleanup())
 
     if err:
         raise RuntimeError("Failures occurred while postprocess:\n%s" % err)

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -11,6 +11,9 @@ import shutil
 import platform
 import netaddr
 
+from abc import ABCMeta
+from abc import abstractmethod
+
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils import wait
@@ -95,6 +98,106 @@ class PolkitConfigCleanupError(PolkitConfigError):
     Thrown when polkit config cleanup is not behaving as expected.
     """
     pass
+
+
+class Setuper(object):
+
+    """
+    Virtual base abstraction of setuper.
+    """
+
+    __metaclass__ = ABCMeta
+
+    #: Skip the cleanup when error occurs
+    skip_cleanup_on_error = False
+
+    def __init__(self, test, params, env):
+        """
+        Initialize the setuper.
+
+        :param test: VirtTest instance.
+        :param params: Dictionary with the test parameters.
+        :param env: Dictionary with test environment.
+        """
+        self.test = test
+        self.params = params
+        self.env = env
+
+    @abstractmethod
+    def setup(self):
+        """Setup procedure."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def cleanup(self):
+        """Cleanup procedure."""
+        raise NotImplementedError
+
+
+class SetupManager(object):
+
+    """
+    Setup Manager implementation.
+
+    The instance can help do the setup stuff before test started and
+    do the cleanup stuff after test finished. This setup-cleanup
+    combined stuff will be performed in LIFO order.
+    """
+
+    def __init__(self):
+        self.__setupers = []
+        self.__setup_args = None
+
+    def initialize(self, test, params, env):
+        """
+        Initialize the setup manager.
+
+        :param test: VirtTest instance.
+        :param params: Dictionary with the test parameters.
+        :param env: Dictionary with test environment.
+        """
+        self.__setup_args = (test, params, env)
+
+    def register(self, setuper_cls):
+        """
+        Register the given setuper class to the manager.
+
+        :param setuper_cls: Setuper class.
+        """
+        if not self.__setup_args:
+            raise RuntimeError("Tried to register setuper "
+                               "without initialization")
+        if not issubclass(setuper_cls, Setuper):
+            raise ValueError("Not supported setuper class")
+        self.__setupers.append(setuper_cls(*self.__setup_args))
+
+    def do_setup(self):
+        """Do setup stuff."""
+        for index, setuper in enumerate(self.__setupers, 1):
+            try:
+                setuper.setup()
+            except Exception:
+                if setuper.skip_cleanup_on_error:
+                    index -= 1
+                # Truncate the list to prevent performing cleanup
+                # for the setuper without having performed setup
+                self.__setupers = self.__setupers[:index]
+                raise
+
+    def do_cleanup(self):
+        """
+        Do cleanup stuff.
+
+        :return: Errors occurred in cleanup procedures.
+        """
+        errors = []
+        while self.__setupers:
+            try:
+                self.__setupers.pop().cleanup()
+            except Exception as err:
+                logging.error(err)
+                errors.append(err)
+        return errors
 
 
 class TransparentHugePageConfig(object):


### PR DESCRIPTION
Currently, the problem of test setup development is, without using `env`, it is hard to keep a persistent context for the `setup` and `cleanup` method of the same setuper instance, that makes the code buggy.

To solve this problem, we can introduce a manager which is alive through whole test phases for the setupers. The manager can register setupers, do all the setup procedures at the beginning of the test and do all the cleanup procedures at the end of the test.

---

Changes from v1 (https://github.com/avocado-framework/avocado-vt/pull/1276):

* Rename some objects
* Initialize `setuper` on `register` time