### PR TITLE
utils_misc: Add function to align values to a particular multiples

### DIFF
--- a/virttest/utils_numeric.py
+++ b/virttest/utils_numeric.py
@@ -1,0 +1,12 @@
+import math
+
+
+def align_factor(value, factor=1024):
+    """
+    Value will be factored to the mentioned number.
+
+    :param value: value to be checked or changed to factor
+    :param factor: value used for align
+    :return: factored value
+    """
+    return int(math.ceil(float(value) / factor) * factor)


### PR DESCRIPTION
Add function to align a value to a particular multiples
example: When given '512000' to align with '1024' multiples then
'524288' will be returned.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>