### PR TITLE
virttest/utils_env.py:params.get('remote_node_address')

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -249,7 +249,7 @@ class Env(UserDict.IterableUserDict):
             session = None
             if remote_pp:
                 client = params.get('remote_shell_client', 'ssh')
-                remote_opts = (params.get['remote_node_address'],
+                remote_opts = (params['remote_node_address'],
                                params.get('remote_shell_port', '22'),
                                params['remote_node_user'],
                                params['remote_node_password'],


### PR DESCRIPTION
Modify params.get['remote_node_address'] to params.get('remote_node_ddress')
TypeError: 'instancemethod' object has no attribute '__getitem__'


Signed-off-by: weikunzz kuwei@redhat.com