### PR TITLE
Makefile: Support old and new "etc" location in "make link"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,15 @@ clean:
 	find . -name '*.pyc' -delete
 
 link:
-	ln -sf ../../../../../$(DIRNAME)/etc/avocado/conf.d/vt.conf ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/
-	ln -sf ../../../../../$(DIRNAME)/etc/avocado/conf.d/vt_joblock.conf ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/
+	for CONF in etc/avocado/conf.d/*; do\
+		[ -d "../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d" ] && ln -sf ../../../../../$(DIRNAME)/$$CONF ../$(AVOCADO_DIRNAME)/avocado/$$CONF || true;\
+		[ -d "../$(AVOCADO_DIRNAME)/etc/avocado/conf.d" ] && ln -sf ../../../../$(DIRNAME)/$$CONF ../$(AVOCADO_DIRNAME)/$$CONF || true;\
+	done
 	$(PYTHON) setup.py develop --user
 
 unlink:
 	$(PYTHON) setup.py develop --uninstall --user
-	test -L ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt.conf && rm -f ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt.conf || true
-	test -L ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt_joblock.conf && rm -f ../$(AVOCADO_DIRNAME)/avocado/etc/avocado/conf.d/vt_joblock.conf || true
+	for CONF in etc/avocado/conf.d/*; do\
+		[ -L ../$(AVOCADO_DIRNAME)/avocado/$$CONF ] && rm -f ../$(AVOCADO_DIRNAME)/avocado/$$CONF || true;\
+		[ -L ../$(AVOCADO_DIRNAME)/$$CONF ] && rm -f ../$(AVOCADO_DIRNAME)/$$CONF || true;\
+	done


### PR DESCRIPTION
The "etc" config files location in Avocado sources changed recently and
included fix to switch to the new location. This location does not work
for older and LTS releases so let's change the behavior to link all
files to both locations, if "conf.d" directory exists.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>