### PR TITLE
utils_net: Fix issue NoneType object has no attribute list_br

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1894,7 +1894,10 @@ def ovs_br_exists(brname, ovs=None):
     if ovs is None:
         ovs = __ovs
 
-    return brname in ovs.list_br()
+    if ovs is not None:
+        return brname in ovs.list_br()
+    else:
+        raise exceptions.TestError("Host does not support OpenVSwitch")
 
 
 @__init_openvswitch
@@ -3161,7 +3164,7 @@ def gen_ipv4_addr(network_num="10.0.0.0", network_prefix="24", exclude_ips=[]):
         exclude_ips.add('.'.join(network_num.split('.')[0:3]) + ".%s" %
                         str(1))
         exclude_ips.add(('.'.join(network_num.split('.')[0:3]) + ".%s" %
-                        str(255)))
+                         str(255)))
     network = netaddr.IPNetwork("%s/%s" % (network_num, network_prefix))
     for ip_address in network:
         if str(ip_address) not in exclude_ips:


### PR DESCRIPTION
Call ovs_br_exists when ovs init failed, we will meet following error:

2018-01-19 17:08:22,842 stacktrace       L0042 ERROR| Reproduced
traceback from:
/var/tmp/libvirt-ci/runtest/avocado-vt/avocado/avocado/core/test.py:596
2018-01-19 17:08:22,842 stacktrace       L0045 ERROR| Traceback (most
recent call last):
2018-01-19 17:08:22,842 stacktrace       L0045 ERROR|   File
"/var/tmp/libvirt-ci/runtest/avocado-vt/avocado-vt/avocado_vt/test.py",
line 270, in runTest
2018-01-19 17:08:22,842 stacktrace       L0045 ERROR|     raise
self.__status  # pylint: disable=E0702
2018-01-19 17:08:22,842 stacktrace       L0045 ERROR| AttributeError:
'NoneType' object has no attribute 'list_br'

Add ovs None check can help skip this error

Signed-off-by: Yan Li <yannli@redhat.com>