### PR TITLE
domcapability_xml: add two cpu related methods

### DIFF
--- a/virttest/libvirt_xml/domcapability_xml.py
+++ b/virttest/libvirt_xml/domcapability_xml.py
@@ -2,6 +2,7 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatdomaincaps.html
 """
+import logging
 
 from virttest import xml_utils
 from virttest.libvirt_xml import base, accessors, xcepts
@@ -31,6 +32,107 @@ class DomCapabilityXML(base.LibvirtXMLBase):
                                tag_name='vcpu', attribute='max')
         super(DomCapabilityXML, self).__init__(virsh_instance)
         self['xml'] = self.__dict_get__('virsh').domcapabilities().stdout.strip()
+
+    def get_additional_feature_list(self, cpu_mode_name):
+        """
+        Get additional CPU features which explicitly specified by <feature>
+        tag in cpu/mode[@name='host-model'] part of virsh domcapabilities.
+
+        In libvirt 3.9 and above, domcapabilities give the overall features supported
+        by current host/qemu/kvm via CPU model and a bunch of additional features. CPU
+        model is one set of features defined by libvirt in '/usr/share/libvirt/cpu_map.xml'
+        Specific features described in domcapabilities are addtional features, the valid
+        policy values are 'require' and 'disable', 'require' means the feature can be emulated
+        by host/qemu/kvm, 'disable' which means feature is disabled by current system due to
+        host CPU doesn't support or qemu/kvm has no ability to emulate it or some other
+        reasons like the feature block migration and so on.
+
+        Below is one snipped CPU host-model part output of domcapabilities.
+        <feature> tag specify addtional feature policy for one certain feature type.
+
+        virsh domcapabilities  | xmllint -xpath "/domainCapabilities/cpu/mode[@name='host-model']" -
+        <mode name="host-model" supported="yes">
+            <model fallback="forbid">Skylake-Client</model>
+            <vendor>Intel</vendor>
+            <feature policy="require" name="ss"/>
+            <feature policy="require" name="hypervisor"/>
+            <feature policy="require" name="tsc_adjust"/>
+            <feature policy="require" name="clflushopt"/>
+            <feature policy="require" name="pdpe1gb"/>
+            <feature policy="require" name="invtsc"/>
+        </mode>
+
+        :param cpu_mode_name: cpu mode name, must be 'host-model' since libvirt3.9
+        :return: list of features, feature is dict-like, feature name is set to dict key,
+                 feature policy is set to dict value.
+                 returen is like [{'ss': 'require'}, {'pdpe1gb', 'require'}]
+        """
+        feature_list = []  # [{feature1: policy}, {feature2: policy}, ...]
+        xmltreefile = self.__dict_get__('xml')
+        try:
+            for mode_node in xmltreefile.findall('/cpu/mode'):
+                # Get mode which name attribute is 'host-model'
+                if mode_node.get('name') == cpu_mode_name:
+                    for feature in mode_node.findall('feature'):
+                        item = {}
+                        item[feature.get('name')] = feature.get('policy')
+                        # Feature invtsc doesn't support migration, so not add it to feature list
+                        if 'invtsc' not in item:
+                            feature_list.append(item)
+        except AttributeError, elem_attr:
+            logging.warn("Failed to find attribute %s" % elem_attr)
+            feature_list = []
+        finally:
+            return feature_list
+
+    def get_hostmodel_name(self):
+        """
+        Get CPU modelname which explicitly specified by <model>.text
+        in cpu/mode[@name='host-model'] part of virsh domcapabilities.
+
+        In libvirt 3.9 and above, domcapabilities give the overall features supported
+        by current host/qemu/kvm via CPU model and a bunch of additional features. CPU
+        model is one set of features defined by libvirt in '/usr/share/libvirt/cpu_map.xml'
+        Specific features described in domcapabilities are addtional features, the valid
+        policy values are 'require' and 'disable', 'require' means the feature can be emulated
+        by host/qemu/kvm, 'disable' which means feature is disabled by current system due to
+        host CPU doesn't support or qemu/kvm has no ability to emulate it or some other
+        reasons like the feature block migration and so on.
+
+        Below is one snipped CPU host-model part output of domcapabilities.
+        <feature> tag specify addtional feature policy for one certain feature type.
+
+        virsh domcapabilities  | xmllint -xpath "/domainCapabilities/cpu/mode[@name='host-model']" -
+        <mode name="host-model" supported="yes">
+            <model fallback="forbid">Skylake-Client</model>
+            <vendor>Intel</vendor>
+            <feature policy="require" name="ss"/>
+            <feature policy="require" name="hypervisor"/>
+            <feature policy="require" name="tsc_adjust"/>
+            <feature policy="require" name="clflushopt"/>
+            <feature policy="require" name="pdpe1gb"/>
+            <feature policy="require" name="invtsc"/>
+        </mode>
+        Below is one snipped CPU host-model part output of domcapabilities.
+        feature tag spcific policy for one specific feature type.
+
+        virsh domcapabilities  | xmllint -xpath "/domainCapabilities/cpu/mode[@name='host-model']" -
+        <mode name="host-model" supported="yes">
+            <model fallback="forbid">Skylake-Client</model>
+            <vendor>Intel</vendor>
+            <feature policy="require" name="ss"/>
+        </mode>
+
+        :return: modelname string
+        """
+        xmltreefile = self.__dict_get__('xml')
+        try:
+            for mode_node in xmltreefile.findall('/cpu/mode'):
+                if mode_node.get('name') == 'host-model':
+                    return mode_node.find('model').text
+        except AttributeError, elem_attr:
+            logging.warn("Failed to find attribute %s" % elem_attr)
+            return ''
 
 
 class DomCapFeaturesXML(base.LibvirtXMLBase):


### PR DESCRIPTION
    domcapability_xml: add two CPU related methods
    
    Since libvirt3.9, libvirt query qemu/kvm to get all supported features
    and store them in domcapabilities.
    
    Since libvirt3.9, domcapabilities give the overall features supported
    by current host/qemu/kvm via CPU model and a bunch of additional features. CPU
    model is one set of features defined by libvirt in '/usr/share/libvirt/cpu_map.xml'
    Specific features described in domcapabilities are addtional features, the valid
    policy values are 'require' and 'disable', 'require' means the feature can be emulated
    by host/qemu/kvm, 'disable' which means feature is disabled by current system due to
    host CPU doesn't support or qemu/kvm has no ability to emulate it or some other
    reasons like the feature block migration and so on.
    
    Added:
    1. get_hostmodel_name() to get CPU modelname in domcapabilities
    2. get_additional_feature_list(mode) to get CPU additional feature
       list when mode is 'host-model'
    
    Signed-off-by: cuzhang <cuzhang@redhat.com>
