### PR TITLE
Fix JeOS.27 file location and make it the default version

### DIFF
--- a/shared/downloads/jeos-27-x86_64.ini
+++ b/shared/downloads/jeos-27-x86_64.ini
@@ -1,6 +1,6 @@
-[jeos-27-64]
+[jeos-27-x86_64]
 title = JeOS 27 x86_64
 url = http://avocado-project.org/data/assets/jeos/27/jeos-27-64.qcow2.xz
 sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_64
-destination = images/jeos-27-64.qcow2.xz
-destination_uncompressed = images/jeos-27-64.qcow2
+destination = images/jeos-27-x86_64.qcow2.xz
+destination_uncompressed = images/jeos-27-x86_64.qcow2

--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -16,7 +16,7 @@ def get_default_guest_os_info():
     Gets the default asset and variant information
     TODO: Check for the ARCH and choose corresponding default asset
     """
-    return {'asset': 'jeos-25-64', 'variant': 'JeOS.25'}
+    return {'asset': 'jeos-27-x86_64', 'variant': 'JeOS.27'}
 
 
 DEFAULT_GUEST_OS = get_default_guest_os_info()['variant']


### PR DESCRIPTION
Currently the JeOS.27 works on all archs except x86_64, where it fails to get the file. Let's take this opportunity to use the proper name (based on arch), rather than the "usual" one (manual shortcut).

Also the 27 is long deployed so let's make it the default one, which should give the best experience as 27 is the first multi-arch JeOS we shipped.