### PR TITLE
Remove test-produced images as default

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -387,6 +387,8 @@ drive_index_cd1 = 1
 drive_rerror_image1 =
 # What to do whether a write error is detected, such as 'stop'
 drive_werror_image1 =
+# Remove image after test finished
+remove_image_image1 = no
 # KVM qcow2 image verification and backup settings
 # Enable backup_image = yes only in some specific tests, such as
 #    unattended_install. In all other tests, it should be no, so keep the global

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -336,7 +336,11 @@ def postprocess_image(test, params, image_name, vm_process_status=None):
     if (not restored and
             params.get("restore_image_after_testing", "no") == "yes"):
         image.backup_image(params, base_dir, "restore", True)
-    if params.get("remove_image") == "yes":
+    if params.get("remove_image", "yes") == "yes":
+        if vm_process_status == "running":
+            logging.warn("Skipped removing image '%s' since "
+                         "the VM is running!" % image_name)
+            return
         logging.info("Remove image on %s." % image.storage_type)
         if clone_master is None:
             image.remove()


### PR DESCRIPTION
Some test could produce additional images to be used by itself, and
these images would be less likely to be used by other tests. Based
on this fact, we can be able to remove test-produced images as the
default operation.
    
Signed-off-by: Xu Han <xuhan@redhat.com>