### PR TITLE
utils_disk: add method to explicitly close guestfs handle

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -578,3 +578,10 @@ class GuestFSModiDisk(object):
                 raise exceptions.TestError(err_msg % file_name)
         finally:
             self.umount_all()
+
+    def close(self):
+        """
+        Explicitly close the guestfs handle.
+        """
+        if self.g:
+            self.g.close()


### PR DESCRIPTION
The handle is closed implicitly when its reference count goes to
zero, eg. when it goes out of scope or the program ends, and we
need a way to force close the handle when it is not out of scope.

ID: 1537363
Signed-off-by: Sitong Liu <siliu@redhat.com>