### PR TITLE
tests-shared.cfg: Move machine.cfg prior to subtests.cfg

### DIFF
--- a/backends/qemu/cfg/tests-shared.cfg
+++ b/backends/qemu/cfg/tests-shared.cfg
@@ -11,9 +11,9 @@ connect_uri = default
 
 # Include the base config files.
 include base.cfg
+include machines.cfg
 include subtests.cfg
 include host-os.cfg
-include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg
 include cdkeys.cfg

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -4,16 +4,12 @@ variants:
     - @i440fx:
         only i386, x86_64
         machine_type = pc
-        unattended_install..cdrom, unattended_install..extra_cdrom_ks:
-            cd_format = ide
         enable_pvpanic = yes
         ioport_pvpanic = 0x505
     - q35:
         only i386, x86_64
         no ide
         machine_type = q35
-        unattended_install..cdrom, unattended_install..extra_cdrom_ks:
-            cd_format = ahci
         enable_pvpanic = yes
         ioport_pvpanic = 0x505
         # Unsupport legacy guest OS WinXP, Win2000 and Win2003, and latest


### PR DESCRIPTION
Currently machine.cfg works after subtests.cfg, which prevents q35
controllers topology redefinition in subtests, so move it upper.

Remove unattended_install..cdrom, unattended_install..extra_cdrom_ks
 configuration from machine.cfg, it will not take effect after above
modification. Actually it is not proper to define such parameters
here, it will be moved to unattended_install itself in tp-qemu.

id: 1537394
Signed-off-by: qizhu <qizhu@redhat.com>