### PR TITLE
virttest.libvirt_xml: Fix the parent class of video class

### DIFF
--- a/virttest/libvirt_xml/devices/video.py
+++ b/virttest/libvirt_xml/devices/video.py
@@ -8,12 +8,12 @@ from virttest.libvirt_xml import accessors
 from virttest.libvirt_xml.devices import base
 
 
-class Video(base.TypedDeviceBase):
+class Video(base.UntypedDeviceBase):
 
     __slots__ = ('model_type', 'model_ram', 'model_vram', 'model_heads',
                  'primary', 'acceleration', 'address')
 
-    def __init__(self, type_name, virsh_instance=base.base.virsh):
+    def __init__(self, virsh_instance=base.base.virsh):
         accessors.XMLAttribute('model_type', self,
                                parent_xpath='/',
                                tag_name='model',
@@ -41,5 +41,4 @@ class Video(base.TypedDeviceBase):
                                  parent_xpath='/',
                                  tag_name='address')
         super(Video, self).__init__(device_tag='video',
-                                    type_name=type_name,
                                     virsh_instance=virsh_instance)


### PR DESCRIPTION
As now the xml of video devices look like,
`<video>
  <model type='qxl' ram='65536' vram='65536' vgamem='16384'/>
</video>`
Change its parent class to UntypedDeviceBase

Signed-off-by: Lily Zhu <lizhu@redhat.com>