### PR TITLE
env_process: added check host component version functionality V2

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -33,6 +33,7 @@ from . import utils_net
 from . import utils_disk
 from . import nfs
 from . import libvirt_vm
+from utils_version import VersionInterval
 
 try:
     import PIL.Image
@@ -742,6 +743,18 @@ def preprocess(test, params, env):
     logging.debug("KVM version: %s" % kvm_version)
     test.write_test_keyval({"kvm_version": kvm_version})
 
+    # Checking required kernel, if not satisfied, cancel test
+    if params.get("required_kernel"):
+        required_kernel = params.get("required_kernel")
+        logging.info("Test requires kernel version: %s" % required_kernel)
+        match = re.search(r'[0-9]+\.[0-9]+\.[0-9](\-[0-9]+)?', kvm_version)
+        if match is None:
+            test.cancel("Can not get host kernel version.")
+        host_kernel = match.group(0)
+        if host_kernel not in VersionInterval(required_kernel):
+            test.cancel("Got host kernel version:%s, which is not in %s" %
+                        (host_kernel, required_kernel))
+
     # Get the KVM userspace version and write it as a keyval
     kvm_userspace_ver_cmd = params.get("kvm_userspace_ver_cmd", "")
 
@@ -764,6 +777,19 @@ def preprocess(test, params, env):
 
     logging.debug("KVM userspace version: %s" % kvm_userspace_version)
     test.write_test_keyval({"kvm_userspace_version": kvm_userspace_version})
+
+    # Checking required qemu, if not satisfied, cancel test
+    if params.get("required_qemu"):
+        required_qemu = params.get("required_qemu")
+        logging.info("Test requires qemu version: %s" % required_qemu)
+        match = re.search(r'[0-9]+\.[0-9]+\.[0-9](\-[0-9]+)?',
+                          kvm_userspace_version)
+        if match is None:
+            test.cancel("Can not get host qemu version.")
+        host_qemu = match.group(0)
+        if host_qemu not in VersionInterval(required_qemu):
+            test.cancel("Got host qemu version:%s, which is not in %s" %
+                        (host_qemu, required_qemu))
 
     libvirtd_inst = utils_libvirtd.Libvirtd()
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -718,27 +718,15 @@ def preprocess(test, params, env):
             env["cpu_model"] = utils_misc.get_qemu_best_cpu_model(params)
         params["cpu_model"] = env.get("cpu_model")
 
-    kvm_ver_cmd = params.get("kvm_ver_cmd", "")
-
-    if kvm_ver_cmd:
-        try:
-            kvm_version = avocado_process.system_output(
-                    kvm_ver_cmd, shell=True).strip()
-        except avocado_process.CmdError:
-            kvm_version = "Unknown"
+    # Get the KVM kernel module version and write it as a keyval
+    if os.path.exists("/dev/kvm"):
+        kvm_version = os.uname()[2]
     else:
-        # Get the KVM kernel module version and write it as a keyval
-        if os.path.exists("/dev/kvm"):
-            try:
-                kvm_version = open("/sys/module/kvm/version").read().strip()
-            except Exception:
-                kvm_version = os.uname()[2]
-        else:
-            warning_msg = "KVM module not loaded"
-            if params.get("enable_kvm", "yes") == "yes":
-                raise exceptions.TestSkipError(warning_msg)
-            logging.warning(warning_msg)
-            kvm_version = "Unknown"
+        warning_msg = "KVM module not loaded"
+        if params.get("enable_kvm", "yes") == "yes":
+            test.cancel(warning_msg)
+        logging.warning(warning_msg)
+        kvm_version = "Unknown"
 
     logging.debug("KVM version: %s" % kvm_version)
     test.write_test_keyval({"kvm_version": kvm_version})

--- a/virttest/utils_version.py
+++ b/virttest/utils_version.py
@@ -1,0 +1,49 @@
+import re
+from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
+
+
+class VersionInterval(object):
+    """
+    A class for a Version Interval object.
+
+    An interval is a string representation of a mathmetical like interval.
+    e.g: "(3,4]", "[3.10.0,)"
+    A verison is a version string.
+
+    Examples::
+        >>> verison_interval = VersionInterval("[2.10.1, 2.11.0)")
+        >>> verison = "2.10.16"
+        >>> verison in verison_interval
+        True
+        >>> verison = "2.13.0"
+        >>> verison in verison_interval
+        False
+
+    """
+
+    def __init__(self, interval):
+        interval_rex = r"^(\[|\()(.*?)\s*,\s*(.*?)(\]|\))$"
+        match = re.search(interval_rex, interval)
+        if match is None:
+            raise ValueError("Invaild string representation of an interval")
+        self.opening, lower, upper, self.closing = match.groups()
+
+        self.lower_bound = LooseVersion(lower) if lower else LooseVersion("0")
+        self.upper_bound = LooseVersion(upper) if upper else LooseVersion("z")
+        if self.lower_bound > self.upper_bound:
+            raise ValueError("Invaild interval")
+
+    def __repr__(self):
+        return '<version interval %s%s, %s%s>' % (self.opening,
+                                                  self.lower_bound,
+                                                  self.upper_bound,
+                                                  self.closing)
+
+    def __contains__(self, version):
+        version = LooseVersion(version)
+        if self.lower_bound < version < self.upper_bound:
+            return True
+        if version == self.lower_bound:
+            return (self.opening == '[')
+        if version == self.upper_bound:
+            return (self.closing == ']')


### PR DESCRIPTION
It enabled using required_kernel and required_qemu to ensure
the test runs only on certain versions.

id: 1519710
Signed-off-by: Haotong Chen hachen@redhat.com