### PR TITLE
run_autotes: Autotest installation fail when file hash differ but autotest path existing.

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -951,7 +951,7 @@ def run_autotest(vm, session, control_path, timeout,
             # Let's be a little more lenient here and see if it wasn't a
             # temporary problem
             remote_hash = "0"
-        if remote_hash == local_hash:
+        if remote_hash == local_hash and directory_exists(destination_autotest_path):
             return None
         logging.debug("Copying %s to guest (remote hash: %s, local hash:%s)",
                       basename, remote_hash, local_hash)
@@ -1178,7 +1178,7 @@ def run_autotest(vm, session, control_path, timeout,
     # Install autotest and autotest client tests to guest
     autotest_tarball = copy_if_hash_differs(vm, compressed_autotest_path,
                                             compressed_autotest_path)
-    if autotest_tarball or not directory_exists(destination_autotest_path):
+    if autotest_tarball:
         extract(vm, autotest_tarball, destination_autotest_path)
         tests_dir = "%s/tests" % destination_autotest_path
         if not directory_exists(tests_dir):


### PR DESCRIPTION
When autotest_tarball==None and directory_exists(destination_autotest_path)==None,extract(vm, autotest_tarball, destination_autotest_path) will fail as autotest_tarball is none. So modify it.

ID:1483484

Signed-off-by: Li Jin <lijin@redhat.com>