### PR TITLE
utils_numeric: rename align_factor to align_value

### DIFF
--- a/virttest/utils_numeric.py
+++ b/virttest/utils_numeric.py
@@ -1,12 +1,12 @@
 import math
 
 
-def align_factor(value, factor=1024):
+def align_value(value, factor=1024):
     """
     Value will be factored to the mentioned number.
 
     :param value: value to be checked or changed to factor
     :param factor: value used for align
-    :return: factored value
+    :return: aligned value
     """
     return int(math.ceil(float(value) / factor) * factor)


### PR DESCRIPTION
Rename align_factor to align_value
align_value is having a better meaning than align_factor

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>