### PR TITLE
env_process: handle migration presetups in pre/post process

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -504,6 +504,11 @@ remote_user = root
 remote_pwd = "${local_pwd}"
 
 ##### migration use only parameters
+
+# Enable this param to "yes" to perform migration setup required
+# in destination host
+migration_setup = "no"
+
 ##### host information for destination and source
 migrate_source_host = ENTER.YOUR.SOURCE.EXAMPLE.COM
 migrate_source_pwd = PASSWORD.SOURCE.EXAMPLE

--- a/virttest/env_process.py.orig
+++ b/virttest/env_process.py.orig
@@ -1274,6 +1274,9 @@ def postprocess(test, params, env):
         try:
             image_nfs = nfs.Nfs(params)
             image_nfs.cleanup()
+<<<<<<< Updated upstream
+        except Exception as details:
+=======
             if migration_setup:
                 # Cleanup NFS client on remote host
                 nfs_client = nfs.NFSClient(params)
@@ -1281,7 +1284,8 @@ def postprocess(test, params, env):
                 # Cleanup selinux on remote host
                 seLinuxBool = utils_misc.SELinuxBoolean(params)
                 seLinuxBool.cleanup(keep_authorized_keys=True)
-        except Exception as details:
+        except Exception, details:
+>>>>>>> Stashed changes
             err += "\nnfs cleanup: %s" % str(details).replace('\\n', '\n  ')
 
     # cleanup migration presetup in post process


### PR DESCRIPTION
Each tests for migration have to perform the presetups before migration
and clean up after test completes, so it is better to handle it in pre/post
process to make more efficient and to reduce redundancy in test code.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>