### PR TITLE
shared/cfg/base.cfg: Set qmp as default monitor type

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -265,13 +265,13 @@ image_unbootable_pattern = "Hard Disk.*not a bootable disk"
 
 #
 # List of hypervisor-monitor object names (one per guest),
-#    used to communicate with hypervisor to control guests.
-#    Order cooresponds to 'vms' list above.
-monitors = hmp1
+# used to communicate with hypervisor to control guests.
+# Order cooresponds to 'vms' list above.
+monitors = qmpmonitor1
 # hmp1 monitor type (protocol), if only hmp1 type is going to be set
-#monitor_type_hmp1 = human
+# monitor_type_hmp1 = human
 # Default monitor type (protocol), if multiple types to be used
-monitor_type = human
+monitor_type = qmp
 # If set catch_monitor, will start another monitor in qemu for
 # VmRegister and ScreenDump threads.
 catch_monitor = catch_monitor


### PR DESCRIPTION
HMP is not officially supported except some basic commands,
set QMP instead as default monitor type.

Signed-off-by: Cong Li <coli@redhat.com>

id: 1539557