### PR TITLE
guest-hw: Correct cd_format when install vm from cdrom

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -88,6 +88,11 @@ variants:
         # NOTE:  scsi-block and scsi-generic are pass-through physical dev only
         drive_format=scsi-hd
         cd_format=scsi-cd
+        unattended_install.cdrom, unattended_install..extra_cdrom_ks:
+            i440fx:
+                cd_format = ide
+            q35:
+                cd_format = ahci
         scsi_hba=virtio-scsi-pci
         libvirt_controller=virtio-scsi
     - spapr_vscsi:


### PR DESCRIPTION
When install vm from cdrom, to aviod vm can not identify cdrom
as no driver, use ide for i440fx and ahci for q35 instead.

id: 1542520
Signed-off-by: Yanan Fu <yfu@redhat.com>