### PR TITLE
VirtTestLoader: Remove machine type for guest_listing and arch_listing

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -48,7 +48,7 @@ def guest_listing(options):
     for params in guest_name_parser.get_dicts():
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())
         image_name = storage.get_image_filename(params, base_dir)
-        name = params['name']
+        name = params['name'].replace('.%s' % options.vt_machine_type, '')
         if os.path.isfile(image_name):
             out = name
         else:
@@ -66,10 +66,10 @@ def arch_listing(options):
         extra = " for guest os \"%s\"" % options.vt_guest_os
     else:
         extra = ""
-    LOG.info("Available machine_type/arch profiles%s", extra)
+    LOG.info("Available arch profiles%s", extra)
     guest_name_parser = standalone_test.get_guest_name_parser(options)
     for params in guest_name_parser.get_dicts():
-        LOG.debug(params["name"])
+        LOG.debug(params['name'].replace('.%s' % options.vt_machine_type, ''))
     LOG.debug("")
 
 

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -125,7 +125,7 @@ def get_guest_name_list(options):
     if GUEST_NAME_LIST is None:
         guest_name_list = []
         for params in get_guest_name_parser(options).get_dicts():
-            shortname = ".".join(params['name'].split(".")[1:])
+            shortname = ".".join(params['name'].split(".")[1:-1])
             guest_name_list.append(shortname)
 
         GUEST_NAME_LIST = guest_name_list


### PR DESCRIPTION
The guest name should be independent from machine type. It is not
necessary to list machine type for --vt-list-guests. The machine
type is not like arch, it actually does not matter whether it is
included in the guest name. However, it has to be filtered by
machine.cfg, so remove the suffix after the parser finish its work.

id: 1542862
Signed-off-by: qizhu <qizhu@redhat.com>