### PR TITLE
libvirt_xml/devices/interface.py: Add coalesce support

### DIFF
--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -12,7 +12,7 @@ from virttest.libvirt_xml.devices import base, librarian
 class Interface(base.TypedDeviceBase):
 
     __slots__ = ('source', 'hostdev_address', 'managed', 'mac_address',
-                 'bandwidth', 'model', 'link_state', 'target', 'driver',
+                 'bandwidth', 'model', 'coalesce', 'link_state', 'target', 'driver',
                  'address', 'boot_order', 'filterref', 'backend',
                  'virtualport_type')
 
@@ -87,6 +87,11 @@ class Interface(base.TypedDeviceBase):
                                parent_xpath='/',
                                tag_name='model',
                                attribute='type')
+        accessors.XMLElementDict(property_name="coalesce",
+                                 libvirtxml=self,
+                                 forbidden=None,
+                                 parent_xpath='/coalesce/rx',
+                                 tag_name='frames')
         accessors.XMLElementNest('address', self, parent_xpath='/',
                                  tag_name='address', subclass=self.Address,
                                  subclass_dargs={'type_name': 'pci',


### PR DESCRIPTION
    libvirt_xml/devices/interface.py: Add coalesce support
    
    coalesce is newly added tag, format like below:
```
       <interface>
          ...
          <coalesce>
             <rx>
                <frames max='32'/>
             </rx>
          </coalesce>
          ...
       </interface>
 ```
    This commit is to add new dict xml 'coalesce' to manipulate
    coalesce operatation.
    
    Usage:
    InterfaceObj.coalesce = {'max':coalesce_value}
    
    Signed-off-by: cuzhang <cuzhang@redhat.com>
