### PR TITLE
Server infrastructure: switch default URLs to HTTPS

### DIFF
--- a/docs/source/DownloadableImages.rst
+++ b/docs/source/DownloadableImages.rst
@@ -30,7 +30,7 @@ Winutils ISO
 
 The windows utils file can be currently found at:
 
-http://avocado-project.org/data/assets/winutils.iso
+https://avocado-project.org/data/assets/winutils.iso
 
 How to update `winutils.iso`
 ----------------------------
@@ -44,11 +44,11 @@ JeOS image
 
 You can find the JeOS images currently available here:
 
-http://avocado-project.org/data/assets/jeos-23-64.qcow2.xz
+https://avocado-project.org/data/assets/jeos-23-64.qcow2.xz
 
-http://avocado-project.org/data/assets/SHA1SUM_JEOS23_XZ
+https://avocado-project.org/data/assets/SHA1SUM_JEOS23_XZ
 
-You can browse through http://avocado-project.org/data/assets/jeos/ and find
+You can browse through https://avocado-project.org/data/assets/jeos/ and find
 other JeOS versions available.
 
 How to update JeOS

--- a/docs/source/Networking.rst
+++ b/docs/source/Networking.rst
@@ -59,7 +59,7 @@ test windows. First, download the iso. :doc:`The get started documentation <GetS
 can help you out with downloading if you like it, but the direct download
 link is here:
 
-http://avocado-project.org/data/assets/winutils.iso
+https://avocado-project.org/data/assets/winutils.iso
 
 You need to put all its contents on a folder and create a new iso. Let's say you
 want to download the iso to ``/home/kermit/Downloads/winutils.iso``.

--- a/shared/downloads/jeos-23-64.ini
+++ b/shared/downloads/jeos-23-64.ini
@@ -1,6 +1,6 @@
 [jeos-23-64]
 title = JeOS 23 x86_64
-url = http://avocado-project.org/data/assets/jeos-23-64.qcow2.xz
-sha1_url = http://avocado-project.org/data/assets/SHA1SUM_JEOS23_XZ
+url = https://avocado-project.org/data/assets/jeos-23-64.qcow2.xz
+sha1_url = https://avocado-project.org/data/assets/SHA1SUM_JEOS23_XZ
 destination = images/jeos-23-64.qcow2.xz
 destination_uncompressed = images/jeos-23-64.qcow2

--- a/shared/downloads/jeos-25-64.ini
+++ b/shared/downloads/jeos-25-64.ini
@@ -1,6 +1,6 @@
 [jeos-25-64]
 title = JeOS 25 x86_64
-url = http://avocado-project.org/data/assets/jeos-25-64.qcow2.xz
-sha1_url = http://avocado-project.org/data/assets/SHA1SUM_JEOS25
+url = https://avocado-project.org/data/assets/jeos-25-64.qcow2.xz
+sha1_url = https://avocado-project.org/data/assets/SHA1SUM_JEOS25
 destination = images/jeos-25-64.qcow2.xz
 destination_uncompressed = images/jeos-25-64.qcow2

--- a/shared/downloads/jeos-27-aarch64.ini
+++ b/shared/downloads/jeos-27-aarch64.ini
@@ -1,6 +1,6 @@
 [jeos-27-aarch64]
 title = JeOS 27 aarch64
-url = http://avocado-project.org/data/assets/jeos/27/jeos-27-aarch64.qcow2.xz
-sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_AARCH64
+url = https://avocado-project.org/data/assets/jeos/27/jeos-27-aarch64.qcow2.xz
+sha1_url = https://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_AARCH64
 destination = images/jeos-27-aarch64.qcow2.xz
 destination_uncompressed = images/jeos-27-aarch64.qcow2

--- a/shared/downloads/jeos-27-ppc64.ini
+++ b/shared/downloads/jeos-27-ppc64.ini
@@ -1,6 +1,6 @@
 [jeos-27-ppc64]
 title = JeOS 27 ppc64
-url = http://avocado-project.org/data/assets/jeos/27/jeos-27-ppc64.qcow2.xz
-sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_PPC64
+url = https://avocado-project.org/data/assets/jeos/27/jeos-27-ppc64.qcow2.xz
+sha1_url = https://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_PPC64
 destination = images/jeos-27-ppc64.qcow2.xz
 destination_uncompressed = images/jeos-27-ppc64.qcow2

--- a/shared/downloads/jeos-27-ppc64le.ini
+++ b/shared/downloads/jeos-27-ppc64le.ini
@@ -1,6 +1,6 @@
 [jeos-27-ppc64le]
 title = JeOS 27 ppc64le
-url = http://avocado-project.org/data/assets/jeos/27/jeos-27-ppc64le.qcow2.xz
-sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_PPC64LE
+url = https://avocado-project.org/data/assets/jeos/27/jeos-27-ppc64le.qcow2.xz
+sha1_url = https://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_PPC64LE
 destination = images/jeos-27-ppc64le.qcow2.xz
 destination_uncompressed = images/jeos-27-ppc64le.qcow2

--- a/shared/downloads/jeos-27-s390x.ini
+++ b/shared/downloads/jeos-27-s390x.ini
@@ -1,6 +1,6 @@
 [jeos-27-s390x]
 title = JeOS 27 s390x
-url = http://avocado-project.org/data/assets/jeos/27/jeos-27-s390x.qcow2.xz
-sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_S390X
+url = https://avocado-project.org/data/assets/jeos/27/jeos-27-s390x.qcow2.xz
+sha1_url = https://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_S390X
 destination = images/jeos-27-s390x.qcow2.xz
 destination_uncompressed = images/jeos-27-s390x.qcow2

--- a/shared/downloads/jeos-27-x86_64.ini
+++ b/shared/downloads/jeos-27-x86_64.ini
@@ -1,6 +1,6 @@
 [jeos-27-x86_64]
 title = JeOS 27 x86_64
-url = http://avocado-project.org/data/assets/jeos/27/jeos-27-64.qcow2.xz
-sha1_url = http://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_64
+url = https://avocado-project.org/data/assets/jeos/27/jeos-27-64.qcow2.xz
+sha1_url = https://avocado-project.org/data/assets/jeos/27/SHA1SUM_JEOS_27_64
 destination = images/jeos-27-x86_64.qcow2.xz
 destination_uncompressed = images/jeos-27-x86_64.qcow2

--- a/shared/downloads/winutils.ini
+++ b/shared/downloads/winutils.ini
@@ -1,5 +1,5 @@
 [winutils]
 title = Windows Utils ISO
-url = http://avocado-project.org/data/assets/winutils.iso
-sha1_url = http://avocado-project.org/data/assets/SHA1SUM_WINUTILS
+url = https://avocado-project.org/data/assets/winutils.iso
+sha1_url = https://avocado-project.org/data/assets/SHA1SUM_WINUTILS
 destination = isos/windows/winutils.iso


### PR DESCRIPTION
HTTPS has been enabled on the avocado-project.org server, so let's use
it by default on docs and when downloading images from it.

Signed-off-by: Cleber Rosa <crosa@redhat.com>