### PR TITLE
utils_misc: initialize original value of selinux in init

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3911,6 +3911,9 @@ class SELinuxBoolean(object):
         self.local_bool_value = params.get("local_boolean_value")
         self.remote_bool_value = params.get("remote_boolean_value",
                                             self.local_bool_value)
+        # initialize original value as off, if not it will override in setup
+        self.local_boolean_orig = "off"
+        self.remote_boolean_orig = "off"
         try:
             self.selinux_disabled = utils_selinux.get_status() == "disabled"
         except utils_selinux.SeCmdError, utils_selinux.SelinuxError:


### PR DESCRIPTION
As original value for selinux boolean for local and remote
configuration is used in both setup and in clean up it is better
to initialize from __init__

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>