### PR TITLE
utils_package: incorrect parameter for apt-get used to assume "yes"

### DIFF
--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -55,7 +55,7 @@ class RemotePackageMgr(object):
         elif self.package_manager == 'apt-get':
             self.query_cmd = "dpkg -s "
             self.remove_cmd = "apt-get --purge remove -y "
-            self.install_cmd = "apt-get install -n "
+            self.install_cmd = "apt-get install -y "
         else:
             self.query_cmd = "rpm -q "
             self.remove_cmd = self.package_manager + " remove -y "


### PR DESCRIPTION
In ubuntu distro, for installation of packages incorrect parameter for automatic
yes causes test to error out.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>