### PR TITLE
Make avocado guest background test tuneable from testcase

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1718,6 +1718,9 @@ def run_avocado_bg(vm, params, test):
     avocado_timeout = int(params.get("avocado_timeout", 3600))
     avocado_testrepo = params.get("avocado_testrepo",
                                   "https://github.com/avocado-framework-tests/avocado-misc-tests.git")
+    avocado_reinstall = params.get("avocado_reinstall", False)
+    avocado_installtype = params.get("avocado_installtype", "pip")
+    avocado_ignoreresult = params.get("avocado_ignoreresult", False)
     for index, item in enumerate(avocado_test.split(',')):
         try:
             mux = ''
@@ -1728,8 +1731,9 @@ def run_avocado_bg(vm, params, test):
     if testlist:
         bt = BackgroundTest(run_avocado,
                             [vm, params, test, testlist,
-                             avocado_timeout, avocado_testrepo, "pip",
-                             True, avocado_testargs, True])
+                             avocado_timeout, avocado_testrepo,
+                             avocado_installtype, avocado_reinstall,
+                             avocado_testargs, avocado_ignoreresult])
         bt.start()
         return bt
     else:


### PR DESCRIPTION
This patch introduces config params to make further tunable
the guest background avocado-misc tests, inorder to control
it from testcase rather than just defaulting.

Recently started seeing the reinstall of avocado framework crashes
while test invoke, to be rootcasued though but we should be able
to workaround by disabling reinstall.

This will help us address if any such workarounds and issues.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>