### PR TITLE
data_dir: handle get_tmp_dir for Ubuntu to avoid apparmor denial

### DIFF
--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -10,6 +10,7 @@ import shutil
 import stat
 
 from avocado.core import data_dir
+from avocado.utils import distro
 
 if hasattr(sys, 'real_prefix'):
     # unlike default execution venv prefix does not contain /usr
@@ -203,7 +204,12 @@ def get_tmp_dir(public=True):
 
     :param public: If public for all users' access
     """
-    tmp_dir = data_dir.get_tmp_dir()
+    tmp_dir = None
+    # apparmor deny /tmp/* /var/tmp/* and cause failure across tests
+    # it is better to handle here
+    if distro.detect().name == 'Ubuntu':
+        tmp_dir = "/var/lib/libvirt/images"
+    tmp_dir = data_dir.get_tmp_dir(basedir=tmp_dir)
     if public:
         tmp_dir_st = os.stat(tmp_dir)
         os.chmod(tmp_dir, tmp_dir_st.st_mode | stat.S_IXUSR |


### PR DESCRIPTION
In ubuntu, apparmor deny libvirt operations from /tmp/* and /var/tmp/*
and causes the tests to error/fail, suggested path is to use
/var/lib/libvirt/images which is open by default.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>