### PR TITLE
selinux: avoid using selinux on ubuntu by default

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2920,6 +2920,12 @@ class VM(virt_vm.BaseVM):
 
         :param mode: SELinux mode [Enforcing|Permissive|1|0]
         """
+        # SELinux is not supported by Ubuntu by default
+        selinux_force = self.params.get("selinux_force", "no") == "yes"
+        vm_distro = self.get_distro()
+        if vm_distro.lower() == 'ubuntu' and not selinux_force:
+            logging.warning("Ubuntu doesn't support selinux by default")
+            return
         self.install_package('selinux-policy')
         self.install_package('selinux-policy-targeted')
         self.install_package('libselinux-utils')


### PR DESCRIPTION
configuring selinux in ubuntu cause unnecessary test errors/fails, it is
better not to configure selinux by default for ubuntu and use selinux_force
param to force it if required.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>