### PR TITLE
utils_test/__init__: update boot configuration for ubuntu

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3742,7 +3742,8 @@ def get_bootloader_cfg(session=None):
         '/boot/grub2/grub.cfg',
         '/etc/grub.conf',
         '/etc/grub2.cfg',
-        '/boot/etc/yaboot.conf'
+        '/boot/etc/yaboot.conf',
+        '/etc/default/grub'
     ]
     cfg_path = ''
     for path in bootloader_cfg:


### PR DESCRIPTION
add API update_boot_option_ubuntu() to handle boot configuration as grubby
doesn't work for ubuntu

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>