### PR TITLE
Python 3: Replace iteratable.next() with built-in next()

### DIFF
--- a/selftests/unit/test_installer.py
+++ b/selftests/unit/test_installer.py
@@ -60,7 +60,7 @@ vm_type = test"""
 
         config_parser = cartesian_config.Parser()
         config_parser.parse_string(config)
-        params = config_parser.get_dicts().next()
+        params = next(config_parser.get_dicts())
 
         instance = installer.make_installer("test_install_mode_test", params)
         self.assertTrue(isinstance(instance, Installer))

--- a/selftests/unit/test_utils_misc.py
+++ b/selftests/unit/test_utils_misc.py
@@ -72,7 +72,7 @@ git_repo_foo_commit = bc732ad8b2ed8be52160b893735417b43a1e91a8
 """
         config_parser = cartesian_config.Parser()
         config_parser.parse_string(config)
-        params = config_parser.get_dicts().next()
+        params = next(config_parser.get_dicts())
 
         h = build_helper.GitRepoParamHelper(params, 'foo', '/tmp/foo')
         self.assertEqual(h.name, 'foo')

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -471,7 +471,7 @@ def create_subtests_cfg(t_type):
             if re.match("type\s*=.*", line):
                 cartesian_parser = cartesian_config.Parser()
                 cartesian_parser.parse_string(line)
-                td = cartesian_parser.get_dicts().next()
+                td = next(cartesian_parser.get_dicts())
                 values = td['type'].split(" ")
                 for value in values:
                     if t_type not in non_dropin_tests:
@@ -506,7 +506,7 @@ def create_subtests_cfg(t_type):
             if re.match("type\s*=.*", line):
                 cartesian_parser = cartesian_config.Parser()
                 cartesian_parser.parse_string(line)
-                td = cartesian_parser.get_dicts().next()
+                td = next(cartesian_parser.get_dicts())
                 values = td['type'].split(" ")
                 for value in values:
                     if value not in non_dropin_tests:

--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -1111,10 +1111,10 @@ class Lexer(object):
                         token = tokens_map[char]()
                     elif char == "\"":
                         chars = ""
-                        pos, char = li.next()
+                        pos, char = next(li)
                         while char != "\"":
                             chars += char
-                            pos, char = li.next()
+                            pos, char = next(li)
                         yield LString(chars)
                     elif char == "#":
                         break
@@ -1156,10 +1156,10 @@ class Lexer(object):
     def get_until_gen(self, end_tokens=None):
         if end_tokens is None:
             end_tokens = [LEndL]
-        token = self.generator.next()
+        token = next(self.generator)
         while type(token) not in end_tokens:
             yield token
-            token = self.generator.next()
+            token = next(self.generator)
         yield token
 
     def get_until(self, end_tokens=None):
@@ -1206,10 +1206,10 @@ class Lexer(object):
         return [x for x in self.get_until_gen(end_tokens) if type(x) != LWhite]
 
     def rest_line_gen(self):
-        token = self.generator.next()
+        token = next(self.generator)
         while type(token) != LEndL:
             yield token
-            token = self.generator.next()
+            token = next(self.generator)
 
     def rest_line(self):
         return [x for x in self.rest_line_gen()]
@@ -1219,12 +1219,12 @@ class Lexer(object):
 
     def rest_line_as_LString(self):
         self.rest_as_string = True
-        lstr = self.generator.next()
-        self.generator.next()
+        lstr = next(self.generator)
+        next(self.generator)
         return lstr
 
     def get_next_check(self, lType):
-        token = self.generator.next()
+        token = next(self.generator)
         if type(token) in lType:
             return type(token), token
         else:
@@ -1234,9 +1234,9 @@ class Lexer(object):
                               self.line, self.filename, self.linenum)
 
     def get_next_check_nw(self, lType):
-        token = self.generator.next()
+        token = next(self.generator)
         while type(token) == LWhite:
-            token = self.generator.next()
+            token = next(self.generator)
         if type(token) in lType:
             return type(token), token
         else:
@@ -1256,9 +1256,9 @@ class Lexer(object):
 
 
 def next_nw(gener):
-    token = gener.next()
+    token = next(gener)
     while type(token) == LWhite:
-        token = gener.next()
+        token = next(gener)
     return token
 
 
@@ -1282,8 +1282,8 @@ def parse_filter(lexer, tokens):
     """
     or_filters = []
     tokens = iter(tokens + [LEndL()])
-    typet, token = lexer.check_token(tokens.next(), [LIdentifier, LLRBracket,
-                                                     LEndL, LWhite])
+    typet, token = lexer.check_token(next(tokens), [LIdentifier, LLRBracket,
+                                                    LEndL, LWhite])
     and_filter = []
     con_filter = []
     dots = 1
@@ -1337,16 +1337,16 @@ def parse_filter(lexer, tokens):
                                   " Identifier.", lexer.line, lexer.filename,
                                   lexer.linenum)
             dots = 1
-            token = tokens.next()
+            token = next(tokens)
             while type(token) == LWhite:
-                token = tokens.next()
+                token = next(tokens)
             typet, token = lexer.check_token(token, [LIdentifier,
                                                      LComa, LDot,
                                                      LLRBracket, LEndL])
             continue
-        typet, token = lexer.check_token(tokens.next(), [LIdentifier, LComa,
-                                                         LDot, LLRBracket,
-                                                         LEndL, LWhite])
+        typet, token = lexer.check_token(next(tokens), [LIdentifier, LComa,
+                                                        LDot, LLRBracket,
+                                                        LEndL, LWhite])
     if and_filter:
         if con_filter:
             and_filter.append(con_filter)
@@ -1608,9 +1608,9 @@ class Parser(object):
                             name = [x for x in name[:-1]
                                     if type(x) == LIdentifier]
 
-                        token = lexer.generator.next()
+                        token = next(lexer.generator)
                         while type(token) == LWhite:
-                            token = lexer.generator.next()
+                            token = next(lexer.generator)
                         tokens = None
                         if type(token) != LEndL:
                             tokens = [token] + lexer.get_until([LEndL])

--- a/virttest/element_tree.py
+++ b/virttest/element_tree.py
@@ -959,7 +959,7 @@ class iterparse(object):
             return self
     except NameError:
         def __getitem__(self, index):
-            return self.next()
+            return next(self)
 
 #
 # Parses an XML document from a string constant.  This function can

--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -144,7 +144,7 @@ class StoragePool(object):
             head_iter = enumerate(head.split())
             while True:
                 try:
-                    (index, column) = head_iter.next()
+                    (index, column) = next(head_iter)
                 except StopIteration:
                     break
                 if re.match("[N|n]ame", column):

--- a/virttest/remote_commander/remote_master.py
+++ b/virttest/remote_commander/remote_master.py
@@ -386,7 +386,7 @@ class CommanderMaster(messenger.Messenger):
         if timeout is not None:
             time_step = timeout / 10.0
         w = wait_timeout(timeout)
-        while (w.next()):
+        while (next(w)):
             r_cmd = self.listen_messenger(time_step)
             if r_cmd is not None and r_cmd == m_cmd.basecmd:
                 return m_cmd

--- a/virttest/staging/backports/__init__.py
+++ b/virttest/staging/backports/__init__.py
@@ -28,18 +28,18 @@ def _next(*args):
     :type iterator: iterator
     :param default: the value to return if the iterator raises StopIteration
     :type default: object
-    :return: The object returned by iterator.next()
+    :return: The object returned by next(iterator)
     :rtype: object
     """
     if len(args) == 2:
         try:
-            return args[0].next()
+            return next(args[0])
         except StopIteration:
             return args[1]
     elif len(args) > 2:
         raise TypeError("next expected at most 2 arguments, %s" % len(args))
     else:
-        return args[0].next()
+        return next(args[0])
 
 # pylint: disable=W0622
 # noinspection PyShadowingBuiltins

--- a/virttest/staging/backports/simplejson/ordered_dict.py
+++ b/virttest/staging/backports/simplejson/ordered_dict.py
@@ -68,9 +68,9 @@ class OrderedDict(dict, DictMixin):
         # http://code.google.com/p/simplejson/issues/detail?id=53
         if last:
             # pylint: disable=E0111
-            key = reversed(self).next()
+            key = next(reversed(self))
         else:
-            key = iter(self).next()
+            key = next(iter(self))
         value = self.pop(key)
         return key, value
 


### PR DESCRIPTION
Python 3 remove iteratable.next() function,and need use
built-in method next() to replace them

Signed-off-by: chunfuwen <chwen@redhat.com>