### PR TITLE
Workaround ImportError

### DIFF
--- a/virttest/qemu_devices/qbuses.py
+++ b/virttest/qemu_devices/qbuses.py
@@ -7,7 +7,8 @@ or match the autotest params into qemu qdev structure.
 :copyright: 2012-2013 Red Hat Inc.
 """
 # Autotest imports
-from virttest.qemu_devices import qdevices
+# TODO: solve the circular import problem
+import qdevices
 from virttest.qemu_devices.utils import none_or_int
 
 

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -15,7 +15,8 @@ import traceback
 from virttest import qemu_monitor
 from virttest import utils_misc
 
-from virttest.qemu_devices import qbuses
+# TODO: solve the circular import problem
+import qbuses
 from virttest.qemu_devices.utils import DeviceError
 
 try:


### PR DESCRIPTION
A circular import problem occurred after commit daf3fa6.

    | ImportError('cannot import name qdevices',)

This patch help workaround this issue for python 2.7, and the
repair will be coming soon.

Signed-off-by: Xu Han <xuhan@redhat.com>