### PR TITLE
qemu_guest_agent: Update shutdown()

### DIFF
--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -509,8 +509,10 @@ class QemuAgent(Monitor):
         if mode in [self.SHUTDOWN_MODE_POWERDOWN, self.SHUTDOWN_MODE_REBOOT,
                     self.SHUTDOWN_MODE_HALT]:
             args = {"mode": mode}
-        self.cmd(cmd=cmd, args=args, success_resp=False)
-        return True
+        try:
+            self.cmd(cmd=cmd, args=args)
+        except VAgentProtocolError:
+            pass
 
     @error_context.context_aware
     def sync(self, sync_mode="guest-sync"):


### PR DESCRIPTION
guest_agent: Update shutdown()

Currently, shutdown() returns "{}" or no response after sending the shutdown command,
remove success_resp=False option to raise error message,and remove useless
"return True" and ignore VAgentProtocolErro at the same time.

ID: 1468530, 1476648

Signed-off-by: Xiangchun Fu xfu@redhat.com
