### PR TITLE
env_process: Refresh "vm" on "vt_type" change

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -119,7 +119,7 @@ def preprocess_vm(test, params, env, name):
     target = params.get('target')
 
     create_vm = False
-    if not vm:
+    if not vm or not isinstance(vm, virt_vm.BaseVM.lookup_vm_class(vm_type, target)):
         create_vm = True
     elif vm_type == 'libvirt':
         connect_uri = libvirt_vm.normalize_connect_uri(connect_uri)


### PR DESCRIPTION
It's possible to use 2 different "vt_types" within a single job, but
"env_process" does not cope with that (it used to be impossible) and
simply proceeds with vm object of different class, when available in
env. This patch adds "isinstance(vm, expected_class)" check that makes
sure we use the right object and refreshes it otherwise.

@clebergnu @apahim this blocks me from using mux-suite (as I'm combining libvirt and qemu executions), would you please take a look at this?