### PR TITLE
Python 3:remove __init__.py under virttest/utils_test dependence on autotest

### DIFF
--- a/virttest/utils_test/base_check_version.py
+++ b/virttest/utils_test/base_check_version.py
@@ -1,0 +1,68 @@
+import glob
+import os
+import re
+import sys
+
+
+class base_check_python_version:
+
+    def __init__(self):
+        version = None
+        try:
+            version = sys.version_info[0:2]
+        except AttributeError:
+            pass  # pre 2.0, no neat way to get the exact number
+
+        # The change to prefer 2.4 really messes up any systems which have both
+        # the new and old version of Python, but where the newer is default.
+        # This is because packages, libraries, etc are all installed into the
+        # new one by default. Some things (like running under mod_python) just
+        # plain don't handle python restarting properly. I know that I do some
+        # development under ipython and whenever I run (or do anything that
+        # runs) 'import common  # pylin: disable=W0611' it restarts my shell. Overall, the change was
+        # fairly annoying for me (and I can't get around having 2.4 and 2.5
+        # installed with 2.5 being default).
+        if not version or version < (2, 4) or version >= (3, 0):
+            try:
+                # We can't restart when running under mod_python.
+                from mod_python import apache
+            except ImportError:
+                self.restart()
+
+    def extract_version(self, path):
+        match = re.search(r'/python(\d+)\.(\d+)$', path)
+        if match:
+            return (int(match.group(1)), int(match.group(2)))
+        else:
+            return None
+
+    PYTHON_BIN_GLOB_STRINGS = ['/usr/bin/python2*', '/usr/local/bin/python2*']
+
+    def find_desired_python(self):
+        """Returns the path of the desired python interpreter."""
+        pythons = []
+        for glob_str in self.PYTHON_BIN_GLOB_STRINGS:
+            pythons.extend(glob.glob(glob_str))
+
+        possible_versions = []
+        best_python = (0, 0), ''
+        for python in pythons:
+            version = self.extract_version(python)
+            if version and version >= (2, 4):
+                possible_versions.append((version, python))
+
+        possible_versions.sort()
+
+        if not possible_versions:
+            raise ValueError('Python 2.x version 2.4 or better is required')
+        # Return the lowest possible version so that we use 2.4 if available
+        # rather than more recent versions.
+        return possible_versions[0][1]
+
+    def restart(self):
+        python = self.find_desired_python()
+        sys.stderr.write('NOTE: %s switching to %s\n' %
+                         (os.path.basename(sys.argv[0]), python))
+        sys.argv.insert(0, '-u')
+        sys.argv.insert(0, python)
+        os.execv(sys.argv[0], sys.argv)

--- a/virttest/utils_test/check_version.py
+++ b/virttest/utils_test/check_version.py
@@ -1,0 +1,11 @@
+from virttest.utils_test.base_check_version import base_check_python_version
+try:
+    from virttest.utils_test.site_check_version import site_check_python_version
+except ImportError:
+    class site_check_python_version:
+        pass
+
+
+class check_python_version(site_check_python_version,
+                           base_check_python_version):
+    pass

--- a/virttest/utils_test/common.py
+++ b/virttest/utils_test/common.py
@@ -1,0 +1,13 @@
+import os
+import sys
+try:
+    import virttest.utils_test.setup_modules as setup_modules
+    client_dir = os.path.dirname(setup_modules.__file__)
+except ImportError:
+    client_dir = os.path.dirname(sys.modules[__name__].__file__)
+    sys.path.insert(0, client_dir)
+    import setup_modules
+    sys.path.pop(0)
+
+setup_modules.setup(base_path=client_dir,
+                    root_module_name="autotest.client")

--- a/virttest/utils_test/settings.py
+++ b/virttest/utils_test/settings.py
@@ -1,0 +1,247 @@
+"""
+A singleton class for accessing global config values.
+
+provides access to global configuration file.
+"""
+
+__author__ = 'raphtee@google.com (Travis Miller)'
+
+try:
+    import configparser as ConfigParser
+except ImportError:
+    import ConfigParser
+import os
+import sys
+
+
+def _context_message(e):
+    s = exception_context(e)
+    if s:
+        return "    [context: %s]" % s
+    else:
+        return ""
+
+
+def exception_context(e):
+    """Return the context of a given exception (or None if none is defined)."""
+    if hasattr(e, "_context"):
+        return e._context
+
+
+class AutotestError(Exception):
+
+    """The parent of all errors deliberately thrown within the client code."""
+
+    def __str__(self):
+        return Exception.__str__(self) + _context_message(self)
+
+
+class SettingsError(AutotestError):
+    pass
+
+
+class SettingsValueError(SettingsError):
+    pass
+
+
+settings_filename = 'global_config.ini'
+shadow_config_filename = 'shadow_config.ini'
+
+shared_dir = os.path.dirname(sys.modules[__name__].__file__)
+client_dir = os.path.dirname(shared_dir)
+root_dir = os.path.dirname(client_dir)
+
+if hasattr(sys, "real_prefix"):
+    default_autotest_top = os.path.join(sys.prefix, "etc", "autotest")
+else:
+    default_autotest_top = "/etc/autotest"
+system_wide_dir = os.environ.get('AUTOTEST_TOP_PATH', default_autotest_top)
+
+# Check if the config files are in the system wide directory
+settings_path_system_wide = os.path.join(system_wide_dir,
+                                         settings_filename)
+shadow_config_path_system_wide = os.path.join(system_wide_dir,
+                                              shadow_config_filename)
+config_in_system_wide = os.path.exists(settings_path_system_wide)
+
+# Check if the config files are at autotest's root dir
+# This will happen if client is executing inside a full autotest tree, or if
+# other entry points are being executed
+settings_path_root = os.path.join(root_dir, settings_filename)
+shadow_config_path_root = os.path.join(root_dir, shadow_config_filename)
+config_in_root = (os.path.exists(settings_path_root) and
+                  os.path.exists(shadow_config_path_root))
+
+# Check if the config files are at autotest's client dir
+# This will happen if a client stand alone execution is happening
+settings_path_client = os.path.join(client_dir, 'global_config.ini')
+config_in_client = os.path.exists(settings_path_client)
+
+if config_in_system_wide:
+    DEFAULT_CONFIG_FILE = settings_path_system_wide
+    DEFAULT_SHADOW_FILE = shadow_config_path_system_wide
+    RUNNING_STAND_ALONE_CLIENT = False
+elif config_in_root:
+    DEFAULT_CONFIG_FILE = settings_path_root
+    DEFAULT_SHADOW_FILE = shadow_config_path_root
+    RUNNING_STAND_ALONE_CLIENT = False
+elif config_in_client:
+    DEFAULT_CONFIG_FILE = settings_path_client
+    DEFAULT_SHADOW_FILE = None
+    RUNNING_STAND_ALONE_CLIENT = True
+else:
+    DEFAULT_CONFIG_FILE = None
+    DEFAULT_SHADOW_FILE = None
+    RUNNING_STAND_ALONE_CLIENT = True
+
+
+class Settings(object):
+    _NO_DEFAULT_SPECIFIED = object()
+
+    config = None
+    config_file = DEFAULT_CONFIG_FILE
+    shadow_file = DEFAULT_SHADOW_FILE
+    running_stand_alone_client = RUNNING_STAND_ALONE_CLIENT
+
+    def check_stand_alone_client_run(self):
+        return self.running_stand_alone_client
+
+    def set_config_files(self, config_file=DEFAULT_CONFIG_FILE,
+                         shadow_file=DEFAULT_SHADOW_FILE):
+        self.config_file = config_file
+        self.shadow_file = shadow_file
+        self.config = None
+
+    def _handle_no_value(self, section, key, default):
+        if default is self._NO_DEFAULT_SPECIFIED:
+            msg = ("Value '%s' not found in section '%s'" %
+                   (key, section))
+            raise SettingsError(msg)
+        else:
+            return default
+
+    def get_section_values(self, sections):
+        """
+        Return a config parser object containing a single section of the
+        global configuration, that can be later written to a file object.
+
+        :param section: Tuple with sections we want to turn into a config parser
+                object.
+        :return: ConfigParser() object containing all the contents of sections.
+        """
+        self._ensure_config_parsed()
+
+        if isinstance(sections, str):
+            sections = [sections]
+        cfgparser = ConfigParser.ConfigParser()
+        for section in sections:
+            cfgparser.add_section(section)
+            for option, value in self.config.items(section):
+                cfgparser.set(section, option, value)
+        return cfgparser
+
+    def get_value(self, section, key, type=str, default=_NO_DEFAULT_SPECIFIED,
+                  allow_blank=False):
+        self._ensure_config_parsed()
+
+        try:
+            val = self.config.get(section, key)
+        except ConfigParser.Error:
+            return self._handle_no_value(section, key, default)
+
+        if not val.strip() and not allow_blank:
+            return self._handle_no_value(section, key, default)
+
+        return self._convert_value(key, section, val, type)
+
+    def override_value(self, section, key, new_value):
+        """
+        Override a value from the config file with a new value.
+        """
+        self._ensure_config_parsed()
+        self.config.set(section, key, new_value)
+
+    def reset_values(self):
+        """
+        Reset all values to those found in the config files (undoes all
+        overrides).
+        """
+        self.parse_config_file()
+
+    def _ensure_config_parsed(self):
+        if self.config is None:
+            self.parse_config_file()
+
+    def merge_configs(self, shadow_config):
+        # overwrite whats in config with whats in shadow_config
+        sections = shadow_config.sections()
+        for section in sections:
+            # add the section if need be
+            if not self.config.has_section(section):
+                self.config.add_section(section)
+            # now run through all options and set them
+            options = shadow_config.options(section)
+            for option in options:
+                val = shadow_config.get(section, option)
+                self.config.set(section, option, val)
+
+    def parse_config_file(self):
+        self.config = ConfigParser.ConfigParser()
+        if self.config_file and os.path.exists(self.config_file):
+            self.config.read(self.config_file)
+        else:
+            raise SettingsError('%s not found' % (self.config_file))
+
+        # now also read the shadow file if there is one
+        # this will overwrite anything that is found in the
+        # other config
+        if self.shadow_file and os.path.exists(self.shadow_file):
+            shadow_config = ConfigParser.ConfigParser()
+            shadow_config.read(self.shadow_file)
+            # now we merge shadow into global
+            self.merge_configs(shadow_config)
+
+    # the values that are pulled from ini
+    # are strings.  But we should attempt to
+    # convert them to other types if needed.
+    def _convert_value(self, key, section, value, value_type):
+        # strip off leading and trailing white space
+        sval = value.strip()
+
+        # if length of string is zero then return None
+        if len(sval) == 0:
+            if value_type == str:
+                return ""
+            elif value_type == bool:
+                return False
+            elif value_type == int:
+                return 0
+            elif value_type == float:
+                return 0.0
+            elif value_type == list:
+                return []
+            else:
+                return None
+
+        if value_type == bool:
+            if sval.lower() == "false":
+                return False
+            else:
+                return True
+
+        if value_type == list:
+            # Split the string using ',' and return a list
+            return [val.strip() for val in sval.split(',')]
+
+        try:
+            conv_val = value_type(sval)
+            return conv_val
+        except Exception:
+            msg = ("Could not convert %s value %r in section %s to type %s" %
+                   (key, sval, section, value_type))
+            raise SettingsValueError(msg)
+
+
+# insure the class is a singleton.  Now the symbol settings
+# will point to the one and only one instace of the class
+settings = Settings()

--- a/virttest/utils_test/setup_modules.py
+++ b/virttest/utils_test/setup_modules.py
@@ -1,0 +1,98 @@
+"""
+Module used to create the autotest namespace for single dir use case.
+
+Autotest programs can be used and developed without requiring it to be
+installed system-wide. In order for the code to see the library namespace:
+
+from autotest.client.shared import error
+from autotest.server import hosts
+...
+
+Without system wide install, we need some hacks, that are performed here.
+
+:author: John Admanski (jadmanski@google.com)
+"""
+import os
+import sys
+
+try:
+    from virttest.utils_test import check_version
+except ImportError:
+    # This must run on Python versions less than 2.4.
+    dirname = os.path.dirname(sys.modules[__name__].__file__)
+    common_dir = os.path.abspath(os.path.join(dirname, "shared"))
+    sys.path.insert(0, common_dir)
+    import check_version
+    sys.path.pop(0)
+
+check_version.check_python_version()
+
+import new
+import imp
+
+
+def _create_module(name):
+    """
+    Create a single top-level module and add it to sys.modules.
+
+    :param name: Module name, such as 'autotest'.
+    """
+    module = new.module(name)
+    sys.modules[name] = module
+    return module
+
+
+def _create_module_and_parents(name):
+    """
+    Create a module, and all the necessary parents and add them to sys.modules.
+
+    :param name: Module name, such as 'autotest.client'.
+    """
+    parts = name.split(".")
+    # first create the top-level module
+    parent = _create_module(parts[0])
+    created_parts = [parts[0]]
+    parts.pop(0)
+    # now, create any remaining child modules
+    while parts:
+        child_name = parts.pop(0)
+        module = new.module(child_name)
+        setattr(parent, child_name, module)
+        created_parts.append(child_name)
+        sys.modules[".".join(created_parts)] = module
+        parent = module
+
+
+def import_module(module, from_where):
+    """
+    Equivalent to 'from from_where import module'.
+
+    :param module: Module name.
+    :param from_where: Package from where the module is being imported.
+    :return: The corresponding module.
+    """
+    from_module = __import__(from_where, globals(), locals(), [module])
+    return getattr(from_module, module)
+
+
+def setup(base_path, root_module_name="autotest"):
+    """
+    Setup a library namespace, with the appropriate top root module name.
+
+    Perform all the necessary setup so that all the packages at
+    'base_path' can be imported via "import root_module_name.package".
+
+    :param base_path: Base path for the module.
+    :param root_module_name: Top level name for the module.
+    """
+    if root_module_name in sys.modules:
+        # already set up
+        return
+
+    _create_module_and_parents(root_module_name)
+    imp.load_package(root_module_name, base_path)
+
+    # Allow locally installed third party packages to be found.
+    # This is primarily for the benefit of frontend and tko so that they
+    # may use libraries other than those available as system packages.
+    sys.path.insert(0, os.path.join(base_path, "site-packages"))


### PR DESCRIPTION
settings,common moudle and related dependence are ported from previous autotest
with minimum changes

Signed-off-by: chunfuwen <chwen@redhat.com>