### PR TITLE
Python 3: Converts basestring to six.string_types

### DIFF
--- a/virttest/staging/backports/collections/namedtuple.py
+++ b/virttest/staging/backports/collections/namedtuple.py
@@ -7,6 +7,8 @@ from operator import itemgetter as _itemgetter
 from keyword import iskeyword as _iskeyword
 import sys as _sys
 
+from six import string_types as basestring
+
 
 # pylint: disable=I0011,R0914,W0122,W0612,C0103,W0212,R0912
 def namedtuple(typename, field_names, verbose=False, rename=False):

--- a/virttest/staging/backports/simplejson/encoder.py
+++ b/virttest/staging/backports/simplejson/encoder.py
@@ -3,6 +3,8 @@
 import re
 from decimal import Decimal
 
+from six import string_types as basestring
+
 
 def _import_speedups():
     try:

--- a/virttest/unittest_utils/mock.py
+++ b/virttest/unittest_utils/mock.py
@@ -3,7 +3,9 @@ __author__ = "raphtee@google.com (Travis Miller)"
 import collections
 import re
 import sys
+
 from six import StringIO
+from six import string_types as basestring
 
 
 class StubNotFoundError(Exception):


### PR DESCRIPTION
Signed-off-by: Junxiang Li <junli@redhat.com>