### PR TITLE
system_output: set verbose to False in some functions

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1371,9 +1371,11 @@ class VM(virt_vm.BaseVM):
 
         self.qemu_binary = qemu_binary
         self.qemu_version = process.system_output("%s -version" % qemu_binary,
+                                                  verbose=False,
                                                   ignore_status=True,
                                                   shell=True).split(',')[0]
         support_cpu_model = process.system_output("%s -cpu \\?" % qemu_binary,
+                                                  verbose=False,
                                                   ignore_status=True,
                                                   shell=True)
 
@@ -3236,7 +3238,8 @@ class VM(virt_vm.BaseVM):
         """
         try:
             cmd = "ps --ppid=%d -o pid=" % self.process.get_pid()
-            children = process.system_output(cmd, ignore_status=True).split()
+            children = process.system_output(cmd, verbose=False,
+                                             ignore_status=True).split()
             return int(children[0])
         except (TypeError, IndexError, ValueError):
             return None

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1241,7 +1241,7 @@ def qemu_has_option(option, qemu_path="/usr/bin/qemu-kvm"):
     :param qemu_path: Path for qemu-kvm.
     """
     hlp = process.system_output("%s -help" % qemu_path, shell=True,
-                                ignore_status=True)
+                                ignore_status=True, verbose=False)
     return bool(re.search(r"^-%s(\s|$)" % option, hlp, re.MULTILINE))
 
 

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3105,7 +3105,7 @@ def verify_ip_address_ownership(ip, macs, timeout=20.0, devs=None):
         arping_cmd = "%s -f -c3 -w%d -I %s %s" % (arping_bin, int(timeout),
                                                   dev, ip)
         try:
-            o = process.system_output(arping_cmd, shell=True)
+            o = process.system_output(arping_cmd, shell=True, verbose=False)
         except process.CmdError:
             return False
         return bool(regex.search(o))


### PR DESCRIPTION
Set verbose to False to avoid too many lines
of output in debug.log


Signed-off-by: Haotong Chen <hachen@redhat.com>

id: 1555175