### PR TITLE
Modify parent_path of 'pf' tag to '/forward'

### DIFF
--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -399,7 +399,7 @@ class NetworkXMLBase(base.LibvirtXMLBase):
                                  marshal_to=self.marshal_to_address)
         accessors.XMLElementDict('driver', self, parent_xpath='/',
                                  tag_name='driver')
-        accessors.XMLElementDict('pf', self, parent_xpath='/',
+        accessors.XMLElementDict('pf', self, parent_xpath='/forward',
                                  tag_name='pf')
         accessors.XMLElementDict('nat_port', self, parent_xpath='/forward/nat',
                                  tag_name='port')


### PR DESCRIPTION
Using pf as forward device, format like below:
```
<forward ...>
    <pf dev='eth0'/>
</forward>
```
Signed-off-by: yafu <yafu@redhat.com>