### PR TITLE
ip_sniffing: Fix the issue of dropping cache

### DIFF
--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -62,6 +62,8 @@ class AddrCache(object):
     def __delitem__(self, hwaddr):
         hwaddr = self._format_hwaddr(hwaddr)
         with self._lock:
+            if hwaddr not in self._data:
+                return
             del self._data[hwaddr]
         logging.debug("Dropped the address cache of HWADDR (%s)", hwaddr)
 


### PR DESCRIPTION
Under concurrency conditions, a `KeyError` would be raised since
the given `HWADDR` (key) record might have been already dropped
in the context of other thread.

We can fix this issue by checking if the given record is in cache
firstly, so that to ensure we will not drop a non-existent record.

ID: 1556771

Signed-off-by: Xu Han <xuhan@redhat.com>