### PR TITLE
virsh.snapshot-info: Fix match issue

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2917,7 +2917,7 @@ def snapshot_info(name, snapshot, **dargs):
         raise process.CmdError(cmd, sc_output, "Failed to get snapshot info")
 
     for val in values:
-        data = re.search("(?<=%s:) *\w*" % val, sc_output.stdout)
+        data = re.search("(?<=%s:) *\S*" % val, sc_output.stdout)
         if data is None:
             continue
         ret[val] = data.group(0).strip()


### PR DESCRIPTION
This pathc is fix to domain mathch issue of output of 'virsh snapshot-info' cmd.
Use of '\S' in re expression can match all contiguous non-whitespace characters.
While '\w' can only match alphanumeric characters. For case "avocado-vt-vm1", '\S'
match get "avocado-vt-vm1", '\w' match get "avocaodo".

Signed-off-by: cuzhang <cuzhang@redhat.com>