### PR TITLE
Python 3: Fix 2 unsupported issues

### DIFF
--- a/virttest/element_tree.py
+++ b/virttest/element_tree.py
@@ -119,6 +119,11 @@ import re
 from . import element_path as ElementPath
 
 
+try:
+    REPLACE = string.replace
+except AttributeError:
+    REPLACE = str.replace
+
 # TODO: add support for custom namespace resolvers/default namespaces
 # TODO: add improved support for incremental parsing
 
@@ -802,7 +807,7 @@ def _encode_entity(text, pattern=_escape):
 # (or "utf-16")
 
 
-def _escape_cdata(text, encoding=None, replace=string.replace):
+def _escape_cdata(text, encoding=None, replace=REPLACE):
     # escape character data
     try:
         if encoding:
@@ -818,7 +823,7 @@ def _escape_cdata(text, encoding=None, replace=string.replace):
         _raise_serialization_error(text)
 
 
-def _escape_attrib(text, encoding=None, replace=string.replace):
+def _escape_attrib(text, encoding=None, replace=REPLACE):
     # escape attribute value
     try:
         if encoding:

--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -298,7 +298,7 @@ def image_average_hash(image, img_wd=8, img_ht=8):
             return 0
         else:
             return 1
-    return reduce(lambda x, (y, z): x | (z << y),
+    return reduce(lambda x, y_z: x | (y_z[1] << y_z[0]),
                   enumerate(map(_hta, image.getdata())), 0)
 
 


### PR DESCRIPTION
1. module string could not support replace in Python3
2. lambda could not support tuple in Python3

Signed-off-by: Junxiang Li <junli@redhat.com>