### PR TITLE
Python 3 : fix bootstrap issue due to process.run return bytes instea…

### DIFF
--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -83,7 +83,7 @@ def get_status(selinux_force=False):
         raise SeCmdError(cmd, result.stderr)
 
     for status in STATUS_LIST:
-        if result.stdout.lower().count(status):
+        if result.stdout_text.lower().count(status):
             return status
         else:
             continue


### PR DESCRIPTION
…d of string

process.run() return std.out in bytes,rather than string on python3,which
leads to failure in calling count() function

Signed-off-by: chunfuwen <chwen@redhat.com>