### PR TITLE
Minorfix: Fix the no attribute error

### DIFF
--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -83,7 +83,7 @@ def get_status(selinux_force=False):
         raise SeCmdError(cmd, result.stderr)
 
     for status in STATUS_LIST:
-        if result.stdout_text.lower().count(status):
+        if result.stdout_text().lower().count(status):
             return status
         else:
             continue


### PR DESCRIPTION
stdout_text is a function, not a attribute

Signed-off-by: Junxiang Li <junli@redhat.com>