### PR TITLE
This patch will instaall targetcli-fb package to bionic version.

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -843,7 +843,10 @@ class Iscsi(object):
             raise exceptions.TestError("Failed to install iscsi initiator"
                                        " packages")
         # Install linux iscsi target software targetcli
-        iscsi_package = ["targetcli"]
+        if distro.detect().version == '18' and distro.detect().name == 'Ubuntu':
+            iscsi_package = ["targetcli-fb"]
+        else:
+            iscsi_package = ["targetcli"]
         if not utils_package.package_install(iscsi_package):
             logging.error("Failed to install targetcli trying with scsi-"
                           "target-utils or tgt package")


### PR DESCRIPTION
This patch will instaall targetcli-fb package to bionic version. Existing tagetcli package name changed to targetcli-fb in bionic
Signed-off-by: prudhvi <mprudhvi@linux.vnet.ibm.com>