### PR TITLE
Python 3: division fixer

### DIFF
--- a/scripts/github/stale_pulls.py
+++ b/scripts/github/stale_pulls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import print_function, division
 import getpass
 import datetime
 
@@ -51,7 +51,7 @@ print()
 for number in issues.search(criteria):
     if issues[number]['commits'] and issues[number]['commits'] > 0:
         age = datetime.datetime.now() - issues[number]['modified']
-        hours = age.seconds / (60 * 60)
+        hours = age.seconds // (60 * 60)
         days = age.days
         url = issues[number]['url']
         summary = issues[number]['summary']

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -6,6 +6,7 @@ compute and check regression bug.
 :copyright: Red Hat 2011-2012
 :author: Amos Kong <akong@redhat.com>
 """
+from __future__ import division
 import os
 import sys
 import re

--- a/scripts/scan_results.py
+++ b/scripts/scan_results.py
@@ -4,6 +4,7 @@ Script to fetch test status info from sqlit data base. Before use this
 script, avocado We must be lanuch with '--journal' option.
 """
 
+from __future__ import division
 import os
 import sys
 import sqlite3
@@ -41,7 +42,7 @@ def get_total_seconds(td):
     """ Alias for get total_seconds in python2.6 """
     if hasattr(td, 'total_seconds'):
         return td.total_seconds()
-    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 1e6) / 1e6
+    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 1e6) // 1e6
 
 
 def fetch_data(db_file=".journal.sqlite"):

--- a/selftests/unit/test_utils_net.py
+++ b/selftests/unit/test_utils_net.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import division
 import unittest
 import time
 import logging
@@ -148,7 +149,7 @@ class TestVirtIface(unittest.TestCase):
     def test_half_set(self):
         def what_func(propertea):
             return props[propertea]
-        half_prop_end = (len(self.VirtIface.__all_slots__) / 2) + 1
+        half_prop_end = (len(self.VirtIface.__all_slots__) // 2) + 1
         props = {}
         for propertea in self.VirtIface.__all_slots__[0:half_prop_end]:
             props[propertea] = utils_misc.generate_random_string(16)

--- a/shared/scripts/ksm_overcommit_guest.py
+++ b/shared/scripts/ksm_overcommit_guest.py
@@ -7,7 +7,7 @@ Auxiliary script used to allocate memory on guests.
 :author: Jiri Zupka (jzupka@redhat.com)
 """
 
-
+from __future__ import division
 import os
 import array
 import sys
@@ -57,7 +57,7 @@ class MemFill(object):
         else:
             self.f = tempfile.TemporaryFile(prefix='mem', dir=self.tmpdp)
             self.allocate_by = 'L'
-            self.npages = ((mem * 1024 * 1024) / PAGE_SIZE)
+            self.npages = ((mem * 1024 * 1024) // PAGE_SIZE)
             self.random_key = random_key
             self.static_value = static_value
             print("PASS: Initialization (tmpfs size: %dM)" % tmpfs_size)
@@ -74,7 +74,7 @@ class MemFill(object):
         :param original: Data that was expected to be in memory.
         :param inmem: Data in memory.
         """
-        for ip in range(PAGE_SIZE / original.itemsize):
+        for ip in range(PAGE_SIZE // original.itemsize):
             if (not original[ip] == inmem[ip]):  # find which item is wrong
                 originalp = array.array("B")
                 inmemp = array.array("B")
@@ -95,7 +95,7 @@ class MemFill(object):
         :return: return array of bytes size PAGE_SIZE.
         """
         a = array.array("B")
-        for _ in range((PAGE_SIZE / a.itemsize)):
+        for _ in range((PAGE_SIZE // a.itemsize)):
             try:
                 a.append(value)
             except Exception:
@@ -111,7 +111,7 @@ class MemFill(object):
         """
         random.seed(seed)
         a = array.array(self.allocate_by)
-        for _ in range(PAGE_SIZE / a.itemsize):
+        for _ in range(PAGE_SIZE // a.itemsize):
             a.append(random.randrange(0, sys.maxint))
         return a
 
@@ -147,7 +147,7 @@ class MemFill(object):
         page = self.value_page(value)
         for _ in range(self.npages):
             pf = array.array("B")
-            pf.fromfile(self.f, PAGE_SIZE / pf.itemsize)
+            pf.fromfile(self.f, PAGE_SIZE // pf.itemsize)
             if not (page == pf):
                 failure = True
                 self.compare_page(page, pf)
@@ -174,16 +174,16 @@ class MemFill(object):
 
         t_start = datetime.datetime.now()
         for pages in range(self.npages):
-            rand = random.randint(((PAGE_SIZE / page.itemsize) - 1) -
-                                  (n_bytes_on_end / page.itemsize),
-                                  (PAGE_SIZE / page.itemsize) - 1)
+            rand = random.randint(((PAGE_SIZE // page.itemsize) - 1) -
+                                  (n_bytes_on_end // page.itemsize),
+                                  (PAGE_SIZE // page.itemsize) - 1)
             p[rand] = pages
             p.tofile(self.f)
             p[rand] = page[rand]
 
         t_end = datetime.datetime.now()
         delta = t_end - t_start
-        milisec = delta.microseconds / 1e3 + delta.seconds * 1e3
+        milisec = delta.microseconds // 1e3 + delta.seconds * 1e3
         print("PASS: filling duration = %Ld ms" % milisec)
 
     def static_random_verify(self, n_bytes_on_end=PAGE_SIZE):
@@ -200,12 +200,12 @@ class MemFill(object):
         p = copy.copy(page)
         failure = False
         for pages in range(self.npages):
-            rand = random.randint(((PAGE_SIZE / page.itemsize) - 1) -
-                                  (n_bytes_on_end / page.itemsize),
-                                  (PAGE_SIZE / page.itemsize) - 1)
+            rand = random.randint(((PAGE_SIZE // page.itemsize) - 1) -
+                                  (n_bytes_on_end // page.itemsize),
+                                  (PAGE_SIZE // page.itemsize) - 1)
             p[rand] = pages
             pf = array.array(self.allocate_by)
-            pf.fromfile(self.f, PAGE_SIZE / pf.itemsize)
+            pf.fromfile(self.f, PAGE_SIZE // pf.itemsize)
             if not (p == pf):
                 failure = True
                 self.compare_page(p, pf)

--- a/shared/scripts/virtio_console_guest.py
+++ b/shared/scripts/virtio_console_guest.py
@@ -7,6 +7,7 @@ Auxiliary script used to send data between ports on guests.
 :author: Jiri Zupka (jzupka@redhat.com)
 :author: Lukas Doktor (ldoktor@redhat.com)
 """
+from __future__ import division
 import threading
 from threading import Thread
 import os
@@ -547,7 +548,7 @@ class VirtioGuestPosix(VirtioGuest):
             self.port = port
             self.exit_thread = event
             self.data = array.array('L')
-            for _ in range(max(length / self.data.itemsize, 1)):
+            for _ in range(max(length // self.data.itemsize, 1)):
                 self.data.append(random.randrange(sys.maxint))
 
         def run(self):
@@ -1170,7 +1171,7 @@ class VirtioGuestNt(VirtioGuest):
             self.port = port
             self.exit_thread = event
             self.data = array.array('L')
-            for _ in range(max(length / self.data.itemsize, 1)):
+            for _ in range(max(length // self.data.itemsize, 1)):
                 self.data.append(random.randrange(sys.maxint))
 
         def run(self):

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import os
 import time
 import re
@@ -494,7 +495,7 @@ def _process_images_parallel(image_func, test, params, vm_process_status=None):
                               or None for no vm exist.
     """
     images = params.objects("images")
-    no_threads = min(len(images) / 5,
+    no_threads = min(len(images) // 5,
                      2 * multiprocessing.cpu_count())
     exit_event = threading.Event()
     threads = []
@@ -1414,7 +1415,7 @@ def _take_screendumps(test, params, env):
                 if time_inactive > inactivity_treshold:
                     msg = (
                         "%s screen is inactive for more than %d s (%d min)" %
-                        (vm.name, time_inactive, time_inactive / 60))
+                        (vm.name, time_inactive, time_inactive // 60))
                     if inactivity_watcher == "error":
                         try:
                             raise virt_vm.VMScreenInactiveError(vm,

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -7,6 +7,7 @@ target name. And it can support the real iscsi access and emulated
 iscsi in localhost then access it.
 """
 
+from __future__ import division
 import re
 import os
 import logging
@@ -464,7 +465,7 @@ class IscsiTGT(_IscsiComm):
         if not os.path.isfile(self.emulated_image):
             process.system(self.create_cmd)
         else:
-            emulated_image_size = os.path.getsize(self.emulated_image) / 1024
+            emulated_image_size = os.path.getsize(self.emulated_image) // 1024
             if emulated_image_size != self.emulated_expect_size:
                 # No need to remvoe, rebuild is fine
                 process.system(self.create_cmd)
@@ -673,7 +674,7 @@ class IscsiLIO(_IscsiComm):
         if not os.path.isfile(self.emulated_image):
             process.system(self.create_cmd)
         else:
-            emulated_image_size = os.path.getsize(self.emulated_image) / 1024
+            emulated_image_size = os.path.getsize(self.emulated_image) // 1024
             if emulated_image_size != self.emulated_expect_size:
                 # No need to remvoe, rebuild is fine
                 process.system(self.create_cmd)

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -4,6 +4,7 @@ Utility classes and functions to handle Virtual Machine creation using libvirt.
 :copyright: 2011 Red Hat Inc.
 """
 
+from __future__ import division
 import time
 import string
 import os
@@ -513,9 +514,9 @@ class VM(virt_vm.BaseVM):
                 numa_nodes = vcpus
                 params['numa_nodes'] = vcpus
             if vcpus > 1:
-                cpus = vcpus / numa_nodes
+                cpus = vcpus // numa_nodes
                 cpus_balance = vcpus % numa_nodes
-                memory = max_mem / numa_nodes
+                memory = max_mem // numa_nodes
                 memory_balance = max_mem % numa_nodes
             else:
                 cpus = vcpus
@@ -1602,7 +1603,7 @@ class VM(virt_vm.BaseVM):
         session = self.wait_for_login()
         try:
             # Get memory size.
-            swap_size = self.get_used_mem() / 1024
+            swap_size = self.get_used_mem() // 1024
 
             # Create, change permission, and make a swap file.
             cmd = ("dd if=/dev/zero of={1} bs=1M count={0} && "

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -21,6 +21,7 @@ Required params:
     pv_name
         PhysicalVolume name eg, /dev/sdb or /dev/sdb1;
 """
+from __future__ import division
 import os
 import time
 import re

--- a/virttest/postprocess_iozone.py
+++ b/virttest/postprocess_iozone.py
@@ -9,6 +9,7 @@ is not present, functionality degrates gracefully.
 :copyright: Red Hat 2010
 """
 
+from __future__ import division
 import os
 import sys
 import optparse

--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -4,6 +4,7 @@ Utility functions to deal with ppm (qemu screendump format) files.
 :copyright: Red Hat 2008-2009
 """
 
+from __future__ import division
 import os
 import struct
 import time
@@ -242,7 +243,7 @@ def image_comparison(width, height, data1, data2):
         # Compute average of the two values
         value = int((value1 + value2) / 2)
         # Scale value to the upper half of the range [0, 255]
-        value = 128 + value / 2
+        value = 128 + value // 2
         # Compare pixels
         if pixel1_str == pixel2_str:
             # Equal -- give the pixel a greenish hue

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -8,6 +8,7 @@ interact and verify the qemu qdev structure.
 """
 
 # Python imports
+from __future__ import division
 import logging
 import re
 import os
@@ -740,7 +741,7 @@ class DevContainer(object):
             if _is_oldscsi or _scsi_without_device:
                 i += 1
 
-        for i in xrange(i / 7):     # Autocreated lsi hba
+        for i in xrange(i // 7):     # Autocreated lsi hba
             if arch.ARCH in ('ppc64', 'ppc64le'):
                 _name = 'spapr-vscsi%s' % i
                 bus = qdevices.QSCSIBus("scsi.0", 'SCSI', [8, 16384],

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -4,6 +4,7 @@ Interfaces to the QEMU monitor.
 :copyright: 2008-2010 Red Hat Inc.
 """
 
+from __future__ import division
 import socket
 import time
 import threading
@@ -1233,7 +1234,7 @@ class HumanMonitor(Monitor):
                      qmp monitor will use bytes as unit for the block size
         :return: Command output
         """
-        size = int(size) / 1024 / 1024
+        size = int(size) // 1024 // 1024
         cmd = "block_resize device=%s,size=%s" % (device, size)
         return self.send_args_cmd(cmd)
 

--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -3,6 +3,7 @@ Interfaces and helpers for the virtio_serial ports.
 
 :copyright: 2012 Red Hat Inc.
 """
+from __future__ import division
 from threading import Thread
 from collections import deque
 import logging
@@ -902,7 +903,7 @@ class ThRecvCheck(Thread):
                                               "lowered as there is not enough "
                                               "data after 1s. Using sendidx="
                                               "%s.", self.getName(), sendidx)
-                            for _ in xrange(sendidx / self.blocklen):
+                            for _ in xrange(sendidx // self.blocklen):
                                 if self.exitevent.isSet():
                                     break
                                 buf += self.port.sock.recv(self.blocklen)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4,6 +4,7 @@ Utility classes and functions to handle Virtual Machine creation using qemu.
 :copyright: 2008-2009, 2014 Red Hat Inc.
 """
 
+from __future__ import division
 import time
 import os
 import logging

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -1,6 +1,7 @@
 """
 Functions and classes used for logging into guests and transferring files.
 """
+from __future__ import division
 import logging
 import time
 import re

--- a/virttest/remote_commander/remote_master.py
+++ b/virttest/remote_commander/remote_master.py
@@ -6,6 +6,8 @@ Created on Dec 6, 2013
 :author: jzupka, astepano
 :contact: Andrei Stepanov <astepano@redhat.com>
 '''
+
+from __future__ import division
 import sys
 import time
 import inspect

--- a/virttest/rss_client.py
+++ b/virttest/rss_client.py
@@ -6,6 +6,7 @@ Client for file transfer services offered by RSS (Remote Shell Server).
 :copyright: 2008-2010 Red Hat Inc.
 """
 
+from __future__ import division
 import socket
 import struct
 import time

--- a/virttest/staging/utils_memory.py
+++ b/virttest/staging/utils_memory.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import re
 import glob
 import math
@@ -62,7 +63,7 @@ def numa_nodes():
 
 def node_size():
     nodes = max(len(numa_nodes()), 1)
-    return ((memtotal() * 1024) / nodes)
+    return ((memtotal() * 1024) // nodes)
 
 
 def get_huge_page_size():
@@ -282,4 +283,4 @@ def getpagesize():
 
     :return: pagesize in kB
     """
-    return os.sysconf('SC_PAGE_SIZE') / 1024
+    return os.sysconf('SC_PAGE_SIZE') // 1024

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -5,6 +5,7 @@ This exports:
   - two functions for get image/blkdebug filename
   - class for image operates and basic parameters
 """
+from __future__ import division
 import logging
 import os
 import shutil

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1,6 +1,7 @@
 """
 Library to perform pre/post test setup for virt test.
 """
+from __future__ import division
 import os
 import logging
 import time
@@ -488,7 +489,7 @@ class HugePageConfig(object):
         # memory of all VMs plus qemu overhead of 128MB per guest
         # (this value can be overridden in your cartesian config)
         vmsm = self.vms * (self.mem + self.qemu_overhead)
-        target_hugepages = int(vmsm * 1024 / self.hugepage_size)
+        target_hugepages = int(vmsm * 1024 // self.hugepage_size)
 
         # FIXME Now the buddyinfo can not get chunk info which is bigger
         # than 4M. So this will only fit for 2M size hugepages. Can not work
@@ -521,7 +522,7 @@ class HugePageConfig(object):
                              " biggest number the system can support.")
                 target_hugepages = available_hugepages
                 available_mem = available_hugepages * self.hugepage_size
-                self.suggest_mem = int(available_mem / self.vms / 1024 -
+                self.suggest_mem = int(available_mem // self.vms // 1024 -
                                        self.qemu_overhead)
                 if self.suggest_mem < self.lowest_mem_per_vm:
                     raise MemoryError("This host doesn't have enough free "

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import logging
 import time
 import re
@@ -1241,7 +1242,7 @@ def run(test, params, env):
         mig_protocol = params.get("migration_protocol", "tcp")
 
     logging.info("Waiting for installation to finish. Timeout set to %d s "
-                 "(%d min)", install_timeout, install_timeout / 60)
+                 "(%d min)", install_timeout, install_timeout // 60)
     error_context.context("waiting for installation to finish")
 
     start_time = time.time()
@@ -1361,7 +1362,7 @@ def run(test, params, env):
 
     time_elapsed = time.time() - start_time
     logging.info("Guest reported successful installation after %d s (%d min)",
-                 time_elapsed, time_elapsed / 60)
+                 time_elapsed, time_elapsed // 60)
 
     if params.get("shutdown_cleanly", "yes") == "yes":
         shutdown_cleanly_timeout = int(params.get("shutdown_cleanly_timeout",

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -4,6 +4,7 @@ Virtualization test utility functions.
 :copyright: 2008-2009 Red Hat Inc.
 """
 
+from __future__ import division
 import time
 import string
 import random

--- a/virttest/utils_numeric.py
+++ b/virttest/utils_numeric.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import math
 
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -16,6 +16,7 @@ More specifically:
 :copyright: 2008-2013 Red Hat Inc.
 """
 
+from __future__ import division
 import glob
 import imp
 import locale
@@ -338,9 +339,9 @@ def get_memory_info(lvms):
 
     try:
         meminfo = "Host: memfree = "
-        meminfo += str(int(utils_memory.read_from_meminfo('MemFree')) / 1024) + "M; "
+        meminfo += str(int(utils_memory.read_from_meminfo('MemFree')) // 1024) + "M; "
         meminfo += "swapfree = "
-        mf = int(utils_memory.read_from_meminfo("SwapFree")) / 1024
+        mf = int(utils_memory.read_from_meminfo("SwapFree")) // 1024
         meminfo += str(mf) + "M; "
     except Exception as e:
         raise exceptions.TestFail("Could not fetch host free memory info, "
@@ -2065,7 +2066,7 @@ class RemoteDiskManager(object):
         """
         free = self.get_free_space(disk_type, path, vgname)
         logging.debug("Allowed space on remote path:%sGB", free)
-        occupied_size = free - need_size / 2
+        occupied_size = int(free - need_size / 2)
         occupied_path = os.path.join(os.path.dirname(path), "occupied")
         return self.create_image(disk_type, occupied_path, occupied_size,
                                  vgname, "occupied", False, timeout)

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -16,6 +16,7 @@ More specifically:
 :copyright: 2014 Red Hat Inc.
 """
 
+from __future__ import division
 import re
 import os
 import ast
@@ -2727,7 +2728,7 @@ def attach_disks(vm, path, vgname, params):
         prefix_list = []
         while count > 0:
             # Out of range for current prefix_list
-            if (index / 26) > 0:
+            if (index // 26) > 0:
                 # Update prefix_list to expand disks, such as [] -> ['a'],
                 # ['z'] -> ['a', 'a'], ['z', 'z'] -> ['a', 'a', 'a']
                 prefix_index = len(prefix_list)

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import logging
 import time
 import glob
@@ -424,7 +425,7 @@ class VMScreenInactiveError(VMError):
 
     def __str__(self):
         msg = ("%s screen is inactive for %d s (%d min)" %
-               (self.vm.name, self.inactive_time, self.inactive_time / 60))
+               (self.vm.name, self.inactive_time, self.inactive_time // 60))
         return msg
 
 


### PR DESCRIPTION
`from __future__ import division` was added into all modules that
use the division operator, so that the / operator to behave the
same in Python 2 as it does in Python 3.

Changed / to //, if the operator should be changed to //.

Signed-off-by: Haotong Chen <hachen@redhat.com>