### PR TITLE
utils_windows/drive: Add extend_partition_windows() and shrink_partition_windows()

### DIFF
--- a/virttest/utils_windows/drive.py
+++ b/virttest/utils_windows/drive.py
@@ -37,3 +37,49 @@ def get_floppy_drives_letter(session):
     """
     cond = "MediaType!=0 AND MediaType!=11 AND MediaType!=12"
     return _logical_disks(session, cond=cond, props=["DeviceID"])
+
+
+def rescan_disks(session):
+    """
+    Rescan disks in windows guest.
+
+    :param session: Session object.
+    """
+    script_path = r"%TEMP%\rescan.dp"
+    rescan_cmd = "echo rescan > {0} && diskpart /s {0}"
+    session.cmd(rescan_cmd.format(script_path))
+
+
+def extend_volume(session, vol_id, size=None):
+    """
+    Extend a volume in windows guest.
+
+    :param session: Session object.
+    :param vol_id: Drive letter or Volume number.
+    :param size: Default extend the volume to maximum available size,
+                 if size is specified, extend the volume to size.
+                 The default unit of size is M.
+    """
+    script_path = r"%TEMP%\extend_{0}.dp".format(vol_id)
+    extend_cmd = 'echo select volume %s > {0} && ' % vol_id
+    if not size:
+        extend_cmd += 'echo extend >> {0} && diskpart /s {0}'
+    else:
+        extend_cmd += 'echo extend desired=%s >> {0} ' % size
+        extend_cmd += '&& diskpart /s {0}'
+    session.cmd(extend_cmd.format(script_path))
+
+
+def shrink_volume(session, vol_id, size):
+    """
+    Shrink a volume in windows guest.
+
+    :param session: Session object.
+    :param vol_id: Drive letter or Volume number.
+    :param size: Desired decrease size. The default unit of size is M.
+    """
+    script_path = r"%TEMP%\shrink_{0}.dp".format(vol_id)
+    shrink_cmd = 'echo select volume %s > {0} && ' % vol_id
+    shrink_cmd += 'echo shrink desired=%s >> {0} ' % size
+    shrink_cmd += '&& diskpart /s {0}'
+    session.cmd(shrink_cmd.format(script_path))


### PR DESCRIPTION
Moved from utils_misc.py.
Define new functions to complete the windows disk extend and shrink.
For disk shrink, need to query maximum shrunk value, then to do shrink.
Define rescan_windows_disk() due to many process need to run these steps.

id: 1411207 1390485
Signed-off-by: Peixiu Hou phou@redhat.com