### PR TITLE
Modify regrex to match 'info cpus' output format in qemu[Do not merge]

### DIFF
--- a/selftests/unit/unittest_data/testcfg.huge/base.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/base.cfg
@@ -178,7 +178,7 @@ monitor_type = human
 # Pattern to get vcpu threads from monitor.
 #    human monitor: thread_id=(\d+)
 #    qmp monitor: u'thread_id':\s+(\d+)
-vcpu_thread_pattern = "thread_id=(\d+)"
+vcpu_thread_pattern = "thread[_,-]id=(\d+)"
 
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc

--- a/selftests/unit/unittest_data/testcfg.huge/subtests.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/subtests.cfg
@@ -1468,13 +1468,13 @@ variants:
         type = qmp_basic
         monitors = qmp1
         monitor_type = qmp
-        vcpu_thread_pattern = "u'thread_id':\s+(\d+)"
+        vcpu_thread_pattern = "u'thread[_,-]id':\s+(\d+)"
     - qmp_basic_rhel6: install setup image_copy unattended_install.cdrom
         virt_test_type = qemu
         type = qmp_basic_rhel6
         monitors = qmp1
         monitor_type = qmp
-        vcpu_thread_pattern = "u'thread_id':\s+(\d+)"
+        vcpu_thread_pattern = "u'thread[_,-]id':\s+(\d+)"
     - rv_connect:
         virt_test_type = qemu
         no JeOS

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -277,7 +277,7 @@ monitor_type = qmp
 catch_monitor = catch_monitor
 #monitor_type_catch_monitor = qmp
 # Pattern to get vcpu threads from monitor.both support
-vcpu_thread_pattern = "thread_id.?[:|=]\s*(\d+)"
+vcpu_thread_pattern = "thread[_,-]id.?[:|=]\s*(\d+)"
 
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2245,7 +2245,7 @@ class VM(virt_vm.BaseVM):
         """
         output = virsh.qemu_monitor_command(self.name, "info cpus", "--hmp",
                                             uri=self.connect_uri)
-        vcpu_pids = re.findall(r'thread_id=(\d+)', output.stdout)
+        vcpu_pids = re.findall(r'thread[_,-]id=(\d+)', output.stdout)
         return vcpu_pids
 
     def get_shell_pid(self):


### PR DESCRIPTION
Qemu changes `info cpus` output format in this commit
https://github.com/qemu/qemu/commit/137b5cb6ab565cb3781d5337591e155932b4230e

This patch address the regrex pattern change to accommodate it.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>