### PR TITLE
[ignore]ip_sniffing.py: add re string to class TcpdumpSniffer re.search

### DIFF
--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -258,7 +258,7 @@ class TcpdumpSniffer(Sniffer):
             self._context["mac"] = matches.group(1)
             return True
 
-        if re.search(r"DHCP.Message.*:\s+ACK", line, re.I):
+        if re.search(r"(?:DHCP.Message.*:\s+ACK|pxelinux.0)", line, re.I):
             mac = self._context.get("mac")
             ip = self._context.get("ip")
             if mac and ip:


### PR DESCRIPTION
1.In my test env can't get ACK info but can get pxeboot.0 info.
2.Not sure this pr influences some others, so please ignore this pr

Signed-off-by: kuwei <kuwei@redhat.com>