### PR TITLE
Python3: Overriding get() method in Params

### DIFF
--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -23,11 +23,18 @@ class Params(IterableUserDict):
     def __getitem__(self, key):
         """ overrides the error messages of missing params[$key] """
         try:
-            return IterableUserDict.__getitem__(self, key)
+            return super(Params, self).__getitem__(key)
         except KeyError:
             raise ParamNotFound("Mandatory parameter '%s' is missing. "
                                 "Check your cfg files for typos/mistakes" %
                                 key)
+
+    def get(self, key, default=None):
+        """ overrides the behavior to catch ParamNotFound error"""
+        try:
+            return self[key]
+        except ParamNotFound:
+            return default
 
     def objects(self, key):
         """


### PR DESCRIPTION
As IterableUserDict is not supported in Python3, Params inherits
UserDict from collections, whereas it inherits IterableUserDict
from UserDict in Python2.

Due it's different parent class, `get` method need to be override
to catch ParamNotFound error riased by `__getitem__` called by
`get` in Python3.

Signed-off-by: Haotong Chen <hachen@redhat.com>