### PR TITLE
python 3 : fix process.run return bytes instead of text ,but call string interfaces issue

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -39,7 +39,7 @@ class QemuImg(storage.QemuImg):
         self.image_cmd = utils_misc.get_qemu_img_binary(params)
         q_result = process.run(self.image_cmd + ' -h', ignore_status=True,
                                shell=True, verbose=False)
-        self.help_text = q_result.stdout
+        self.help_text = q_result.stdout_text
         self.cap_force_share = '-U' in self.help_text
 
     @error_context.context_aware

--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -731,7 +731,7 @@ class Factory(object):
             :return: executable name for PID 1, aka init
             :rtype:  str
             """
-            output = self.run("ps -o comm 1").stdout
+            output = self.run("ps -o comm 1").stdout_text
             return output.splitlines()[-1].strip()
 
         def get_generic_service_manager_type(self):

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -594,7 +594,7 @@ def generate_random_string(length, ignore_str=string.punctuation,
     """
     r = random.SystemRandom()
     sr = ""
-    chars = string.letters + string.digits + string.punctuation
+    chars = string.ascii_letters + string.digits + string.punctuation
     if not ignore_str:
         ignore_str = ""
     for i in ignore_str:

--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -83,7 +83,7 @@ def get_status(selinux_force=False):
         raise SeCmdError(cmd, result.stderr)
 
     for status in STATUS_LIST:
-        if result.stdout.lower().count(status):
+        if result.stdout_text.lower().count(status):
             return status
         else:
             continue


### PR DESCRIPTION
process.run return bytes instead of text in general case,
need enforcedly call stdout_text if text value needed

Signed-off-by: chunfuwen <chwen@redhat.com>