### PR TITLE
Python 3: default to use string and fix Python3 setdefault keyerror

### DIFF
--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -36,6 +36,11 @@ class Params(IterableUserDict):
         except ParamNotFound:
             return default
 
+    def setdefault(self, key, failobj=None):
+        if key not in self:
+            self[key] = failobj
+        return self[key]
+
     def objects(self, key):
         """
         Return the names of objects defined using a given key.


### PR DESCRIPTION
1. Make Params.get() return string
2. Fix setdefault() raise keyerror in python3 when key is not in dict

without setdefault part fix, below similar 'KeyError' will report.
340 2018-04-02 13:45:00,623 stacktrace       L0047 ERROR|   File "/root/code-python3/p3-ve/lib64/python3.4/collections/__init__.py", line 913, in __getitem__
341 2018-04-02 13:45:00,623 stacktrace       L0047 ERROR|     raise KeyError(key)
342 2018-04-02 13:45:00,623 stacktrace       L0047 ERROR| KeyError: 'queues'
369 2018-04-02 13:45:00,625 stacktrace       L0047 ERROR|   File "/root/code-python3/avocado-vt/virttest/utils_net.py", line 2686, in __init__
370 2018-04-02 13:45:00,625 stacktrace       L0047 ERROR|     nic_params = self.__set_default_params__(nic_name, nic_params)
371 2018-04-02 13:45:00,625 stacktrace       L0047 ERROR|   File "/root/code-python3/avocado-vt/virttest/utils_net.py", line 2729, in __set_default_params__
372 2018-04-02 13:45:00,625 stacktrace       L0047 ERROR|     nic_params.setdefault(key, val)
373 2018-04-02 13:45:00,625 stacktrace       L0047 ERROR|   File "/root/code-python3/p3-ve/lib64/python3.4/_collections_abc.py", line 605, in setdefault
374 2018-04-02 13:45:00,625 stacktrace       L0047 ERROR|     return self[key]

So overwrite setdefault() in Params class, to make it work well.

Signed-off-by: cuzhang <cuzhang@redhat.com>