### PR TITLE
python 3 force stdout or stderror to be text instead of bytes

### DIFF
--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -2,6 +2,7 @@ import logging
 import imp
 
 from avocado.utils import process
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 from .. import propcan, xml_utils, virsh
 from ..libvirt_xml import xcepts
@@ -221,6 +222,8 @@ class LibvirtXMLBase(propcan.PropCanBase):
         if schema_name:
             command += ' %s' % schema_name
         cmdresult = process.run(command, ignore_status=True)
+        cmdresult.stdout = results_stdout_52lts(cmdresult)
+        cmdresult.stderr = results_stderr_52lts(cmdresult)
         return cmdresult
 
 

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -165,7 +165,8 @@ class QemuImg(storage.QemuImg):
         if cmd_result.exit_status != 0 and not ignore_errors:
             raise exceptions.TestError("Failed to create image %s" %
                                        self.image_filename)
-
+        cmd_result.stdout = results_stdout_52lts(cmd_result)
+        cmd_result.stderr = results_stderr_52lts(cmd_result)
         return self.image_filename, cmd_result
 
     def convert(self, params, root_dir, cache_mode=None):
@@ -482,6 +483,9 @@ class QemuImg(storage.QemuImg):
                 raise exceptions.TestFail("Compared images differ")
             else:
                 raise exceptions.TestError("Error in image comparison")
+
+            cmd_result.stdout = results_stdout_52lts(cmd_result)
+            cmd_result.stderr = results_stderr_52lts(cmd_result)
             return cmd_result
 
     def check_image(self, params, root_dir, force_share=False):
@@ -623,6 +627,8 @@ class QemuImg(storage.QemuImg):
         cmd_list.append("-f %s %s" % (self.image_format, self.image_filename))
         logging.info("Amend image %s" % self.image_filename)
         cmd_result = process.run(" ".join(cmd_list), ignore_status=False)
+        cmd_result.stdout = results_stdout_52lts(cmd_result)
+        cmd_result.stderr = results_stderr_52lts(cmd_result)
         return cmd_result
 
 

--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -22,7 +22,7 @@ import logging
 from tempfile import mktemp
 
 from avocado.utils import process
-from virttest.compat_52lts import results_stdout_52lts
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 _COMMAND_TABLE_DOC = """
@@ -473,6 +473,8 @@ class _SpecificServiceManager(object):
             logging.debug("Setting ignore_status to True.")
             kwargs["ignore_status"] = True
             result = run_func(" ".join(command(service_name)), **kwargs)
+            result.stdout = results_stdout_52lts(result)
+            result.stderr = results_stderr_52lts(result)
             return parse_func(result)
         return run
 

--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -82,6 +82,8 @@ def lgf_command(cmd, ignore_status=True, debug=False, timeout=60):
         logging.debug("stderr: %s", results_stderr_52lts(ret).strip())
 
     # Return CmdResult instance when ignore_status is True
+    ret.stdout = results_stdout_52lts(ret)
+    ret.stderr = results_stderr_52lts(ret)
     return ret
 
 
@@ -354,6 +356,8 @@ class GuestfishRemote(object):
         exit_status, stdout = self.cmd_status_output(cmd)
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
+        result.stdout = results_stdout_52lts(result)
+        result.stderr = results_stderr_52lts(result)
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Guestfish Command returned non-zero exit status")
@@ -364,6 +368,8 @@ class GuestfishRemote(object):
         exit_status, stdout = self.cmd_status_output(cmd)
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
+        result.stdout = results_stdout_52lts(result)
+        result.stderr = results_stderr_52lts(result)
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Guestfish Command returned non-zero exit status")

--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -404,6 +404,8 @@ def set_defcon(context_type, pathregex, context_range=None, selinux_force=False)
     if pathregex:
         cmd += ' "%s"' % pathregex
     result = process.run(cmd, ignore_status=True)
+    result.stdout = result.stdout_text
+    result.stderr = result.stderr_text
     _no_semanage(result)
     if result.exit_status != 0:
         raise SeCmdError(cmd, results_stderr_52lts(result))
@@ -425,6 +427,8 @@ def del_defcon(context_type, pathregex, selinux_force=False):
 
     cmd = ("semanage fcontext --delete -t %s '%s'" % (context_type, pathregex))
     result = process.run(cmd, ignore_status=True)
+    result.stdout = results_stdout_52lts(result)
+    result.stderr = results_stderr_52lts(result)
     _no_semanage(result)
     if result.exit_status != 0:
         raise SeCmdError(cmd, results_stderr_52lts(result))

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -11,6 +11,7 @@ import logging
 
 from avocado.utils import path
 from avocado.utils import process
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 from virttest import ovirt
 from virttest.utils_test import libvirt
@@ -704,6 +705,8 @@ def v2v_cmd(params):
     cmd = '%s %s' % (V2V_EXEC, options)
     cmd_result = process.run(cmd, timeout=v2v_timeout,
                              verbose=True, ignore_status=True)
+    cmd_result.stdout = results_stdout_52lts(cmd_result)
+    cmd_result.stderr = results_stderr_52lts(cmd_result)
     return cmd_result
 
 

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -233,6 +233,8 @@ class VirshSession(aexpect.ShellSession):
                                    "Virsh Command returned non-zero exit status")
         if debug:
             logging.debug(result)
+        result.stdout = results_stdout_52lts(result)
+        result.stderr = results_stderr_52lts(result)
         return result
 
     def read_until_output_matches(self, patterns, filter_func=lambda x: x,
@@ -692,12 +694,14 @@ def command(cmd, **dargs):
                           shell=True)
         # Mark return as not coming from persistent virsh session
         ret.from_session_id = None
+        ret.stdout = results_stdout_52lts(ret)
+        ret.stderr = results_stderr_52lts(ret)
 
     # Always log debug info, if persistent session or not
     if debug:
         logging.debug("status: %s", ret.exit_status)
-        logging.debug("stdout: %s", results_stdout_52lts(ret).strip())
-        logging.debug("stderr: %s", results_stderr_52lts(ret).strip())
+        logging.debug("stdout: %s", ret.stdout.strip())
+        logging.debug("stderr: %s", ret.stderr.strip())
 
     # Return CmdResult instance when ignore_status is True
     return ret

--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -228,6 +228,8 @@ class VirtadminSession(aexpect.ShellSession):
         exit_status, stdout = self.cmd_status_output(cmd, timeout=timeout)
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
+        result.stdout = results_stdout_52lts(result)
+        result.stderr = results_stderr_52lts(result)
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Virtadmin Command returned non-zero exit status")
@@ -689,12 +691,14 @@ def command(cmd, **dargs):
                           shell=True)
         # Mark return as not coming from persistent virtadmin session
         ret.from_session_id = None
+        ret.stdout = results_stdout_52lts(ret)
+        ret.stderr = results_stderr_52lts(ret)
 
     # Always log debug info, if persistent session or not
     if debug:
         logging.debug("status: %s", ret.exit_status)
-        logging.debug("stdout: %s", results_stdout_52lts(ret).strip())
-        logging.debug("stderr: %s", results_stderr_52lts(ret).strip())
+        logging.debug("stdout: %s", ret.stdout.strip())
+        logging.debug("stderr: %s", ret.stderr.strip())
 
     # Return CmdResult instance when ignore_status is True
     return ret


### PR DESCRIPTION
,which make it behaves consistently on python 2 and 3

Signed-off-by: chunfuwen <chwen@redhat.com>