### PR TITLE
Call "CmdResult.*_text" methods in backward compatible way

### DIFF
--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -27,6 +27,7 @@ except ImportError:
 from virttest import bootstrap
 from virttest import defaults
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class VTBootstrap(CLICmd):
@@ -111,12 +112,14 @@ class VTBootstrap(CLICmd):
             else:
                 logging.error('Bootstrap command failed')
                 logging.error('Command: %s', ce.command)
-                if ce.result.stderr_text:
+                stderr = results_stderr_52lts(ce.result)
+                if stderr:
                     logging.error('stderr output:')
-                    logging.error(ce.result.stderr_text)
-                if ce.result.stdout_text:
+                    logging.error(stderr)
+                stdout = results_stdout_52lts(ce.result)
+                if stdout:
                     logging.error('stdout output:')
-                    logging.error(ce.result.stdout_text)
+                    logging.error(stdout)
             sys.exit(1)
         except KeyboardInterrupt:
             logging.info('Bootstrap interrupted by user')

--- a/examples/tests/hostname.py
+++ b/examples/tests/hostname.py
@@ -9,6 +9,7 @@ Before this test please set your hostname to something meaningful.
 import logging
 
 from avocado.utils import process
+from virttest.compat_52lts import results_stdout_52lts
 
 
 def run(test, params, env):
@@ -20,4 +21,5 @@ def run(test, params, env):
     :param env: Dictionary with test environment.
     """
     result = process.run("hostname")
-    logging.info("Output of 'hostname' cmd is '%s'", result.stdout_text)
+    logging.info("Output of 'hostname' cmd is '%s'",
+                 results_stdout_52lts(result))

--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -7,6 +7,8 @@ import os
 import unittest
 
 from avocado.utils import process
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
+
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
 basedir = os.path.abspath(basedir)
@@ -32,8 +34,8 @@ class DocBuildTest(unittest.TestCase):
         doc_dir = os.path.join(basedir, 'docs')
         process.run('make -C %s clean' % doc_dir)
         result = process.run('make -C %s html' % doc_dir)
-        stdout = result.stdout_text.splitlines()
-        stderr = result.stderr_text.splitlines()
+        stdout = results_stdout_52lts(result).splitlines()
+        stderr = results_stderr_52lts(result).splitlines()
         output_lines = stdout + stderr
         for line in output_lines:
             ignore_msg = False

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -18,6 +18,8 @@ from . import cartesian_config
 from . import utils_selinux
 from . import defaults
 from . import arch
+from .compat_52lts import results_stdout_52lts
+
 
 LOG = logging.getLogger("avocado.app")
 
@@ -285,7 +287,8 @@ def sync_download_dir(interactive):
                 diff_cmd, ignore_status=True, verbose=False)
             if diff_result.exit_status != 0:
                 LOG.debug("%s result:\n %s",
-                          diff_result.command, diff_result.stdout_text)
+                          diff_result.command,
+                          results_stdout_52lts(diff_result))
                 answer = genio.ask('Download file "%s" differs from "%s". '
                                    'Overwrite?' % (dst_file, src_file),
                                    auto=not interactive)
@@ -600,7 +603,8 @@ def create_config_files(test_dir, shared_dir, interactive, t_type, step=None,
                 diff_cmd, ignore_status=True, verbose=False)
             if diff_result.exit_status != 0:
                 LOG.info("%s result:\n %s",
-                         diff_result.command, diff_result.stdout_text)
+                         diff_result.command,
+                         results_stdout_52lts(diff_result))
                 answer = genio.ask("Config file  %s differs from %s."
                                    "Overwrite?" % (dst_file, src_file),
                                    auto=force_update or not interactive)

--- a/virttest/compat_52lts.py
+++ b/virttest/compat_52lts.py
@@ -1,0 +1,42 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2018
+# Author: Lukas Doktor <ldoktor@redhat.com>
+
+"""
+This module contains helpers that allows running Avocado-vt with Avocado
+master as well as with 52.x LTS release.
+"""
+
+
+def results_stdout_52lts(result):
+    """
+    Get decoded stdout text in 52.x LTS backward compatible way
+
+    :param result: result object
+    """
+    if hasattr(result, "stdout_text"):
+        return result.stdout_text
+    else:   # 52lts stores string
+        return result.stdout
+
+
+def results_stderr_52lts(result):
+    """
+    Get decoded stderr text in 52.x LTS backward compatible way
+
+    :param result: result object
+    """
+    if hasattr(result, "stderr_text"):
+        return result.stderr_text
+    else:   # 52lts stores string
+        return result.stderr

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -22,6 +22,8 @@ from . import utils_net
 from . import data_dir
 from . import utils_package
 from .staging import service
+from .compat_52lts import results_stderr_52lts
+
 
 ISCSI_CONFIG_FILE = "/etc/iscsi/initiatorname.iscsi"
 
@@ -149,8 +151,9 @@ def iscsi_logout(target_name=None):
     except process.CmdError as detail:
         # iscsiadm will fail when no matching sessions found
         # This failure makes no sense when target name is not specified
-        if not target_name and 'No matching sessions' in detail.result.stderr_text:
-            logging.info("%s: %s", detail, detail.result.stderr_text)
+        stderr = results_stderr_52lts(detail.result)
+        if not target_name and 'No matching sessions' in stderr:
+            logging.info("%s: %s", detail, stderr)
         else:
             raise
 

--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -14,6 +14,7 @@ from avocado.utils import process
 
 from . import storage
 from . import virsh
+from .compat_52lts import results_stdout_52lts
 
 
 class QemuImg(storage.QemuImg):
@@ -131,7 +132,7 @@ class StoragePool(object):
         # Allow it raise exception if command has executed failed.
         result = self.virsh_instance.pool_list("--all", ignore_status=False)
         pools = {}
-        lines = result.stdout_text.strip().splitlines()
+        lines = results_stdout_52lts(result).strip().splitlines()
         if len(lines) > 2:
             head = lines[0]
             lines = lines[2:]
@@ -201,7 +202,7 @@ class StoragePool(object):
         except process.CmdError:
             return info
 
-        for line in result.stdout_text.splitlines():
+        for line in results_stdout_52lts(result).splitlines():
             params = line.split(':')
             if len(params) == 2:
                 name = params[0].strip()
@@ -438,7 +439,7 @@ class PoolVolume(object):
             logging.error('List volume failed: %s', detail)
             return volumes
 
-        lines = result.stdout_text.strip().splitlines()
+        lines = results_stdout_52lts(result).strip().splitlines()
         if len(lines) > 2:
             head = lines[0]
             lines = lines[2:]
@@ -472,7 +473,7 @@ class PoolVolume(object):
             logging.error("Get volume information failed: %s", detail)
             return info
 
-        for line in result.stdout_text.strip().splitlines():
+        for line in results_stdout_52lts(result).strip().splitlines():
             attr = line.split(':')[0]
             value = line.split("%s:" % attr)[-1].strip()
             info[attr] = value
@@ -563,4 +564,4 @@ def check_qemu_image_lock_support():
                                "qemu-img command is not found")
     cmd_result = process.run(binary_path + ' -h', ignore_status=True,
                              shell=True, verbose=False)
-    return '-U' in cmd_result.stdout_text
+    return '-U' in results_stdout_52lts(cmd_result)

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -31,6 +31,7 @@ from . import xml_utils
 from . import utils_selinux
 from . import test_setup
 from . import utils_package
+from .compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 def normalize_connect_uri(connect_uri):
@@ -133,9 +134,9 @@ class Monitor(object):
         result = virsh.qemu_monitor_command(self.name, cmd,
                                             options=self.protocol, **dargs)
         if result.exit_status != 0:
-            raise exceptions.TestError("Failed to execute monitor cmd %s: %s" %
-                                       cmd, result.stderr_text)
-        return result.stdout_text
+            raise exceptions.TestError("Failed to execute monitor cmd %s: %s"
+                                       % cmd, results_stderr_52lts(result))
+        return results_stderr_52lts(result)
 
     def system_powerdown(self):
         """
@@ -259,8 +260,8 @@ class VM(virt_vm.BaseVM):
         Return True if VM is persistent.
         """
         try:
-            dominfo = (virsh.dominfo(self.name,
-                                     uri=self.connect_uri).stdout_text.strip())
+            result = virsh.dominfo(self.name, uri=self.connect_uri)
+            dominfo = results_stdout_52lts(result).strip()
             return bool(re.search(r"^Persistent:\s+[Yy]es", dominfo,
                                   re.MULTILINE))
         except process.CmdError:
@@ -271,8 +272,8 @@ class VM(virt_vm.BaseVM):
         Return True if VM is autostart.
         """
         try:
-            dominfo = (virsh.dominfo(self.name,
-                                     uri=self.connect_uri).stdout_text.strip())
+            result = virsh.dominfo(self.name, uri=self.connect_uri)
+            dominfo = results_stdout_52lts(result).strip()
             return bool(re.search(r"^Autostart:\s+enable", dominfo,
                                   re.MULTILINE))
         except process.CmdError:
@@ -315,19 +316,22 @@ class VM(virt_vm.BaseVM):
         """
         Return domain state.
         """
-        return virsh.domstate(self.name, uri=self.connect_uri).stdout_text.strip()
+        result = virsh.domstate(self.name, uri=self.connect_uri)
+        return results_stdout_52lts(result).strip()
 
     def get_id(self):
         """
         Return VM's ID.
         """
-        return virsh.domid(self.name, uri=self.connect_uri).stdout_text.strip()
+        result = virsh.domid(self.name, uri=self.connect_uri)
+        return results_stdout_52lts(result).strip()
 
     def get_xml(self):
         """
         Return VM's xml file.
         """
-        return virsh.dumpxml(self.name, uri=self.connect_uri).stdout_text.strip()
+        result = virsh.dumpxml(self.name, uri=self.connect_uri)
+        return results_stdout_52lts(result).strip()
 
     def backup_xml(self, active=False):
         """
@@ -1942,7 +1946,7 @@ class VM(virt_vm.BaseVM):
             try:
                 process.run(install_command, verbose=True, shell=True)
             except process.CmdError as details:
-                stderr = details.result.stderr_text.strip()
+                stderr = results_stderr_52lts(details.result).strip()
                 # This is a common newcomer mistake, be more helpful...
                 if stderr.count('IDE CDROM must use'):
                     testname = params.get('name', "")
@@ -1974,8 +1978,8 @@ class VM(virt_vm.BaseVM):
             utils_misc.wait_for(func=self.is_alive, timeout=60,
                                 text=("waiting for domain %s to start" %
                                       self.name))
-            self.uuid = virsh.domuuid(self.name,
-                                      uri=self.connect_uri).stdout_text.strip()
+            result = virsh.domuuid(self.name, uri=self.connect_uri)
+            self.uuid = results_stdout_52lts(result).strip()
             # Create isa serial ports.
             self.create_serial_console()
         finally:
@@ -2032,7 +2036,8 @@ class VM(virt_vm.BaseVM):
                                    debug=debug)
         if result.exit_status:
             logging.error("Failed to attach disk %s to VM."
-                          "Detail: %s." % (source, result.stderr_text))
+                          "Detail: %s."
+                          % (source, results_stderr_52lts(result)))
             return None
         return target
 
@@ -2157,7 +2162,8 @@ class VM(virt_vm.BaseVM):
         """
         Return VM's UUID.
         """
-        uuid = virsh.domuuid(self.name, uri=self.connect_uri).stdout_text.strip()
+        result = virsh.domuuid(self.name, uri=self.connect_uri)
+        uuid = results_stdout_52lts(result).strip()
         # only overwrite it if it's not set
         if self.uuid is None:
             self.uuid = uuid
@@ -2178,7 +2184,7 @@ class VM(virt_vm.BaseVM):
         if cmd_result.exit_status:
             raise exceptions.TestFail("dumpxml %s failed.\n"
                                       "Detail: %s.\n" % (self.name, cmd_result))
-        thexml = cmd_result.stdout_text.strip()
+        thexml = results_stdout_52lts(cmd_result).strip()
         xtf = xml_utils.XMLTreeFile(thexml)
         interfaces = xtf.find('devices').findall('interface')
         # Range check
@@ -2245,7 +2251,8 @@ class VM(virt_vm.BaseVM):
         """
         output = virsh.qemu_monitor_command(self.name, "info cpus", "--hmp",
                                             uri=self.connect_uri)
-        vcpu_pids = re.findall(r'thread_id=(\d+)', output.stdout_text)
+        vcpu_pids = re.findall(r'thread_id=(\d+)',
+                               results_stdout_52lts(output))
         return vcpu_pids
 
     def get_shell_pid(self):
@@ -2351,8 +2358,8 @@ class VM(virt_vm.BaseVM):
         """
         Starts this VM.
         """
-        self.uuid = virsh.domuuid(self.name,
-                                  uri=self.connect_uri).stdout_text.strip()
+        uid_result = virsh.domuuid(self.name, uri=self.connect_uri)
+        self.uuid = results_stdout_52lts(uid_result).strip()
 
         logging.debug("Starting vm '%s'", self.name)
         result = virsh.start(self.name, uri=self.connect_uri)
@@ -2364,13 +2371,14 @@ class VM(virt_vm.BaseVM):
             if has_started is None:
                 raise virt_vm.VMStartError(self.name, "libvirt domain not "
                                                       "active after start")
-            self.uuid = virsh.domuuid(self.name,
-                                      uri=self.connect_uri).stdout_text.strip()
+            uid_result = virsh.domuuid(self.name, uri=self.connect_uri)
+            self.uuid = results_stdout_52lts(uid_result).strip()
             # Establish a session with the serial console
             if autoconsole:
                 self.create_serial_console()
         else:
-            raise virt_vm.VMStartError(self.name, result.stderr_text.strip())
+            raise virt_vm.VMStartError(self.name,
+                                       results_stderr_52lts(result).strip())
 
         # Pull in mac addresses from libvirt guest definition
         for index, nic in enumerate(self.virtnet):
@@ -2463,7 +2471,8 @@ class VM(virt_vm.BaseVM):
         result = virsh.save(self.name, path, uri=self.connect_uri)
         if result.exit_status:
             raise virt_vm.VMError("Save VM to %s failed.\n"
-                                  "Detail: %s." % (path, result.stderr_text))
+                                  "Detail: %s."
+                                  % (path, results_stderr_52lts(result)))
         if self.is_alive():
             raise virt_vm.VMStatusError("VM not shut off after save")
         self.cleanup_serial_console()
@@ -2479,7 +2488,8 @@ class VM(virt_vm.BaseVM):
         result = virsh.restore(path, uri=self.connect_uri)
         if result.exit_status:
             raise virt_vm.VMError("Restore VM from %s failed.\n"
-                                  "Detail: %s." % (path, result.stderr_text))
+                                  "Detail: %s."
+                                  % (path, results_stderr_52lts(result)))
         if self.is_dead():
             raise virt_vm.VMStatusError(
                 "VM should not be %s after restore." % self.state())
@@ -2496,7 +2506,8 @@ class VM(virt_vm.BaseVM):
         result = virsh.managedsave(self.name, uri=self.connect_uri)
         if result.exit_status:
             raise virt_vm.VMError("Managed save VM failed.\n"
-                                  "Detail: %s." % result.stderr_text)
+                                  "Detail: %s."
+                                  % results_stderr_52lts(result))
         if self.is_alive():
             raise virt_vm.VMStatusError("VM not shut off after managed save")
         self.cleanup_serial_console()
@@ -2513,7 +2524,8 @@ class VM(virt_vm.BaseVM):
                                     duration=duration, uri=self.connect_uri)
         if result.exit_status:
             raise virt_vm.VMError("PM suspending VM failed.\n"
-                                  "Detail: %s." % result.stderr_text)
+                                  "Detail: %s."
+                                  % results_stderr_52lts(result))
         self.cleanup_serial_console()
 
     def pmwakeup(self):
@@ -2527,7 +2539,8 @@ class VM(virt_vm.BaseVM):
         result = virsh.dompmwakeup(self.name, uri=self.connect_uri)
         if result.exit_status:
             raise virt_vm.VMError("PM waking up VM failed.\n"
-                                  "Detail: %s." % result.stderr_text)
+                                  "Detail: %s."
+                                  % results_stderr_52lts(result))
         self.create_serial_console()
 
     def vcpupin(self, vcpu, cpu_list, options=""):
@@ -2544,7 +2557,8 @@ class VM(virt_vm.BaseVM):
         """
         Return a dict include vm's information.
         """
-        output = virsh.dominfo(self.name, uri=self.connect_uri).stdout_text.strip()
+        result = virsh.dominfo(self.name, uri=self.connect_uri)
+        output = results_stdout_52lts(result).strip()
         # Key: word before ':' | value: content after ':' (stripped)
         dominfo_dict = {}
         for line in output.splitlines():
@@ -2557,8 +2571,8 @@ class VM(virt_vm.BaseVM):
         """
         Return a dict's list include vm's vcpu information.
         """
-        output = virsh.vcpuinfo(self.name,
-                                uri=self.connect_uri).stdout_text.strip()
+        result = virsh.vcpuinfo(self.name, uri=self.connect_uri)
+        output = results_stdout_52lts(result).strip()
         # Key: word before ':' | value: content after ':' (stripped)
         vcpuinfo_list = []
         vcpuinfo_dict = {}
@@ -2576,8 +2590,8 @@ class VM(virt_vm.BaseVM):
         via virsh command
         """
         result = virsh.domfsinfo(self.name, ignore_status=False,
-                                 uri=self.connect_uri).stdout_text.strip()
-        lines = result.splitlines()
+                                 uri=self.connect_uri)
+        lines = results_stdout_52lts(result).strip().splitlines()
         domfsinfo_list = []
         if len(lines) > 2:
             head = lines[0]
@@ -2609,7 +2623,7 @@ class VM(virt_vm.BaseVM):
         options = "--details"
         result = virsh.domblklist(self.name, options, ignore_status=True,
                                   uri=self.connect_uri)
-        blklist = result.stdout_text.strip().splitlines()
+        blklist = results_stdout_52lts(result).strip().splitlines()
         if result.exit_status != 0:
             logging.info("Get vm devices failed.")
         else:
@@ -2643,7 +2657,7 @@ class VM(virt_vm.BaseVM):
         options = "--details"
         result = virsh.domblklist(self.name, options, ignore_status=True,
                                   uri=self.connect_uri)
-        blklist = result.stdout_text.strip().splitlines()
+        blklist = results_stdout_52lts(result).strip().splitlines()
         if result.exit_status != 0:
             logging.info("Get vm devices failed.")
         else:
@@ -2659,7 +2673,7 @@ class VM(virt_vm.BaseVM):
         device_details = {}
         result = virsh.domblkinfo(self.name, device_target,
                                   uri=self.connect_uri)
-        details = result.stdout_text.strip().splitlines()
+        details = results_stdout_52lts(result).strip().splitlines()
         if result.exit_status != 0:
             logging.info("Get vm device details failed.")
         else:
@@ -2709,7 +2723,7 @@ class VM(virt_vm.BaseVM):
     def get_job_type(self):
         jobresult = virsh.domjobinfo(self.name, uri=self.connect_uri)
         if not jobresult.exit_status:
-            for line in jobresult.stdout_text.splitlines():
+            for line in results_stdout_52lts(jobresult).splitlines():
                 key = line.split(':')[0]
                 value = line.split(':')[-1]
                 if key.count("type"):

--- a/virttest/libvirt_xml/domcapability_xml.py
+++ b/virttest/libvirt_xml/domcapability_xml.py
@@ -6,6 +6,7 @@ import logging
 
 from virttest import xml_utils
 from virttest.libvirt_xml import base, accessors, xcepts
+from virttest.compat_52lts import results_stdout_52lts
 
 
 class DomCapabilityXML(base.LibvirtXMLBase):
@@ -31,7 +32,8 @@ class DomCapabilityXML(base.LibvirtXMLBase):
         accessors.XMLAttribute('max', self, parent_xpath='/',
                                tag_name='vcpu', attribute='max')
         super(DomCapabilityXML, self).__init__(virsh_instance)
-        self['xml'] = self.__dict_get__('virsh').domcapabilities().stdout_text.strip()
+        result = self.__dict_get__('virsh').domcapabilities()
+        self['xml'] = results_stdout_52lts(result).strip()
 
     def get_additional_feature_list(self, cpu_mode_name):
         """

--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -8,6 +8,7 @@ import logging
 from virttest import xml_utils
 from virttest.libvirt_xml import base, xcepts, accessors
 from virttest.libvirt_xml.devices import librarian
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class RangeList(list):
@@ -681,7 +682,8 @@ class NetworkXML(NetworkXMLBase):
         networks = list(new_netxml.virsh.net_state_dict(**params).keys())
         for net_name in networks:
             new_copy = new_netxml.copy()
-            new_copy.xml = virsh_instance.net_dumpxml(net_name).stdout_text.strip()
+            dump_result = virsh_instance.net_dumpxml(net_name)
+            new_copy.xml = results_stdout_52lts(dump_result).strip()
             result[net_name] = new_copy
         return result
 
@@ -695,8 +697,8 @@ class NetworkXML(NetworkXMLBase):
         :return: New initialized NetworkXML instance
         """
         netxml = NetworkXML(virsh_instance=virsh_instance)
-        netxml['xml'] = virsh_instance.net_dumpxml(network_name,
-                                                   extra).stdout_text.strip()
+        dump_result = virsh_instance.net_dumpxml(network_name, extra)
+        netxml['xml'] = results_stdout_52lts(dump_result).strip()
         return netxml
 
     @staticmethod
@@ -768,7 +770,8 @@ class NetworkXML(NetworkXMLBase):
         if cmd_result.exit_status:
             raise xcepts.LibvirtXMLError("Failed to undefine network %s.\n"
                                          "Detail: %s" %
-                                         (self.name, cmd_result.stderr_text))
+                                         (self.name,
+                                          results_stderr_52lts(cmd_result)))
 
     def define(self):
         """
@@ -778,7 +781,8 @@ class NetworkXML(NetworkXMLBase):
         if cmd_result.exit_status:
             raise xcepts.LibvirtXMLError("Failed to define network %s.\n"
                                          "Detail: %s" %
-                                         (self.name, cmd_result.stderr_text))
+                                         (self.name,
+                                          results_stderr_52lts(cmd_result)))
 
     def start(self):
         """
@@ -788,7 +792,8 @@ class NetworkXML(NetworkXMLBase):
         if cmd_result.exit_status:
             raise xcepts.LibvirtXMLError("Failed to start network %s.\n"
                                          "Detail: %s" %
-                                         (self.name, cmd_result.stderr_text))
+                                         (self.name,
+                                          results_stderr_52lts(cmd_result)))
 
     def sync(self, state=None):
         """

--- a/virttest/libvirt_xml/nodedev_xml.py
+++ b/virttest/libvirt_xml/nodedev_xml.py
@@ -6,6 +6,7 @@ http://libvirt.org/formatnode.html
 import os
 
 from virttest.libvirt_xml import base, xcepts, accessors
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class CAPXML(base.LibvirtXMLBase):
@@ -444,10 +445,10 @@ class NodedevXML(NodedevXMLBase):
         nodedevxml = NodedevXML(virsh_instance=virsh_instance)
         dumpxml_result = virsh_instance.nodedev_dumpxml(dev_name)
         if dumpxml_result.exit_status:
+            stderr = results_stderr_52lts(dumpxml_result)
             raise xcepts.LibvirtXMLError("Nodedev_dumpxml %s failed.\n"
-                                         "Error: %s."
-                                         % (dev_name, dumpxml_result.stderr_text))
-        nodedevxml.xml = dumpxml_result.stdout_text
+                                         "Error: %s." % (dev_name, stderr))
+        nodedevxml.xml = results_stdout_52lts(dumpxml_result)
 
         return nodedevxml
 

--- a/virttest/libvirt_xml/nwfilter_xml.py
+++ b/virttest/libvirt_xml/nwfilter_xml.py
@@ -5,6 +5,7 @@ http://libvirt.org/formatnwfilter.html
 
 from virttest.libvirt_xml import base, xcepts, accessors
 from virttest.libvirt_xml.nwfilter_protocols import librarian
+from virttest.compat_52lts import results_stdout_52lts
 
 
 class NwfilterRulesProtocol(list):
@@ -308,9 +309,8 @@ class NwfilterXML(NwfilterXMLBase):
         :return: New initialized NwfilterXML instance
         """
         filter_xml = NwfilterXML(virsh_instance=virsh_instance)
-        filter_xml['xml'] = virsh_instance.nwfilter_dumpxml(uuid,
-                                                            options=options
-                                                            ).stdout_text.strip()
+        result = virsh_instance.nwfilter_dumpxml(uuid, options=options)
+        filter_xml['xml'] = results_stdout_52lts(result).strip()
 
         return filter_xml
 

--- a/virttest/libvirt_xml/pool_xml.py
+++ b/virttest/libvirt_xml/pool_xml.py
@@ -11,6 +11,7 @@ from avocado.utils import process
 from .. import data_dir
 from .. import libvirt_storage
 from ..libvirt_xml import base, xcepts, accessors
+from ..compat_52lts import results_stderr_52lts
 
 
 class SourceXML(base.LibvirtXMLBase):
@@ -304,7 +305,8 @@ class PoolXML(PoolXMLBase):
         result = self.virsh.pool_define(self.xml)
         if result.exit_status:
             logging.error("Define %s failed.\n"
-                          "Detail: %s.", self.name, result.stderr_text)
+                          "Detail: %s.", self.name,
+                          results_stderr_52lts(result))
             return False
         return True
 

--- a/virttest/libvirt_xml/secret_xml.py
+++ b/virttest/libvirt_xml/secret_xml.py
@@ -5,6 +5,7 @@ http://libvirt.org/formatsecret.html
 
 from virttest.libvirt_xml import base, accessors
 from virttest.libvirt_xml import xcepts
+from virttest.compat_52lts import results_stdout_52lts
 
 
 class SecretXMLBase(base.LibvirtXMLBase):
@@ -96,7 +97,8 @@ class SecretXML(SecretXMLBase):
         :return: New initialized SecretXML instance
         """
         secret_xml = SecretXML(virsh_instance=virsh_instance)
-        secret_xml['xml'] = virsh_instance.secret_dumpxml(uuid).stdout_text.strip()
+        result = virsh_instance.secret_dumpxml(uuid)
+        secret_xml['xml'] = results_stdout_52lts(result).strip()
 
         return secret_xml
 

--- a/virttest/libvirt_xml/snapshot_xml.py
+++ b/virttest/libvirt_xml/snapshot_xml.py
@@ -7,6 +7,7 @@ from virttest import xml_utils
 from virttest.libvirt_xml import base, accessors
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml import xcepts
+from virttest.compat_52lts import results_stdout_52lts
 
 
 class SnapshotXMLBase(base.LibvirtXMLBase):
@@ -81,8 +82,8 @@ class SnapshotXML(SnapshotXMLBase):
         :return: New initialized SnapshotXML instance
         """
         snapshot_xml = SnapshotXML(virsh_instance=virsh_instance)
-        snapshot_xml['xml'] = virsh_instance.snapshot_dumpxml(
-            name, snap_name).stdout_text.strip()
+        result = virsh_instance.snapshot_dumpxml(name, snap_name)
+        snapshot_xml['xml'] = results_stdout_52lts(result).strip()
 
         return snapshot_xml
 

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -10,6 +10,7 @@ from .. import xml_utils
 from .. import utils_misc
 from ..libvirt_xml import base, accessors, xcepts
 from ..libvirt_xml.devices import librarian
+from ..compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class VMXMLDevices(list):
@@ -581,8 +582,8 @@ class VMXML(VMXMLBase):
         """
         # TODO: Look up hypervisor_type on incoming XML
         vmxml = VMXML(virsh_instance=virsh_instance)
-        vmxml['xml'] = virsh_instance.dumpxml(vm_name,
-                                              extra=options).stdout_text.strip()
+        result = virsh_instance.dumpxml(vm_name, extra=options)
+        vmxml['xml'] = results_stdout_52lts(result).strip()
         return vmxml
 
     @staticmethod
@@ -622,7 +623,8 @@ class VMXML(VMXMLBase):
         result = virsh_instance.define(self.xml)
         if result.exit_status:
             logging.debug("Define %s failed.\n"
-                          "Detail: %s.", self.vm_name, result.stderr_text)
+                          "Detail: %s.", self.vm_name,
+                          results_stderr_52lts(result))
             return False
         return True
 

--- a/virttest/libvirt_xml/vol_xml.py
+++ b/virttest/libvirt_xml/vol_xml.py
@@ -5,6 +5,7 @@ http://libvirt.org/formatstorage.html#StorageVol
 
 from virttest.libvirt_xml import base, accessors
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
+from virttest.compat_52lts import results_stdout_52lts
 
 
 class VolXMLBase(base.LibvirtXMLBase):
@@ -119,8 +120,8 @@ class VolXML(VolXMLBase):
         :return: New initialized VolXML instance
         """
         volxml = VolXML(virsh_instance=virsh_instance)
-        volxml['xml'] = virsh_instance.vol_dumpxml(vol_name, pool_name)\
-                                      .stdout_text.strip()
+        result = virsh_instance.vol_dumpxml(vol_name, pool_name)
+        volxml['xml'] = results_stdout_52lts(result).strip()
         return volxml
 
     @staticmethod

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -33,6 +33,7 @@ from avocado.utils import process
 
 from . import utils_misc
 from . import data_dir
+from .compat_52lts import results_stdout_52lts
 
 UNIT = "B"
 COMMON_OPTS = "--noheading --nosuffix --unit=%s" % UNIT
@@ -50,7 +51,7 @@ def cmd_output(cmd, res="[\w/]+"):
     if result.exit_status != 0:
         logging.warn(result)
         return None
-    output = result.stdout_text
+    output = results_stdout_52lts(result)
     for line in output.splitlines():
         val = re.findall(res, line)
         if val:

--- a/virttest/lvsbs.py
+++ b/virttest/lvsbs.py
@@ -7,6 +7,7 @@ from avocado.utils import service
 
 from . import lvsb_base
 from . import virsh
+from .compat_52lts import results_stdout_52lts
 
 
 class SandboxService(object):
@@ -94,7 +95,7 @@ class SandboxService(object):
         cmdresult = self.virsh.dom_list()  # uri is passed automatically
         result = []
         column_names = None  # scope outside loop
-        for lineno, line in cmdresult.stdout_text.strip():
+        for lineno, line in results_stdout_52lts(cmdresult).strip():
             if lineno == 0:
                 column_names = line.strip().split()
                 assert len(column_names) > 2
@@ -110,4 +111,5 @@ class SandboxService(object):
     # Specialized list calls can just call self.virsh.dom_list() directly
     @property  # behave like attribute for easy passing to XML handling methods
     def xmlstr(self):
-        return self.virsh.dumpxml(self.service_name).stdout_text.strip()
+        result = self.virsh.dumpxml(self.service_name)
+        return results_stdout_52lts(result).strip()

--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -7,6 +7,7 @@ from avocado.utils import path
 from avocado.utils import process
 from avocado.utils import linux_modules
 
+from .compat_52lts import results_stdout_52lts
 from .versionable_class import VersionableClass, Manager, factory
 from . import utils_misc
 
@@ -171,7 +172,8 @@ class OpenVSwitchControl(object):
             result = process.run("%s --version" %
                                  path.find_command("ovs-vswitchd"))
             pattern = "ovs-vswitchd \(Open vSwitch\) (\d+\.\d+\.\d+).*"
-            version = re.search(pattern, result.stdout_text).group(1)
+            version = re.search(pattern,
+                                results_stdout_52lts(result)).group(1)
         except process.CmdError:
             logging.debug("OpenVSwitch is not available in system.")
         return version
@@ -264,7 +266,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
                            ignore_status=ignore_status, verbose=False)
 
     def status(self):
-        return self.ovs_vsctl(["show"]).stdout_text
+        return results_stdout_52lts(self.ovs_vsctl(["show"]))
 
     def add_br(self, br_name):
         self.ovs_vsctl(["add-br", br_name])
@@ -290,7 +292,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
         return True
 
     def list_br(self):
-        return self.ovs_vsctl(["list-br"]).stdout_text.splitlines()
+        return results_stdout_52lts(self.ovs_vsctl(["list-br"])).splitlines()
 
     def add_port(self, br_name, port_name):
         self.ovs_vsctl(["add-port", br_name, port_name])
@@ -313,7 +315,8 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
         self.ovs_vsctl(["set", "Port", port_name, "vlan-mode=%s" % vlan_mode])
 
     def list_ports(self, br_name):
-        return self.ovs_vsctl(["list-ports", br_name]).stdout_text.splitlines()
+        result = self.ovs_vsctl(["list-ports", br_name])
+        return results_stdout_52lts(result).splitlines()
 
     def port_to_br(self, port_name):
         """
@@ -324,7 +327,8 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
         """
         bridge = None
         try:
-            bridge = self.ovs_vsctl(["port-to-br", port_name]).stdout_text.strip()
+            result = self.ovs_vsctl(["port-to-br", port_name])
+            bridge = results_stdout_52lts(result).strip()
         except process.CmdError as e:
             if e.result.exit_status == 1:
                 pass

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -25,6 +25,7 @@ from .. import arch, storage, data_dir, virt_vm
 from . import qdevices
 from .utils import (DeviceError, DeviceHotplugError, DeviceInsertError,
                     DeviceRemoveError, DeviceUnplugError, none_or_int)
+from ..compat_52lts import results_stdout_52lts
 
 #
 # Device container (device representation of VM)
@@ -433,14 +434,14 @@ class DevContainer(object):
                                  ignore_status=True,
                                  shell=True,
                                  verbose=False)
-            if result.exit_status and "machine specified" in result.stdout_text:
+            if result.exit_status and b"machine specified" in result.stdout:
                 # TODO: Arm requires machine to be specified, let's try again
                 # with dummy "virt" machine
                 result = process.run("%s -machine virt %s 2>&1"
                                      % (self.__qemu_binary, options),
                                      ignore_status=True, shell=True,
                                      verbose=False)
-            self.__execute_qemu_out = str(result.stdout_text)
+            self.__execute_qemu_out = results_stdout_52lts(result)
         self.__execute_qemu_last = options
         return self.__execute_qemu_out
 

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -19,6 +19,7 @@ from . import virt_vm
 from . import storage
 from . import data_dir
 from . import error_context
+from .compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class QemuImg(storage.QemuImg):
@@ -39,7 +40,7 @@ class QemuImg(storage.QemuImg):
         self.image_cmd = utils_misc.get_qemu_img_binary(params)
         q_result = process.run(self.image_cmd + ' -h', ignore_status=True,
                                shell=True, verbose=False)
-        self.help_text = q_result.stdout_text
+        self.help_text = results_stdout_52lts(q_result)
         self.cap_force_share = '-U' in self.help_text
 
     @error_context.context_aware
@@ -472,7 +473,8 @@ class QemuImg(storage.QemuImg):
                                      shell=True)
 
             if verbose:
-                logging.debug("Output from command: %s" % cmd_result.stdout_text)
+                logging.debug("Output from command: %s",
+                              results_stdout_52lts(cmd_result))
 
             if cmd_result.exit_status == 0:
                 logging.info("Compared images are equal")
@@ -523,9 +525,11 @@ class QemuImg(storage.QemuImg):
                 # Error check, large chances of a non-fatal problem.
                 # There are chances that bad data was skipped though
                 if cmd_result.exit_status == 1:
-                    for e_line in cmd_result.stdout_text.splitlines():
+                    stdout = results_stdout_52lts(cmd_result)
+                    for e_line in stdout.splitlines():
                         logging.error("[stdout] %s", e_line)
-                    for e_line in cmd_result.stderr_text.splitlines():
+                    stderr = results_stderr_52lts(cmd_result)
+                    for e_line in stderr.splitlines():
                         logging.error("[stderr] %s", e_line)
                     chk = params.get("backup_image_on_check_error", "no")
                     if chk == "yes":
@@ -536,9 +540,11 @@ class QemuImg(storage.QemuImg):
                 # Exit status 2 is data corruption for sure,
                 # so fail the test
                 elif cmd_result.exit_status == 2:
-                    for e_line in cmd_result.stdout_text.splitlines():
+                    stdout = results_stdout_52lts(cmd_result)
+                    for e_line in stdout.splitlines():
                         logging.error("[stdout] %s", e_line)
-                    for e_line in cmd_result.stderr_text.splitlines():
+                    stderr = results_stderr_52lts(cmd_result)
+                    for e_line in stderr.splitlines():
                         logging.error("[stderr] %s", e_line)
                     chk = params.get("backup_image_on_check_error", "no")
                     if chk == "yes":

--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -22,6 +22,8 @@ import logging
 from tempfile import mktemp
 
 from avocado.utils import process
+from virttest.compat_52lts import results_stdout_52lts
+
 
 _COMMAND_TABLE_DOC = """
 
@@ -96,7 +98,7 @@ def sysvinit_status_parser(cmdResult=None):
     """
     # If service is stopped, exit_status is also not zero.
     # So, we can't use exit_status to check result.
-    result = cmdResult.stdout_text.lower()
+    result = results_stdout_52lts(cmdResult).lower()
     if re.search(r"unrecognized", result):
         return None
     dead_flags = [r"stopped", r"not running", r"dead"]
@@ -117,7 +119,7 @@ def systemd_status_parser(cmdResult=None):
     """
     # If service is stopped, exit_status is also not zero.
     # So, we can't use exit_status to check result.
-    result = cmdResult.stdout_text
+    result = results_stdout_52lts(cmdResult)
     # check for systemctl status XXX.service.
     if not re.search(r"Loaded: loaded", result):
         return None
@@ -147,7 +149,7 @@ def sysvinit_list_parser(cmdResult=None):
     _status_on_target = {}
     # Dict to store the status for service based on xinetd.
     _service2statusOnXinet_dict = {}
-    lines = cmdResult.stdout_text.strip().splitlines()
+    lines = results_stdout_52lts(cmdResult).strip().splitlines()
     for line in lines:
         sublines = line.strip().split()
         if len(sublines) == 8:
@@ -192,7 +194,7 @@ def systemd_list_parser(cmdResult=None):
         raise process.CmdError(cmdResult.command, cmdResult)
     # store service name and status.
     _service2status_dict = {}
-    lines = cmdResult.stdout_text.strip().splitlines()
+    lines = results_stdout_52lts(cmdResult).strip().splitlines()
     for line in lines:
         sublines = line.strip().split()
         if (not len(sublines) == 2) or (not sublines[0].endswith("service")):
@@ -731,7 +733,7 @@ class Factory(object):
             :return: executable name for PID 1, aka init
             :rtype:  str
             """
-            output = self.run("ps -o comm 1").stdout_text
+            output = results_stdout_52lts(self.run("ps -o comm 1"))
             return output.splitlines()[-1].strip()
 
         def get_generic_service_manager_type(self):

--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -20,6 +20,7 @@ from avocado.utils import software_manager
 from avocado.utils import process
 
 from . import service
+from ..compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class Cgroup(object):
@@ -203,8 +204,8 @@ class Cgroup(object):
         lscgroup_cmd = "lscgroup %s:/" % self.module
         result = process.run(lscgroup_cmd, ignore_status=True)
         if result.exit_status:
-            raise exceptions.TestFail(result.stderr_text.strip())
-        cgroup_list = result.stdout_text.strip().splitlines()
+            raise exceptions.TestFail(results_stderr_52lts(result).strip())
+        cgroup_list = results_stdout_52lts(result).strip().splitlines()
         # Remove root cgroup
         cgroup_list = cgroup_list[1:]
         self.root = get_cgroup_mountpoint(self.module)
@@ -661,7 +662,7 @@ def get_all_controllers():
     """
     try:
         result = process.run("lssubsys", ignore_status=False)
-        controllers_str = result.stdout_text.strip()
+        controllers_str = results_stdout_52lts(result).strip()
         controller_list = []
         for controller in controllers_str.splitlines():
             controller_sub_list = controller.split(",")

--- a/virttest/staging/utils_memory.py
+++ b/virttest/staging/utils_memory.py
@@ -6,12 +6,13 @@ import os
 
 from avocado.core import exceptions
 from avocado.utils import process
+from virttest.compat_52lts import results_stdout_52lts
 
 
 # Returns total memory in kb
 def read_from_meminfo(key):
     cmd_result = process.run('grep %s /proc/meminfo' % key, verbose=False)
-    meminfo = cmd_result.stdout_text
+    meminfo = results_stdout_52lts(cmd_result)
     return int(re.search(r'\d+', meminfo).group(0))
 
 
@@ -182,7 +183,7 @@ def read_from_numastat(pid, key):
     Get the process numastat from numastat output.
     """
     cmd = "numastat %s" % pid
-    numa_mem = process.run(cmd).stdout_text.strip()
+    numa_mem = results_stdout_52lts(process.run(cmd)).strip()
     mem_line = re.findall(r"^%s.*" % key, numa_mem, re.M)[0]
     return re.findall(r"(\d+.\d+)", mem_line)
 

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -34,6 +34,8 @@ from . import utils_libvirtd
 from . import utils_config
 from .staging import service
 from .staging import utils_memory
+from .compat_52lts import results_stderr_52lts
+
 
 ARCH = platform.machine()
 
@@ -2185,7 +2187,7 @@ def switch_indep_threads_mode(state="Y", params=None):
         try:
             thread_mode = process.system_output(cmd, shell=True)
         except process.CmdError as info:
-            thread_mode = info.result.stderr_text.strip()
+            thread_mode = results_stderr_52lts(info.result).strip()
             raise exceptions.TestSetupFail("Unable to get indep_threads_mode "
                                            "for power9 compat mode enablement"
                                            ": %s" % thread_mode)
@@ -2244,7 +2246,7 @@ def switch_smt(state="off", params=None):
         try:
             smt_output = process.system_output(cmd, shell=True).strip()
         except process.CmdError as info:
-            smt_output = info.result.stderr_text.strip()
+            smt_output = results_stderr_52lts(info.result).strip()
             if smt_output not in SMT_DISABLED_STRS:
                 raise exceptions.TestSetupFail("Couldn't get SMT of server: %s"
                                                % smt_output)

--- a/virttest/utils_conn.py
+++ b/virttest/utils_conn.py
@@ -13,6 +13,7 @@ from avocado.utils import process
 
 from . import propcan, remote, utils_libvirtd
 from . import data_dir
+from .compat_52lts import results_stderr_52lts
 
 
 class ConnectionError(Exception):
@@ -1275,7 +1276,7 @@ def build_client_key(tmp_dir, client_cn="TLSClient", certtool="certtool",
     cmd = "%s --generate-privkey > %s" % (certtool, clientkey_path)
     CmdResult = process.run(cmd, ignore_status=True, shell=True)
     if CmdResult.exit_status:
-        raise ConnPrivKeyError(clientkey_path, CmdResult.stderr_text)
+        raise ConnPrivKeyError(clientkey_path, results_stderr_52lts(CmdResult))
 
     # prepare a info file to build clientcert.
     clientinfo_file = open(clientinfo_path, "w")
@@ -1294,7 +1295,7 @@ def build_client_key(tmp_dir, client_cn="TLSClient", certtool="certtool",
             cakey_path, clientinfo_path, clientcert_path))
     CmdResult = process.run(cmd, ignore_status=True)
     if CmdResult.exit_status:
-        raise ConnCertError(clientinfo_path, CmdResult.stderr_text)
+        raise ConnCertError(clientinfo_path, results_stderr_52lts(CmdResult))
 
 
 def build_server_key(tmp_dir, ca_cakey_path=None,
@@ -1338,7 +1339,7 @@ def build_server_key(tmp_dir, ca_cakey_path=None,
     cmd = "%s --generate-privkey > %s" % (certtool, serverkey_path)
     cmd_result = process.run(cmd, ignore_status=True, shell=True)
     if cmd_result.exit_status:
-        raise ConnPrivKeyError(serverkey_path, cmd_result.stderr_text)
+        raise ConnPrivKeyError(serverkey_path, results_stderr_52lts(cmd_result))
 
     # prepare a info file to build servercert and serverkey
     serverinfo_file = open(serverinfo_path, "w")
@@ -1357,7 +1358,7 @@ def build_server_key(tmp_dir, ca_cakey_path=None,
             cakey_path, serverinfo_path, servercert_path))
     CmdResult = process.run(cmd, ignore_status=True)
     if CmdResult.exit_status:
-        raise ConnCertError(serverinfo_path, CmdResult.stderr_text)
+        raise ConnCertError(serverinfo_path, results_stderr_52lts(CmdResult))
 
 
 def build_CA(tmp_dir, cn="AUTOTEST.VIRT", ca_cakey_path=None,
@@ -1391,7 +1392,7 @@ def build_CA(tmp_dir, cn="AUTOTEST.VIRT", ca_cakey_path=None,
         cmd = "%s --generate-privkey > %s " % (certtool, cakey_path)
         cmd_result = process.run(cmd, ignore_status=True, timeout=10, shell=True)
         if cmd_result.exit_status:
-            raise ConnPrivKeyError(cakey_path, cmd_result.stderr_text)
+            raise ConnPrivKeyError(cakey_path, results_stderr_52lts(cmd_result))
     # prepare a info file to build certificate file
     cainfo_file = open(cainfo_path, "w")
     cainfo_file.write("cn = %s\n" % cn)
@@ -1405,7 +1406,7 @@ def build_CA(tmp_dir, cn="AUTOTEST.VIRT", ca_cakey_path=None,
            (certtool, cakey_path, cainfo_path, cacert_path))
     CmdResult = process.run(cmd, ignore_status=True)
     if CmdResult.exit_status:
-        raise ConnCertError(cainfo_path, CmdResult.stderr_text)
+        raise ConnCertError(cainfo_path, results_stderr_52lts(CmdResult))
 
 
 class UNIXConnection(ConnectionBase):

--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -12,6 +12,7 @@ from avocado.utils import path
 from avocado.utils import process
 
 from . import propcan
+from .compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class LibguestfsCmdError(Exception):
@@ -77,8 +78,8 @@ def lgf_command(cmd, ignore_status=True, debug=False, timeout=60):
 
     if debug:
         logging.debug("status: %s", ret.exit_status)
-        logging.debug("stdout: %s", ret.stdout_text.strip())
-        logging.debug("stderr: %s", ret.stderr_text.strip())
+        logging.debug("stdout: %s", results_stdout_52lts(ret).strip())
+        logging.debug("stderr: %s", results_stderr_52lts(ret).strip())
 
     # Return CmdResult instance when ignore_status is True
     return ret
@@ -312,7 +313,7 @@ class GuestfishRemote(object):
                                   verbose=True, timeout=60)
             except process.CmdError as detail:
                 raise LibguestfsCmdError(detail)
-            self.a_id = re.search("\d+", ret.stdout_text.strip()).group()
+            self.a_id = re.search(b"\d+", ret.stdout.strip()).group()
         else:
             self.a_id = a_id
 
@@ -338,15 +339,15 @@ class GuestfishRemote(object):
             raise LibguestfsCmdError(detail)
 
         for line in self.ERROR_REGEX_LIST:
-            if re.search(line, ret.stdout_text.strip()):
+            if re.search(line, results_stdout_52lts(ret).strip()):
                 e_msg = ('Error pattern %s found on output of %s: %s' %
-                         (line, cmd, ret.stdout_text.strip()))
+                         (line, cmd, results_stdout_52lts(ret).strip()))
                 raise LibguestfsCmdError(e_msg)
 
         logging.debug("command: %s", cmd)
-        logging.debug("stdout: %s", ret.stdout_text.strip())
+        logging.debug("stdout: %s", results_stdout_52lts(ret).strip())
 
-        return 0, ret.stdout_text.strip()
+        return 0, results_stdout_52lts(ret).strip()
 
     def cmd(self, cmd, ignore_status=False):
         """Mimic process.run()"""
@@ -4332,7 +4333,7 @@ def virt_sysprep_operations():
     """Get virt-sysprep support operation"""
     sys_list_cmd = "virt-sysprep --list-operations"
     result = lgf_command(sys_list_cmd, ignore_status=False)
-    oper_info = result.stdout_text.strip()
+    oper_info = results_stdout_52lts(result).strip()
     oper_dict = {}
     for oper_item in oper_info.splitlines():
         oper = oper_item.split("*")[0].strip()
@@ -4351,7 +4352,7 @@ def virt_cmd_contain_opt(virt_cmd, opt):
     result = lgf_command(virt_help_cmd, ignore_status=False)
     # "--add" will not equal to "--addxxx"
     opt = " " + opt.strip() + " "
-    return (result.stdout_text.count(opt) != 0)
+    return (results_stdout_52lts(result).count(opt) != 0)
 
 
 def virt_ls_cmd(disk_or_domain, file_dir_path, is_disk=False, options=None,

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -57,6 +57,7 @@ from virttest import utils_disk
 from virttest import logging_manager
 from virttest.staging import utils_koji
 from virttest.xml_utils import XMLTreeFile
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 import six
 from six.moves import xrange
@@ -836,7 +837,7 @@ def get_pci_id_using_filter(pci_filter, session=None):
     else:
         cmd_output = process.run(cmd, shell=True)
         status = cmd_output.exit_status
-        output = cmd_output.stdout_text
+        output = results_stdout_52lts(cmd_output)
     if status != 0 or not output:
         return []
     return str(output).strip().split()
@@ -860,7 +861,7 @@ def get_interface_from_pci_id(pci_id, session=None, nic_regex=""):
     else:
         cmd_output = process.run(cmd, shell=True)
         status = cmd_output.exit_status
-        output = cmd_output.stdout_text
+        output = results_stdout_52lts(cmd_output)
     if status:
         return None
     ethnames = re.findall(nic_regex, output.strip())
@@ -871,7 +872,7 @@ def get_interface_from_pci_id(pci_id, session=None, nic_regex=""):
         else:
             cmd_output = process.run(cmd, shell=True)
             status = cmd_output.exit_status
-            output = cmd_output.stdout_text
+            output = results_stdout_52lts(cmd_output)
         if status:
             continue
         if pci_id in output.strip():
@@ -1501,7 +1502,7 @@ def get_node_cpus(i=0):
     :rtype: builtin.list
     """
     cmd = process.run("numactl --hardware")
-    return re.findall("node %s cpus: (.*)" % i, cmd.stdout_text)[0].split()
+    return re.findall("node %s cpus: (.*)" % i, results_stdout_52lts(cmd))[0].split()
 
 
 def cpu_str_to_list(origin_str):
@@ -1649,7 +1650,7 @@ class NumaInfo(object):
         """
         cmd = process.run("numactl --hardware")
         try:
-            node_distances = cmd.stdout_text.split("node distances:")[-1].strip()
+            node_distances = results_stdout_52lts(cmd).split("node distances:")[-1].strip()
             node_distance = re.findall("%s:.*" % node_id, node_distances)[0]
             node_distance = node_distance.split(":")[-1]
         except Exception:
@@ -1760,7 +1761,7 @@ class NumaNode(object):
         :param i: Index of the CPU inside the node.
         """
         cmd = process.run("numactl --hardware")
-        cpus = re.findall("node %s cpus: (.*)" % i, cmd.stdout_text)
+        cpus = re.findall("node %s cpus: (.*)" % i, results_stdout_52lts(cmd))
         if cpus:
             cpus = cpus[0]
         else:
@@ -1843,7 +1844,7 @@ class NumaNode(object):
         Flush pin dict, remove the record of exited process.
         """
         cmd = process.run("ps -eLf | awk '{print $4}'", shell=True)
-        all_pids = cmd.stdout_text
+        all_pids = results_stdout_52lts(cmd)
         for i in self.cpus:
             for j in self.dict[i]:
                 if str(j) not in all_pids:
@@ -2225,7 +2226,7 @@ def get_qemu_cpu_models(qemu_binary):
     """
     cmd = qemu_binary + " -cpu '?'"
     result = process.run(cmd, verbose=False)
-    return extract_qemu_cpu_models(result.stdout_text)
+    return extract_qemu_cpu_models(results_stdout_52lts(result))
 
 
 def _get_backend_dir(params):
@@ -3113,7 +3114,7 @@ def check_qemu_image_lock_support():
     binary_path = utils_path.find_command(cmd)
     cmd_result = process.run(binary_path + ' -h', ignore_status=True,
                              shell=True, verbose=False)
-    return '-U' in cmd_result.stdout_text
+    return b'-U' in cmd_result.stdout
 
 
 def get_image_info(image_file):
@@ -3537,7 +3538,7 @@ def verify_dmesg(dmesg_log_file=None, ignore_result=False, level_check=3,
         out = process.run(cmd, timeout=30, ignore_status=True,
                           verbose=False, shell=True)
         status = out.exit_status
-        output = out.stdout_text
+        output = results_stdout_52lts(out)
     if status == 0:
         err = "Found failures in %s dmesg log" % environ
         d_log = "dmesg log:\n%s" % output
@@ -3918,7 +3919,7 @@ class SELinuxBoolean(object):
             cmd = "%s'getenforce'" % self.ssh_cmd
             try:
                 result = process.run(cmd, shell=True)
-                self.rem_selinux_disabled = (result.stdout_text.strip().lower() ==
+                self.rem_selinux_disabled = (results_stdout_52lts(result).strip().lower() ==
                                              "disabled")
             except process.CmdError:
                 self.rem_selinux_disabled = True
@@ -3948,7 +3949,7 @@ class SELinuxBoolean(object):
             self.local_bool_var)
         logging.debug("The command: %s", get_sebool_cmd)
         result = process.run(get_sebool_cmd, shell=True)
-        return result.stdout_text.strip()
+        return results_stdout_52lts(result).strip()
 
     def get_sebool_remote(self):
         """
@@ -3959,7 +3960,7 @@ class SELinuxBoolean(object):
                (get_sebool_cmd + "'| awk -F'-->' '{print $2}''"))
         logging.debug("The command: %s", cmd)
         result = process.run(cmd, shell=True)
-        return result.stdout_text.strip()
+        return results_stdout_52lts(result).strip()
 
     def setup(self):
         """
@@ -3988,7 +3989,7 @@ class SELinuxBoolean(object):
             result = process.run("setsebool %s %s" % (self.local_bool_var,
                                                       self.local_boolean_orig))
             if result.exit_status:
-                raise exceptions.TestError(result.stderr_text.strip())
+                raise exceptions.TestError(results_stderr_52lts(result).strip())
 
         # Recover remote SELinux boolean value
         if self.cleanup_remote and not self.rem_selinux_disabled:
@@ -3996,7 +3997,7 @@ class SELinuxBoolean(object):
                    (self.remote_bool_var, self.remote_boolean_orig))
             result = process.run(cmd)
             if result.exit_status:
-                raise exceptions.TestError(result.stderr_text.strip())
+                raise exceptions.TestError(results_stderr_52lts(result).strip())
 
         # Recover SSH connection
         if self.ssh_obj.auto_recover and not keep_authorized_keys:
@@ -4016,12 +4017,12 @@ class SELinuxBoolean(object):
         result = process.run("setsebool %s %s" % (self.local_bool_var,
                                                   self.local_bool_value))
         if result.exit_status:
-            raise exceptions.TestSkipError(result.stderr_text.strip())
+            raise exceptions.TestSkipError(results_stderr_52lts(result).strip())
 
         boolean_curr = self.get_sebool_local()
         logging.debug("To check local boolean value: %s", boolean_curr)
         if boolean_curr != self.local_bool_value:
-            raise exceptions.TestFail(result.stderr_text.strip())
+            raise exceptions.TestFail(results_stderr_52lts(result).strip())
 
     def setup_remote(self):
         """
@@ -4039,12 +4040,12 @@ class SELinuxBoolean(object):
 
         result = process.run(set_boolean_cmd)
         if result.exit_status:
-            raise exceptions.TestSkipError(result.stderr_text.strip())
+            raise exceptions.TestSkipError(results_stderr_52lts(result).strip())
 
         boolean_curr = self.get_sebool_remote()
         logging.debug("To check remote boolean value: %s", boolean_curr)
         if boolean_curr != self.remote_bool_value:
-            raise exceptions.TestFail(result.stderr_text.strip())
+            raise exceptions.TestFail(results_stderr_52lts(result).strip())
 
 
 def get_model_features(model_name):

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -26,6 +26,7 @@ from virttest import data_dir
 from virttest import propcan
 from virttest import utils_misc
 from virttest import arch
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 from virttest.versionable_class import factory
 
 
@@ -1274,7 +1275,7 @@ def find_dnsmasq_listen_address():
 
 
 def local_runner(cmd, timeout=None, shell=False):
-    return process.run(cmd, verbose=False, timeout=timeout, shell=shell).stdout_text
+    return results_stdout_52lts(process.run(cmd, verbose=False, timeout=timeout, shell=shell))
 
 
 def local_runner_status(cmd, timeout=None, shell=False):
@@ -2206,7 +2207,7 @@ class IPv6Manager(propcan.PropCanBase):
         if result.exit_status:
             raise exceptions.TestSkipError("The '%s' destination is "
                                            "unreachable: %s", server_ipv6,
-                                           result.stderr_text)
+                                           results_stderr_52lts(result))
         else:
             logging.info("The '%s' destination is connectivity!", server_ipv6)
 
@@ -2228,7 +2229,8 @@ class IPv6Manager(propcan.PropCanBase):
         result = process.run(flush_cmd, ignore_status=True)
         if result.exit_status:
             raise exceptions.TestFail("%s on local host:%s" %
-                                      (test_fail_err, result.stderr_text))
+                                      (test_fail_err,
+                                       results_stderr_52lts(result)))
         else:
             logging.info("%s on the local host", flush_cmd_pass)
 

--- a/virttest/utils_npiv.py
+++ b/virttest/utils_npiv.py
@@ -11,6 +11,7 @@ from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.nodedev_xml import NodedevXML
 from virttest.libvirt_xml.devices import hostdev
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 _FC_HOST_PATH = "/sys/class/fc_host"
@@ -98,16 +99,16 @@ def find_hbas(hba_type="hba", status="online"):
     # so leave it here as a placeholder.
     result = virsh.nodedev_list(cap="scsi_host")
     if result.exit_status:
-        raise exceptions.TestFail(result.stderr_text)
-    scsi_hosts = result.stdout_text.strip().splitlines()
+        raise exceptions.TestFail(results_stderr_52lts(result))
+    scsi_hosts = results_stdout_52lts(result).strip().splitlines()
     online_hbas_list = []
     online_vhbas_list = []
     # go through all scsi hosts, and split hbas/vhbas into lists
     for scsi_host in scsi_hosts:
         result = virsh.nodedev_dumpxml(scsi_host)
-        stdout = result.stdout_text.strip()
+        stdout = results_stdout_52lts(result).strip()
         if result.exit_status:
-            raise exceptions.TestFail(result.stderr_text)
+            raise exceptions.TestFail(results_stderr_52lts(result))
         if (re.search('vport_ops', stdout)
                 and not re.search('<fabric_wwn>ffffffffffffffff</fabric_wwn>', stdout)
                 and not re.search('<fabric_wwn>0</fabric_wwn>', stdout)):
@@ -178,7 +179,7 @@ def nodedev_create_from_xml(params):
     # Remove temprorary file
     os.unlink(vhba_file)
     libvirt.check_exit_status(result, status_error)
-    output = result.stdout_text
+    output = results_stdout_52lts(result)
     logging.info(output)
     for scsi in output.split():
         if scsi.startswith('scsi_host'):
@@ -207,7 +208,7 @@ def nodedev_destroy(scsi_host, params={}):
     libvirt.check_exit_status(result, status_error)
     # Check nodedev value
     if not check_nodedev(scsi_host):
-        logging.info(result.stdout_text)
+        logging.info(results_stdout_52lts(result))
     else:
         raise exceptions.TestFail("The relevant directory still exists"
                                   " or mismatch with result")
@@ -286,7 +287,7 @@ def find_scsi_luns(scsi_host):
         result = process.run(cmd, shell=True)
     except Exception as e:
         raise exceptions.TestError("run 'multipath' failed: %s" % str(e))
-    tmp_list = result.stdout_text.strip().splitlines()
+    tmp_list = results_stdout_52lts(result).strip().splitlines()
     for lun in tmp_list:
         lun = lun.split(":")
         lun_dicts_item = {}
@@ -307,7 +308,7 @@ def find_mpath_devs():
     cmd = "ls -l /dev/mapper/ | grep mpath | awk -F ' ' '{print $9}' \
            | grep -Ev [0-9]$ |sort -d"
     cmd_result = process.run(cmd, shell=True)
-    mpath_devs = cmd_result.stdout_text.split("\n")
+    mpath_devs = results_stdout_52lts(cmd_result).split("\n")
     return mpath_devs
 
 

--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -8,6 +8,7 @@ import os
 
 from avocado.utils import process
 from avocado.utils import distro
+from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 ubuntu = distro.detect().name == 'Ubuntu'
@@ -80,16 +81,16 @@ def get_status(selinux_force=False):
         raise SeCmdError(cmd, "Command not available")
 
     if result.exit_status:
-        raise SeCmdError(cmd, result.stderr_text)
+        raise SeCmdError(cmd, results_stderr_52lts(result))
 
     for status in STATUS_LIST:
-        if result.stdout_text.lower().count(status):
+        if results_stdout_52lts(result).lower().count(status):
             return status
         else:
             continue
 
     raise SelinuxError("result of 'getenforce' (%s)is not expected."
-                       % result.stdout_text)
+                       % results_stdout_52lts(result))
 
 
 def set_status(status, selinux_force=False):
@@ -122,7 +123,7 @@ def set_status(status, selinux_force=False):
             cmd = "setenforce %s" % status
             result = process.run(cmd, ignore_status=True)
             if result.exit_status:
-                raise SeCmdError(cmd, result.stderr_text)
+                raise SeCmdError(cmd, results_stderr_52lts(result))
             else:
                 current_status = get_status(selinux_force)
                 if not status == current_status:
@@ -238,9 +239,9 @@ def get_context_of_file(filename, selinux_force=False):
     cmd = "getfattr --name security.selinux %s" % filename
     result = process.run(cmd, ignore_status=True)
     if result.exit_status:
-        raise SeCmdError(cmd, result.stderr_text)
+        raise SeCmdError(cmd, results_stderr_52lts(result))
 
-    output = result.stdout_text
+    output = results_stdout_52lts(result)
     return get_context_from_str(output)
 
 
@@ -266,7 +267,7 @@ def set_context_of_file(filename, context, selinux_force=False):
            % (context, filename))
     result = process.run(cmd, ignore_status=True)
     if result.exit_status:
-        raise SeCmdError(cmd, result.stderr_text)
+        raise SeCmdError(cmd, results_stdout_52lts(result))
 
     context_result = get_context_of_file(filename)
     if not context == context_result:
@@ -293,7 +294,7 @@ def get_context_of_process(pid):
 
 def _no_semanage(cmdresult):
     if cmdresult.exit_status == 127:
-        if cmdresult.stdout_text.lower().count('command not found'):
+        if results_stdout_52lts(cmdresult).lower().count('command not found'):
             raise SemanageError()
 
 
@@ -315,8 +316,8 @@ def get_defcon(local=False, selinux_force=False):
         result = process.run("semanage fcontext --list", ignore_status=True)
     _no_semanage(result)
     if result.exit_status != 0:
-        raise SeCmdError('semanage', result.stderr_text)
-    result_list = result.stdout_text.strip().split('\n')
+        raise SeCmdError('semanage', results_stderr_52lts(result))
+    result_list = results_stdout_52lts(result).strip().split('\n')
     # Need to process top-down instead of bottom-up
     result_list.reverse()
     first_line = result_list.pop()
@@ -405,7 +406,7 @@ def set_defcon(context_type, pathregex, context_range=None, selinux_force=False)
     result = process.run(cmd, ignore_status=True)
     _no_semanage(result)
     if result.exit_status != 0:
-        raise SeCmdError(cmd, result.stderr_text)
+        raise SeCmdError(cmd, results_stderr_52lts(result))
 
 
 def del_defcon(context_type, pathregex, selinux_force=False):
@@ -426,7 +427,7 @@ def del_defcon(context_type, pathregex, selinux_force=False):
     result = process.run(cmd, ignore_status=True)
     _no_semanage(result)
     if result.exit_status != 0:
-        raise SeCmdError(cmd, result.stderr_text)
+        raise SeCmdError(cmd, results_stderr_52lts(result))
 
 # Process pathname/dirdesc in uniform way for all defcon functions + unittests
 
@@ -454,7 +455,7 @@ def _run_restorecon(pathname, dirdesc, readonly=True, force=False, selinux_force
         cmd += 'F'
     cmd += ' "%s"' % pathname
     # Always returns 0, even if contexts wrong
-    return process.run(cmd).stdout_text.strip()
+    return results_stdout_52lts(process.run(cmd)).strip()
 
 
 def verify_defcon(pathname, dirdesc=False, readonly=True, forcedesc=False, selinux_force=False):

--- a/virttest/version.py
+++ b/virttest/version.py
@@ -17,6 +17,7 @@ import os
 from avocado.utils import process
 
 from . import data_dir
+from .compat_52lts import results_stdout_52lts
 
 _ROOT_PATH = data_dir.get_root_dir()
 RELEASE_VERSION_PATH = os.path.join(_ROOT_PATH, 'RELEASE-VERSION')
@@ -118,7 +119,7 @@ def get_version(abbrev=4):
             cmd_result = process.run("rpm -q avocado-plugins-vt "
                                      "--queryformat '%{VERSION}'",
                                      shell=True, verbose=False)
-            return '%s (RPM install)' % cmd_result.stdout_text
+            return '%s (RPM install)' % results_stdout_52lts(cmd_result)
         except process.CmdError:
             return 'unknown'
 

--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -35,6 +35,7 @@ from avocado.utils import process
 from . import propcan
 from . import remote
 from . import utils_misc
+from .compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 # list of symbol names NOT to wrap as Virtadmin class methods
@@ -692,8 +693,8 @@ def command(cmd, **dargs):
     # Always log debug info, if persistent session or not
     if debug:
         logging.debug("status: %s", ret.exit_status)
-        logging.debug("stdout: %s", ret.stdout_text.strip())
-        logging.debug("stderr: %s", ret.stderr_text.strip())
+        logging.debug("stdout: %s", results_stdout_52lts(ret).strip())
+        logging.debug("stderr: %s", results_stderr_52lts(ret).strip())
 
     # Return CmdResult instance when ignore_status is True
     return ret


### PR DESCRIPTION
The fda9b8934 uses new "CmdResult.stdout_text" and
"CmdResult.stderr_text" methods, which are not part of 52.x LTS release.
Let's create a new "compat_52lts" file to store wrappers needed to run
52.X and master and use it to get stdout/stderr from process.CmdResult.

On some places pure "stdout" or "stderr" is used and bytes are used to
compare with. This should work always on master and ony 52.X it'd
compare string to bytes. This works well on python2 but fails on
python3, but python3 was not supported on 52.X so I believe it's fine.

Occasionally I used the raw "stdout" or "stderr" to write to binary
files. Again, on python2 it should work and on master we'll be writing
bytes.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>