### PR TITLE
virttest/qemu_devices/qcontainer.py: Transfer 'max_ports' to int type

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1136,7 +1136,7 @@ class DevContainer(object):
                                       params.get('masterbus'),
                                       params.get('firstport'),
                                       params.get('freq'),
-                                      params.get('max_ports', 6),
+                                      int(params.get('max_ports', 6)),
                                       params.get('pci_addr'))
 
     # USB Device related methods


### PR DESCRIPTION
Transfer 'max_ports' to int type when using it

ID: 1563531
Signed-off-by: Nini Gu <ngu@redhat.com>