### PR TITLE
Python 3: Fix TypeError: list indices must be integers

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2674,6 +2674,7 @@ class ParamsNet(VMNet):
         result_list = []
         nic_name_list = self.params.objects('nics')
         for nic_name in nic_name_list:
+            nic_name = str(nic_name)
             # nic name is only in params scope
             nic_dict = {'nic_name': nic_name}
             nic_params = self.params.object_params(nic_name)


### PR DESCRIPTION
This patch is to fix below error:

ERROR|   File "/root/code-python3/avocado-vt/virttest/env_process.py", line 133, in preprocess_vm
ERROR|     vm = env.create_vm(vm_type, target, name, params, test.bindir)
ERROR|   File "/root/code-python3/avocado-vt/virttest/utils_env.py", line 165, in create_vm
ERROR|     vm = vm_class(name, params, bindir, self.get("address_cache"))
ERROR|   File "/root/code-python3/avocado-vt/virttest/libvirt_vm.py", line 201, in __init__
ERROR|     super(VM, self).__init__(name, params)
ERROR|   File "/root/code-python3/avocado-vt/virttest/virt_vm.py", line 533, in __init__
ERROR|     self.instance)
ERROR|   File "/root/code-python3/avocado-vt/virttest/utils_net.py", line 2931, in __init__
ERROR|     ParamsNet.__init__(self, params, vm_name)
ERROR|   File "/root/code-python3/avocado-vt/virttest/utils_net.py", line 2693, in __init__
ERROR|     existing_value = getattr(self[nic_name], propertea, None)
ERROR|   File "/root/code-python3/avocado-vt/virttest/utils_net.py", line 2492, in __getitem__
ERROR|     return super(VMNet, self).__getitem__(index_or_name)
ERROR| TypeError: list indices must be integers, not unicode

Signed-off-by: cuzhang <cuzhang@redhat.com>