### PR TITLE
shared: Add SLES.12.3.s390x variant

### DIFF
--- a/shared/cfg/guest-os/Linux/SLES/12.3.s390x.cfg
+++ b/shared/cfg/guest-os/Linux/SLES/12.3.s390x.cfg
@@ -1,0 +1,21 @@
+- 12.3.s390x:
+    image_name = images/sles12sp3-s390x
+    vm_arch_name = s390x
+    os_variant = sles12
+    unattended_install, svirt_install:
+        unattended_file = unattended/SLES-12.xml
+        cdrom_unattended = images/sles-12-3-s390x/autoyast.iso
+        kernel_params = "autoyast=device://sr1/autoinst.xml console=ttyS0,115200 console=tty0"
+        kernel = images/sles-12-3-s390x/linux
+        initrd = images/sles-12-3-s390x/initrd
+        boot_path = boot/s390x
+    unattended_install.cdrom, svirt_install:
+        cdrom_cd1 = isos/linux/SLE-12-SP3-Server-DVD-s390x-GM-DVD1.iso
+        md5sum_cd1 = bdbcb2d250cd516c9484d63bf376fe6d
+        md5sum_1m_cd1 = e4dbeefca703d03607675f099e554d36
+    unattended_install.url, unattended_install.nfs:
+        kernel_params = "autoyast=device://sr0/autoinst.xml console=ttyS0,115200 console=tty0"
+    unattended_install..floppy_ks:
+        kernel_params = "autoyast=device://fd0/autoinst.xml console=ttyS0,115200 console=tty0"
+        floppies = "fl"
+        floppy_name = images/sles-12-3-s390x/autoyast.vfd

--- a/shared/unattended/SLES-12.xml
+++ b/shared/unattended/SLES-12.xml
@@ -461,7 +461,13 @@
   <partitioning config:type="list">
     <drive>
       <initialize config:type="boolean">true</initialize>
-      <partitions config:type="list"/>
+      <partitions config:type="list">
+        <partition>
+          <mount>/</mount>
+          <filesystem  config:type="symbol">xfs</filesystem>
+          <size>auto</size>
+        </partition>
+     </partitions>
       <pesize/>
       <type config:type="symbol">CT_DISK</type>
       <use>all</use>


### PR DESCRIPTION
Unfortunately s390x can't boot from "btrfs" partition so adding s390x
variant means changing the default to "xfs", which should work on all
archs.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>