### PR TITLE
Freeze the requirements for aexpect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2
-aexpect>=1.3.1
+aexpect==1.3.1
 simplejson>=3.5.3
 netaddr>=0.7.18
 netifaces>=0.10.5


### PR DESCRIPTION
Could not connect the guest with aexpect 1.4.0

Signed-off-by: Junxiang Li <junli@redhat.com>