### PR TITLE
backport: aexpect-1.4.0 cause some failed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2
-aexpect>=1.3.1
+aexpect==1.3.1
 simplejson>=3.5.3
 netaddr>=0.7.18
 netifaces>=0.10.5


### PR DESCRIPTION
The error message: No ipv4 DHCP lease for MAC

Signed-off-by: Junxiang Li <junli@redhat.com>