### PR TITLE
Enable libvirt vm start in preprocess

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -421,6 +421,11 @@ skip_image_check_during_running = no
 # skip cluster leak warning message in image check
 skip_cluster_leak_warn = no
 
+# Create libvirt multi vms
+# To enable multi libvirt vms setup, make create_vm_libvirt="yes" in addition
+# to vms = vm1 vm2 vm3 and make sure `master_images_clone = img1` not be None
+# inorder to get three vms cloned, provided main_vm = vm1
+create_vm_libvirt = no
 # Some preprocessor params
 # If there is any conflict between 'start_vm' and 'kill_vm_before_test',
 # the final desicion is made by start_vm.

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -133,6 +133,9 @@ def preprocess_vm(test, params, env, name):
         pass
     if create_vm:
         vm = env.create_vm(vm_type, target, name, params, test.bindir)
+        if params.get("create_vm_libvirt") == "yes" and vm_type == 'libvirt':
+            params["medium"] = "import"
+            vm.create(params=params)
 
     old_vm = copy.copy(vm)
 

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -447,7 +447,7 @@ class QemuImg(object):
                     logging.info("Clone master image for vms.")
                     process.run(params.get("image_clone_command") %
                                 (m_image_fn, image_fn))
-
+            params["image_name_%s" % vm_name] = vm_image_name
             params["image_name_%s_%s" % (image_name, vm_name)] = vm_image_name
 
     @staticmethod


### PR DESCRIPTION
This patch enables the libvirt vm start in preprocess
without explicit need of `import` test to called
provided `create_vm_libvirt` params is enabled by test.

This feature helps us incase of multi vm boot scenarios
where as framework already gives us support to create/clone images,
just an additional step of create vm is required incase of
libvirt which is available incase of qemu already,
here we are safely assuming import test considering
we have working guest images present.

Signed-off-by: Mallesh Koti <mallesh@linux.vnet.ibm.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>