### PR TITLE
Python 3: Replace test.tmpdir with virttest

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -51,6 +51,7 @@ from virttest import utils_misc
 from virttest import utils_net
 from virttest import virt_vm
 from virttest import utils_package
+from virttest import data_dir
 from virttest.staging import utils_memory
 from virttest.compat_52lts import results_stdout_52lts
 
@@ -565,7 +566,7 @@ def run_file_transfer(test, params, env):
     clean_cmd = params.get("clean_cmd", "rm -f")
     filesize = int(params.get("filesize", 4000))
     count = int(filesize / 10) or 1
-    host_path = tempfile.mktemp(prefix="tmp-", dir=test.tmpdir)
+    host_path = tempfile.mktemp(prefix="tmp-", dir=data_dir.get_tmp_dir())
     if params.get("os_type") != 'windows':
         tmp_dir = params.get("tmp_dir", "/var/tmp")
         guest_path = tempfile.mktemp(prefix="transferred-", dir=tmp_dir)
@@ -715,7 +716,7 @@ def run_virtio_serial_file_transfer(test, params, env, port_name=None,
         vm.copy_files_to(link, guest_path, timeout=60)
     host_device = get_virtio_port_host_file(vm, port_name)
 
-    dir_name = test.tmpdir
+    dir_name = data_dir.get_tmp_dir()
     transfer_timeout = int(params.get("transfer_timeout", 720))
     tmp_dir = params.get("tmp_dir", data_dir.get_tmp_dir())
     filesize = int(params.get("filesize", 10))

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -48,6 +48,7 @@ from .. import utils_net
 from .. import gluster
 from .. import remote
 from .. import test_setup
+from .. import data_dir
 from ..utils_iptables import Iptables
 from ..staging import lv_utils
 from ..utils_libvirtd import service_libvirtd_control
@@ -912,7 +913,7 @@ class PoolVolumeTest(object):
     """Test class for storage pool or volume"""
 
     def __init__(self, test, params):
-        self.tmpdir = test.tmpdir
+        self.tmpdir = data_dir.get_tmp_dir()
         self.params = params
         self.selinux_bak = ""
 


### PR DESCRIPTION
This change is due to avocado #2543, with which test.tmpdir can't
be public to any user anymore. Since libvirt testing sometimes use
non-creating user to access, so change to use
virttest.data_dir.get_tmp_dir(), which is designed for public user
dedicatedly

Signed-off-by: Yan Li <yannli@redhat.com>