### PR TITLE
utils_test.libvirt: Fix the wrong alias for s390x

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3406,7 +3406,7 @@ def check_machine_type_arch(machine_type):
         return
     arch_machine_map = {'x86_64': ['pc', 'q35'],
                         'ppc64le': ['pseries'],
-                        's390x': ['ccw']}
+                        's390x': ['s390-ccw-virtio']}
     arch = platform.machine()
     if machine_type not in arch_machine_map[arch]:
         raise exceptions.TestSkipError("This machine type '%s' is not "


### PR DESCRIPTION
Signed-off-by: Dan Zheng <dzheng@redhat.com>