### PR TITLE
Postcopy testing

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -77,6 +77,10 @@ class MonitorNotSupportedCmdError(MonitorNotSupportedError):
                 (self.cmd, self.monitor))
 
 
+class MonitorNotSupportedMigCapError(MonitorNotSupportedError):
+    pass
+
+
 class QMPCmdError(MonitorError):
 
     def __init__(self, cmd, qmp_args, data):
@@ -1275,6 +1279,7 @@ class HumanMonitor(Monitor):
 
         :param state: Bool value of capability.
         :param capability: capability which need to set.
+        :raise MonitorNotSupportedMigCapError: if the capability is unknown
         """
         cmd = "migrate_set_capability"
         self.verify_supported_cmd(cmd)
@@ -1282,18 +1287,28 @@ class HumanMonitor(Monitor):
         if state:
             value = "on"
         cmd += " %s %s" % (capability, value)
-        return self.cmd(cmd)
+        result = self.cmd(cmd)
+        if result != "":
+            raise MonitorNotSupportedMigCapError("Failed to set capability"
+                                                 "%s: %s" %
+                                                 (capability, result))
+        return result
 
     def get_migrate_capability(self, capability):
         """
         Get the state of migrate-capability.
 
         :param capability: capability which need to get.
+        :raise MonitorNotSupportedMigCapError: if the capability is unknown
         :return: the state of migrate-capability.
         """
         capability_info = self.query("migrate_capabilities")
         pattern = r"%s:\s+(on|off)" % capability
-        value = re.search(pattern, capability_info, re.M).group(1)
+        match = re.search(pattern, capability_info, re.M)
+        if match is None:
+            raise MonitorNotSupportedMigCapError("Unknown capability %s" %
+                                                 capability)
+        value = match.group(1)
         return value == "on"
 
     def set_migrate_cache_size(self, value):
@@ -2370,11 +2385,24 @@ class QMPMonitor(Monitor):
 
         :param state: Bool value of capability.
         :param capability: capability which need to set.
+        :raise MonitorNotSupportedMigCapError: if the capability is unsettable
         """
         cmd = "migrate-set-capabilities"
         self.verify_supported_cmd(cmd)
         args = {"capabilities": [{"state": state, "capability": capability}]}
-        return self.cmd(cmd, args)
+        # If the capability doesn't exist or can't be used in this situation
+        # we'll get a GenericError with text explaining, but it's not always
+        # clear if it's another reason for the error
+        try:
+            return self.cmd(cmd, args)
+        except QMPCmdError as e:
+            if e.data['class'] in ['GenericError']:
+                logging.debug(
+                    "Error in set_migrate_capability for %s: %s" % (capability, e))
+                raise MonitorNotSupportedMigCapError("set capability failed for %s (%s)" %
+                                                     (capability, e))
+            else:
+                raise e
 
     def get_migrate_capability(self, capability):
         """
@@ -2382,12 +2410,14 @@ class QMPMonitor(Monitor):
 
         :param capability: capability which need to get.
         :return: the state of migrate-capability.
+        :raise MonitorNotSupportedMigCapError: if the capability is unknown
         """
         capability_infos = self.query("migrate-capabilities")
         for item in capability_infos:
             if item["capability"] == capability:
                 return item["state"]
-        return False
+        raise MonitorNotSupportedMigCapError("Unknown capability %s" %
+                                             capability)
 
     def set_migrate_cache_size(self, value):
         """

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1353,6 +1353,13 @@ class HumanMonitor(Monitor):
         value = parameter_info[parameter_info.index("parameter")+1]
         return value
 
+    def migrate_start_postcopy(self):
+        """
+        Switch into postcopy migrate mode
+        """
+
+        return self.cmd("migrate_start_postcopy")
+
     def system_powerdown(self):
         """
         Requests that a guest perform a powerdown operation.
@@ -2459,6 +2466,12 @@ class QMPMonitor(Monitor):
             return parameter_info[parameter]
         else:
             return False
+
+    def migrate_start_postcopy(self):
+        """
+        Switch into postcopy migrate mode
+        """
+        return self.cmd("migrate-start-postcopy")
 
     def system_powerdown(self):
         """

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1360,6 +1360,27 @@ class HumanMonitor(Monitor):
 
         return self.cmd("migrate_start_postcopy")
 
+    def get_migrate_progress(self):
+        """
+        Return the transfered / remaining ram ratio
+
+        :return: percentage remaining for RAM transfer
+        """
+        status = self.info("migrate", debug=False)
+        rem = re.search(r"remaining ram: (\d+) kbytes", status)
+        total = re.search(r"total ram: (\d+) kbytes", status)
+        if rem and total:
+            ret = 100 - 100 * int(rem.group(1)) / int(total.group(1))
+            logging.debug("Migration progress: %s%%", ret)
+            return ret
+        if "Migration status: completed" in status:
+            logging.debug("Migration progress: 100%")
+            return 100
+        elif "Migration status: setup" in status:
+            logging.debug("Migration progress: 0%")
+            return 0
+        raise MonitorError("Unable to parse migration progress:\n%s" % status)
+
     def system_powerdown(self):
         """
         Requests that a guest perform a powerdown operation.
@@ -2466,6 +2487,31 @@ class QMPMonitor(Monitor):
             return parameter_info[parameter]
         else:
             return False
+
+    def get_migrate_progress(self):
+        """
+        Return the transfered / remaining ram ratio
+
+        :return: percentage remaining for RAM transfer
+        """
+        migration_info = self.query("migrate")
+        status = migration_info["status"]
+        if "ram" in migration_info:
+            ram_stats = migration_info["ram"]
+            rem = ram_stats["remaining"]
+            total = ram_stats["total"]
+            ret = 100.0 - 100.0 * rem / total
+            logging.debug("Migration progress: %s%%", ret)
+            return ret
+        else:
+            if status == "completed":
+                logging.debug("Migration progress: 100%")
+                return 100
+            elif status == "setup":
+                logging.debug("Migration progress: 0%")
+                return 0
+            else:
+                raise MonitorError("Unable to parse migration progress:\n%s" % status)
 
     def migrate_start_postcopy(self):
         """

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -599,6 +599,23 @@ class Monitor:
         finally:
             self._log_lock.release()
 
+    def wait_for_migrate_progress(self, target):
+        """
+        Wait for migration progress to hit a target %
+        Note: We exit if we've gone onto another pass rather than wait
+        for a target we might never hit.
+        """
+        old_progress = 0
+        while True:
+            progress = self.get_migrate_progress()
+            if (progress < old_progress or
+                    progress >= target):
+                break
+            # progress < old_progress indicates we must be on
+            # another pass (we could also check the sync count)
+            old_progress = progress
+            time.sleep(0.1)
+
 
 class HumanMonitor(Monitor):
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3751,7 +3751,7 @@ class VM(virt_vm.BaseVM):
                 remote_port=None, not_wait_for_migration=False,
                 fd_src=None, fd_dst=None, migration_exec_cmd_src=None,
                 migration_exec_cmd_dst=None, env=None,
-                migrate_capabilities=None):
+                migrate_capabilities=None, mig_inner_funcs=None):
         """
         Migrate the VM.
 
@@ -3786,6 +3786,8 @@ class VM(virt_vm.BaseVM):
                 default to listening on a random TCP port
         :param env: Dictionary with test environment
         :param migrate_capabilities: The capabilities for migration to need set.
+        :param mig_inner_funcs: Functions to be executed just after the migration is
+                started
         """
         if protocol not in self.MIGRATION_PROTOS:
             raise virt_vm.VMMigrateProtoUnknownError(protocol)
@@ -3912,6 +3914,18 @@ class VM(virt_vm.BaseVM):
 
             logging.info("Migrating to %s", uri)
             self.monitor.migrate(uri)
+
+            if mig_inner_funcs:
+                for (func, param) in mig_inner_funcs:
+                    if func == "postcopy":
+                        # trigger a postcopy at somewhere below the given % of
+                        # the 1st pass
+                        self.monitor.wait_for_migrate_progress(random.randrange(param))
+                        self.monitor.migrate_start_postcopy()
+                    else:
+                        msg = ("Unknown migration inner function '%s'" % func)
+                        raise exceptions.TestError(msg)
+
             if not_wait_for_migration:
                 return clone
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3705,9 +3705,9 @@ class VM(virt_vm.BaseVM):
                 ret = len(re.findall("true", str(s.get("migrated")), re.I)) > 0
         o = self.monitor.info("migrate")
         if isinstance(o, str):
-            return ret and ("status: active" not in o)
+            return ret and not re.search(r"status: *[\w-]*active", o)
         else:
-            return ret and (o.get("status") != "active")
+            return ret and not ("active" in o.get("status"))
 
     def mig_succeeded(self):
         o = self.monitor.info("migrate")

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3902,6 +3902,13 @@ class VM(virt_vm.BaseVM):
                         msg = ("Migrate capability '%s' should be '%s', "
                                "but actual result is '%s'" % (key, state, s))
                         raise exceptions.TestError(msg)
+                    clone.monitor.set_migrate_capability(state, key)
+                    s = clone.monitor.get_migrate_capability(key)
+                    if s != state:
+                        msg = ("Migrate capability '%s' should be '%s', "
+                               "but actual result is '%s' on destination guest"
+                               % (key, state, s))
+                        raise exceptions.TestError(msg)
 
             logging.info("Migrating to %s", uri)
             self.monitor.migrate(uri)

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1476,6 +1476,8 @@ class BaseVM(object):
         :param save_path: The path for state files.
         :param dest_host: Destination host (defaults to 'localhost').
         :param remote_port: Port to use for remote migration.
+        :param mig_inner_funcs: Functions to be executed just after the migration
+                is started.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
This supercedes my (2 year old) pull request for postcopy; I've cleaned it up a bit and made sure I've got implementations on more hmp/qmp pairs.
I've kept with the use of exceptions to spot QEMUs that can't do postcopy; it's the easiest way to keep it clean, and also QEMUs errors aren't that clear in the case we need to test, so it's best to keep the code together with teh capabilities code rather than spread the complication around.
I'm using this with my tp changes at: https://github.com/dagrh/tp-qemu/tree/postcopy