### PR TITLE
Use autotest libs on autotest control files

### DIFF
--- a/shared/control/install_pkg.control
+++ b/shared/control/install_pkg.control
@@ -13,7 +13,7 @@ It using --args for passing package names.
 
 ..../autotest-local --args="gcc make"
 '''
-from avocado.utils import software_manager
+from autotest.client.shared import software_manager
 
 sm = software_manager.SoftwareManager()
 

--- a/shared/control/stress_memory_heavy.control
+++ b/shared/control/stress_memory_heavy.control
@@ -11,21 +11,23 @@ to heavily stress a machine's memory.
 '''
 
 import os
+from autotest.client import utils
 
-from avocado.utils import cpu as cpu_utils
-from avocado.utils import disk as disk_utils
+try:
+    from virttest.staging import utils_memory
+except ImportError:
+    from autotest.client.shared import utils_memory
 
-from virttest.staging import utils_memory
 
 # Assemble the parameters specially to stress memory
 
 # We will use 2 workers of each type for each CPU detected
-threads = 2 * cpu_utils.online_cpus_count()
+threads = 2 * utils.count_cpus()
 
 mem = utils_memory.read_from_meminfo('MemTotal') / 1024 / 512
 memory_per_thread = 256 * 1024
 
-free_disk = disk_utils.freespace(os.getcwd())
+free_disk = utils.freespace(os.getcwd())
 file_size_per_thread = 1024 ** 2
 if (0.9 * free_disk) < file_size_per_thread * threads:
     file_size_per_thread = (0.9 * free_disk) / threads

--- a/shared/control/xfstests.control
+++ b/shared/control/xfstests.control
@@ -60,7 +60,7 @@ Make sure you have them or a real spare device to test things.
 """
 # Define the partitions you want to use.
 #
-from avocado.utils import partition
+from autotest.client import partition
 import re
 
 disks=[]


### PR DESCRIPTION
It makes no sense to depend on Avocado libraries on files that are
supposed to be run by Autotest, as it actually increases the
requirements and complexity of the code.

This is a partial revert of 7b7c5960ede3d2201775d1fd8f47c1df8d7d413c.

Reference: https://github.com/avocado-framework/avocado-vt/issues/1512
Signed-off-by: Cleber Rosa <crosa@redhat.com>