### PR TITLE
Fix behavior related to "boot_savevm.default_savevm" test

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -98,6 +98,7 @@ class VM(virt_vm.BaseVM):
 
     # By default we inherit all timeouts from the base VM class except...
     CLOSE_SESSION_TIMEOUT = 30
+    MIGRATE_TIMEOUT = 2000
 
     def __init__(self, name, params, root_dir, address_cache, state=None):
         """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4136,7 +4136,7 @@ class VM(virt_vm.BaseVM):
         self.create(name=self.name, params=self.params, root_dir=self.root_dir,
                     timeout=self.MIGRATE_TIMEOUT, migration_mode="exec",
                     migration_exec_cmd="cat " + path, mac_source=self)
-        self.verify_status('running')  # Throws exception if not
+        self.resume()
 
     def savevm(self, tag_name):
         """


### PR DESCRIPTION
There are 2 little fixes related to "boot_savevm.default_savevm" test. See the details in commit messages.