### PR TITLE
Python 3: Force open file with text instead of  "bytes" to make python 2 and 3 compatible

### DIFF
--- a/virttest/element_tree.py
+++ b/virttest/element_tree.py
@@ -578,7 +578,7 @@ class ElementTree(object):
 
     def parse(self, source, parser=None):
         if not hasattr(source, "read"):
-            source = open(source, "rb")
+            source = open(source, "r")
         if not parser:
             parser = XMLTreeBuilder()
         while 1:
@@ -657,7 +657,7 @@ class ElementTree(object):
     def write(self, file, encoding="us-ascii"):
         assert self._root is not None
         if not hasattr(file, "write"):
-            file = open(file, "wb")
+            file = open(file, "w")
         if not encoding:
             encoding = "us-ascii"
         elif encoding != "utf-8" and encoding != "us-ascii":
@@ -891,7 +891,7 @@ class iterparse(object):
 
     def __init__(self, source, events=None):
         if not hasattr(source, "read"):
-            source = open(source, "rb")
+            source = open(source, "r")
         self._file = source
         self._events = []
         self._index = 0

--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -98,7 +98,7 @@ def image_read_from_ppm_file(filename):
     :return: A 3 element tuple containing the width, height and data of the
             image.
     """
-    fin = open(filename, "rb")
+    fin = open(filename, "r")
     fin.readline()
     l2 = fin.readline()
     fin.readline()
@@ -117,7 +117,7 @@ def image_write_to_ppm_file(filename, width, height, data):
     :param width: PPM file width (pixels)
     :param height: PPM file height (pixels)
     """
-    fout = open(filename, "wb")
+    fout = open(filename, "w")
     fout.write("P6\n")
     fout.write("%d %d\n" % (width, height))
     fout.write("255\n")
@@ -202,7 +202,7 @@ def image_verify_ppm_file(filename):
     """
     try:
         size = os.path.getsize(filename)
-        fin = open(filename, "rb")
+        fin = open(filename, "r")
         assert(fin.readline().strip() == "P6")
         (width, height) = list(map(int, fin.readline().split()))
         assert(width > 0 and height > 0)

--- a/virttest/remote_build.py
+++ b/virttest/remote_build.py
@@ -110,7 +110,7 @@ class Builder(object):
                 Calculate hex-encoded hash of a file
                 :param file_name: File to hash
                 """
-                f = open(file_name, mode='rb')
+                f = open(file_name, mode='r')
                 h = hashlib.sha1()
                 while True:
                     buf = f.read(4096)

--- a/virttest/staging/backports/simplejson/tool.py
+++ b/virttest/staging/backports/simplejson/tool.py
@@ -20,11 +20,11 @@ def main():
         infile = sys.stdin
         outfile = sys.stdout
     elif len(sys.argv) == 2:
-        infile = open(sys.argv[1], 'rb')
+        infile = open(sys.argv[1], 'r')
         outfile = sys.stdout
     elif len(sys.argv) == 3:
-        infile = open(sys.argv[1], 'rb')
-        outfile = open(sys.argv[2], 'wb')
+        infile = open(sys.argv[1], 'r')
+        outfile = open(sys.argv[2], 'w')
     else:
         raise SystemExit(sys.argv[0] + " [infile [outfile]]")
     try:

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1116,7 +1116,7 @@ def dumpxml(name, extra="", to_file="", **dargs):
     cmd = "dumpxml %s %s" % (name, extra)
     result = command(cmd, **dargs)
     if to_file:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
     return result
@@ -1686,7 +1686,7 @@ def net_dumpxml(name, extra="", to_file="", **dargs):
     cmd = "net-dumpxml %s %s" % (name, extra)
     result = command(cmd, **dargs)
     if to_file:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
     return result
@@ -2242,7 +2242,7 @@ def pool_dumpxml(name, extra="", to_file="", **dargs):
     cmd = "pool-dumpxml %s %s" % (name, extra)
     result = command(cmd, **dargs)
     if to_file:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
     if result.exit_status:
@@ -2419,7 +2419,7 @@ def vol_dumpxml(volume_name, pool_name, to_file=None, options="", **dargs):
            (volume_name, pool_name, options))
     result = command(cmd, **dargs)
     if to_file is not None:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
     return result
@@ -2500,7 +2500,7 @@ def capabilities(option='', to_file=None, **dargs):
     """
     cmd_result = command('capabilities %s' % option, **dargs)
     if to_file is not None:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(cmd_result.stdout.strip())
         result_file.close()
 
@@ -2900,7 +2900,7 @@ def snapshot_dumpxml(name, snapshot, options=None, to_file=None, **dargs):
         cmd += " %s" % options
     result = command(cmd, **dargs)
     if to_file is not None:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
 
@@ -3161,7 +3161,7 @@ def nodedev_dumpxml(name, options="", to_file=None, **dargs):
     cmd = ('nodedev-dumpxml %s %s' % (name, options))
     result = command(cmd, **dargs)
     if to_file is not None:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
 
@@ -3449,7 +3449,7 @@ def iface_dumpxml(iface, extra="", to_file="", **dargs):
     cmd = "iface-dumpxml %s %s" % (iface, extra)
     result = command(cmd, **dargs)
     if to_file:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
     if result.exit_status:
@@ -3623,7 +3623,7 @@ def secret_dumpxml(uuid, to_file="", options=None, **dargs):
         cmd += " %s" % options
     result = command(cmd, **dargs)
     if to_file:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
     if result.exit_status:
@@ -3792,7 +3792,7 @@ def nwfilter_dumpxml(name, options="", to_file=None, **dargs):
     cmd = ('nwfilter-dumpxml %s %s' % (name, options))
     result = command(cmd, **dargs)
     if to_file is not None:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
 
@@ -4009,7 +4009,7 @@ def save_image_dumpxml(state_file, options="", to_file="", **dargs):
     cmd = "save-image-dumpxml %s %s" % (state_file, options)
     result = command(cmd, **dargs)
     if to_file:
-        result_file = open(to_file, 'wb')
+        result_file = open(to_file, 'w')
         result_file.write(result.stdout.strip())
         result_file.close()
     return result

--- a/virttest/xml_utils.py
+++ b/virttest/xml_utils.py
@@ -59,7 +59,7 @@ class TempXMLFile(object):
     Temporary XML file auto-removed on instance del / module exit.
     """
 
-    def __init__(self, suffix=TMPSFX, prefix=TMPPFX, mode="wb+", buffsz=1):
+    def __init__(self, suffix=TMPSFX, prefix=TMPPFX, mode="w+", buffsz=1):
         """
         Initialize temporary XML file removed on instance destruction.
 
@@ -229,7 +229,7 @@ class XMLBackup(TempXMLFile):
         super(XMLBackup, self).flush()
         super(XMLBackup, self).seek(0)
         super(XMLBackup, self).truncate(0)
-        with open(self.sourcefilename, "rb") as source_file:
+        with open(self.sourcefilename, "r") as source_file:
             shutil.copyfileobj(source_file,
                                super(XMLBackup, self))
         super(XMLBackup, self).flush()
@@ -240,7 +240,7 @@ class XMLBackup(TempXMLFile):
         """
         super(XMLBackup, self).flush()
         super(XMLBackup, self).seek(0)
-        with open(self.sourcefilename, "wb") as source_file:
+        with open(self.sourcefilename, "w") as source_file:
             source_file.truncate(0)
             shutil.copyfileobj(super(XMLBackup, self),
                                source_file)
@@ -268,7 +268,7 @@ class XMLTreeFile(ElementTree.ElementTree, XMLBackup):
         # to hold the original content.
         try:
             # Test if xml is a valid filename
-            self.sourcebackupfile = open(xml, "rb")
+            self.sourcebackupfile = open(xml, "r")
             self.sourcebackupfile.close()
             # XMLBackup init will take care of creating a copy
         except (IOError, OSError):


### PR DESCRIPTION
Change file open mode without "b" to get it compatible both
py2 and py3. The old way openning file with "rb" & "wb" return bytes
instead of string in Python3, and this will broke tp-libvirt testing
as tp-libvirt use string in most cases.

Signed-off-by: Yan Li <yannli@redhat.com>