### PR TITLE
Python 3: Minor fix for expat parser

### DIFF
--- a/virttest/element_tree.py
+++ b/virttest/element_tree.py
@@ -1164,7 +1164,7 @@ class XMLTreeBuilder(object):
         except AttributeError:
             pass
         encoding = None
-        if not parser.returns_unicode:
+        if hasattr(parser, "returns_unicode") and not parser.returns_unicode:
             encoding = "utf-8"
         # target.xml(encoding, None)
         self._doctype = None


### PR DESCRIPTION
It's to fix the Attribute Error issue when with python3, and
get compatible with python2 at the same time

Signed-off-by: Yan Li <yannli@redhat.com>