### PR TITLE
qemu_qtree: handle ovmf additional drives in check_disk_params

### DIFF
--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -171,8 +171,8 @@ class QtreeDev(QtreeNode):
         guess = {True: QtreeDisk, False: QtreeDev}
         is_disk = ('drive' in self.qtree)
         # HOOK when usb-storage-containter is detected as disk
-        is_disk = (is_disk and (self.qtree['type'] != 'usb-storage'))
-        is_disk = (is_disk and (self.qtree['type'] != 'spapr-nvram'))
+        non_disk_type = ('usb-storage', 'spapr-nvram', 'cfi.pflash01')
+        is_disk = (is_disk and (self.qtree['type'] not in non_disk_type))
         return guess[is_disk]
 
 


### PR DESCRIPTION
Ovmf add up 2 specific drive without device attached, which will fail check_disk_params since they are not managed in params 'images'.
So skip these 2 drive checking in check_disk_params

ID: 1399929
Signed-off-by: qizhu <qizhu@redhat.com>
