### PR TITLE
Python 3: Add decode after encode for Python3 to force return a str o…

### DIFF
--- a/virttest/element_tree.py
+++ b/virttest/element_tree.py
@@ -116,6 +116,7 @@ import string
 import sys
 import re
 
+from six import PY3
 from . import element_path as ElementPath
 
 
@@ -756,7 +757,10 @@ def dump(elem):
 
 def _encode(s, encoding):
     try:
-        return s.encode(encoding)
+        if PY3:
+            return s.encode(encoding).decode(encoding)
+        else:
+            return s.encode(encoding)
     except AttributeError:
         return s  # 1.5.2: assume the string uses the right encoding
 


### PR DESCRIPTION
In PYTHON2, s.encode() returns a str object. However in PYTHON3, this
approach returns bytes instead of string. To be compatible each other,
Need add decode after encode for PYTHON3 to force return a str object

Signed-off-by: Yan Li <yannli@redhat.com>