### PR TITLE
Python 3: Fixup issue unable to save environment

### DIFF
--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -74,7 +74,7 @@ class Env(IterableUserDict):
         if filename:
             try:
                 if os.path.isfile(filename):
-                    f = open(filename, "r")
+                    f = open(filename, "rb")
                     env = cPickle.load(f)
                     f.close()
                     if env.get("version", 0) >= version:
@@ -110,7 +110,7 @@ class Env(IterableUserDict):
             raise EnvSaveError("No filename specified for this env file")
         self.save_lock.acquire()
         try:
-            f = open(filename, "w")
+            f = open(filename, "wb")
             cPickle.dump(self.data, f)
             f.close()
         finally:


### PR DESCRIPTION
This issue is to fix following issue with Python3, as “Pickling” 
converts a object into a byte stream instead of text
Unable to save environment: write() argument must be str, not bytes
({'version': 1, 'address_cache': {}, 'vm__avocado-vt-vm1':
<virttest.libvirt_vm.VM object at 0x7fa58f432a90>})

Signed-off-by: Yan Li <yannli@redhat.com>