### PR TITLE
Undefine libvirt vm using param during postprocess

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -429,6 +429,10 @@ kill_vm_gracefully = yes
 kill_unresponsive_vms = yes
 # Wait time before kill vm
 kill_timeout = 60
+
+# Undefines vm from libvirt environment if set
+kill_vm_libvirt = no
+
 # Verify host dmesg in postprocess.
 verify_host_dmesg = yes
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -385,6 +385,8 @@ def postprocess_vm(test, params, env, name):
         if kill_vm_timeout:
             utils_misc.wait_for(vm.is_dead, kill_vm_timeout, 0, 1)
         vm.destroy(gracefully=params.get("kill_vm_gracefully") == "yes")
+        if params.get("kill_vm_libvirt") == "yes" and params.get("vm_type") == "libvirt":
+            vm.undefine()
 
     if params.get("enable_strace") == "yes":
         strace = test_setup.StraceQemu(test, params, env)


### PR DESCRIPTION
This patch introduces a new param 'kill_vm_libvirt' to undefine
a libvirt vm during test postprocess given that param is set.

This would be helpful incase of cleaning the env properly for
next test with right set of params(create_vm_libvirt) we can
create a newer vm based on given params for next test.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>