### PR TITLE
build_helper: Fix AttributeError of RemoteTarHelper.destination_dir

### DIFF
--- a/virttest/build_helper.py
+++ b/virttest/build_helper.py
@@ -341,7 +341,7 @@ class RemoteTarHelper(LocalTarHelper):
         it using the functionality present in the parent class.
         """
         name = os.path.basename(self.source)
-        base_dest = os.path.dirname(self.destination_dir)
+        base_dest = os.path.dirname(self.destination)
         dest = os.path.join(base_dest, name)
         download.get_file(self.source, dest)
         self.source = dest


### PR DESCRIPTION
Line 344 referenced `self.destination_dir`, but init function defined it as `self.destination`. Correct to `self.destination`

    base_dest = os.path.dirname(self.destination_dir)
AttributeError: 'RemoteTarHelper' object has no attribute 'destination_dir'

Id: 1572069
Signed-off-by: qizhu <qizhu@redhat.com>