### PR TITLE
remote: Proper importing on remote host.

### DIFF
--- a/virttest/remote_commander/messenger.py
+++ b/virttest/remote_commander/messenger.py
@@ -12,6 +12,8 @@ import logging
 import select
 import time
 import base64
+import importlib
+
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -21,7 +23,10 @@ try:
 except ImportError:
     import cPickle
 
-from virttest.remote_commander import remote_interface
+if __package__ is None:  # import when remote_runner.py script run directly
+    remote_interface = importlib.import_module('remote_interface')
+else:
+    from virttest.remote_commander import remote_interface
 
 
 class IOWrapper(object):
@@ -297,7 +302,10 @@ class Messenger(object):
                 rdata_len = len(rdata)
             rdataIO = StringIO(self.stdin.decode(rdata))
             unp = cPickle.Unpickler(rdataIO)
-            unp.find_global = _map_path
+            if cPickle.__name__ == 'pickle':
+                unp.find_class = _map_path
+            else:
+                unp.find_global = _map_path
             data = unp.load()
         except Exception as e:
             logging.error("ERROR data:%s rdata:%s" % (data, rdata))

--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -10,6 +10,7 @@ Created on Dec 6, 2013
 import os
 import sys
 import imp
+import importlib
 import select
 import time
 import stat
@@ -23,8 +24,12 @@ import shutil
 import signal
 import tempfile
 
-from virttest.remote_commander import remote_interface
-from virttest.remote_commander import messenger as ms
+if __name__ == '__main__':
+    remote_interface = importlib.import_module('remote_interface')
+    ms = importlib.import_module('messenger')
+else:
+    from virttest.remote_commander import remote_interface
+    from virttest.remote_commander import messenger as ms
 
 
 from six.moves import input


### PR DESCRIPTION
Signed-off-by: Radek Duda <rduda@redhat.com>

According to https://www.python.org/dev/peps/pep-0008/#imports

> Implicit relative imports should never be used and have been removed in Python 3.

Implicit relative imports have thus been removed here:
https://github.com/avocado-framework/avocado-vt/commit/bc37aa1f2fb6d53253b3a9429f10de13b419ac3e

This causes problems with `vm.commander()`, which copies `"remote_runner.py", "remote_interface.py", "messenger.py"` files to guest vm. There `remote_runner.py` is executed by `remote.remote_commander()` (command `ssh -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=password -p $port $user@$host $path/remote_runner.py agent_base64`). On vm there is no `virttest` package (neither any other package), so import of copied modules fails.

I tested this without problem using `Python 2.7.5` and Avocado 52.0 LTS