### PR TITLE
Add sgio and rawio attr for disk xml in create_disk_xml method

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1860,6 +1860,12 @@ def create_disk_xml(params):
         alias = params.get('alias')
         if alias:
             diskxml.alias = {'name': alias}
+        sgio = params.get('sgio')
+        if sgio:
+            diskxml.sgio = sgio
+        rawio = params.get('rawio')
+        if rawio:
+            diskxml.rawio = rawio
         diskxml.xmltreefile.write()
     except Exception as detail:
         logging.error("Fail to create disk XML:\n%s", detail)


### PR DESCRIPTION
Disk xml has rawio and sgio attributes, add them.

Signed-off-by: Yi Sun <yisun@redhat.com>