### PR TITLE
virttest.qemu_vm: Wait for resume after migration

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3983,7 +3983,10 @@ class VM(virt_vm.BaseVM):
             # self points to a dead VM object
             if not not_wait_for_migration:
                 if self.is_alive() and self.is_paused():
-                    self.resume()
+                    # For short period of time the status can be "inmigrate"
+                    # for example when using external program
+                    # (qemu commit fe823b6f87b2ebedd692ca480ceb9693439d816e)
+                    self.resume(60)
                 clone.destroy(gracefully=False)
                 if env:
                     env.unregister_vm("%s_clone" % self.name)
@@ -4164,12 +4167,15 @@ class VM(virt_vm.BaseVM):
         self.monitor.cmd("stop")
         self.verify_status("paused")
 
-    def resume(self):
+    def resume(self, timeout=None):
         """
         Resume the VM operation in case it's stopped.
         """
         self.monitor.cmd("cont")
-        self.verify_status("running")
+        if timeout:
+            self.wait_for_status('running', timeout, 0.1)
+        else:
+            self.verify_status("running")
 
     def set_link(self, netdev_name, up):
         """


### PR DESCRIPTION
After migration the incoming guest might still be in "inmigration" state
for certain period, especially when external command (like gzip_exec) is
used. Let's allow up-to 60s period when we wait for the right status.

This fixes random issues with migrate.with_reboot.exec.gzip_exec test
that after the fe823b6f87b2ebedd692ca480ceb9693439d816e qemu commit
started failing reporting "inmigration" state (which is expected).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>