### PR TITLE
avocado_vt.test: Fix permissions of job-tmp-dir to allow user access

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -107,6 +107,7 @@ class VirtTest(test.Test):
         self.builddir = os.path.join(self.workdir, 'backends',
                                      vt_params.get("vm_type", ""))
         self.tmpdir = os.path.dirname(self.workdir)
+        os.chmod(self.tmpdir, os.stat(data_dir.get_tmp_dir()).st_mode)
         # Move self.params to self.avocado_params and initialize virttest
         # (cartesian_config) params
         try:


### PR DESCRIPTION
On Avocado 51.0 the Test.tmpdir was created like this:

    $avocado_tmp_dir/$Test.tmpdir

where avocado_tmp_dir == avocado_job_tmp

In Avocado 60.0 we allowed multiple jobs to coexist in a single
execution and the tmpdir became:

    $avocado_tmp_dir/$avocado_job_tmp/$Test.tmpdir

Avocado-vt frequently requires user-access to this tmpdir and contains a
"hack" where just by installing Avocado-vt the permissions are always
modified to:

    $avocado_tmp_dir: drwxr-xr-x
    $Test.tmpdir: drwxrwxr-x.

but left the $avocado_job_tmp on Avocado >60.0 in drwx------., therefor
no child dirs were accessible by other users. This patch additionally
changes the $avocado_job_tmp permissions so it becomes:

    $avocado_job_tmp: drwxr-xr-x.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>