### PR TITLE
Python 3: fixed a bug related to filter

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -2159,14 +2159,12 @@ class QMPMonitor(Monitor):
 
         :return: dict about job info, return empty dict if no active job
         """
-        job = dict()
-        output = str(self.info("block-jobs"))
+        output = self.info("block-jobs")
         try:
-            job = filter(lambda x: x.get("device") == device,
-                         eval(output))
+            job = filter(lambda x: x.get("device") == device, output)
             job = list(job)[0]
         except Exception:
-            pass
+            job = dict()
         return job
 
     def get_backingfile(self, device):


### PR DESCRIPTION
There was a bug when `self.info("block-jobs")` returns `[]`:
Although the `query_block_job` should return `{}`,
it returns `[]` on Python 2.
In later condition check, `if []`is equivalent to `if {}`,
so some cases passed.
However on Python 3, it returns `<fiter object>`, `if <fiter object>`
is qeuivalent to `if True`, which leads to case failures.

Signed-off-by: Haotong Chen <hachen@redhat.com>