### PR TITLE
q35: Update default configurations

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -108,6 +108,11 @@ pseries:
     usb_controller = xhci
     usb_type = nec-usb-xhci
     usb_type_usb1 = nec-usb-xhci
+#use qemu-xchi as the default controller for q35
+q35:
+    usb_controller = xhci
+    usb_type = qemu-xhci
+    usb_type_usb1 = qemu-xhci
 
 # Serial port support
 # You can assign more than one serial to guest with this parameter.

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -16,11 +16,7 @@ variants:
         # RHEL.5, RHEL.6 guest unsupport attach pcie device to downstream
         # port of pcie-switch, see RHBZ#1380285
         no WinXP Win2000 Win2003 RHEL.5 RHEL.6
-        pci_controllers = dmi2pci_bridge pci_bridge
         pci_bus = pci.0
-        type_dmi2pci_bridge = i82801b11-bridge
-        type_pci_bridge = pci-bridge
-        pci_bus_pci_bridge = dmi2pci_bridge
     - @pseries:
         only ppc64, ppc64le
         machine_type = pseries

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1806,7 +1806,7 @@ class QPCIEBus(QPCIBus):
         pcie_devices = ["virtio-net-pci", "virtio-blk-pci",
                         "virtio-scsi-pci", "virtio-balloon-pci",
                         "virtio-serial-pci", "virtio-rng-pci",
-                        "e1000e", "virtio-gpu-device"]
+                        "e1000e", "virtio-gpu-device", "qemu-xhci"]
         if device.get_param("driver") in pcie_devices and (
                     device.get_param("pcie_direct_plug", "no") == "no"):
             return False


### PR DESCRIPTION
1. Remove pci-bridge from q35 default command line, per qemu bz 1363768 closed as WONTFIX
2. Use qemu-xchi as q35 default usb controller, and plug it into pcie-root-port instead of pcie.0 direct, per qemu bz 1568500 and 1568503

id: 1572437, 1572436
Signed-off-by: qizhu <qizhu@redhat.com>