### PR TITLE
Python3: correct base64 encoding usage

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -27,6 +27,7 @@ import re
 import weakref
 import time
 import select
+import locale
 import base64
 import aexpect
 
@@ -3660,7 +3661,9 @@ def secret_set_value(uuid, password, options=None, encode=False, **dargs):
     cmd = "secret-set-value --secret %s" % uuid
     if password:
         if encode:
-            cmd += " --base64 %s" % base64.b64encode(password)
+            encoding = locale.getpreferredencoding()
+            cmd += (" --base64 %s"
+                    % base64.b64encode(password.encode(encoding)).decode(encoding))
         else:
             cmd += " --base64 %s" % password
     if options:


### PR DESCRIPTION
Make necessary change for python 3 base64 usage for libvirt secret
operation.

Signed-off-by: Yi Sun <yisun@redhat.com>