### PR TITLE
Q35: Boot up with extra root port, and hotplug to empty root port instead of pcie.0

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -17,6 +17,7 @@ variants:
         # port of pcie-switch, see RHBZ#1380285
         no WinXP Win2000 Win2003 RHEL.5 RHEL.6
         pci_bus = pci.0
+        pcie_extra_root_port = 3
     - @pseries:
         only ppc64, ppc64le
         machine_type = pseries

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1785,6 +1785,9 @@ class DevContainer(object):
             elif driver == 'i82801b11-bridge':  # addr 0x1-0x13
                 bus_length = 20
                 bus_first_port = 1
+            elif driver in ('pcie-root-port', 'ioh3420'):
+                bus_length = 1  # multifunction off by default
+                bus_first_port = 0
             else:   # addr = 0x0-0x1f
                 bus_length = 32
                 bus_first_port = 0

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1476,6 +1476,15 @@ class QSparseBus(object):
         self.bus[addr] = device
         return []
 
+    def prepare_hotplug(self, device):
+        """
+        Prepares a device to be hot-plugged into this bus;
+        You need to call "insert" afterwards. Concurrent calls
+        of "prepare_hotplug" and "insert" are not supported
+        :param device: QDevice object
+        """
+        device.set_param("bus", self.busid)
+
     def remove(self, device):
         """
         Remove device from this bus
@@ -1899,6 +1908,20 @@ class QPCIEBus(QPCIBus):
                 return root_port.busid
 
         return None
+
+    def prepare_hotplug(self, device):
+        """
+        Prepares a device to be hot-plugged into this bus;
+        You need to call "insert" afterwards. Concurrent calls
+        of "prepare_hotplug" and "insert" are not supported
+        :param device: The QDevice object
+        """
+        root_port = self.get_free_root_port()
+        device.set_param("bus", root_port)
+        if not isinstance(device.parent_bus, (tuple, list)):
+            device.parent_bus = [device.parent_bus]
+        device.parent_bus = tuple(bus for bus in device.parent_bus
+                                  if not self.match_bus(bus)) + ({"busid": root_port},)
 
 
 class QPCISwitchBus(QPCIBus):

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1889,6 +1889,17 @@ class QPCIEBus(QPCIBus):
         else:
             self.__root_ports[addr[0]].insert(device)
 
+    def get_free_root_port(self):
+        """
+        Get a free slot from any pcie root port
+        :return: The free root port busid
+        """
+        for root_port in self.__root_ports.values():
+            if len(root_port.bus) < root_port.addr_lengths[0]:
+                return root_port.busid
+
+        return None
+
 
 class QPCISwitchBus(QPCIBus):
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1339,6 +1339,10 @@ class VM(virt_vm.BaseVM):
             for pcic in params.objects("pci_controllers"):
                 dev = devices.pcic_by_params(pcic, params.object_params(pcic))
                 pcics.append(dev)
+            pcie_extra_root_port = params.get('pcie_extra_root_port', 0)
+            for num in range(int(pcie_extra_root_port)):
+                pcics.append(devices.pcic_by_params("pcie_root_port_%s" % num,
+                                                    {"type": "pcie-root-port"}))
             if params.get("pci_controllers_autosort", "yes") == "yes":
                 pcics.sort(key=sort_key, reverse=False)
             map(devices.insert, pcics)


### PR DESCRIPTION
1. qcontainer: fix default bus_length of pcie-root-port to 1
2. qdevices.QPCIEBus: define get_free_root_port() for hotplug
3. Add extra root port when boot up vm
4. qemu_vm: add an unified hotplug and unplug, supporting q35

id: 1532521
Signed-off-by: qizhu <qizhu@redhat.com>