### PR TITLE
Add param to cleanup env

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -430,7 +430,7 @@ class VirtTest(test.Test):
                                       "postprocessing: %s",
                                       sys.exc_info()[1])
                 finally:
-                    if self.__safe_env_save(env):
+                    if self.__safe_env_save(env) or params.get("env_cleanup", "no") == "yes":
                         env.destroy()   # Force-clean as it can't be stored
 
         except Exception as e:

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -443,6 +443,9 @@ kill_timeout = 60
 # Undefines vm from libvirt environment if set
 kill_vm_libvirt = no
 
+# Cleans up the env if set
+env_cleanup = no
+
 # Verify host dmesg in postprocess.
 verify_host_dmesg = yes
 


### PR DESCRIPTION
This patch introduces a param `env_cleanup`, if set
will clear the env from environment, which is needed
while `create_vm_libvirt` and `kill_vm_libvirt` is enbled.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>