### PR TITLE
base.cfg: move stress args from Linux.cfg to base.cfg

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -616,3 +616,8 @@ virtinstall_extra_args = ""
 
 # Add network proxies setting
 #network_proxies = "https_proxy: https://proxy.com:8080/; ftp_proxy: ftp://proxy.com:3128/"
+
+Linux:
+    # param for stress tests
+    stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 256M'
+    download_url_stress = 'http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz'

--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -19,8 +19,6 @@
     cdrom_check_cdrom_pattern = "/dev/cdrom-\w+|/dev/cdrom\d*"
     cdrom_test_cmd = "dd if=%s of=/dev/null bs=1 count=1"
     cdrom_info_cmd = "cat /proc/sys/dev/cdrom/info"
-    stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 256M'
-    download_url_stress = http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz
     timedrift, timerdevice..boot_test:
         i386, x86_64:
             extra_params += " -no-kvm-pit-reinjection"


### PR DESCRIPTION
Having stress args in base.cfg helps to configure and instrument the
stress args from each testcase granularity, currently it is in Linux.cfg
which overrides the subtests.cfg.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>