### PR TITLE
hotfix: change iter.next() to next(iter)

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4218,7 +4218,7 @@ class VM(virt_vm.BaseVM):
                 while iters:
                     item = iters.pop()
                     try:
-                        k, v = item.next()
+                        k, v = next(item)
                     except StopIteration:
                         continue
                     iters.append(item)


### PR DESCRIPTION
Signed-off-by: Haotong Chen <hachen@redhat.com>