### PR TITLE
unattended_install: To add feature for kickstart cfg

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -396,8 +396,18 @@ class UnattendedInstallConfig(object):
                                                     self.nfs_dir)
         else:
             raise ValueError("Unexpected installation medium %s" % self.url)
-
         contents = re.sub(dummy_medium_re, content, contents)
+
+        dummy_repos_re = r'\bKVM_TEST_REPOS\b'
+        if re.search(dummy_repos_re, contents):
+            repo_list = self.params.get("kickstart_extra_repos", "").split()
+            lines = ["# Extra repositories"]
+            for index, repo_url in enumerate(repo_list, 1):
+                line = ("repo --name=extra_repo%d --baseurl=%s --install "
+                        "--noverifyssl" % (index, repo_url))
+                lines.append(line)
+            content = "\n".join(lines)
+            contents = re.sub(dummy_repos_re, content, contents)
 
         dummy_logging_re = r'\bKVM_TEST_LOGGING\b'
         if re.search(dummy_logging_re, contents):


### PR DESCRIPTION
Add a new feature to support configuring extra repos for kickstart
configuration file.

One who wants to configure extra repos is required to:

1. add the content "KVM_TEST_REPOS" into the commands field of
   kickstart configuration
2. set the param "kickstart_extra_repos" for the test,
   for example:

       kickstart_extra_repos = <url1> <url2> ...

And finally, the dummy content will be replaced by:

    repo --name=extra_repo1 --baseurl=<url1> ...
    repo --name=extra_repo2 --baseurl=<url2> ...
    ...

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1579082