### PR TITLE
Python 3: Update aexpect

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,7 @@
 Sphinx==1.3b1
 inspektor==0.4.5
 autotest>=0.16.2; python_version < '3.0'
-aexpect==1.4.0
+aexpect==1.5.0
 simplejson==3.8.0
 netaddr>=0.7.18
 netifaces>=0.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2; python_version < '3.0'
-aexpect>=1.3.1
+aexpect>=1.5.0
 simplejson>=3.5.3
 netaddr>=0.7.18
 netifaces>=0.10.5


### PR DESCRIPTION
On python3, aexpect always could not get vm's ip address with 1.4.0 and
below version

Signed-off-by: Junxiang Li <junli@redhat.com>