### PR TITLE
unattended_install: does nothing if not .ks file

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -676,6 +676,8 @@ class UnattendedInstallConfig(object):
 
             start_unattended_server_thread(self.unattended_server_port,
                                            self.tmpdir)
+        else:
+            return
 
         # Point installation to this kickstart url
         unattended_file_url = 'http://%s:%s/%s' % (self.url_auto_content_ip,


### PR DESCRIPTION
If unattended file is not a kickstart file, dest_fname would be used
but not declared. So add this patch to fix it.

Signed-off-by: Zheng Xiang <xiang.zheng@linaro.org>