### PR TITLE
[Python3] Fix openvswitch issues

### DIFF
--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -158,7 +158,7 @@ class OpenVSwitchControl(object):
             int_ver = ''.join(a)
         except Exception:
             raise ValueError("Wrong version format '%s'" % version)
-        return int_ver
+        return int(int_ver)
 
     @classmethod
     def get_version(cls):
@@ -356,9 +356,7 @@ class OpenVSwitchSystem(OpenVSwitchControlCli_CNT, OpenVSwitchControlDB_CNT):
         :param ovs_pidfile: Path of OVS ovs-vswitchd pid.
         :param install_prefix: Path where is openvswitch installed.
         """
-        sup = super(man[self.__class__, OpenVSwitchSystem], self)
-        sup.__init__(self, db_path, db_socket, db_pidfile, ovs_pidfile,
-                     dbschema, install_prefix)
+        super(man[self.__class__, OpenVSwitchSystem], self).__init__()
 
         self.cleanup = False
         self.pid_files_path = None
@@ -459,9 +457,7 @@ class OpenVSwitch(OpenVSwitchSystem):
         :param ovs_pidfile: Path of OVS ovs-vswitchd pid.
         :param install_prefix: Path where is openvswitch installed.
         """
-        super(man[self, OpenVSwitch], self).__init__(db_path, db_socket,
-                                                     db_pidfile, ovs_pidfile,
-                                                     dbschema, install_prefix)
+        super(man[self.__class__, OpenVSwitch], self).__init__()
         self.tmpdir = "/%s/openvswitch" % (tmpdir)
         try:
             os.mkdir(self.tmpdir)


### PR DESCRIPTION
1. Change str to int as in python3 str can not compare with int
2. Fix python3 __init__ parameters error when base class is object, which report
"TypeError: object.__init__() takes no parameters"
3. Fix existing format issues and error

Signed-off-by: Kylazhang <weizhan@redhat.com>