### PR TITLE
Added support Libvirt package build test

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -660,6 +660,9 @@ libvirtd_debug_file = ""
 enable_host_sosreport = "no"
 enable_remote_host_sosreport = "no"
 
+# libvirt installer default options
+rpmbuild_path = "/root/rpmbuild/"
+
 Linux:
     # param for stress tests
     stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 256M'

--- a/virttest/build_helper.py
+++ b/virttest/build_helper.py
@@ -688,6 +688,15 @@ class GnuSourceBuildHelper(object):
 
     install = make_install
 
+    def make_rpm(self):
+        """
+        Run "make rpm"
+        """
+        os.chdir(self.build_dir)
+        process.system("make rpm")
+
+    package = make_rpm
+
     def execute(self):
         """
         Runs appropriate steps for *building* this source code tree

--- a/virttest/installer.py
+++ b/virttest/installer.py
@@ -10,6 +10,7 @@ from avocado.core import exceptions
 
 from . import base_installer
 from . import qemu_installer
+from . import libvirt_installer
 
 __all__ = ['InstallerRegistry', 'INSTALLER_REGISTRY', 'make_installer',
            'run_installers']
@@ -132,6 +133,10 @@ INSTALLER_REGISTRY.register('local_tar',
 INSTALLER_REGISTRY.register('remote_tar',
                             qemu_installer.RemoteSourceTarInstaller,
                             'qemu')
+
+INSTALLER_REGISTRY.register('git_repo',
+                            libvirt_installer.GitRepoInstaller,
+                            'libvirt')
 
 
 def installer_name_split(fullname, virt=None):

--- a/virttest/libvirt_installer.py
+++ b/virttest/libvirt_installer.py
@@ -1,0 +1,135 @@
+"""
+Installer code that implement KVM specific bits.
+
+See BaseInstaller class in base_installer.py for interface details.
+"""
+
+import os
+import platform
+import logging
+
+from avocado.utils import process
+from virttest import base_installer
+
+
+__all__ = ['GitRepoInstaller', 'LocalSourceDirInstaller',
+           'LocalSourceTarInstaller', 'RemoteSourceTarInstaller']
+
+
+class LIBVIRTBaseInstaller(base_installer.BaseInstaller):
+
+    '''
+    Base class for libvirt installations
+    '''
+
+    def _set_install_prefix(self):
+        """
+        Prefix for installation of application built from source
+
+        When installing virtualization software from *source*, this is where
+        the resulting binaries will be installed. Usually this is the value
+        passed to the configure script, ie: ./configure --prefix=<value>
+        """
+        prefix = self.test_builddir
+        self.install_prefix = os.path.abspath(prefix)
+
+    def _install_phase_package(self):
+        """
+        Create libvirt package
+        """
+        self.rpmbuild_path = self.params.get("rpmbuild_path", "/root/rpmbuild/")
+        if os.path.isdir(self.rpmbuild_path):
+            process.system("rm -rf %s/*" % self.rpmbuild_path)
+        logging.debug("Build libvirt rpms")
+        process.system("make rpm", allow_output_check="combined")
+
+    def _install_phase_package_verify(self):
+        """
+        Check if rpms are generated
+        """
+        logging.debug("Check for libvirt rpms")
+        found = False
+        for fl in os.listdir('%s/RPMS/%s/' % (self.rpmbuild_path,
+                                              platform.machine())):
+            if fl.endswith('.rpm'):
+                found = True
+        if not found:
+            self.test.fail("Failed to build rpms")
+
+    def _install_phase_install(self):
+        """
+        Install libvirt package
+        """
+        logging.debug("Install libvirt rpms")
+        package_install_cmd = "rpm -Uvh --nodeps --replacepkgs"
+        package_install_cmd += " --replacefiles --oldpackage"
+        package_install_cmd += " %s/RPMS/%s/libvirt*" % (self.rpmbuild_path,
+                                                         platform.machine())
+        process.system(package_install_cmd, allow_output_check="combined")
+
+    def _install_phase_init(self):
+        """
+        Initializes the built and installed software
+
+        :return: None
+        """
+        logging.debug("Initialize installed libvirt package")
+        process.system("service libvirtd restart", allow_output_check="combined")
+
+    def _install_phase_init_verify(self):
+        """
+        Check if package install is success
+
+        :return: None
+        """
+        logging.debug("Check libvirt package install")
+        process.system("service libvirtd status", allow_output_check="combined")
+        process.system("virsh capabilities", allow_output_check="combined")
+
+    def uninstall(self):
+        '''
+        Performs the uninstallation of KVM userspace component
+
+        :return: None
+        '''
+        self._cleanup_links()
+        super(LIBVIRTBaseInstaller, self).uninstall()
+
+    def install(self):
+        super(LIBVIRTBaseInstaller, self).install(package=True)
+
+
+class GitRepoInstaller(LIBVIRTBaseInstaller,
+                       base_installer.GitRepoInstaller):
+
+    '''
+    Installer that deals with source code on Git repositories
+    '''
+    pass
+
+
+class LocalSourceDirInstaller(LIBVIRTBaseInstaller,
+                              base_installer.LocalSourceDirInstaller):
+
+    """
+    Installer that deals with source code on local directories
+    """
+    pass
+
+
+class LocalSourceTarInstaller(LIBVIRTBaseInstaller,
+                              base_installer.LocalSourceTarInstaller):
+
+    """
+    Installer that deals with source code on local tarballs
+    """
+    pass
+
+
+class RemoteSourceTarInstaller(LIBVIRTBaseInstaller,
+                               base_installer.RemoteSourceTarInstaller):
+
+    """
+    Installer that deals with source code on remote tarballs
+    """
+    pass


### PR DESCRIPTION
The patch implements the build capability for avocado-vt for libvirt sources
from the git repository. The implemention is to get libvirt git repo and make
binaries and build rpms and install as part of the build test.

Signed-off-by: Shivaprasad G Bhat <sbhat@linux.vnet.ibm.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>