### PR TITLE
qemu_vm.add_chardev: Correct reference error

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -496,9 +496,9 @@ class VM(virt_vm.BaseVM):
             dynamic = False
             chardev = qdevices.CharDevice(params=params)
             if not qid:
-                devid = utils_misc.generate_random_id()
+                qid = utils_misc.generate_random_id()
                 dynamic = True
-            chardev.set_param("id", devid, dynamic=dynamic)
+            chardev.set_param("id", qid, dynamic=dynamic)
 
             return chardev
 


### PR DESCRIPTION
Hit error when `qid` is not None:

File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-61.0-py2.7.egg/virttest/qemu_vm.py", line 503, in add_chardev
    chardev.set_param("id", devid, dynamic=dynamic)
UnboundLocalError: local variable 'devid' referenced before assignment

id:1581633

Signed-off-by: qizhu <qizhu@redhat.com>