### PR TITLE
Minor fixes for custom boot params

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -876,11 +876,11 @@ class VM(virt_vm.BaseVM):
                 if has_sub_option("boot", "initrd") and initrd_path:
                     result += "initrd=%s," % initrd_path
                 if has_sub_option("boot", "kernel_args") and kernel_args:
-                    result += "kernel_args=%s," % kernel_args
+                    result += "kernel_args=\"%s\"," % kernel_args
             else:
                 result = ""
                 logging.warning("boot option is not supported")
-            return result.strip(',')
+            return result.rstrip(',')
 
         # End of command line option wrappers
 


### PR DESCRIPTION
Modified to rstrip instead of strip as we need
to keep leading `,` and we need kernel params
to be given in quotes as virt-install cmdline
complains.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>