### PR TITLE
Enable libvirtd debug logs by default for libvirt tests

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -29,6 +29,7 @@ except ImportError:
 from avocado.core import exceptions
 from avocado.core import test
 from avocado.utils import stacktrace
+from avocado.utils import process
 
 from virttest import asset
 from virttest import bootstrap
@@ -253,6 +254,29 @@ class VirtTest(test.Test):
             details = sys.exc_info()[1]
             self.__status = details
         finally:
+            # Clean libvirtd debug logs if the test is not fail or error
+            if(self.params.get("vm_type") == 'libvirt' and
+               self.params.get("enable_libvirtd_debug_log", "yes") == "yes"):
+                libvirtd_log = self.params["libvirtd_debug_file"]
+                if("TestFail" not in str(sys.exc_info()[0]) and
+                   "TestError" not in str(sys.exc_info()[0])):
+                    if libvirtd_log and os.path.isfile(libvirtd_log):
+                        logging.info("cleaning libvirtd logs...")
+                        os.remove(libvirtd_log)
+                else:
+                    # tar the libvirtd log and archive
+                    logging.info("archiving libvirtd debug logs")
+                    from virttest import utils_package
+                    if utils_package.package_install("tar"):
+                        archive = os.path.join(libvirtd_log.strip(os.path.basename(libvirtd_log)),
+                                               "libvirtd.tar.gz")
+                        cmd = "tar -zcf %s -P %s" % (archive, libvirtd_log)
+                        if process.system(cmd) == 0:
+                            os.remove(libvirtd_log)
+                    else:
+                        logging.error("Unable to find tar to compress libvirtd "
+                                      "logs")
+
             if env_lang:
                 os.environ['LANG'] = env_lang
             else:

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -613,6 +613,13 @@ virtinstall_extra_args = ""
 #realtime_mlock = on
 #keyboard_layout = en-us
 
+# Params for enable/disable Libvirtd debug logs by default it is
+# enabled and retrieve logs for fail and error tests, the logs
+# are saved in default debug dir
+enable_libvirtd_debug_log = "yes"
+libvirtd_debug_level = "1"
+libvirtd_debug_file = ""
+
 # Add the params to attach strace to start qemu processes
 #enable_strace = no
 #strace_vms = ${main_vm}

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -712,13 +712,14 @@ def preprocess(test, params, env):
 
     vm_type = params.get('vm_type')
 
-    if vm_type == 'libvirt' and params.get("enable_libvirtd_debug_log", False):
-        log_level = params.get("libvirtd_debug_level", 1)
-        log_file = params.get("libvirtd_debug_file", "")
-        libvirtd_debug_log = test_setup.LibvirtdDebugLog(test,
-                                                         log_level,
-                                                         log_file)
-        libvirtd_debug_log.enable()
+    if vm_type == 'libvirt':
+        if params.get("enable_libvirtd_debug_log", "yes") == "yes":
+            log_level = params.get("libvirtd_debug_level", 1)
+            log_file = params.get("libvirtd_debug_file", "")
+            libvirtd_debug_log = test_setup.LibvirtdDebugLog(test,
+                                                             log_level,
+                                                             log_file)
+            libvirtd_debug_log.enable()
 
     setup_pb = False
     ovs_pb = False
@@ -1286,7 +1287,7 @@ def postprocess(test, params, env):
                 err += "\nPolkit cleanup: %s" % str(details
                                                     ).replace('\\n', '\n  ')
                 logging.error("Unexpected error: %s" % details)
-        if params.get("enable_libvirtd_debug_log", False):
+        if params.get("enable_libvirtd_debug_log", "yes") == "yes":
             libvirtd_debug_log = test_setup.LibvirtdDebugLog(test)
             libvirtd_debug_log.disable()
 

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2357,6 +2357,8 @@ class LibvirtdDebugLog(object):
         if not self.log_file or not os.path.isdir(os.path.dirname(self.log_file)):
             self.log_file = utils_misc.get_path(self.test.debugdir,
                                                 "libvirtd.log")
+        # param used during libvirtd cleanup
+        self.test.params["libvirtd_debug_file"] = self.log_file
         logging.debug("libvirtd debug log stored in: %s", self.log_file)
         self.libvirtd_conf["log_level"] = self.log_level
         self.libvirtd_conf["log_outputs"] = '"%s:file:%s"' % (self.log_level,


### PR DESCRIPTION
libvirtd debug logs can be enabled by default, tar compress and archieve 
it only on libvirt tests fail or error and it would be deleted on any other
case. This would help not miss the log for debugging or one time occurence
issues. Still user can override it by setting 'enable_libvirtd_debug_log'
param as "no"

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>