### PR TITLE
Add Fedora.28 and fix Fedora.27

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/27.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/27.cfg
@@ -20,7 +20,7 @@
         # Unattended-file does not require any changes
         unattended_file = unattended/Fedora-25.ks
         # ARCH dependent things
-        aarc64:
+        aarch64:
             kernel_params = "console=ttyAMA0 console=ttyS0 serial"
             unattended_install.cdrom:
                 md5sum_cd1 = 1a9cb7c3feeb5a6d5c4319dd9b60aa93

--- a/shared/cfg/guest-os/Linux/Fedora/27.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/27.cfg
@@ -19,6 +19,12 @@
         initrd = images/f27-${vm_arch_name}/initrd.img
         # Unattended-file does not require any changes
         unattended_file = unattended/Fedora-25.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            # Unless overridden use secondary url, because it's the most common one
+            url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/27/Server/${vm_arch_name}/os/
         # ARCH dependent things
         aarch64:
             kernel_params = "console=ttyAMA0 console=ttyS0 serial"
@@ -68,11 +74,6 @@
                 sha1sum_initrd = 6b465695c57b9a8dac4ec3afc86e7b23
         # Shared specific setting
         unattended_install.url:
-            # Installation works fine with mem=1024 on methods such as cdrom
-            # but fails ("No space left on device") with methods such as url.
-            mem = 2048
-            # Unless overridden use secondary url, because it's the most common one
-            url ?= http://dl.fedoraproject.org/pub/fedora-secondary/releases/27/Server/${vm_arch_name}/os/
             kernel_params += " inst.repo=${url}"
         unattended_install.cdrom:
             cdrom_cd1 = isos/linux/Fedora-Server-dvd-${vm_arch_name}-27-1.6.iso

--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -1,0 +1,84 @@
+- 28:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64:
+            vm_arch_name = ppc64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    image_name = images/f28-${vm_arch_name}
+    os_variant = fedora28
+    # default boot path is set in ../Fedora.cfg: boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel = images/f28-${vm_arch_name}/vmlinuz
+        initrd = images/f28-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/Fedora-25.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            # Unless overridden use secondary url, because it's the most common one
+            url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/28/Server/${vm_arch_name}/os/
+        # ARCH dependent things
+        aarch64:
+            kernel_params = "console=ttyAMA0 console=ttyS0 serial"
+            unattended_install.cdrom:
+                md5sum_cd1 = 5629a2ae883f8afbc5f675f94798398c
+                md5sum_1m_cd1 = eebbca4eb53a276d79063fe30ddc6558
+            unattended_install.url:
+                url = http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Server/${vm_arch_name}/os
+                sha1sum_vmlinuz = f1bc444f795b5c3eb7f7cc229bfa5abb
+                sha1sum_initrd = 63c069ce4a4057abc23dcd54897fb03e
+        ppc64:
+            kernel_params = "console=hvc0 serial"
+            boot_path = ppc/ppc64
+            unattended_install.cdrom:
+                md5sum_cd1 = fdbc46e96cd1c210ab62f7a3ad51b938
+                md5sum_1m_cd1 = 2ef20babadfa30544fd9e94f9d3b573f
+            unattended_install.url:
+                sha1sum_vmlinuz = a682caf6ea9718cf48bda511f464a8a0
+                sha1sum_initrd = 824ae6ec75a39117b873ea85c48a5038
+        ppc64le:
+            kernel_params = "console=hvc0 serial"
+            boot_path = ppc/ppc64
+            unattended_install.cdrom:
+                md5sum_cd1 = c01d0d04b481c56380c88ea2c6e11ce5
+                md5sum_1m_cd1 = 0c78f0233155031b8f4183fb78631ffe
+            unattended_install.url:
+                sha1sum_vmlinuz = a816007723db93411b98cba454452b37
+                sha1sum_initrd = f0d51189f496e6ad8ed9336bd1128f8a
+        s390x:
+            kernel_params = "console=ttysclp0 serial"
+            boot_path = images
+            kernel = images/f28-s390x/kernel.img
+            unattended_install.cdrom:
+                md5sum_cd1 = 2694a40333d0f698fa9b4f7faea18ad7
+                md5sum_1m_cd1 = 4b6e4bbfa315283235ea014245b21d1d
+            unattended_install.url:
+                sha1sum_vmlinuz = 956a22a1134972dc08422b13595aac53
+                sha1sum_initrd = 735a5698f95463f4fbf7e1c90a75c1a2
+        x86_64:
+            kernel_params = "console=tty0 console=ttyS0"
+            unattended_install.cdrom:
+                md5sum_cd1 = 18740b445159c54d10bd887650e8d1d7
+                md5sum_1m_cd1 = cf06d7246d515d06ebb73e6e4a2f547f
+            unattended_install.url:
+                url = http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Server/${vm_arch_name}/os
+                sha1sum_vmlinuz = 93b2351535ed8cfe9e3440b4bba2402d
+                sha1sum_initrd = 0d7bb4b536872954e4c455c87599157b
+        # Shared specific setting
+        unattended_install.url:
+            kernel_params += " inst.repo=${url}"
+        unattended_install.cdrom:
+            cdrom_cd1 = isos/linux/Fedora-Server-dvd-${vm_arch_name}-28-1.1.iso
+        extra_cdrom_ks:
+            kernel_params += " ks=cdrom"
+            cdrom_unattended = images/f28-${vm_arch_name}/ks.iso
+        syslog_server_proto = tcp
+        kernel_params += " nicdelay=60"


### PR DESCRIPTION
I noticed a typo and broken urls for unattended_install.url on Fedora.27 (sorry for that, I shuffled it several times and the last optimization broke it). Also I added Fedora.28. I noticed some odd warnings, but the installation process worked well on x86_64 and the installation began on other arches using TCG as well.