### PR TITLE
env_process: archive sosreport of host/guest/remote host if enabled

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -653,7 +653,14 @@ libvirtd_debug_file = ""
 #Client profile to run for uperf tests
 #client_profile_uperf = "shared/deps/uperf/iperf.xml"
 
+# params to enable/disable sosreport for host/remote host
+enable_host_sosreport = "no"
+enable_remote_host_sosreport = "no"
+
 Linux:
     # param for stress tests
     stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 256M'
     download_url_stress = 'http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz'
+
+    # param to enable/disable sosreport for guest
+    enable_guest_sosreport = "no"


### PR DESCRIPTION
check for the param that enables sosreport and archive it during the
postprocess of the test.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>