### PR TITLE
Add guest config file for CentOS 7.5 ppc64le

### DIFF
--- a/shared/cfg/guest-os/Linux/CentOS/7.5.cfg
+++ b/shared/cfg/guest-os/Linux/CentOS/7.5.cfg
@@ -1,0 +1,4 @@
+- 7.5:
+    no setup
+    image_name = images/centos75
+    os_variant = centos7.0

--- a/shared/cfg/guest-os/Linux/CentOS/7.5/ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/CentOS/7.5/ppc64le.cfg
@@ -1,0 +1,10 @@
+- ppc64le:
+    grub_file = /boot/grub/grub.conf
+    vm_arch_name = ppc64le
+    image_name += -ppc64le
+    boot_path = "ppc/ppc64"
+    unattended_install.url:
+        unattended_file = unattended/CentOS-7-4.ks
+        url = http://mirror.centos.org/altarch/7.5.1804/os/ppc64le/
+        sha1sum_vmlinuz = bf17ccd20d3d5b34bad7c9369e9bd94e6948483f
+        sha1sum_initrd = 496b7d5f32b920b31f31e2df58aad568533c0fb9


### PR DESCRIPTION
Add config file to support CentOS 7.5 ppc64le
guest.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>