### PR TITLE
utils_net: fixed a struct bug

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1299,7 +1299,9 @@ def get_net_if(runner=None, state=None):
     if state is None:
         state = ".*"
     cmd = "ip link"
-    result = runner(cmd)
+    # As the runner converts stdout to unicode on Python2,
+    # it has to be converted to string for struct.pack().
+    result = str(runner(cmd))
     return re.findall(r"^\d+: (\S+?)[@:].*state %s.*$" % (state),
                       result,
                       re.MULTILINE)


### PR DESCRIPTION
Avocado process.stdout_text will convert stdout string to unicode,
it has to be converted to string for struct.pack() on Python 2.

In avocado/utils/process.py:
```python
@property
def stdout_text(self):
    if hasattr(self.stdout, 'decode'):
         return self.stdout.decode(self.encoding)
```
it converts stdout from str to unicode, whereas struct.pack() on Python 2 takes string not unicode.
```
11:43:28 ERROR| Traceback (most recent call last):
11:43:28 ERROR|   File "/usr/lib/python2.7/site-packages/virttest/error_context.py", line 135, in new_fn
11:43:28 ERROR|     return fn(*args, **kwargs)
11:43:28 ERROR|   File "/var/lib/avocado/data/avocado-vt/test-providers.d/downloads/io-github-autotest-qemu/qemu/tests/create_macvtap_device.py", line 48, in run
11:43:28 ERROR|     ifname = utils_net.get_macvtap_base_iface(ifname)
11:43:28 ERROR|   File "/usr/lib/python2.7/site-packages/virttest/utils_net.py", line 928, in get_macvtap_base_iface
11:43:28 ERROR|     if base_inter.is_up():
11:43:28 ERROR|   File "/usr/lib/python2.7/site-packages/virttest/utils_net.py", line 372, in new_func
11:43:28 ERROR|     return func(*args, **argkw)
11:43:28 ERROR|   File"/usr/lib/python2.7/site-packages/virttest/utils_net.py", line 429, in is_up
11:43:28 ERROR|     ifreq = struct.pack('16sh', self.name, 0)
11:43:28 ERROR| error: argument for 's' must be a string
```

id: 1586017

Signed-off-by: Haotong Chen <hachen@redhat.com>