### PR TITLE
utils_misc: Fixup join bytes list in python3

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -4184,7 +4184,7 @@ class BgJob(object):
                 data.append(os.read(pipe.fileno(), 1024))
                 if len(data[-1]) == 0:
                     break
-            data = "".join(data)
+            data = b"".join(data)
         else:
             # Perform a single read
             data = os.read(pipe.fileno(), 1024)


### PR DESCRIPTION
"".join(data) raise "TypeError: sequence item 0:
expected str instance, bytes found"

Signed-off-by: Yan Li <yannli@redhat.com>