### PR TITLE
Python3: Fix bytes-like object error

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -11,6 +11,7 @@ import logging
 
 from avocado.utils import path
 from avocado.utils import process
+from virttest.compat_52lts import decode_to_text
 from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 from virttest import ovirt
@@ -773,7 +774,7 @@ def check_log(params, log):
             expected = 'expected' if expect else 'not expected'
             logging.info('Searching for %s log: %s' % (expected, pattern))
             compiled_pattern = re.compile(line)
-            search = re.search(compiled_pattern, log)
+            search = re.search(compiled_pattern, decode_to_text(log))
             if search:
                 logging.info('Found log: %s', search.group(0))
                 if not expect:


### PR DESCRIPTION
Fix below TypeError for virt-v2v

Traceback (most recent call last):
  File "/root/Documents/tp-libvirt/v2v/tests/src/v2v_options.py", line 721, in run
    check_result(cmd, cmd_result, status_error)
  File "/root/Documents/tp-libvirt/v2v/tests/src/v2v_options.py", line 485, in check_result
    log_check = utils_v2v.check_log(params, output)
  File "/root/Documents/avocado-vt/virttest/utils_v2v.py", line 795, in check_log
    if _check_log(msg_list, expect=expect):
  File "/root/Documents/avocado-vt/virttest/utils_v2v.py", line 776, in _check_log
    search = re.search(compiled_pattern, log)
  File "/usr/lib64/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object

Signed-off-by: xiaodwan <xiaodwan@redhat.com>