### PR TITLE
CharDevice.get_supported_options: fix the elif logic error

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1011,8 +1011,8 @@ class CharDevice(QCustomDevice):
                            "spiceport", "spicevmc"]:
             common_opts.append("mux")
 
-        elif backend in ["file", "pipe", "serial",
-                         "tty", "parallel", "parport"]:
+        if backend in ["file", "pipe", "serial",
+                       "tty", "parallel", "parport"]:
             special_opts.append("path")
 
         elif backend in ["spicevmc", "spiceport"]:


### PR DESCRIPTION
Current `elif` will never be stepped into, since it is all covered by the first `if` condition.

id: 1589693
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>