### PR TITLE
Fix the download type for git

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1878,7 +1878,7 @@ class Stress(object):
         self.stress_args = self.params.get("%s_args" % stress_type, stress_args)
         self.download_url = self.params.get('download_url_%s' % stress_type,
                                             download_url)
-        self.download_type = download_type
+        self.download_type = self.params.get('download_type_%s' % stress_type, download_type)
         self.base_name = self.download_url.split("/")[-1]
         self.make_cmds = self.params.get('make_cmds_%s' % stress_type, make_cmds)
         self.make_cmds = self.make_cmds or './configure && make install'


### PR DESCRIPTION
Currently independent of what users give as download type,
default download_type was been assigned as `tarball`. Incase of
git tree clone, this would fail. This fixes this issue

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>