### PR TITLE
Consider only online nodes with cpu and memory for guest numa

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -994,7 +994,7 @@ class VM(virt_vm.BaseVM):
             if params.get("numa_pin", "no") == "yes":
                 # Get online host numa nodes
                 host_numa_node = utils_misc.NumaInfo()
-                host_numa_node_list = host_numa_node.online_nodes
+                host_numa_node_list = host_numa_node.online_nodes_withcpumem
                 # check if memory is available in host numa node
                 for each_numa in host_numa_node_list:
                     if hugepage:

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1605,6 +1605,9 @@ class NumaInfo(object):
         self.all_nodes = self.get_all_nodes(all_nodes_path)
         self.online_nodes = self.get_online_nodes(online_nodes_path)
         self.online_nodes_withmem = self.get_online_nodes_withmem()
+        self.online_nodes_withcpu = self.get_online_nodes_withcpu()
+        self.online_nodes_withcpumem = list(set(self.online_nodes_withcpu) &
+                                            set(self.online_nodes_withmem))
         self.nodes = {}
         self.distances = {}
         for node_id in self.online_nodes:
@@ -1720,6 +1723,23 @@ class NumaInfo(object):
             online_nodes_mem_file.close()
         else:
             logging.warning("sys numa node with memory file not"
+                            "present, fallback to online nodes")
+            return self.online_nodes
+        return cpu_str_to_list(nodes_info)
+
+    def get_online_nodes_withcpu(self):
+        """
+        Get online node with cpu
+        """
+
+        online_nodes_cpu = get_path(self.numa_sys_path,
+                                    "has_cpu")
+        if os.path.isfile(online_nodes_cpu):
+            online_nodes_cpu_file = open(online_nodes_cpu, "r")
+            nodes_info = online_nodes_cpu_file.read()
+            online_nodes_cpu_file.close()
+        else:
+            logging.warning("sys numa node with cpu file not"
                             "present, fallback to online nodes")
             return self.online_nodes
         return cpu_str_to_list(nodes_info)


### PR DESCRIPTION
There are systems with numa nodes where as only memory is present.

e.x. Power9 OpenPower systems with Volta GPU will show GPU memory
as numa node memory with node numbers > 249 where these nodes need
not be used for guest numa pinning etc.,

So lets handle such environments by supplying only
online nodes with both cpu and memory present.

This patch adds a method to get nodes with cpu and
calculates the nodes with both cpu and memory.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>