### PR TITLE
Use aexpect-1.5.1

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,7 @@
 Sphinx==1.3b1
 inspektor==0.4.5
 autotest>=0.16.2; python_version < '3.0'
-aexpect>=1.3.1,!=1.5.0
+aexpect==1.5.1
 simplejson==3.8.0
 netaddr>=0.7.18
 netifaces>=0.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2; python_version < '3.0'
-aexpect>=1.3.1,!=1.5.0
+aexpect>1.5.0
 simplejson>=3.5.3
 netaddr>=0.7.18
 netifaces>=0.10.5

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2540,6 +2540,7 @@ class VM(virt_vm.BaseVM):
         name = self.name
         params = self.params
         root_dir = self.root_dir
+        pass_fds = []
 
         # Verify the md5sum of the ISO images
         for cdrom in params.objects("cdroms"):
@@ -2673,6 +2674,9 @@ class VM(virt_vm.BaseVM):
 
                     if nic.nettype in ['bridge', 'network', 'macvtap']:
                         self._nic_tap_add_helper(nic)
+                        if bool(nic.tapfds):
+                            for fd in nic.tapfds.split(':'):
+                                pass_fds.append(int(fd))
 
                     if ((nic_params.get("vhost") in ['on',
                                                      'force',
@@ -2683,6 +2687,8 @@ class VM(virt_vm.BaseVM):
                             vhostfds.append(str(os.open("/dev/vhost-net",
                                                         os.O_RDWR)))
                         nic.vhostfds = ':'.join(vhostfds)
+                        for fd in vhostfds:
+                            pass_fds.append(int(fd))
                     elif nic.nettype == 'user':
                         logging.info("Assuming dependencies met for "
                                      "user mode nic %s, and ready to go"
@@ -2804,7 +2810,8 @@ class VM(virt_vm.BaseVM):
                                                 None,
                                                 logging.info,
                                                 "[qemu output] ",
-                                                auto_close=False)
+                                                auto_close=False,
+                                                pass_fds=pass_fds)
 
             logging.info("Created qemu process with parent PID %d",
                          self.process.get_pid())


### PR DESCRIPTION
The aexpect-1.5.1 has been released so we have a working py3k compatible version. Let's bring back the dependent patches so we can benefit from them.

The fact that py3 aexpect was released means we should not need the: https://github.com/avocado-framework/avocado-vt/pull/1611