### PR TITLE
qcontainer.py: modify regex pattern to exclude tab-starting lines

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -55,7 +55,7 @@ class DevContainer(object):
                                                      "stdio -vnc none" % qemu_binary,
                                                      timeout=10, ignore_status=True,
                                                      shell=True, verbose=False))
-            _ = re.findall(r'^([^\| \[\n]+\|?\w+)', _, re.M)
+            _ = re.findall(r'^([^()\|\[\sA-Z]+\|?\w+)', _, re.M)
             hmp_cmds = []
             for cmd in _:
                 if '|' not in cmd:


### PR DESCRIPTION
for result from hmp help command, lines starting with tab and parenthesis should not be included in the resulting commands list.

Signed-off-by: lolyu <lolyu@redhat.com>