### PR TITLE
setup.py: use find_packages() instead of manually listing them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import sys
 import glob
 
 # pylint: disable=E0611
-from setuptools import setup
+from setuptools import setup, find_packages
 
 VERSION = open('VERSION', 'r').read().strip()
 
@@ -85,20 +85,7 @@ setup(name='avocado-plugins-vt',
       author='Avocado Developers',
       author_email='avocado-devel@redhat.com',
       url='http://github.com/avocado-framework/avocado-vt',
-      packages=['avocado_vt',
-                'avocado_vt.plugins',
-                'virttest',
-                'virttest.libvirt_xml',
-                'virttest.libvirt_xml.devices',
-                'virttest.libvirt_xml.nwfilter_protocols',
-                'virttest.qemu_devices',
-                'virttest.remote_commander',
-                'virttest.staging',
-                'virttest.staging.backports',
-                'virttest.tests',
-                'virttest.unittest_utils',
-                'virttest.utils_test',
-                'virttest.utils_test.qemu'],
+      packages=find_packages(exclude=('selftests*',)),
       package_data={"virttest": ["*.*"]},
       data_files=get_data_files(),
       entry_points={


### PR DESCRIPTION
This prevents manual errors like forgetting to list new packages
when they are introduced.

Currently, this change is equivalent to adding the following packages:

 * virttest.staging.backports.collections
 * virttest.staging.backports.simplejson
 * virttest.utils_windows

Reference: https://github.com/avocado-framework/avocado-vt/pull/1627
Signed-off-by: Cleber Rosa <crosa@redhat.com>