### PR TITLE
env_process: default to log libvirtd info

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -711,7 +711,8 @@ def preprocess(test, params, env):
 
     if vm_type == 'libvirt':
         if params.get("enable_libvirtd_debug_log", "yes") == "yes":
-            log_level = params.get("libvirtd_debug_level", "1")
+            # By default log the info level
+            log_level = params.get("libvirtd_debug_level", "2")
             log_file = params.get("libvirtd_debug_file", "")
             libvirtd_debug_log = test_setup.LibvirtdDebugLog(test,
                                                              log_level,


### PR DESCRIPTION
As the libvirtd is enabled by default to capture debug logs for
all the tests but archive it only for fail/error, it is better to
enable the log level to `info` so as to debug and get close to the
issue as well not polluting the archiving space.

Also back up of the libvirtd config should be done before enabling
and restarting the libvirtd is the right thing to do.

Suggested-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>