### PR TITLE
Use "six.string_types" to check for string

### DIFF
--- a/selftests/unit/test_qemu_qtree.py
+++ b/selftests/unit/test_qemu_qtree.py
@@ -199,10 +199,10 @@ class QtreeContainerTest(unittest.TestCase):
                              (i, reference_nodes[i], type(reference_nodes))))
 
         tree = qtree.get_qtree()
-        self.assertTrue(isinstance(tree.str_qtree(), str),
+        self.assertTrue(isinstance(tree.str_qtree(), six.string_types),
                         "qtree.str_qtree() returns nonstring output.")
 
-        self.assertTrue(isinstance(str(tree), str),
+        self.assertTrue(isinstance(str(tree), six.string_types),
                         "str(qtree) returns nonstring output.")
 
     def test_bad_qtree(self):
@@ -250,7 +250,7 @@ class QtreeDiskContainerTest(unittest.TestCase):
                          (0, 0, 1, 0))
         # Check the full disk output (including params)
         for disk in disks.disks:
-            self.assertTrue(isinstance(str(disk), str),
+            self.assertTrue(isinstance(str(disk), six.string_types),
                             "str(disk) returns nonstring output.")
 
     def test_check_params_bad(self):

--- a/shared/deps/run_autotest/boottool.py
+++ b/shared/deps/run_autotest/boottool.py
@@ -1021,7 +1021,7 @@ class Grubby(object):
         '''
         if isinstance(data, int):
             return True
-        elif isinstance(data, str) and data.isdigit():
+        elif isinstance(data, six.string_types) and data.isdigit():
             return True
         return False
 
@@ -1031,10 +1031,10 @@ class Grubby(object):
         '''
         if self._is_number(data):
             return data
-        elif isinstance(data, str) and data.startswith('/'):
+        elif isinstance(data, six.string_types) and data.startswith('/'):
             # assume it's the kernel filename
             return data
-        elif isinstance(data, str):
+        elif isinstance(data, six.string_types):
             return self._kernel_for_title(data)
         else:
             raise ValueError("Bad value for 'kernel' parameter. Expecting "
@@ -2025,7 +2025,7 @@ class BoottoolApp(object):
             result = action_method()
             if result is None:
                 result = 0
-            elif isinstance(result, str):
+            elif isinstance(result, six.string_types):
                 print(result)
                 result = 0
             sys.exit(result)
@@ -2107,7 +2107,7 @@ class BoottoolApp(object):
             print()
             for key, val in list(entry.items()):
                 # remove quotes
-                if isinstance(val, str):
+                if isinstance(val, six.string_types):
                     if val.startswith('"') and val.endswith('"'):
                         val = val[1:-1]
 

--- a/virttest/libvirt_xml/domcapability_xml.py
+++ b/virttest/libvirt_xml/domcapability_xml.py
@@ -3,6 +3,7 @@ Module simplifying manipulation of XML described at
 http://libvirt.org/formatdomaincaps.html
 """
 import logging
+import six
 
 from virttest import xml_utils
 from virttest.libvirt_xml import base, accessors, xcepts
@@ -219,7 +220,7 @@ class EnumXML(base.LibvirtXMLBase):
         """Convert a EnumXML instance into a tag + attributes"""
         del index           # not used
         del libvirtxml      # not used
-        if isinstance(item, str):
+        if isinstance(item, six.string_types):
             return ("value", {}, item)
         else:
             raise xcepts.LibvirtXMLError("Expected a str attributes,"

--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -4,6 +4,7 @@ http://libvirt.org/formatnetwork.html
 """
 
 import logging
+import six
 
 from virttest import xml_utils
 from virttest.libvirt_xml import base, xcepts, accessors
@@ -197,7 +198,7 @@ class DNSXML(base.LibvirtXMLBase):
             """Convert a HostnameXML instance into a tag + attributes"""
             del index           # not used
             del libvirtxml      # not used
-            if isinstance(item, str):
+            if isinstance(item, six.string_types):
                 return ("hostname", {}, item)
             else:
                 raise xcepts.LibvirtXMLError("Expected a str attributes,"

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1286,7 +1286,7 @@ class QSparseBus(object):
         for addr, dev in six.iteritems(self.bus):
             out += '%s< %4s >%s\n  ' % ('-' * 15, addr,
                                         '-' * 15)
-            if isinstance(dev, str):
+            if isinstance(dev, six.string_types):
                 out += '"%s"\n  ' % dev
             else:
                 out += dev.str_long().replace('\n', '\n  ')
@@ -1429,7 +1429,7 @@ class QSparseBus(object):
         :param addr: Desired address
         :type addr: internal [addr1, addr2, ..] or stor format "addr1-addr2-.."
         """
-        if not isinstance(addr, str):
+        if not isinstance(addr, six.string_types):
             addr = self._addr2stor(addr)
         self.bus[addr] = "reserved"
 
@@ -1696,7 +1696,7 @@ class QDenseBus(QSparseBus):
             if hasattr(dev, 'str_long'):
                 out += dev.str_long().replace('\n', '\n  ')
                 out = out[:-3]
-            elif isinstance(dev, str):
+            elif isinstance(dev, six.string_types):
                 out += '"%s"' % dev
             else:
                 out += "%s" % dev
@@ -1750,7 +1750,7 @@ class QPCIBus(QSparseBus):
             return [addr, 0]
         elif not addr:    # not defined
             return [None, 0]
-        elif isinstance(addr, str):     # addr or addr.func
+        elif isinstance(addr, six.string_types):     # addr or addr.func
             addr = [int(_, 16) for _ in addr.split('.', 1)]
             if len(addr) < 2:   # only addr
                 addr.append(0)
@@ -1760,7 +1760,7 @@ class QPCIBus(QSparseBus):
         """ Convert addr to the format used by qtree """
         device.set_param(self.bus_item, self.busid)
         orig_addr = device.get_param('addr')
-        if addr[1] or (isinstance(orig_addr, str) and
+        if addr[1] or (isinstance(orig_addr, six.string_types) and
                        orig_addr.find('.') != -1):
             device.set_param('addr', '0x%x.%x' % (addr[0], addr[1]))
         else:
@@ -2008,7 +2008,7 @@ class QBusUnitBus(QDenseBus):
     def _check_bus(self, device):
         """ This bus is compound of m-buses + n-units, check correct busid """
         bus = device.get_param('bus')
-        if isinstance(bus, str):
+        if isinstance(bus, six.string_types):
             bus = bus.rsplit('.', 1)
             if len(bus) == 2 and bus[0] != self.busid:  # aaa.3
                 return False
@@ -2021,7 +2021,7 @@ class QBusUnitBus(QDenseBus):
         bus = None
         unit = None
         busid = device.get_param('bus')
-        if isinstance(busid, str):
+        if isinstance(busid, six.string_types):
             if busid.isdigit():
                 bus = int(busid)
             else:
@@ -2072,7 +2072,7 @@ class QFloppyBus(QDenseBus):
     def _dev2addr(self, device):
         """ Read None, number or drive$CHAR and convert to int() """
         addr = device.get_param('property')
-        if isinstance(addr, str):
+        if isinstance(addr, six.string_types):
             if addr.startswith('drive') and len(addr) > 5:
                 addr = ord(addr[5])
             elif addr.isdigit():

--- a/virttest/qemu_devices/utils.py
+++ b/virttest/qemu_devices/utils.py
@@ -4,6 +4,8 @@ Shared classes and functions (exceptions, ...)
 :copyright: 2013 Red Hat Inc.
 """
 
+import six
+
 
 #
 # Exceptions
@@ -67,7 +69,7 @@ def none_or_int(value):
         return value
     elif not value:   # "", None, False
         return None
-    elif isinstance(value, str) and value.isdigit():
+    elif isinstance(value, six.string_types) and value.isdigit():
         return int(value)
     else:
         raise TypeError("This parameter has to be int or none")

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -474,7 +474,7 @@ class Monitor:
         :return: Dict of disk parameters
         """
         info = self.info('block', debug)
-        if isinstance(info, str):
+        if isinstance(info, six.string_types):
             try:
                 return self._parse_info_block_old(info)
             except ValueError:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -391,7 +391,7 @@ class VM(virt_vm.BaseVM):
                     return fmt % (option, "off")
             elif value and isinstance(value, bool):
                 return fmt % (option, "on")
-            elif value and isinstance(value, str):
+            elif value and isinstance(value, six.string_types):
                 # "EMPTY_STRING" and "NULL_STRING" is used for testing illegal
                 # foramt of option.
                 # "EMPTY_STRING": set option as a empty string "".
@@ -3724,26 +3724,26 @@ class VM(virt_vm.BaseVM):
         if (self.params["display"] == "spice" and
                 self.get_spice_var("spice_seamless_migration") == "on"):
             s = self.monitor.info("spice")
-            if isinstance(s, str):
+            if isinstance(s, six.string_types):
                 ret = len(re.findall("migrated: true", s, re.I)) > 0
             else:
                 ret = len(re.findall("true", str(s.get("migrated")), re.I)) > 0
         o = self.monitor.info("migrate")
-        if isinstance(o, str):
+        if isinstance(o, six.string_types):
             return ret and not re.search(r"status: *[\w-]*active", o)
         else:
             return ret and not ("active" in o.get("status"))
 
     def mig_succeeded(self):
         o = self.monitor.info("migrate")
-        if isinstance(o, str):
+        if isinstance(o, six.string_types):
             return "status: completed" in o
         else:
             return o.get("status") == "completed"
 
     def mig_failed(self):
         o = self.monitor.info("migrate")
-        if isinstance(o, str):
+        if isinstance(o, six.string_types):
             return "status: failed" in o
         else:
             return o.get("status") == "failed"
@@ -3755,7 +3755,7 @@ class VM(virt_vm.BaseVM):
         elif self.mig_failed():
             raise virt_vm.VMMigrateFailedError("Migration failed")
         o = self.monitor.info("migrate")
-        if isinstance(o, str):
+        if isinstance(o, six.string_types):
             return ("Migration status: cancelled" in o or
                     "Migration status: canceled" in o)
         else:
@@ -4242,7 +4242,7 @@ class VM(virt_vm.BaseVM):
 
         :return: Matched block device name, None when not find any device.
         """
-        if isinstance(blocks_info, str):
+        if isinstance(blocks_info, six.string_types):
             for block in blocks_info.splitlines():
                 match = True
                 for key, value in six.iteritems(p_dict):
@@ -4359,7 +4359,7 @@ class VM(virt_vm.BaseVM):
         assert value in str(blocks_info), \
             "Device %s not listed in monitor's output" % value
 
-        if isinstance(blocks_info, str):
+        if isinstance(blocks_info, six.string_types):
             lock_str = "locked=1"
             lock_str_new = "locked"
             no_lock_str = "not locked"

--- a/virttest/staging/backports/simplejson/encoder.py
+++ b/virttest/staging/backports/simplejson/encoder.py
@@ -48,7 +48,7 @@ def encode_basestring(s):
     """Return a JSON representation of a Python string
 
     """
-    if isinstance(s, str) and HAS_UTF8.search(s) is not None:
+    if isinstance(s, six.string_types) and HAS_UTF8.search(s) is not None:
         s = s.decode('utf-8')
 
     def replace(match):
@@ -60,7 +60,7 @@ def py_encode_basestring_ascii(s):
     """Return an ASCII-only JSON representation of a Python string
 
     """
-    if isinstance(s, str) and HAS_UTF8.search(s) is not None:
+    if isinstance(s, six.string_types) and HAS_UTF8.search(s) is not None:
         s = s.decode('utf-8')
 
     def replace(match):
@@ -218,7 +218,7 @@ class JSONEncoder(object):
         """
         # This is for extremely simple cases and benchmarks.
         if isinstance(o, basestring):
-            if isinstance(o, str):
+            if isinstance(o, six.string_types):
                 _encoding = self.encoding
                 if (_encoding is not None and
                         not (_encoding == 'utf-8')):
@@ -259,7 +259,7 @@ class JSONEncoder(object):
         if self.encoding != 'utf-8':
             # pylint: disable=E0102
             def _encoder(o, _orig_encoder=_encoder, _encoding=self.encoding):
-                if isinstance(o, str):
+                if isinstance(o, six.string_types):
                     o = o.decode(_encoding)
                 return _orig_encoder(o)
 

--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -13,6 +13,7 @@ import subprocess
 import time
 import re
 import random
+import six
 from tempfile import mkdtemp
 
 from avocado.core import exceptions
@@ -69,7 +70,7 @@ class Cgroup(object):
         :param cgroup: cgroup name
         :return: cgroup's full path
         """
-        if not isinstance(cgroup, str):
+        if not isinstance(cgroup, six.string_types):
             raise exceptions.TestError("cgroup type isn't string!")
         return os.path.join(self.root, cgroup) + '/'
 

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1522,7 +1522,7 @@ def cpu_str_to_list(origin_str):
     :return: A list of the cpu ids
     :rtype: builtin.list
     """
-    if isinstance(origin_str, str):
+    if isinstance(origin_str, six.string_types):
         origin_str = "".join([_ for _ in origin_str if _ in string.printable])
         cpu_list = []
         for cpu in origin_str.strip().split(","):

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -18,6 +18,7 @@ from avocado.core import exceptions
 from avocado.utils import path as utils_path
 from avocado.utils import process
 
+import six
 from six.moves import xrange
 
 from virttest import openvswitch
@@ -1727,7 +1728,7 @@ def refresh_neigh_table(interface_name=None, neigh_address="ff02::1"):
     """
     if isinstance(interface_name, list):
         interfaces = interface_name
-    elif isinstance(interface_name, str):
+    elif isinstance(interface_name, six.string_types):
         interfaces = interface_name.split()
     else:
         interfaces = list(filter(lambda x: "-" not in x, get_net_if()))
@@ -1883,7 +1884,7 @@ def change_iface_bridge(ifname, new_bridge, ovs=None):
     if br_manager_new is None:
         raise BRNotExistError(new_bridge, "")
 
-    if isinstance(ifname, str):
+    if isinstance(ifname, six.string_types):
         (br_manager_old, br_old) = find_current_bridge(ifname, ovs)
         if br_manager_old is not None:
             br_manager_old.del_port(br_old, ifname)
@@ -1958,7 +1959,7 @@ def add_to_bridge(ifname, brname, ovs=None):
         ovs = __ovs
 
     _ifname = None
-    if isinstance(ifname, str):
+    if isinstance(ifname, six.string_types):
         _ifname = ifname
     elif issubclass(type(ifname), VirtIface):
         _ifname = ifname.ifname
@@ -1988,7 +1989,7 @@ def del_from_bridge(ifname, brname, ovs=None):
         ovs = __ovs
 
     _ifname = None
-    if isinstance(ifname, str):
+    if isinstance(ifname, six.string_types):
         _ifname = ifname
     elif issubclass(type(ifname), VirtIface):
         _ifname = ifname.ifname
@@ -2357,7 +2358,7 @@ class VirtIface(propcan.PropCan, object):
         Corner-case prevention where nic_name is not a sane string value
         """
         try:
-            return isinstance(nic_name, str) and len(nic_name) > 1
+            return isinstance(nic_name, six.string_types) and len(nic_name) > 1
         except (TypeError, KeyError, AttributeError):
             return False
 
@@ -2496,7 +2497,7 @@ class VMNet(list):
         VMNet.__init__(self, self.container_class, state)
 
     def __getitem__(self, index_or_name):
-        if isinstance(index_or_name, str):
+        if isinstance(index_or_name, six.string_types):
             index_or_name = self.nic_name_index(index_or_name)
         return super(VMNet, self).__getitem__(index_or_name)
 
@@ -2504,7 +2505,7 @@ class VMNet(list):
         if not isinstance(value, dict):
             raise VMNetError
         if self.container_class.name_is_valid(value['nic_name']):
-            if isinstance(index_or_name, str):
+            if isinstance(index_or_name, six.string_types):
                 index_or_name = self.nic_name_index(index_or_name)
             self.process_mac(value)
             super(VMNet, self).__setitem__(index_or_name,
@@ -2513,7 +2514,7 @@ class VMNet(list):
             raise VMNetError
 
     def __delitem__(self, index_or_name):
-        if isinstance(index_or_name, str):
+        if isinstance(index_or_name, six.string_types):
             index_or_name = self.nic_name_index(index_or_name)
         super(VMNet, self).__delitem__(index_or_name)
 
@@ -2573,7 +2574,7 @@ class VMNet(list):
         """
         Return the index number for name, or raise KeyError
         """
-        if not isinstance(name, str):
+        if not isinstance(name, six.string_types):
             raise TypeError("nic_name_index()'s nic_name must be a string")
         nic_name_list = self.nic_name_list()
         try:

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -18,6 +18,7 @@ More specifically:
 
 import os
 import re
+import six
 import time
 import logging
 from functools import reduce
@@ -36,7 +37,7 @@ from virttest.compat_52lts import decode_to_text
 
 def guest_active(vm):
     o = vm.monitor.info("status")
-    if isinstance(o, str):
+    if isinstance(o, six.string_types):
         return "status: running" in o
     else:
         if "status" in o:

--- a/virttest/utils_test/qemu/migration.py
+++ b/virttest/utils_test/qemu/migration.py
@@ -12,6 +12,7 @@ import socket
 import threading
 import time
 import re
+import six
 try:
     import pickle as cPickle
 except ImportError:
@@ -42,7 +43,7 @@ except ImportError:
 
 def guest_active(vm):
     o = vm.monitor.info("status")
-    if isinstance(o, str):
+    if isinstance(o, six.string_types):
         return "status: running" in o
     else:
         if "status" in o:
@@ -96,7 +97,7 @@ def migrate(vm, env=None, mig_timeout=3600, mig_protocol="tcp",
             raise exceptions.TestFail("Source VM died during migration")
         try:
             o = vm.monitor.info("migrate")
-            if isinstance(o, str):
+            if isinstance(o, six.string_types):
                 return "status: active" not in o
             else:
                 return o.get("status") != "active"
@@ -105,21 +106,21 @@ def migrate(vm, env=None, mig_timeout=3600, mig_protocol="tcp",
 
     def mig_succeeded():
         o = vm.monitor.info("migrate")
-        if isinstance(o, str):
+        if isinstance(o, six.string_types):
             return "status: completed" in o
         else:
             return o.get("status") == "completed"
 
     def mig_failed():
         o = vm.monitor.info("migrate")
-        if isinstance(o, str):
+        if isinstance(o, six.string_types):
             return "status: failed" in o
         else:
             return o.get("status") == "failed"
 
     def mig_cancelled():
         o = vm.monitor.info("migrate")
-        if isinstance(o, str):
+        if isinstance(o, six.string_types):
             return ("Migration status: cancelled" in o or
                     "Migration status: canceled" in o)
         else:
@@ -1584,7 +1585,7 @@ class MigrationBase(object):
         if self.is_src:
             vm = self.env.get_vm(self.params["main_vm"])
             o = vm.monitor.info("migrate")
-            if isinstance(o, str):
+            if isinstance(o, six.string_types):
                 return ("Migration status: cancelled" in o or
                         "Migration status: canceled" in o)
             else:


### PR DESCRIPTION
More and more we start using "astring.to_text" which frequently produces
"unicode" on python2. The problem is that "unicode" is not instance of
"str", therefor "isinstance(foo, str)" results to false.

Let's address all places where "isinstance(.*, str)" is used by using
"six.string_types" which works well for py2 and py3.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>