### PR TITLE
Fix stress check command

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1902,8 +1902,9 @@ class Stress(object):
         self.uninstall_cmds = self.uninstall_cmds or './configure && make uninstall'
         self.work_path = self.params.get('%s_work_path' % stress_type,
                                          work_path)
-        self.check_cmd = "pidof -s %s" % stress_type
-        self.stop_cmd = "pkill -9 %s" % stress_type
+        check_cmd = self.stress_cmds.split(" ")[0]
+        self.check_cmd = "pidof -s %s" % check_cmd
+        self.stop_cmd = "pkill -9 %s" % check_cmd
         self.dst_path = self.params.get('stress_dst_path', '/home')
         self.cmd_status_output = process.getstatusoutput
         self.cmd_output_safe = process.getoutput


### PR DESCRIPTION
Currently check_cmd would be assigned with stress_type, which will not hold
good all the time. Example, when we run netperf : stress_type would be netperf
but the actual command running on host would be netstress. This commit fixes
this by assigning check_cmd with actual stress command instead of stress_type.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>