### PR TITLE
network_xml: Update net_create to add **dargs

### DIFF
--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -732,11 +732,11 @@ class NetworkXML(NetworkXMLBase):
         if self.defined:
             return self.virsh.net_state_dict(virsh_instance=self.virsh)[self.name]
 
-    def create(self):
+    def create(self, **dargs):
         """
         Adds non-persistant / transient network to libvirt with net-create
         """
-        cmd_result = self.virsh.net_create(self.xml)
+        cmd_result = self.virsh.net_create(self.xml, **dargs)
         if cmd_result.exit_status:
             raise xcepts.LibvirtXMLError("Failed to create transient network %s.\n"
                                          "Detail: %s" %


### PR DESCRIPTION
Add **dargs to pass non default key-word arguments, such
as readonly.

Signed-off-by: Yan Li <yannli@redhat.com>