### PR TITLE
Add support for riscv64

### DIFF
--- a/docs/source/Experimental.rst
+++ b/docs/source/Experimental.rst
@@ -1,0 +1,74 @@
+.. _experimental:
+
+=====================
+Experimental features
+=====================
+
+
+riscv64
+=======
+
+The support for riscv64 is very experimental and requires special
+preparations. Basically you need to prepare your system according to:
+
+    https://fedorapeople.org/groups/risc-v/disk-images/readme.txt
+
+Which means you need to install latest qemu-system-riscv (tested
+with qemu ``00928a421d47f49691cace1207481b7aad31b1f1``) or install
+the one provided by Rich:
+
+    https://copr.fedorainfracloud.org/coprs/rjones/riscv/
+
+And you need to download a suitable image and bootable kernel to
+the right location:
+
+* kernel: https://fedorapeople.org/groups/risc-v/disk-images/bbl
+  needs to be downloaded in ``$AVOCADO_VT_DATA/images/f28-riscv64-kernel``
+* image: https://fedorapeople.org/groups/risc-v/disk-images/stage4-disk.img.xz
+  needs to be downloaded in ``$AVOCADO_VT_DATA/images/``, extracted
+  and converted to ``qcow2`` using name ``f28-riscv64.qcow2``.
+
+Basically you can go into ``$AVOCADO_VT_DATA/images`` and execute::
+
+    curl https://fedorapeople.org/groups/risc-v/disk-images/bbl -o f28-riscv64-kernel
+    curl https://fedorapeople.org/groups/risc-v/disk-images/stage4-disk.img.xz | xz -d > stage4-disk.img
+    qemu-img convert -f raw -O qcow2 stage4-disk.img f28-riscv64.qcow2
+    rm stage4-disk.img
+
+Also I'd recommend booting the guest::
+
+    qemu-system-riscv64 \
+        -nographic \
+        -machine virt \
+        -smp 4 \
+        -m 2G \
+        -kernel f28-riscv64-kernel \
+        -object rng-random,filename=/dev/urandom,id=rng0 \
+        -device virtio-rng-device,rng=rng0 \
+        -append "console=ttyS0 ro root=/dev/vda" \
+        -device virtio-blk-device,drive=hd0 \
+        -drive file=f28-riscv64.qcow2,format=qcow2,id=hd0 \
+        -device virtio-net-device,netdev=usernet \
+        -netdev user,id=usernet,hostfwd=tcp::10000-:22
+
+and running the Fedora-25.ks post-install steps::
+
+    dnf -y install @standard @c-development @development-tools python net-tools sg3_utils python-pip
+    grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+    dhclient
+    chkconfig sshd on
+    iptables -F
+    systemctl mask tmp.mount
+    echo 0 > /selinux/enforce
+    sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+    # if package groups were missing from main installation repo
+    # try again from installed system
+    dnf -y groupinstall c-development development-tools
+    # include avocado: allows using this machine with remote runner
+    # Fallback to pip as it's not yet built for riscv64
+    dnf -y install python2-avocado || pip install python2-avocado
+
+.. tip:: If you want to use riscv without kvm (eg. on x86 host) use something
+         like ``avocado run --vt-machine-type riscv64-mmio --vt-arch riscv64
+         --vt-extra-params enable_kvm=no --vt-guest-os Fedora.28 -- boot``
+         which sets the right machine/arch and disables kvm (uses tcg).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ Contents:
    RunQemuUnittests
    ParallelJobs
    contributing/index
+   Experimental
 
 =============
 API Reference

--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -41,7 +41,7 @@ variants:
             # Device selection for the NDISTest server machine
             dp_regex_servermsgdev = VirtIO Ethernet Adapter$
             dp_regex_serversupportdev = VirtIO Ethernet Adapter #2$
-        arm64-mmio, s390-virtio:
+        arm64-mmio, s390-virtio, riscv64-mmio:
             # Currently arm/s390x does not support msix vectors
             enable_msix_vectors = no
     - xennet:

--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -6,6 +6,22 @@
             vm_arch_name = ppc64
         - ppc64le:
             vm_arch_name = ppc64le
+        - riscv64:
+            # Image provided by Rich Jones, for instructions read:
+            # https://avocado-vt.readthedocs.io/en/latest/Experimental.html#riscv64
+            no install, setup, unattended_install, svirt_install
+            vm_arch_name = riscv64
+            # The provided image uses "riscv" password
+            password = riscv
+            # Double the usual timeouts
+            timeout = 1200
+            login_timeout = 720
+            kill_timeout = 120
+            # Currently we have to boot via custom kernel
+            kernel = images/f28-${vm_arch_name}-kernel
+            kernel_params = "console=ttyS0 ro root=/dev/sda"
+            virtio_blk:
+                kernel_params = "console=ttyS0 ro root=/dev/vda"
         - s390x:
             vm_arch_name = s390x
         - x86_64:

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -67,6 +67,21 @@ variants:
         # Currently no USB support
         usbs =
         usb_devices =
+    - riscv64-mmio:
+        only riscv64
+        # USB subsystem not available
+        no usb, usb_device_check, boot_from_usb, usb_d
+        no systemtap_tracing
+        auto_cpu_model = "no"
+        cpu_model = any
+        machine_type = riscv64-mmio:virt
+        # No support for VGA yet
+        vga = none
+        inactivity_watcher = none
+        take_regular_screendumps = no
+        # Currently no USB support
+        usbs =
+        usb_devices =
     - s390-virtio:
         only s390x
         # USB subsystem not available

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -903,7 +903,6 @@ class DevContainer(object):
                                       "AAVMF variables file.")
             logging.warn('Support for aarch64 is highly experimental!')
             devices = []
-            devices.append(qdevices.QStringDevice('machine', cmdline=cmd))
             # EFI pflash
             aavmf_code = ("-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,"
                           "if=pflash,format=raw,unit=0,readonly=on")
@@ -953,7 +952,6 @@ class DevContainer(object):
                                       "AAVMF variables file.")
             logging.warn('Support for aarch64 is highly experimental!')
             devices = []
-            devices.append(qdevices.QStringDevice('machine', cmdline=cmd))
             # EFI pflash
             aavmf_code = ("-drive file=/usr/share/AAVMF/AAVMF_CODE.fd,"
                           "if=pflash,format=raw,unit=0,readonly=on")

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1013,6 +1013,30 @@ class DevContainer(object):
                                                   aobject="virtio-blk-ccw"))
             return devices
 
+        def machine_riscv64_mmio(cmd=False):
+            """
+            riscv doesn't support PCI bus, only MMIO transports.
+            :param cmd: If set uses "-M $cmd" to force this machine type
+            :return: List of added devices (including default buses)
+            """
+            logging.warn("Support for riscv64 is highly experimental. See "
+                         "https://avocado-vt.readthedocs.io"
+                         "/en/latest/Experimental.html#riscv64 for "
+                         "setup information.")
+            devices = []
+            # Add virtio-bus
+            # TODO: Currently this uses QNoAddrCustomBus and does not
+            # set the device's properties. This means that the qemu qtree
+            # and autotest's representations are completelly different and
+            # can't be used.
+            bus = qdevices.QNoAddrCustomBus('bus', [['addr'], [32]],
+                                            'virtio-mmio-bus', 'virtio-bus',
+                                            'virtio-mmio-bus')
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
+                                                  child_bus=bus,
+                                                  aobject="virtio-mmio-bus"))
+            return devices
+
         def machine_other(cmd=False):
             """
             isapc or unknown machine type. This type doesn't add any default
@@ -1053,6 +1077,8 @@ class DevContainer(object):
                     devices = machine_arm64_mmio(cmd)
                 elif machine_type.startswith("s390"):
                     devices = machine_s390_virtio(cmd)
+                elif avocado_machine == 'riscv64-mmio':
+                    devices = machine_riscv64_mmio(cmd)
                 elif 'isapc' not in machine_type:   # i440FX
                     devices = machine_i440FX(cmd)
                 else:   # isapc (or other)

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1031,10 +1031,11 @@ class DevContainer(object):
         machine_type = params.get('machine_type')
         machine_type_extra_params = params.get('machine_type_extra_params')
         if machine_type:
-            if machine_type.startswith('arm64'):
-                arm_machine, machine_type = machine_type.split(':', 1)
+            split_machine_type = machine_type.split(':', 1)
+            if len(split_machine_type) == 1:
+                avocado_machine = ''
             else:
-                arm_machine = False
+                avocado_machine, machine_type = split_machine_type
             m_types = []
             for _ in self.__machine_types.splitlines()[1:]:
                 m_types.append(_.split()[0])
@@ -1048,9 +1049,9 @@ class DevContainer(object):
                     cmd = ""
                 if 'q35' in machine_type:   # Q35 + ICH9
                     devices = machine_q35(cmd)
-                elif arm_machine == 'arm64-pci':
+                elif avocado_machine == 'arm64-pci':
                     devices = machine_arm64_pci(cmd)
-                elif arm_machine == 'arm64-mmio':
+                elif avocado_machine == 'arm64-mmio':
                     devices = machine_arm64_mmio(cmd)
                 elif machine_type.startswith("s390"):
                     devices = machine_s390_virtio(cmd)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -582,7 +582,7 @@ class VM(virt_vm.BaseVM):
             dev.set_param("server", 'NO_EQUAL_STRING')
             dev.set_param("nowait", 'NO_EQUAL_STRING')
             devices.insert(dev)
-            if params.get('machine_type').startswith("arm64-mmio"):
+            if '-mmio:' in params.get('machine_type'):
                 dev = QDevice('virtio-serial-device')
             elif params.get('machine_type').startswith("s390"):
                 dev = QDevice("virtio-serial-ccw")
@@ -619,7 +619,7 @@ class VM(virt_vm.BaseVM):
                     machine_type = self.params.get("machine_type")
                     if "s390" in machine_type:
                         model = "virtio-net-ccw"
-                    elif "mmio" in machine_type:
+                    elif '-mmio:' in machine_type:
                         model = "virtio-net-device"
                     else:
                         model = "virtio-net-pci"
@@ -1584,7 +1584,7 @@ class VM(virt_vm.BaseVM):
                 # when the port is a virtio console.
                 if (port_params.get('virtio_port_type') == 'console' and
                         params.get('virtio_port_bus') is None):
-                    if params.get('machine_type').startswith("arm64-mmio"):
+                    if '-mmio:' in params.get('machine_type'):
                         dev = QDevice('virtio-serial-device')
                     elif params.get('machine_type').startswith("s390"):
                         dev = QDevice("virtio-serial-ccw")
@@ -1596,7 +1596,7 @@ class VM(virt_vm.BaseVM):
                     devices.insert(dev)
                     no_virtio_serial_pcis += 1
                 for i in range(no_virtio_serial_pcis, bus + 1):
-                    if params.get('machine_type').startswith("arm64-mmio"):
+                    if '-mmio:' in params.get('machine_type'):
                         dev = QDevice('virtio-serial-device')
                     elif params.get('machine_type').startswith("s390"):
                         dev = QDevice("virtio-serial-ccw")

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1179,7 +1179,8 @@ class VM(virt_vm.BaseVM):
 
         def add_boot(devices, opts):
             machine_type = params.get('machine_type', "")
-            if machine_type.startswith("arm"):
+            if (machine_type.startswith("arm") or
+                    machine_type.startswith('riscv')):
                 logging.warn("-boot on %s is usually not supported, use "
                              "bootindex instead.", machine_type)
                 return ""

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1178,11 +1178,12 @@ class VM(virt_vm.BaseVM):
             return cmd
 
         def add_boot(devices, opts):
-            if params.get('machine_type', "").startswith("arm"):
-                logging.warn("-boot on ARM is usually not supported, use "
-                             "bootindex instead.")
+            machine_type = params.get('machine_type', "")
+            if machine_type.startswith("arm"):
+                logging.warn("-boot on %s is usually not supported, use "
+                             "bootindex instead.", machine_type)
                 return ""
-            if params.get('machine_type', "").startswith("s390"):
+            if machine_type.startswith("s390"):
                 logging.warn("-boot on s390x only support boot strict=on")
                 return "-boot strict=on"
             cmd = " -boot"


### PR DESCRIPTION
Hello guys,

yet another interesting architecture is getting more and more attention, let's include it in Avocado-vt to help them testing their bits.

Currently riscv64 support is still very basic. It require `-kernel` to boot and there is no `DVD` to install it from, but despite that we can already run several tests.