### PR TITLE
utils_misc: extend get_distro to retrieve for remote host

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -44,6 +44,7 @@ from aexpect.utils.genio import _open_log_files
 
 from avocado.core import status
 from avocado.core import exceptions
+from avocado.utils import distro
 from avocado.utils import git
 from avocado.utils import path as utils_path
 from avocado.utils import process
@@ -4594,3 +4595,25 @@ def start_rsyslogd():
         logging.info("Need to start rsyslog service")
         return rsyslogd.start()
     return True
+
+
+def get_distro(session=None):
+    """
+    Get distribution name of the Host/Guest/Remote Host
+
+    :param session: ShellSession object of VM or remote host
+    :return: distribution name of type str
+    """
+    if not session:
+        return distro.detect().name
+    else:
+        distro_name = ""
+        cmd = "cat /etc/os-release | grep '^ID='"
+        try:
+            status, output = session.cmd_status_output(cmd, timeout=300)
+            if status:
+                logging.debug("Unable to get the distro name: %s" % output)
+            else:
+                distro_name = output.split('=')[1].strip()
+        finally:
+            return distro_name

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -627,18 +627,10 @@ class BaseVM(object):
         """
         Get distribution name of the vm instance.
         """
-        distro = ""
         session = self.wait_for_login()
-        cmd = "cat /etc/os-release | grep '^ID='"
-        try:
-            status, output = session.cmd_status_output(cmd, timeout=300)
-            if status:
-                logging.debug("Unable to get the distro name: %s" % output)
-            else:
-                distro = output.split('=')[1].strip()
-        finally:
-            session.close()
-            return distro
+        distro_name = utils_misc.get_distro(session=session)
+        session.close()
+        return distro_name
 
     def get_mac_address(self, nic_index=0):
         """


### PR DESCRIPTION
reuse get_distro() for vm to retrieve for remote host that can
be used in tests and framework to decide based on distribution.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>