### PR TITLE
shared: add Debian-9.4.0 guest for aarch64

### DIFF
--- a/shared/cfg/guest-os/Linux/Debian/9.4.0.aarch64.cfg
+++ b/shared/cfg/guest-os/Linux/Debian/9.4.0.aarch64.cfg
@@ -1,0 +1,14 @@
+- 9.4.0.aarch64:
+    image_name += -9.4.0-aarch64
+    vm_arch_name = aarch64
+    os_variant = debianstretch
+    unattended_install, svirt_install:
+        kernel = images/debian-9-4-0-aarch64/vmlinuz
+        initrd = images/debian-9-4-0-aarch64/initrd.gz
+        boot_path = install.a64
+        kernel_params = "console=ttyS0,115200 console=ttyAMA0"
+    unattended_install.cdrom, svirt_install:
+        unattended_file = unattended/Debian-9.4.0.arm64.preseed
+        cdrom_cd1 = isos/linux/debian-9.4.0-arm64-xfce-CD-1.iso
+        md5sum_cd1 = 21e777d1524b3f6cfc6912527a223dee
+        md5sum_1m_cd1 = 97dd2bee994633ae8077d41696762e26

--- a/shared/downloads/debian-9.4.0-aarch64.ini
+++ b/shared/downloads/debian-9.4.0-aarch64.ini
@@ -1,0 +1,4 @@
+[debian-9.4.0-aarch64]
+title = Debian 9.4.0 aarch64
+url = https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/debian-9.4.0-arm64-xfce-CD-1.iso
+destination = isos/linux/debian-9.4.0-arm64-xfce-CD-1.iso

--- a/shared/unattended/Debian-9.4.0.arm64.preseed
+++ b/shared/unattended/Debian-9.4.0.arm64.preseed
@@ -1,0 +1,58 @@
+debconf debconf/priority string critical
+unknown debconf/priority string critical
+d-i debconf/priority string critical
+d-i debian-installer/locale string en_US
+d-i console-tools/archs select at
+d-i keyboard-configuration/xkb-keymap select us
+
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string autotest-debian-guest
+d-i netcfg/get_domain string virt-tests
+d-i netcfg/wireless_wep string
+d-i netcfg/get_nameservers string
+
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Eastern
+
+d-i partman-auto/method string regular
+d-i partman-auto/choose_recipe select atomic
+d-i partman/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean false
+d-i passwd/root-password password 12345678
+d-i passwd/root-password-again password 12345678
+
+d-i mirror/country string manual
+d-i mirror/http/hostname string deb.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+tasksel tasksel/first multiselect standard
+
+d-i pkgsel/include string openssh-server build-essential lvm2 ethtool \
+sg3-utils lsscsi libaio-dev libtime-hires-perl acpid tgt rt-tests tcpdump
+
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i debian-installer/add-kernel-opts string console=ttyAMA0 console=ttyS0,115200
+
+d-i apt-setup/security_host string
+base-config apt-setup/security-updates boolean false
+
+ubiquity ubiquity/summary note
+ubiquity ubiquity/reboot boolean true
+
+d-i finish-install/reboot_in_progress note
+d-i debian-installer/exit/poweroff boolean true
+d-i preseed/late_command string \
+echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
+echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
+echo "respawn exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
+echo "DefaultTasksMax=infinity" >> /target/etc/systemd/system.conf; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc; in-target update-grub; \
+sed -i "s/^#PermitRootLogin prohibit\-password/PermitRootLogin yes/g" /target/etc/ssh/sshd_config


### PR DESCRIPTION
This patch adds Debian 9.4.0 guest config files for aarch64.

Unattended installation by cdrom passed successfully with this
patch on aarch64 machine.

Signed-off-by: Zheng Xiang <xiang.zheng@linaro.org>