### PR TITLE
unattended_install: Attempt to log useful files in case of failure

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -105,4 +105,4 @@
             kernel_params += " ks=cdrom"
             cdrom_unattended = images/f28-${vm_arch_name}/ks.iso
         syslog_server_proto = tcp
-        kernel_params += " nicdelay=60"
+        kernel_params += " nicdelay=60 inst.sshd"

--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -6,7 +6,7 @@
     block_hotplug:
         modprobe_module = acpiphp
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install, with_installation:
-        kernel_params = "ks=cdrom"
+        kernel_params = "ks=cdrom inst.sshd"
         # The below config breaks RHEL6 x86, so it's commented out until we figure out a decent
         # solution that works across the board.
         #extra_cdrom_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/8.cfg
@@ -46,3 +46,4 @@
         x86_64:
             grub_file = /boot/grub2/grub.cfg
             kernel_params = "console=tty0 console=ttyS0"
+        kernel_params += " inst.sshd"


### PR DESCRIPTION
Most distribution generate some ".log" files during installation that
are essential to debug installation failures. Let's attempt to get them
from the most common locations and attach them in
test.outputdir/vm.name. It only works on running VM as those location
are not usually stored on the destination disk.

Currently the list is based on Fedora/RHEL (/tmp/*.log) and few other
locations were added to cover the most common locations. Feel free to
add other locations, it should simply ignore missing locations (or other
failures while obtaining the files)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>