### PR TITLE
remote: Enlarge login_timeout to 300s

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -410,7 +410,7 @@ def wait_for_login(client, host, port, username, password, prompt,
 
 
 def _remote_scp(
-        session, password_list, transfer_timeout=600, login_timeout=20):
+        session, password_list, transfer_timeout=600, login_timeout=300):
     """
     Transfer files using SCP, given a command line.
 
@@ -484,7 +484,7 @@ def _remote_scp(
 
 
 def remote_scp(command, password_list, log_filename=None, transfer_timeout=600,
-               login_timeout=20):
+               login_timeout=300):
     """
     Transfer files using SCP, given a command line.
 


### PR DESCRIPTION
 Since the default LoginGraceTime is 2m in sshd_config file, we need
 to provide login_timeout more than 2m, and some designed case like
nic_bonding needs more ssh lantency. enlarge login_timeout to 300s


Signed-off-by: Wenli Quan <wquan@redhat.com>

id: 1283511