### PR TITLE
Fix deprecated param

### DIFF
--- a/selftests/unit/unittest_data/testcfg.huge/guest-os.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/guest-os.cfg
@@ -18,7 +18,9 @@ variants:
         mem_chk_cur_cmd = grep MemTotal /proc/meminfo
         cpu_chk_cmd = grep -c "^processor\b" /proc/cpuinfo
         timedrift:
-            extra_params += " -no-kvm-pit-reinjection"
+            extra_params += " -global kvm-pit.lost_tick_policy=discard"
+            Host_RHEL.m6:
+                extra_params += " -no-kvm-pit-reinjection"
             time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
             time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"
             time_format = "%m/%d/%Y %H:%M:%S"

--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -21,7 +21,9 @@
     cdrom_info_cmd = "cat /proc/sys/dev/cdrom/info"
     timedrift, timerdevice..boot_test:
         i386, x86_64:
-            extra_params += " -no-kvm-pit-reinjection"
+            extra_params += " -global kvm-pit.lost_tick_policy=discard"
+            Host_RHEL.m6:
+                extra_params += " -no-kvm-pit-reinjection"
         time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
         time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"
         time_format = "%m/%d/%Y %H:%M:%S"


### PR DESCRIPTION
qemu-kvm: -no-kvm-pit-reinjection: warning: deprecated, replaced by
-global kvm-pit.lost_tick_policy=discard

Signed-off-by: Sitong Liu <siliu@redhat.com>