### PR TITLE
qemu_vm: Use '-device' expression for primary vga

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -300,6 +300,9 @@ vnc_autoport = yes
 
 # Guest VGA type (cirrus,  std, vmware, qxl, xenfb, none)
 vga = std
+# Whether use '-vga' expression to represent the VGA device,
+# if no, using '-device' expression.
+vga_use_legacy_expression = no
 
 # Add a sga device to guest.
 #enable_sga = yes


### PR DESCRIPTION
Since VM management tool (e.g. libvirt) represents the primary vga
device by using the '-device' expression, it is better to have the
same behaviour for vt tests, so now the command line will be:

> -device VGA_DRIVER,...

Also, add a new param `vga_use_legacy_expression` to let user be
able to fallback using the legacy expression.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1598410