### PR TITLE
shared: Fix Fedora/RHEL unattended file ECHO command

### DIFF
--- a/shared/unattended/Fedora-25.ks
+++ b/shared/unattended/Fedora-25.ks
@@ -27,9 +27,10 @@ sg3_utils
 %end
 
 %post
-# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
 # https://bugzilla.redhat.com/show_bug.cgi?id=1351968
-function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
 ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient

--- a/shared/unattended/JeOS-25.ks
+++ b/shared/unattended/JeOS-25.ks
@@ -168,9 +168,10 @@ python
 %end
 
 %post
-# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
 # https://bugzilla.redhat.com/show_bug.cgi?id=1351968
-function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
 ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient

--- a/shared/unattended/RHEL-7-devel.ks
+++ b/shared/unattended/RHEL-7-devel.ks
@@ -61,9 +61,10 @@ sg3_utils
 %end
 
 %post
-# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
 # https://bugzilla.redhat.com/show_bug.cgi?id=1351968
-function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
 ECHO "OS install is completed"
 ECHO "remove rhgb quiet by grubby"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -49,9 +49,10 @@ prelink
 %end
 
 %post
-# FIXME: Remove the /dev/ttysclp0 workaround when s390x console bug is resolved
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
 # https://bugzilla.redhat.com/show_bug.cgi?id=1351968
-function ECHO { for TTY in `[ -e /dev/ttysclp0 ] && echo ttysclp0; cat /proc/consoles | cut -f1 -d' '`; do echo "$*" > /dev/$TTY; done }
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
 ECHO "OS install is completed"
 ECHO "remove rhgb quiet by grubby"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)


### PR DESCRIPTION
The ECHO command is there to workaround issue where /proc/consoles fails
to list the right devices. Anyway as pointed in:

    https://bugzilla.redhat.com/show_bug.cgi?id=1351968#c7

it lists the right "major:minor", only the name is wrong. Let's switch
to using "major:minor" until this issue is resolved. (tested on x86,
ppc64le and s390x)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>