### PR TITLE
base.cfg: set libvirtd debug log to INFO by default

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -625,7 +625,7 @@ virtinstall_extra_args = ""
 # enabled and retrieve logs for fail and error tests, the logs
 # are saved in default debug dir
 enable_libvirtd_debug_log = "yes"
-libvirtd_debug_level = "1"
+libvirtd_debug_level = "2"
 libvirtd_debug_file = ""
 
 # Add the params to attach strace to start qemu processes


### PR DESCRIPTION
`libvirtd_debug_level` param overrides from base.cfg to DEBUG level,
let's have the default to INFO level to avoid polluting the archive
space in test debug directory.

Reported-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>