### PR TITLE
unattended_install: Get autounattend file name for ovmf correctly

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -214,7 +214,7 @@ class UnattendedInstallConfig(object):
             self.unattended_file = unattended_file
 
         if params.get('use_ovmf_autounattend'):
-            self.unattended_file = re.sub("\.", "_ovmf.",
+            self.unattended_file = re.sub("autounattend.", "autounattend_ovmf.",
                                           self.unattended_file)
 
         if getattr(self, 'finish_program'):


### PR DESCRIPTION
The full name of "unattended_file" may contain not only one dots
use strict match to get correct name for ovmf.
id: 1602780
Signed-off-by: Yanan Fu <yfu@redhat.com>