### PR TITLE
guest-os: Define "unattended_file" for ovmf in guest-os

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -356,7 +356,6 @@ variants:
         unattended_install:
             restore_ovmf_vars = yes
             Windows:
-                use_ovmf_autounattend = yes
                 send_key_at_install = ret
 
 # Nettype

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -8,6 +8,8 @@
         md5sum_cd1 = a67722adfaf209c72eacb3ab910ee65e
         md5sum_1m_cd1 = 0e246b56b7b63f0526c3367eb160ff7d
         unattended_file = unattended/win10-64-autounattend.xml
+        ovmf:
+            unattended_file = unattended/win10-64-autounattend_ovmf.xml
         floppies = "fl"
         floppy_name = images/win10-64/answer.vfd
         extra_cdrom_ks:

--- a/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
@@ -30,6 +30,8 @@
                 md5sum_cd1 = 27c58cdb3d620f28c36333a5552f271c
                 md5sum_1m_cd1 = efdcc11d485a1ef9afa739cb8e0ca766
                 unattended_file = unattended/win2008-64-autounattend.xml
+                ovmf:
+                    unattended_file = unattended/win2008-64-autounattend_ovmf.xml
                 floppies = "fl"
                 floppy_name = images/win2008-sp1-64/answer.vfd
                 extra_cdrom_ks:
@@ -50,6 +52,8 @@
                 sha1sum_cd1 = 34c7d726c57b0f8b19ba3b40d1b4044c15fc2029
                 sha1sum_1m_cd1 = 8fe08b03e3531906855a60a78020ac9577dff5ba
                 unattended_file = unattended/win2008-64-autounattend.xml
+                ovmf:
+                    unattended_file = unattended/win2008-64-autounattend_ovmf.xml
                 floppies = "fl"
                 floppy_name = images/win2008-sp2-64/answer.vfd
                 extra_cdrom_ks:
@@ -70,6 +74,8 @@
                 sha1sum_cd1 = ad855ea913aaec3f1d0e1833c1aef7a0de326b0a
                 sha1sum_1m_cd1 = 9194a3aabae25b36e5f73cad001314b2c8d07d14
                 unattended_file = unattended/win2008-r2-autounattend.xml
+                ovmf:
+                    unattended_file = unattended/win2008-r2-autounattend_ovmf.xml
                 floppies = "fl"
                 floppy_name = images/win2008-r2-64/answer.vfd
                 extra_cdrom_ks:

--- a/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
@@ -8,9 +8,10 @@
         sha1sum_cd1 = d3fd7bf85ee1d5bdd72de5b2c69a7b470733cd0a
         sha1sum_1m_cd1 = 9194a3aabae25b36e5f73cad001314b2c8d07d14
         unattended_file = unattended/win2012-autounattend.xml
+        ovmf:
+            unattended_file = unattended/win2012-autounattend_ovmf.xml
         floppies = "fl"
         floppy_name = images/win2012-64/answer.vfd
-        unattended_file = unattended/win2012-autounattend.xml
         extra_cdrom_ks:
             floppies = ""
             unattended_delivery_method = cdrom
@@ -36,6 +37,8 @@
                 md5sum_cd1 = 0e7c09aab20dec3cd7eab236dab90e78
                 md5sum_1m_cd1 = fab118cfa7f66d3606c38dc1330a769e
                 unattended_file = unattended/win2012r2-autounattend.xml
+                ovmf:
+                    unattended_file = unattended/win2012r2-autounattend_ovmf.xml
                 floppies = "fl"
                 floppy_name = images/win2012r2-64/answer.vfd
                 extra_cdrom_ks:

--- a/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
@@ -7,7 +7,9 @@
         cdrom_cd1 = isos/ISO/Win2016/en_windows_server_2016_x64_dvd_9327751.iso
         md5sum_cd1 = 91d7b2ebcff099b3557570af7a8a5cd6
         md5sum_1m_cd1 = 5f297f2178a618c166d1116475ed6368
-        unattended_file = unattended/win2016-64-autounattend.xml
+        unattended_file = unattended/win2016-autounattend.xml
+        ovmf:
+            unattended_file = unattended/win2016-autounattend_ovmf.xml
         floppies = "fl"
         floppy_name = images/win2016-64/answer.vfd
         extra_cdrom_ks:
@@ -19,7 +21,7 @@
             drive_index_unattended = 3
             cdrom_unattended = "images/win2016-64/autounattend.iso"
     sysprep:
-        unattended_file = win2016-64-autounattend.xml
+        unattended_file = win2016-autounattend.xml
     balloon_service, balloon_hotplug:
         install_balloon_service = "%s:\Balloon\2k16\amd64\blnsvr.exe -i"
         uninstall_balloon_service = "%s:\Balloon\2k16\amd64\blnsvr.exe -u"

--- a/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/x86_64.cfg
@@ -18,6 +18,8 @@
         sha1sum_cd1 = 326327cc2ff9f05379f5058c41be6bc5e004baa7
         sha1sum_1m_cd1 = 4a3903bd5157de54f0702e5263e0a683c5775515
         unattended_file = unattended/win7-64-autounattend.xml
+        ovmf:
+            unattended_file = unattended/win7-64-autounattend_ovmf.xml
         floppies = "fl"
         floppy_name = images/win7-64/answer.vfd
         extra_cdrom_ks:

--- a/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
@@ -14,6 +14,8 @@
         md5sum_cd1 = 27aa354b8088527ffcd32007b51b25bf
         md5sum_1m_cd1 = 06f8883a669f55f27e98938e71e90d67
         unattended_file = unattended/win8-64-autounattend.xml
+        ovmf:
+            unattended_file = unattended/win8-64-autounattend_ovmf.xml
         floppies = "fl"
         floppy_name = images/win8-64/answer.vfd
         extra_cdrom_ks:
@@ -50,6 +52,8 @@
                 md5sum_cd1 = 8e194185fcce4ea737f274ee9005ddf0
                 md5sum_1m_cd1 = ec868109e725742b83363908405d21f3
                 unattended_file = unattended/win8-64-autounattend.xml
+                ovmf:
+                    unattended_file = unattended/win8-64-autounattend_ovmf.xml
                 floppies = "fl"
                 floppy_name = images/win8.1-64/answer.vfd
                 extra_cdrom_ks:

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -213,10 +213,6 @@ class UnattendedInstallConfig(object):
                     break
             self.unattended_file = unattended_file
 
-        if params.get('use_ovmf_autounattend'):
-            self.unattended_file = re.sub("\.", "_ovmf.",
-                                          self.unattended_file)
-
         if getattr(self, 'finish_program'):
             self.finish_program = os.path.join(test.virtdir,
                                                self.finish_program)


### PR DESCRIPTION
1. Remove params "use_ovmf_autounattend" and also the logic
   to get "unattended_file" for ovmf.
2. Define "unattended_file" for ovmf in guest-os.
3. Fix "unattended_file" name mismatch problem for Win2016 guest.

id: 1602780
Signed-off-by: Yanan Fu <yfu@redhat.com>