### PR TITLE
qcontainer: Drop cache option for empty drives

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1508,7 +1508,11 @@ class DevContainer(object):
                 # cache.direct=on or cache=none, It will be error out.
                 # Please refer to qemu commit d657c0c.
                 cache = cache not in ['none', 'directsync'] and 'none' or cache
-            devices[-1].set_param('cache', cache)
+        # Forbid to specify the cache mode for empty drives.
+        # More info from qemu commit 91a097e74.
+        if not filename:
+            cache = None
+        devices[-1].set_param('cache', cache)
         devices[-1].set_param('media', media)
         devices[-1].set_param('format', imgfmt)
         if blkdebug is not None:


### PR DESCRIPTION
It didn't have any effect if specifying
the cache mode for empty drives.

Signed-off-by: Yongxue Hong <yhong@redhat.com>

ID: 1578616