### PR TITLE
qemu_vm.add_pci_controllers: Drop unecessary map usage to adapt python3

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1368,7 +1368,7 @@ class VM(virt_vm.BaseVM):
                                                     {"type": "pcie-root-port"}))
             if params.get("pci_controllers_autosort", "yes") == "yes":
                 pcics.sort(key=sort_key, reverse=False)
-            map(devices.insert, pcics)
+            devices.insert(pcics)
         # End of command line option wrappers
 
         # If nothing changed and devices exists, return immediately


### PR DESCRIPTION
For python3, `map()` should be replaced by `list(map())`, however here
`devices.insert()` can handle list by itself, not necessary to have map(),
so simply drop it.
id: 1608168
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>