### PR TITLE
utils_test: support different stress type on different VM

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -2069,7 +2069,13 @@ class VMStress(Stress):
         :param stress_args: the arguments of the stress tool
         :param download_type: currently support "git" or "tarball"
         """
-        super(VMStress, self).__init__(stress_type, params, download_url=download_url,
+        # This enables VM specific stress params like stress_cmds_virt-tests-vm1, etc.,
+        # to run different stress type on different VM
+        self.stress_type = params.get("stress_type_%s" % vm.name, stress_type)
+        self.params = params.object_params(vm.name)
+
+        super(VMStress, self).__init__(self.stress_type, self.params,
+                                       download_url=download_url,
                                        make_cmds=make_cmds, stress_cmds=stress_cmds,
                                        stress_args=stress_args, work_path=work_path,
                                        uninstall_cmds=uninstall_cmds,


### PR DESCRIPTION
currently the stress type (stress or stress-ng or etc.,) is common across
all the VMs in multi vm environment. But to have different stress type
for different VM we do not have support. This patch enables it and the params
have to be suffixed with _VMNAME.

Example if we have VM1 name as virt-tests-vm1 and VM2 name as virt-tests-vm2
then the stress params should be like,

stress_args_virt-tests-vm1 = "--vm 2 --io 2 --cpu 2"
stress_args_virt-tests-vm2 = "-io 4 --cpu 3"

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>