### PR TITLE
Python3: fix filter and map related bug

### DIFF
--- a/shared/scripts/virtio_console_guest.py
+++ b/shared/scripts/virtio_console_guest.py
@@ -685,7 +685,8 @@ class VirtioGuestPosix(VirtioGuest):
         """
         if self.poll_fds:
             p = select.poll()
-            map(p.register, list(self.poll_fds.keys()))
+            for fd_name in self.poll_fds.keys():
+                p.register(fd_name)
 
             masks = p.poll(1)
             print(masks)

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1285,7 +1285,8 @@ def run_autotest(vm, session, control_path, timeout,
         # to ensure client tests can work.
         import ConfigParser
         config = ConfigParser.ConfigParser()
-        map(config.add_section, ['CLIENT', 'COMMON'])
+        for section in ['CLIENT', 'COMMON']:
+            config.add_section(section)
         config.set('COMMON', 'crash_handling_enabled', 'True')
     config.set('CLIENT', 'output_dir', destination_autotest_path)
     config.set('COMMON', 'autotest_top_path', destination_autotest_path)

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -549,10 +549,10 @@ class MemoryBaseTest(object):
         """
         Close opening session, better to call it in the end of test.
         """
-        sessions = filter(None, list(self.sessions.values()))
+        sessions = list(filter(None, list(self.sessions.values())))
         if sessions:
-            sessions = filter(None, reduce(list.__add__, sessions))
-            map(lambda x: x.close(), sessions)
+            sessions = list(filter(None, reduce(list.__add__, sessions)))
+            list(map(lambda x: x.close(), sessions))
         self.sessions.clear()
 
 


### PR DESCRIPTION
`filter` and `map` on Python3 returns an object, without iteration
the call back function will not be executed.

id: 1599978

Signed-off-by: Haotong Chen <hachen@redhat.com>