### PR TITLE
Makefile: Few adjustments related to python3 systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ rpm-release: srpm-release
 	mock --old-chroot --resultdir BUILD/RPM -D "commit $(RELEASE_COMMIT)" --rebuild BUILD/SRPM/avocado-plugins-vt-$(VERSION)-*.src.rpm
 
 requirements:
-	- pip install "pip>=6.0.1"
-	- pip install -r requirements.txt
+	- $(PYTHON) -m pip install "pip>=6.0.1"
+	- $(PYTHON) -m pip install -r requirements.txt
 
 check:
 	inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E1003 --no-license-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON=$(shell which python)
+PYTHON=$(shell which python 2>/dev/null || which python3 2>/dev/null)
 PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/avocado-vt


### PR DESCRIPTION
Python3 systems only often don't contain /bin/python, nor /bin/pip binaries. Let's adjust our Makefile to cope with that.