### PR TITLE
Add support for VGA on s390/arm and fix some arm workarounds

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/27.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/27.cfg
@@ -27,6 +27,10 @@
             url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/27/Server/${vm_arch_name}/os/
         # ARCH dependent things
         aarch64:
+            arm64-mmio:
+                # F27 lacks virtio guest drivers
+                inactivity_watcher = none
+                take_regular_screendumps = no
             kernel_params = "console=ttyAMA0 console=ttyS0 serial"
             unattended_install.cdrom:
                 md5sum_cd1 = 1a9cb7c3feeb5a6d5c4319dd9b60aa93

--- a/shared/cfg/guest-os/Linux/Fedora/27.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/27.cfg
@@ -56,6 +56,10 @@
             kernel_params = "console=ttysclp0 serial"
             boot_path = images
             kernel = images/f27-s390x/kernel.img
+            # Anaconda hardcodes headless installation of F27 on s390x
+            vga = none
+            inactivity_watcher = none
+            take_regular_screendumps = no
             unattended_install.cdrom:
                 md5sum_cd1 = ca754437f6800bcb5dd252fb4c4a4251
                 md5sum_1m_cd1 = 38832089d02673721177c3e34375e73e

--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -43,6 +43,10 @@
             url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/28/Server/${vm_arch_name}/os/
         # ARCH dependent things
         aarch64:
+            arm64-mmio:
+                # Only latest updates contain virtio driver
+                inactivity_watcher = none
+                take_regular_screendumps = no
             kernel_params = "console=ttyAMA0 console=ttyS0 serial"
             unattended_install.cdrom:
                 md5sum_cd1 = 5629a2ae883f8afbc5f675f94798398c

--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -73,6 +73,10 @@
             kernel_params = "console=ttysclp0 serial"
             boot_path = images
             kernel = images/f28-s390x/kernel.img
+            # Anaconda hardcodes headless installation of F28 on s390x
+            vga = none
+            inactivity_watcher = none
+            take_regular_screendumps = no
             unattended_install.cdrom:
                 md5sum_cd1 = 2694a40333d0f698fa9b4f7faea18ad7
                 md5sum_1m_cd1 = 4b6e4bbfa315283235ea014245b21d1d

--- a/shared/cfg/guest-os/Linux/RHEL/7.5/s390x.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.5/s390x.cfg
@@ -1,4 +1,8 @@
 - s390x:
+    # VGA is not properly supported on RHEL.7.5
+    vga = none
+    inactivity_watcher = none
+    take_regular_screendumps = no
     image_name += -s390x
     vm_arch_name = s390x
     os_variant = rhel7

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/s390x.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/s390x.cfg
@@ -5,6 +5,10 @@
     boot_path = images
     install_timeout = 14400
     unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        # Anaconda hardcodes headless installation of RHEL.7 on s390x
+        vga = none
+        inactivity_watcher = none
+        take_regular_screendumps = no
         cdrom_unattended = images/rhel7-s390x/ks.iso
         kernel = images/rhel7-s390x/kernel.img
         initrd = images/rhel7-s390x/initrd.img

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -101,10 +101,12 @@ variants:
         auto_cpu_model = "no"
         cpu_model = host
         machine_type = s390-ccw-virtio
-        # No support for VGA yet
-        vga = none
-        inactivity_watcher = none
-        take_regular_screendumps = no
+        # For not (and probably ever) only virtio VGA is supported
+        vga = virtio
+        inputs = mouse1 keyboard1
+        input_dev_type_mouse1 = mouse
+        input_dev_type_keyboard1 = keyboard
+        input_dev_bus_type = virtio
         # Currently no USB support
         usbs =
         usb_devices =

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -60,11 +60,9 @@ variants:
         # TODO: Change to "gic-version=max" when supported
         machine_type = arm64-pci:virt
         machine_type_extra_params = gic-version=host
-        # No support for VGA yet
-        vga = none
+        # Only virtio-gpu-pci supported for now
+        vga = virtio
         vir_domain_undefine_nvram = yes
-        inactivity_watcher = none
-        take_regular_screendumps = no
     - riscv64-mmio:
         only riscv64
         # USB subsystem not available

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -44,8 +44,12 @@ variants:
         machine_type = arm64-mmio:virt
         # TODO: Change to "gic-version=max" when supported
         machine_type_extra_params = gic-version=host
-        # No support for VGA yet
-        vga = none
+        # Only virtio-gpu supported for now
+        vga = virtio
+        inputs = mouse1 keyboard1
+        input_dev_type_mouse1 = mouse
+        input_dev_type_keyboard1 = keyboard
+        input_dev_bus_type = virtio
         vir_domain_undefine_nvram = yes
         inactivity_watcher = none
         take_regular_screendumps = no
@@ -69,10 +73,12 @@ variants:
         auto_cpu_model = "no"
         cpu_model = any
         machine_type = riscv64-mmio:virt
-        # No support for VGA yet
-        vga = none
-        inactivity_watcher = none
-        take_regular_screendumps = no
+        # Only virtio-gpu supported for now
+        vga = virtio
+        inputs = mouse1 keyboard1
+        input_dev_type_mouse1 = mouse
+        input_dev_type_keyboard1 = keyboard
+        input_dev_bus_type = virtio
         # Currently no USB support
         usbs =
         usb_devices =

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1139,6 +1139,7 @@ class VM(virt_vm.BaseVM):
         def add_vga(devices, vga):
             """Add primary vga device."""
             fallback = params.get("vga_use_legacy_expression") == "yes"
+            machine_type = params.get("machine_type", '')
             parent_bus = {'aobject': 'pci.0'}
             vga_dev_map = {
                 "std": "VGA",
@@ -1148,6 +1149,12 @@ class VM(virt_vm.BaseVM):
                 "virtio": "virtio-vga"
             }
             vga_dev = vga_dev_map.get(vga, None)
+            if machine_type == 's390-ccw-virtio':
+                if vga == 'virtio':
+                    vga_dev = 'virtio-gpu-ccw'
+                    parent_bus = None
+                else:
+                    vga_dev = None
             if vga_dev is None:
                 fallback = True
                 parent_bus = None

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1373,9 +1373,12 @@ class VM(virt_vm.BaseVM):
 
             :return: return QPCIBus object.
             """
+            machine_type = params.get("machine_type", "")
+            if "mmio" in machine_type:
+                return None
             if dtype and "%s_pci_bus" % dtype in params:
                 return {"aobject": params["%s_pci_bus" % dtype]}
-            if params.get("machine_type") == "q35" and not pcie:
+            if machine_type == "q35" and not pcie:
                 pcic = "pci-bridge"
                 devices = [
                     d for d in devices if isinstance(

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1149,7 +1149,11 @@ class VM(virt_vm.BaseVM):
                 "virtio": "virtio-vga"
             }
             vga_dev = vga_dev_map.get(vga, None)
-            if machine_type == 's390-ccw-virtio':
+            if machine_type.startswith('arm64-pci:'):
+                if vga == 'virtio' and not devices.has_device(vga_dev):
+                    # Arm doesn't usually supports 'virtio-vga'
+                    vga_dev = 'virtio-gpu-pci'
+            elif machine_type == 's390-ccw-virtio':
                 if vga == 'virtio':
                     vga_dev = 'virtio-gpu-ccw'
                     parent_bus = None

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1155,6 +1155,12 @@ class VM(virt_vm.BaseVM):
                     parent_bus = None
                 else:
                     vga_dev = None
+            elif '-mmio:' in machine_type:
+                if vga == 'virtio':
+                    vga_dev = 'virtio-gpu-device'
+                    parent_bus = None
+                else:
+                    vga_dev = None
             if vga_dev is None:
                 fallback = True
                 parent_bus = None

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -455,10 +455,17 @@ class VM(virt_vm.BaseVM):
             return cmd
 
         def add_serial(devices, name, filename):
+            # Arm lists "isa-serial" as supported but can't use it,
+            # fallback to "-serial"
+            legacy_cmd = " -serial unix:'%s',server,nowait" % filename
             if (not devices.has_option("chardev") or
-                    not any(devices.has_device(dev)
-                            for dev in ("isa-serial", "sclpconsole", "spapr-vty"))):
-                return " -serial unix:'%s',server,nowait" % filename
+                    'arm' in params.get("machine_type", "")):
+                return legacy_cmd
+            for serial_dev in ("sclpconsole", "spapr-vty", "isa-serial"):
+                if devices.has_device(serial_dev):
+                    break
+            else:
+                return legacy_cmd
 
             serial_id = "serial_id_%s" % name
             cmd = " -chardev socket"
@@ -466,18 +473,12 @@ class VM(virt_vm.BaseVM):
             cmd += _add_option("path", filename)
             cmd += _add_option("server", "NO_EQUAL_STRING")
             cmd += _add_option("nowait", "NO_EQUAL_STRING")
-            if '86' in params.get('vm_arch_name', arch.ARCH):
-                cmd += " -device isa-serial"
-            elif 'ppc' in params.get('vm_arch_name', arch.ARCH):
-                cmd += " -device spapr-vty"
+            cmd += " -device %s" % serial_dev
+            if serial_dev == 'spapr-vty':
                 # Workaround for console issue, details:
                 # http://lists.gnu.org/archive/html/qemu-ppc/2013-10/msg00129.html
                 reg = 0x30000000 + 0x1000 * self.serial_ports.index(name)
                 cmd += _add_option("reg", hex(reg))
-            elif 's390x' in params.get('vm_arch_name', arch.ARCH):
-                # Only for s390x console:
-                # This is only console option supported now.
-                cmd += " -device sclpconsole"
             cmd += _add_option("chardev", serial_id)
             return cmd
 


### PR DESCRIPTION
First 3 commits are about VGA support on s390/arm and then there are several fixes to make arm work properly.

Because Avocado does not support adding mouse (it only supports adding usb devices, ...) I solved it by always including mouse in machine definition when VGA is enabled. It's not 100% clean, but it should work for now.

Note: For virtio-gpu-ccw you need at least updated F28, the virtio-gpu-pci should be less picky, but I only got black screen for now (I plan to try it again with later builds, but the machine definition should be fine).