### PR TITLE
Python3: guest_agent: Correct password type conversion issue

### DIFF
--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -542,7 +542,7 @@ class QemuAgent(Monitor):
             password = decode_to_text(process.system_output(openssl_cmd)).strip('\n')
 
         args = {"crypted": crypted, "username": username,
-                "password": base64.b64encode(password)}
+                "password": base64.b64encode(password.encode()).decode()}
         return self.cmd(cmd=cmd, args=args)
 
     @error_context.context_aware


### PR DESCRIPTION
base64.b64encode() needs a byte input, while self.cmd() needs args
content being string type, so encode first for b64encode() and
then decode for self.cmd()

id: 1610713
Signed-off-by: qizhu <qizhu@redhat.com>