### PR TITLE
avocado_vt: Avoid crash when "--vt-extra-params" not set

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -100,7 +100,7 @@ class VirtTestLoader(loader.TestLoader):
         if vt_extra_params:
             # We don't want to override the original args
             self.args = copy.deepcopy(self.args)
-            if self.args.vt_extra_params is not None:
+            if getattr(self.args, 'vt_extra_params', None) is not None:
                 self.args.vt_extra_params += vt_extra_params
             else:
                 self.args.vt_extra_params = vt_extra_params


### PR DESCRIPTION
When using "mux-suite-loader" and running "avocado" without
"--vt-extra-params" the "self.vt_extra_params" might not be set at all.
Let's use "getattr" to be able to set the vt-extra-params from
mux-suite-loader.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>