### PR TITLE
Fixup: Don't override user given image for multivm scenario

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -470,7 +470,7 @@ class QemuImg(object):
         """
         if not params.get("image_name_%s_%s" % (image_name, vm_name)):
             m_image_name = params.get("image_name", "image")
-            vm_image_name = "%s_%s" % (m_image_name, vm_name)
+            vm_image_name = params.get("image_name_%s" % vm_name, "%s_%s" % (m_image_name, vm_name))
             if params.get("clone_master", "yes") == "yes":
                 image_params = params.object_params(image_name)
                 image_params["image_name"] = vm_image_name


### PR DESCRIPTION
Right now, in multivm tests user given images for guests
are not entertined rather it overrides to default image name
suffixed with vm name, with this fix users are free provide
their own image name for respective guests in multi vm scenario
This will help us to run multi vm tests with different guest
images.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>