### PR TITLE
qemu_vm: Increase range of vnc ports used

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2728,7 +2728,7 @@ class VM(virt_vm.BaseVM):
 
             # Find available VNC port, if needed
             if params.get("display") == "vnc":
-                self.vnc_port = utils_misc.find_free_port(5900, 6100)
+                self.vnc_port = utils_misc.find_free_port(5900, 6900)
 
             # Find random UUID if specified 'uuid = random' in config file
             if params.get("uuid") == "random":


### PR DESCRIPTION
Arbitrarily raising the number of vnc ports. 1000 guests running simultaneously is a bit harder to achieve than 200.