### PR TITLE
env_process: invoke vm.destroy when vm is alive

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -182,8 +182,9 @@ def preprocess_vm(test, params, env, name):
                                     basedir=test.bindir):
                     vm.devices = None
                     start_vm = True
-                    old_vm.destroy(gracefully=gracefully_kill)
                     update_virtnet = True
+                    if old_vm.is_alive():
+                        old_vm.destroy(gracefully=gracefully_kill)
 
     if start_vm:
         if vm_type == "libvirt" and params.get("type") != "unattended_install":
@@ -415,7 +416,8 @@ def postprocess_vm(test, params, env, name):
         kill_vm_timeout = float(params.get("kill_vm_timeout", 0))
         if kill_vm_timeout:
             utils_misc.wait_for(vm.is_dead, kill_vm_timeout, 0, 1)
-        vm.destroy(gracefully=params.get("kill_vm_gracefully") == "yes")
+        if vm.is_alive():
+            vm.destroy(gracefully=params.get("kill_vm_gracefully") == "yes")
         if params.get("kill_vm_libvirt") == "yes" and params.get("vm_type") == "libvirt":
             vm.undefine()
 


### PR DESCRIPTION
During preprocess/postprocess, when destroy a dead vm,
_cleanup is called, but some of vm's properties are
not initialised.
So it will casue attriute error when calling _cleanup.

This patch checks if vm is alive before invoking vm.destroy.

id: 1611920
Signed-off-by: Haotong Chen <hachen@redhat.com>