### PR TITLE
shared: Blacklist "disable_msi" on s390x

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -100,6 +100,8 @@ variants:
         no nmi_watchdog
         # No sound cards
         no audio
+        # msi is mandatory on s390x
+        no disable_msi
         # Only tod clock (timerdevice requires kvm-clock)
         no timerdevice
         auto_cpu_model = "no"


### PR DESCRIPTION
The msi interrupts are mandatory on s390x. Let's disable it as there is
no plan on enabling them.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>