### PR TITLE
utils_env: set protocol to 0 for pickle.dump

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -182,9 +182,8 @@ def preprocess_vm(test, params, env, name):
                                     basedir=test.bindir):
                     vm.devices = None
                     start_vm = True
+                    old_vm.destroy(gracefully=gracefully_kill)
                     update_virtnet = True
-                    if old_vm.is_alive():
-                        old_vm.destroy(gracefully=gracefully_kill)
 
     if start_vm:
         if vm_type == "libvirt" and params.get("type") != "unattended_install":
@@ -416,8 +415,7 @@ def postprocess_vm(test, params, env, name):
         kill_vm_timeout = float(params.get("kill_vm_timeout", 0))
         if kill_vm_timeout:
             utils_misc.wait_for(vm.is_dead, kill_vm_timeout, 0, 1)
-        if vm.is_alive():
-            vm.destroy(gracefully=params.get("kill_vm_gracefully") == "yes")
+        vm.destroy(gracefully=params.get("kill_vm_gracefully") == "yes")
         if params.get("kill_vm_libvirt") == "yes" and params.get("vm_type") == "libvirt":
             vm.undefine()
 

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -110,9 +110,8 @@ class Env(IterableUserDict):
             raise EnvSaveError("No filename specified for this env file")
         self.save_lock.acquire()
         try:
-            f = open(filename, "wb")
-            cPickle.dump(self.data, f)
-            f.close()
+            with open(filename, "wb") as f:
+                cPickle.dump(self.data, f, protocol=0)
         finally:
             self.save_lock.release()
 


### PR DESCRIPTION
Python 2's default protocol is 0, whereas Python3.x is 3 or 4
depending on the x.
For VirNet's attribute, if its value is empty string or None,
it will be preserved when protocol is 0 or 1, the rest protocol are not.
So use protocol 0 on both Python3 and 2 to make it compatiable.

Revert "env_process: invoke vm.destroy when vm is alive"
This reverts commit d363a0b.

Signed-off-by: Haotong Chen <hachen@redhat.com>

id: 1611920