### PR TITLE
 ppm_utils: add 'add_timestamp' to append timestamp bar to image

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1524,11 +1524,13 @@ def _take_screendumps(test, params, env):
                 inactivity[vm.instance] = time.time()
                 try:
                     try:
+                        timestamp = os.stat(temp_filename).st_ctime
                         image = PIL.Image.open(temp_filename)
+                        image = ppm_utils.add_timestamp(image, timestamp)
                         image.save(screendump_filename, format="JPEG",
                                    quality=quality)
                         cache[image_hash] = screendump_filename
-                    except IOError as error_detail:
+                    except (IOError, OSError) as error_detail:
                         logging.warning("VM '%s' failed to produce a "
                                         "screendump: %s", vm.name, error_detail)
                         # Decrement the counter as we in fact failed to


### PR DESCRIPTION
id: 1544632

1. add function add_timestamp to add timestamp to the bottom of image.
2. using 'add_timestamp' in _take_screendump to enable timestamp of screendump.

Signed-off-by: lolyu <lolyu@redhat.com>