### PR TITLE
virtio_console_guest: Fix python3 related issues

### DIFF
--- a/shared/scripts/virtio_console_guest.py
+++ b/shared/scripts/virtio_console_guest.py
@@ -1433,8 +1433,8 @@ class Daemon:
         so.close()
         se.close()
 
-        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
-        sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0)
+        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 1)
+        sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 1)
         return True
 
     def start(self):

--- a/shared/scripts/virtio_console_guest.py
+++ b/shared/scripts/virtio_console_guest.py
@@ -897,19 +897,19 @@ class VirtioGuestPosix(VirtioGuest):
         """
         in_f = self._open([port])
 
-        data = ""
+        data = b""
         writes = 0
 
         if not is_static:
             while len(data) < length:
-                data += "%c" % random.randrange(255)
+                data += b"%c" % random.randrange(255)
             try:
                 writes = os.write(in_f[0], data)
             except Exception as inst:
                 print(inst)
         else:
             while len(data) < 4096:
-                data += "%c" % random.randrange(255)
+                data += b"%c" % random.randrange(255)
         if mode:
             while (writes < length):
                 try:


### PR DESCRIPTION
1. Use buffering=1 for os.fdopen:
python3.6 does not accept unbuffered text I/O for os.fdopen(), so
use buffering=1 instead

2. Encode text for os.write():
python 3.6 requires a bytes-like object instead of str for write()

id: 1611136
Signed-off-by: Xu Han <xuhan@redhat.com>
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>