### PR TITLE
qemu_vm: Fix the bug of passing fd in migration

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2571,6 +2571,8 @@ class VM(virt_vm.BaseVM):
         params = self.params
         root_dir = self.root_dir
         pass_fds = []
+        if migration_fd:
+            pass_fds.append(int(migration_fd))
 
         # Verify the md5sum of the ISO images
         for cdrom in params.objects("cdroms"):


### PR DESCRIPTION
Since aexpect 1.5.1, we have to explicitly pass fd to the destination
qemu process during migration.

Signed-off-by: Xu Han <xuhan@redhat.com>