### PR TITLE
Support virtio input devices for qemu_vm

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -671,3 +671,9 @@ Linux:
 # Add nvdimm device and specify the backend
 # nv_backend = /tmp/nvdimm0
 
+# List of input device object names (whitespace separated)
+inputs = ""
+# Type of input device (currently supports mouse, keyboard and tablet)
+#input_dev_type = ""
+# Bus type of input device (currently supports virtio)
+#input_dev_bus_type = ""

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1903,3 +1903,51 @@ class DevContainer(object):
                 dimm.set_param("memdev", mem.get_qid())
                 devices.append(dimm)
         return devices
+
+    def input_define_by_params(self, params, name, bus=None):
+        """
+        Create input device by params.
+
+        :param params: VM params.
+        :param name: Object name of input device.
+        :param bus: Parent bus.
+        """
+        params = params.object_params(name)
+        dev_map = {"mouse": {"virtio": "virtio-mouse"},
+                   "keyboard": {"virtio": "virtio-keyboard"},
+                   "tablet": {"virtio": "virtio-tablet"}}
+        dev_type = params["input_dev_type"]
+        bus_type = params["input_dev_bus_type"]
+        driver = dev_map.get(dev_type)
+        if not driver:
+            raise ValueError("unsupported input device type")
+        driver = driver.get(bus_type)
+        if not driver:
+            raise ValueError("unsupported input device bus")
+
+        machine_type = params.get("machine_type", "")
+        qbus_type = "PCI"
+        if machine_type.startswith("q35") or machine_type.startswith("arm64"):
+            qbus_type = "PCIE"
+
+        if bus_type == "virtio":
+            if "-mmio:" in machine_type:
+                driver += "-device"
+                qbus_type = "virtio-bus"
+            elif machine_type.startswith("s390"):
+                driver += "-ccw"
+                qbus_type = "virtio-bus"
+            else:
+                driver += "-pci"
+
+        if bus is None:
+            bus = {"type": qbus_type}
+        devices = []
+        if self.has_device(driver):
+            dev = qdevices.QDevice(driver, parent_bus=bus)
+            dev.set_param("id", "input_%s" % name)
+            devices.append(dev)
+        else:
+            logging.warn("'%s' is not supported by your qemu", driver)
+
+        return devices

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2267,6 +2267,10 @@ class VM(virt_vm.BaseVM):
             if cmd:
                 devices.insert(StrDev('ROM', cmdline=cmd))
 
+        for input_device in params.objects("inputs"):
+            devs = devices.input_define_by_params(params, input_device)
+            devices.insert(devs)
+
         for balloon_device in params.objects("balloon"):
             balloon_params = params.object_params(balloon_device)
             balloon_devid = balloon_params.get("balloon_dev_devid")


### PR DESCRIPTION
Example:
```
  <configuration>
  inputs = mouse1 keyboard1
  input_dev_type_mouse1 = mouse
  input_dev_type_keyboard1 = keyboard
  input_dev_bus_type = virtio

  <qemu command line>
  -device virtio-mouse-pci,id=input_mouse1,bus=pci.0,addr=0x6 \
  -device virtio-keyboard-pci,id=input_keyboard1,bus=pci.0,addr=0x7
```
Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1456174