### PR TITLE
shared: Remove check_zero_sym method from virtio_console_guest

### DIFF
--- a/shared/scripts/virtio_console_guest.py
+++ b/shared/scripts/virtio_console_guest.py
@@ -79,12 +79,6 @@ class VirtioGuest:
         """
         raise NotImplementedError
 
-    def check_zero_sym(self):
-        """
-        Check if port the first port symlinks were created.
-        """
-        raise NotImplementedError
-
     def poll(self, port, expected, timeout=500):
         """
         Checks the port POLL status and verify with expected results.
@@ -314,16 +308,6 @@ class VirtioGuestPosix(VirtioGuest):
                 f.close()
 
         return ports
-
-    def check_zero_sym(self):
-        """
-        Check if port /dev/vport0p0 was created.
-        """
-        symlink = "/dev/vport0p0"
-        if os.path.exists(symlink):
-            print("PASS: Symlink %s exists." % symlink)
-        else:
-            print("FAIL: Symlink %s does not exist." % symlink)
 
     def init(self, in_files):
         """


### PR DESCRIPTION
This used to be used by removed "check_zero_sym" test, which used wrong
assumption that this symlink must always exists, but it doesn't have to
be there when other virtio device is present. Let's just rely only on
the "_get_port_status" test which makes sure the number of symlinks
correspondent to number of devices.

Depends on: https://github.com/autotest/tp-qemu/pull/1476
Fixes: https://github.com/avocado-framework/avocado-vt/issues/1736