### PR TITLE
Add flag to cleanup libvirtd debug log

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -259,27 +259,28 @@ class VirtTest(test.Test):
             self.__status = details
         finally:
             # Clean libvirtd debug logs if the test is not fail or error
-            if(self.params.get("vm_type") == 'libvirt' and
-               self.params.get("enable_libvirtd_debug_log", "yes") == "yes"):
-                libvirtd_log = self.params["libvirtd_debug_file"]
-                if("TestFail" not in str(sys.exc_info()[0]) and
-                   "TestError" not in str(sys.exc_info()[0])):
-                    if libvirtd_log and os.path.isfile(libvirtd_log):
-                        logging.info("cleaning libvirtd logs...")
-                        os.remove(libvirtd_log)
-                else:
-                    # tar the libvirtd log and archive
-                    logging.info("archiving libvirtd debug logs")
-                    from virttest import utils_package
-                    if utils_package.package_install("tar"):
-                        archive = os.path.join(libvirtd_log.strip(os.path.basename(libvirtd_log)),
-                                               "libvirtd.tar.gz")
-                        cmd = "tar -zcf %s -P %s" % (archive, libvirtd_log)
-                        if process.system(cmd) == 0:
+            if self.params.get("libvirtd_log_cleanup", "no") == "yes":
+                if(self.params.get("vm_type") == 'libvirt' and
+                   self.params.get("enable_libvirtd_debug_log", "yes") == "yes"):
+                    libvirtd_log = self.params["libvirtd_debug_file"]
+                    if("TestFail" not in str(sys.exc_info()[0]) and
+                       "TestError" not in str(sys.exc_info()[0])):
+                        if libvirtd_log and os.path.isfile(libvirtd_log):
+                            logging.info("cleaning libvirtd logs...")
                             os.remove(libvirtd_log)
                     else:
-                        logging.error("Unable to find tar to compress libvirtd "
-                                      "logs")
+                        # tar the libvirtd log and archive
+                        logging.info("archiving libvirtd debug logs")
+                        from virttest import utils_package
+                        if utils_package.package_install("tar"):
+                            archive = os.path.join(libvirtd_log.strip(os.path.basename(libvirtd_log)),
+                                                   "libvirtd.tar.gz")
+                            cmd = "tar -zcf %s -P %s" % (archive, libvirtd_log)
+                            if process.system(cmd) == 0:
+                                os.remove(libvirtd_log)
+                        else:
+                            logging.error("Unable to find tar to compress libvirtd "
+                                          "logs")
 
             if env_lang:
                 os.environ['LANG'] = env_lang

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -630,6 +630,7 @@ virtinstall_extra_args = ""
 enable_libvirtd_debug_log = "yes"
 libvirtd_debug_level = "2"
 libvirtd_debug_file = ""
+libvirtd_log_cleanup = "yes"
 
 # Add the params to attach strace to start qemu processes
 #enable_strace = no


### PR DESCRIPTION
commit 26fdd19 cleanup the libvirtd log if case is not fail
or error, but sometimes it is expected to keep the plain
libvirtd.log in all cases. So make this new param to support it

Signed-off-by: Yan Li <yannli@redhat.com>