### PR TITLE
Fix two aarch64 specific issues

### DIFF
--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -566,7 +566,7 @@ class Container(unittest.TestCase):
     def tearDown(self):
         self.god.unstub_all()
 
-    def create_qdev(self, vm_name='vm1', strict_mode="no",
+    def create_qdev(self, vm_name='vm1', machine_type='pc', strict_mode="no",
                     allow_hotplugged_vm="yes"):
         """ :return: Initialized qcontainer.DevContainer object """
         qemu_cmd = '/usr/bin/qemu_kvm'
@@ -576,8 +576,9 @@ class Container(unittest.TestCase):
                                                      shell=True,
                                                      verbose=False
                                                      ).and_return(QEMU_HELP)
-        qcontainer.process.system_output.expect_call("%s -device \? 2>&1"
-                                                     % qemu_cmd, timeout=10,
+        qcontainer.process.system_output.expect_call("%s -machine %s -device \? 2>&1"
+                                                     % (qemu_cmd, machine_type),
+                                                     timeout=10,
                                                      ignore_status=True,
                                                      shell=True,
                                                      verbose=False
@@ -616,7 +617,7 @@ class Container(unittest.TestCase):
                                                      verbose=False
                                                      ).and_return(QEMU_QMP)
 
-        qdev = qcontainer.DevContainer(qemu_cmd, vm_name, strict_mode, 'no',
+        qdev = qcontainer.DevContainer(qemu_cmd, vm_name, machine_type, strict_mode, 'no',
                                        allow_hotplugged_vm)
 
         self.god.check_playback()
@@ -825,7 +826,7 @@ fdc
 
     def test_qdev_hotplug(self):
         """ Test the hotplug/unplug functionality """
-        qdev = self.create_qdev('vm1', False, True)
+        qdev = self.create_qdev('vm1', 'pc', False, True)
         devs = qdev.machine_by_params(ParamsDict({'machine_type': 'pc'}))
         for dev in devs:
             qdev.insert(dev)

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -42,11 +42,12 @@ class DevContainer(object):
     """
     # General methods
 
-    def __init__(self, qemu_binary, vmname, strict_mode="no",
+    def __init__(self, qemu_binary, vmname, machine_type, strict_mode="no",
                  workaround_qemu_qmp_crash="no", allow_hotplugged_vm="yes"):
         """
         :param qemu_binary: qemu binary
-        :param vm: related VM
+        :param vmname: related VM
+        :param machine_type: VM machine type
         :param strict_mode: Use strict mode (set optional params)
         """
         def get_hmp_cmds(qemu_binary):
@@ -98,8 +99,9 @@ class DevContainer(object):
                                                                 shell=True, verbose=False))
         # escape the '?' otherwise it will fail if we have a single-char
         # filename in cwd
-        self.__device_help = decode_to_text(process.system_output("%s -device \? 2>&1" %
-                                                                  qemu_binary, timeout=10,
+        self.__device_help = decode_to_text(process.system_output("%s -machine %s -device \? 2>&1" %
+                                                                  (qemu_binary, machine_type),
+                                                                  timeout=10,
                                                                   ignore_status=True,
                                                                   shell=True,
                                                                   verbose=False))

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -457,7 +457,8 @@ class VM(virt_vm.BaseVM):
         def add_serial(devices, name, filename):
             if (not devices.has_option("chardev") or
                     not any(devices.has_device(dev)
-                            for dev in ("isa-serial", "sclpconsole", "spapr-vty"))):
+                            for dev in ("isa-serial", "sclpconsole", "spapr-vty")) or
+                    'aarch64' in params.get('vm_arch_name', arch.ARCH)):
                 return " -serial unix:'%s',server,nowait" % filename
 
             serial_id = "serial_id_%s" % name

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1473,7 +1473,9 @@ class VM(virt_vm.BaseVM):
                 cmd += "numactl -m %s " % n
 
         # Start constructing devices representation
-        devices = qcontainer.DevContainer(qemu_binary, self.name,
+        # Machine_type parameter is defined in machines.cfg
+        machine_type = params.get('machine_type').split(':', 1)[-1]
+        devices = qcontainer.DevContainer(qemu_binary, self.name, machine_type,
                                           params.get('strict_mode'),
                                           params.get(
                                               'workaround_qemu_qmp_crash'),


### PR DESCRIPTION
The PR fixes two issues I hit while running virtio-console tests on aarch64.

- Issue 1: "qemu -device ?" fails because there is no default machine type defined in QEMU for aarch64 guest.
- Issue 2: serial port option generation code doesn't work for aarch64 guest.

With the fix about three quarters of virtio console tests pass on aarch64. The rest ones fail due to separate  issues. 

For details please look at commit messages.
