### PR TITLE
virt_vm: move uptime() of the vm instance from libvirt_vm

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2010,20 +2010,6 @@ class VM(virt_vm.BaseVM):
             fcntl.lockf(lockfile, fcntl.LOCK_UN)
             lockfile.close()
 
-    def uptime(self, connect_uri=None):
-        """
-        Get uptime of the vm instance.
-
-        :param connect_uri: Libvirt connect uri of vm
-        :return: uptime of the vm on success, None on failure
-        """
-        if connect_uri:
-            self.connect_uri = connect_uri
-            session = self.wait_for_serial_login()
-        else:
-            session = self.wait_for_login()
-        return utils_misc.get_uptime(session)
-
     def migrate(self, dest_uri="", option="--live --timeout 60", extra="",
                 **dargs):
         """

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -632,6 +632,27 @@ class BaseVM(object):
         session.close()
         return distro_name
 
+    def uptime(self, connect_uri=None):
+        """
+        Get uptime of the vm instance.
+
+        :param connect_uri: Libvirt connect uri of vm
+        :return: uptime of the vm on success, None on failure
+        """
+        uptime = None
+        session = None
+        try:
+            if connect_uri:
+                self.connect_uri = connect_uri
+                session = self.wait_for_serial_login()
+            else:
+                session = self.wait_for_login()
+            uptime = utils_misc.get_uptime(session)
+        finally:
+            if session:
+                session.close()
+            return uptime
+
     def sosreport(self, path=None, uri=None):
         """
         Get sosreport of the vm instance


### PR DESCRIPTION
move API to get the uptime of vm instance to virt_vm, this would be
helpful in testcases to assert the vm uptime whether vm went
down/restart during and after test.

without this API caused regression with commit 76c2f8f in tp-qemu

Reported-by: qizhu <qizhu@redhat.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>