### PR TITLE
qemu_vm: added an "enable_debug_console" option

### DIFF
--- a/backends/qemu/cfg/tests.cfg
+++ b/backends/qemu/cfg/tests.cfg
@@ -11,5 +11,8 @@ variants:
         only default_bios
         only bridge
         no multi_host
+        # Use enable_debug_console = yes/no in your cfg to enable/disable
+        # isa debug console log 
+        # enable_debug_console = yes
 
 only qemu_kvm_jeos_quick

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -552,9 +552,6 @@ class VM(virt_vm.BaseVM):
             return virtio_port
 
         def add_log_seabios(devices):
-            if not devices.has_device("isa-debugcon"):
-                return ""
-
             default_id = "seabioslog_id_%s" % self.instance
             filename = os.path.join(data_dir.get_tmp_dir(),
                                     "seabios-%s" % self.instance)
@@ -1675,8 +1672,9 @@ class VM(virt_vm.BaseVM):
             parent_bus = _get_pci_bus(devices, rng_params, "vio_rng", True)
             add_virtio_rng(devices, rng_params, parent_bus)
 
-        # Add logging
-        devices.insert(StrDev('isa-log', cmdline=add_log_seabios(devices)))
+        if (devices.has_device("isa-debugcon") and
+                params.get("enable_debug_console", "yes") == "yes"):
+            devices.insert(StrDev('isa-log', cmdline=add_log_seabios(devices)))
         if params.get("anaconda_log", "no") == "yes":
             parent_bus = _get_pci_bus(devices, params, None, True)
             add_log_anaconda(devices, parent_bus)


### PR DESCRIPTION
isa_debugcon is always added if the device is available to the QEMU,
added an "enable_debug_console" param to control whether add the
isa_debugcon device or not.

Signed-off-by: Haotong Chen <hachen@redhat.com>

id: 1632587