### PR TITLE
test_setup: reuse params for remote host info

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2225,9 +2225,9 @@ def remote_session(params):
     :param params: Test params dict for remote machine login details
     :return: remote session object
     """
-    server_ip = params["server_ip"]
-    server_user = params.get("server_user", "root")
-    server_pwd = params["server_pwd"]
+    server_ip = params.get(params.get("server_ip"), params['remote_ip'])
+    server_user = params.get(params.get("server_user"), params['remote_user'])
+    server_pwd = params.get(params.get("server_pwd"), params['remote_pwd'])
     return remote.wait_for_login('ssh', server_ip, '22', server_user,
                                  server_pwd, r"[\#\$]\s*$")
 


### PR DESCRIPTION
This is to make use of two sets of variables which is remote_* and
server_* as they are used in different scenarios. So this is to satisfy
different requirements of usages.

Signed-off-by: Dan Zheng <dzheng@redhat.com>