### PR TITLE
Fix sort error in Python 3

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -16,6 +16,7 @@ try:
     import configparser as ConfigParser
 except ImportError:
     import ConfigParser
+from functools import cmp_to_key
 
 from avocado.core import exceptions
 from avocado.utils import process
@@ -1123,7 +1124,7 @@ class GuestFSModiDisk(object):
         if roots:
             for root in roots:
                 mps = self.g.inspect_get_mountpoints(root)
-                mps.sort(compare)
+                mps.sort(key=cmp_to_key(compare))
                 for mp_dev in mps:
                     try:
                         msg = "Mount dev '%s' partitions '%s' to '%s'"


### PR DESCRIPTION
The cmp argument is not supported in 3.x, and a key function
is needed.

In Python 2.7 and Python 3.2 and later we can use a function
'cmp_to_key' to convert a comparison function to a key function.

ID: 1633083
Signed-off-by: Sitong Liu <siliu@redhat.com>