### PR TITLE
Drop ntp variant use.

### DIFF
--- a/shared/cfg/guest-os/Linux.cfg
+++ b/shared/cfg/guest-os/Linux.cfg
@@ -31,14 +31,6 @@
         guest_load_stop_command = "rm -f /tmp/guest_load_timedrift"
         host_load_command = "/bin/bash -c 'for ((;;)); do X=1; done'"
         get_hw_time_cmd = 'TZ=UTC date +"%s" -d "`hwclock`"'
-        ntp:
-            time_command = "ntpdate -d -q pool.ntp.org"
-            time_filter_re = "originate timestamp:.*, (.\w+\s+\d+\s+\d+\s+\d+:\d+:\d+)\.(.\d+)"
-            time_format = "%b %d %Y %H:%M:%S"
-        date:
-            time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
-            time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"
-            time_format = "%m/%d/%Y %H:%M:%S"
     time_manage:
         time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
         time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -128,14 +128,6 @@
         host_load_command = "bzip2 -c --best /dev/urandom > /dev/null"
         # Alternative host load:
         #host_load_command = "dd if=/dev/urandom of=/dev/null"
-        ntp:
-            time_command = "w32tm /stripchart /samples:1 /computer:pool.ntp.org"
-            time_filter_re = "\d+/\d+/\d+\s\d+:\d+:\d+ [AP]M"
-            time_format = "%m/%d/%Y %H:%M:%S"
-        date:
-            time_command = "echo TIME: %date% %time%"
-            time_filter_re = "(?<=TIME: \w\w\w ).{19}(?=\.\d\d)"
-            time_format = "%m/%d/%Y %H:%M:%S"
     time_manage:
         alive_test_cmd = systeminfo
         time_command = "echo TIME: %date% %time%"


### PR DESCRIPTION
Since we will drop using ntpdate to get local time in rhel8,
so drop ntp variant as well.

ID: 1629672
Signed-off-by: Sitong Liu <siliu@redhat.com>