### PR TITLE
Fixes to get virtio console interrupted_transfer test running

### DIFF
--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -44,7 +44,7 @@ class _VirtioPort(object):
     Define structure to keep information about used port.
     """
 
-    def __init__(self, qemu_id, name, hostfile):
+    def __init__(self, qemu_id, name, hostfile, chardev_id):
         """
         :param name: Name of port for guest side.
         :param hostfile: Path to port on host side.
@@ -52,6 +52,7 @@ class _VirtioPort(object):
         self.qemu_id = qemu_id
         self.name = name
         self.hostfile = hostfile
+        self.chardev_id = chardev_id
         self.is_console = None  # "yes", "no"
         self.sock = None
         self.port_was_opened = None
@@ -149,12 +150,12 @@ class VirtioSerial(_VirtioPort):
 
     """ Class for handling virtio-serialport """
 
-    def __init__(self, qemu_id, name, hostfile):
+    def __init__(self, qemu_id, name, hostfile, chardev_id):
         """
         :param name: Name of port for guest side.
         :param hostfile: Path to port on host side.
         """
-        super(VirtioSerial, self).__init__(qemu_id, name, hostfile)
+        super(VirtioSerial, self).__init__(qemu_id, name, hostfile, chardev_id)
         self.is_console = "no"
 
 
@@ -162,12 +163,12 @@ class VirtioConsole(_VirtioPort):
 
     """ Class for handling virtio-console """
 
-    def __init__(self, qemu_id, name, hostfile):
+    def __init__(self, qemu_id, name, hostfile, chardev_id):
         """
         :param name: Name of port for guest side.
         :param hostfile: Path to port on host side.
         """
-        super(VirtioConsole, self).__init__(qemu_id, name, hostfile)
+        super(VirtioConsole, self).__init__(qemu_id, name, hostfile, chardev_id)
         self.is_console = "yes"
 
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2919,10 +2919,13 @@ class VM(virt_vm.BaseVM):
                     # Get the file path of the device's chardev backend object
                     chardev = self.devices.get_by_qid(device.params.get('chardev'))[0]
                     path = chardev.params.get('path')
+                    chardev_id = chardev.params.get('id')
                     if device.params.get('driver') == 'virtconsole':
-                        portobj = qemu_virtio_port.VirtioConsole(id, name, path)
+                        portobj = qemu_virtio_port.VirtioConsole(id, name, path,
+                                                                 chardev_id)
                     elif device.params.get('driver') == 'virtserialport':
-                        portobj = qemu_virtio_port.VirtioSerial(id, name, path)
+                        portobj = qemu_virtio_port.VirtioSerial(id, name, path,
+                                                                chardev_id)
                     self.virtio_ports.append(portobj)
             except IndexError:
                 raise virt_vm.VMDeviceError('Failed to find all virtio port devices'


### PR DESCRIPTION
These are code changes on avocado-vt side to get virito console interrupted_transfer test running. 

1) The current code in VM.create() put incorrect virtio port information (e.g., device id, etc.) in VirtioConsole and VirtioSerial objects. The change fixes it by querying the actual devices to get those information.

2) Add chardev id to VirtioSerial and VirtioConsole classes. This is useful in QEMU interrupted_transfer test because repluging a virtio device requires its chardev backend id.

I also have code change on tp-qemu side. I'll submit it soon.