### PR TITLE
virttest: remove sniffers from requirements

### DIFF
--- a/docs/source/InstallOptionalPackages.rst
+++ b/docs/source/InstallOptionalPackages.rst
@@ -19,7 +19,7 @@ Install the following packages:
 
     $ yum groupinstall "Development Tools"
 
-#. Install tcpdump, necessary to determine guest IPs automatically
+#. Install tcpdump, useful to determine guest IPs automatically
 
 ::
 
@@ -197,7 +197,7 @@ Install the following packages:
     $ apt-get install xz-utils
 
 
-#. Install tcpdump, necessary to determine guest IPs automatically
+#. Install tcpdump, useful to determine guest IPs automatically
 
 ::
 

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -23,7 +23,7 @@ from .compat_52lts import results_stdout_52lts
 
 LOG = logging.getLogger("avocado.app")
 
-basic_program_requirements = ['xz', 'tcpdump', 'nc', 'ip', 'arping']
+basic_program_requirements = ['xz', 'nc', 'ip', 'arping']
 
 recommended_programs = {'qemu': [('qemu-kvm', 'kvm'), ('qemu-img',),
                                  ('qemu-io',)],
@@ -35,7 +35,8 @@ recommended_programs = {'qemu': [('qemu-kvm', 'kvm'), ('qemu-img',),
                         'openvswitch': [],
                         'lvsb': [('semanage',), ('getfattr',), ('restorecon',), ('virt-sandbox')],
                         'v2v': [],
-                        'libguestfs': [('perl',)]}
+                        'libguestfs': [('perl',)],
+                        'tcpdump': [('tcpdump',)]}
 
 mandatory_programs = {'qemu': basic_program_requirements + ['gcc'],
                       'spice': basic_program_requirements + ['gcc'],

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -799,10 +799,11 @@ def preprocess(test, params, env):
                 params[name_tag] = os.path.join(image_nfs.mount_dir,
                                                 image_name_only)
 
-    # Start ip sniffing if it isn't already running
+    # Start ip sniffing if it isn't already running and allowed in params.
     # The fact it has to be started here is so that the test params
     # have to be honored.
-    env.start_ip_sniffing(params)
+    if not (params.get("run_tcpdump") == "no"):
+        env.start_ip_sniffing(params)
 
     # Add migrate_vms to vms
     migrate_vms = params.objects("migrate_vms")
@@ -1173,7 +1174,8 @@ def postprocess(test, params, env):
             vm.destroy()
 
     # Terminate the ip sniffer thread
-    env.stop_ip_sniffing()
+    if not (params.get("run_tcpdump") == "no"):
+        env.stop_ip_sniffing()
 
     # Kill all aexpect tail threads
     aexpect.kill_tail_threads()


### PR DESCRIPTION
There are many ways to obtain IP address used by guest OS
and network sniffer only one of them. So it is strange to require
it's presence in system and start on each test run.