### PR TITLE
guest os cfg: Modify windows 32 bit max memory under q35

### DIFF
--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -26,3 +26,5 @@
         stop_balloon_service = "%s:\Balloon\w10\x86\blnsvr.exe -s"
     balloon_check, balloon_stop_continue, balloon_stress, balloon_hotplug, balloon_in_use, balloon_service, balloon_illegal, balloon_boot_in_pause, systemtap_tracing.balloon_event, driver_load_stress.with_balloon, win_virtio_driver_update_test.with_balloon:
         vm_mem_limit = 3G
+        q35:
+            vm_mem_limit = 2G

--- a/shared/cfg/guest-os/Windows/Win7/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win7/i386.cfg
@@ -36,6 +36,8 @@
         stop_balloon_service = "%s:\Balloon\w7\x86\blnsvr.exe -s"
     balloon_check, balloon_stop_continue, balloon_stress, balloon_hotplug, balloon_in_use, balloon_service, balloon_illegal, balloon_boot_in_pause, systemtap_tracing.balloon_event, driver_load_stress.with_balloon, win_virtio_driver_update_test.with_balloon:
         vm_mem_limit = 3G
+        q35:
+            vm_mem_limit = 2G
     variants:
         - sp0:
         - sp1:

--- a/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -35,6 +35,8 @@
         stop_balloon_service = "%s:\Balloon\w8\x86\blnsvr.exe -s"
     balloon_check, balloon_stop_continue, balloon_stress, balloon_hotplug, balloon_in_use, balloon_service, balloon_illegal, balloon_boot_in_pause, systemtap_tracing.balloon_event, driver_load_stress.with_balloon, win_virtio_driver_update_test.with_balloon:
         vm_mem_limit = 3G
+        q35:
+            vm_mem_limit = 2G
     variants:
         - @0:
         - 1:


### PR DESCRIPTION
Only 2G memory are usable in windows 32bit guests under q35

ID: 1633567

Signed-off-by: Li Jin <lijin@redhat.com>