### PR TITLE
qemu_storage: fixed a typo

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -406,7 +406,7 @@ class QemuImg(storage.QemuImg):
         if force_share:
             cmd += " -U"
         if backing_chain == "yes":
-            if "--backing_chain" in self.help_text:
+            if "--backing-chain" in self.help_text:
                 cmd += " --backing-chain"
             else:
                 logging.warn("'--backing-chain' option is not supportted")


### PR DESCRIPTION
The option should be `--backing-chain`, the typo makes backing-chain
never add into qemu-img info cmd.

Signed-off-by: Haotong Chen <hachen@redhat.com>