### PR TITLE
env_process: firewall blocks dhcp hand shakes for guest

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -678,3 +678,9 @@ inputs = ""
 #input_dev_type = ""
 # Bus type of input device (currently supports virtio)
 #input_dev_bus_type = ""
+
+# firewalld_service param used as global param to abstract the firewalld configuration
+# the framework can control the firewalld settings with this param set/unset, by default
+# firewalld is enabled
+
+# firewalld_service = "yes"

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -40,6 +40,7 @@ from virttest import utils_net
 from virttest import nfs
 from virttest import libvirt_vm
 from virttest import utils_test
+from virttest import utils_iptables
 from virttest.utils_version import VersionInterval
 from virttest.compat_52lts import decode_to_text
 
@@ -798,6 +799,12 @@ def preprocess(test, params, env):
                 image_name_only = os.path.basename(params[name_tag])
                 params[name_tag] = os.path.join(image_nfs.mount_dir,
                                                 image_name_only)
+
+    # firewall blocks dhcp from guest through virbr0
+    if params.get('firewalld_service', "yes") == "yes":
+        firewall_cmd = utils_iptables.Firewall_cmd()
+        if not firewall_cmd.add_service('dhcp', permanent=True):
+            logging.error('Failed to add dhcp service to be permitted')
 
     # Start ip sniffing if it isn't already running
     # The fact it has to be started here is so that the test params

--- a/virttest/utils_iptables.py
+++ b/virttest/utils_iptables.py
@@ -2,12 +2,15 @@
 Library to perform iptables configuration for virt test.
 """
 import logging
+import re
 
 from avocado.utils import process
 from avocado.core import exceptions
 
 from virttest import remote
+from virttest import utils_package
 from virttest.compat_52lts import decode_to_text
+from virttest.staging import service
 
 
 class Iptables(object):
@@ -84,3 +87,218 @@ class Iptables(object):
         # cleanup server session
         if params:
             server_session.close()
+
+
+def singleton_class(class_name):
+    class_instance = {}
+
+    def get_class(*args, **kwargs):
+        host = "local"
+        if kwargs.get("session"):
+            host = "remote"
+        if host not in class_instance:
+            class_object = class_name(*args, **kwargs)
+            class_instance[host] = class_object
+        return class_instance[host]
+    return get_class
+
+
+@singleton_class
+class Firewalld(object):
+    """
+    class handle firewalld service
+    """
+    def __init__(self, session=None):
+        """
+        Initialize firewalld service by installing and creating service obj
+
+        :param session: ShellSession Object of guest/remote host
+        """
+        self.service_name = "firewalld"
+        self.session = session
+        self.option = ""
+        if not utils_package.package_install(self.service_name, session=session):
+            logging.error("Firewalld package is not available")
+        if self.session:
+            self.firewalld = "systemctl %s firewalld"
+        else:
+            self.firewalld = service.Factory.create_service("firewalld")
+
+        if not self.status():
+            self.start()
+
+    def status(self):
+        """
+        Method to get the status of firewalld service
+        """
+        if self.session:
+            self.option = "status"
+            cmd = self.firewalld % (self.option)
+            status, output = self.session.cmd_status_output(cmd)
+            if status == 0:
+                return bool(re.search(r"active \(running\)", output))
+            else:
+                logging.error(output)
+                return False
+        else:
+            return self.firewalld.status()
+
+    def start(self):
+        """
+        Method to start firewalld service
+        """
+        if self.session:
+            self.option = "start"
+            cmd = self.firewalld % (self.option)
+            status, output = self.session.cmd_status_output(cmd)
+            if status != 0:
+                logging.error(output)
+        else:
+            self.firewalld.start()
+
+    def stop(self):
+        """
+        Method to stop firewalld service
+        """
+        if self.session:
+            self.option = "stop"
+            cmd = self.firewalld % (self.option)
+            status, output = self.session.cmd_status_output(cmd)
+            if status != 0:
+                logging.error(output)
+        else:
+            self.firewalld.stop()
+
+    def restart(self):
+        """
+        Method to restart firewalld service
+        """
+        if self.session:
+            self.option = "restart"
+            cmd = self.firewalld % (self.option)
+            status, output = self.session.cmd_status_output(cmd)
+            if status != 0:
+                logging.error(output)
+        else:
+            self.firewalld.restart()
+
+
+class Firewall_cmd(object):
+    """
+    class handles firewall-cmd methods
+    """
+    def __init__(self, session=None):
+        """
+        initialises the firewall cmd objects
+
+        :param session: ShellSession Object of guest/remote host
+        """
+        self.session = session
+        self.firewalld_obj = Firewalld(session=self.session)
+        self.firewall_cmd = "firewall-cmd"
+        self.func = process.getstatusoutput
+        if self.session:
+            self.func = self.session.cmd_status_output
+
+    def command(self, cmd, **dargs):
+        """
+        Wrapper method to execute firewall-cmd with different options
+
+        :param cmd: firewall-cmd command options
+        :param dargs: Additional arguments for the command
+        """
+        self.cmd = "%s %s" % (self.firewall_cmd, cmd)
+        if dargs.get("permanent", False):
+            self.cmd += " --permanent"
+        # default zone to be public
+        zone = dargs.get("zone", "public")
+        if zone:
+            self.cmd += " --zone=%s" % zone
+        self.status, self.output = self.func(self.cmd)
+        if self.status != 0:
+            logging.error("Failed to execute %s: %s", self.cmd, self.output)
+        # most of the firewall-cmd requires firewalld restart
+        if dargs.get("firewalld_restart", True):
+            self.firewalld_obj.restart()
+
+    def lists(self, key='all', **dargs):
+        """
+        Method to list existing services/ports etc.,
+
+        :param key: key to be listed, eg: all, services etc.,
+        :param dargs: Additional arguments for the command
+
+        :return: output of the --list-*
+        """
+        cmd = "--list-%s" % key
+        dargs['firewalld_restart'] = False
+        self.command(cmd, **dargs)
+        return self.output
+
+    def get(self, key='zones', **dargs):
+        """
+        Method to get existing zones/services etc.,
+
+        :param key: key to be get from firewall-cmd
+        :param dargs: Additional arguments for the command
+
+        :return: output of the --get-*
+        """
+        cmd = "--get-%s" % key
+        dargs['firewalld_restart'] = False
+        self.command(cmd, **dargs)
+        return self.output
+
+    def add_service(self, service_name, **dargs):
+        """
+        Method to add services to be permitted by firewall
+
+        :param service_name: service name to be added
+        :param dargs: Additional arguments for the command
+
+        :return: True on success, False on failure.
+        """
+        cmd = "--add-service=%s" % service_name
+        self.command(cmd, **dargs)
+        return self.status == 0
+
+    def remove_service(self, service_name, **dargs):
+        """
+        Method to remove services from permitted by firewall
+
+        :param service_name: service name to be added
+        :param dargs: Additional arguments for the command
+
+        :return: True on success, False on failure.
+        """
+        cmd = "--remove-service=%s" % service_name
+        self.command(cmd, **dargs)
+        return self.status == 0
+
+    def add_port(self, port, protocol, **dargs):
+        """
+        Method to add port to be permitted by firewall
+
+        :param port: port number to be added
+        :param protocol: protocol respective to the port to be added
+        :param dargs: Additional arguments for the command
+
+        :return: True on success, False on failure.
+        """
+        cmd = "--add-port=%s/%s" % (port, protocol)
+        self.command(cmd, **dargs)
+        return self.status == 0
+
+    def remove_port(self, port, protocol, **dargs):
+        """
+        Method to remove port from permitted by firewall
+
+        :param port: port number to be added
+        :param protocol: protocol respective to the port to be added
+        :param dargs: Additional arguments for the command
+
+        :return: True on success, False on failure.
+        """
+        cmd = "--remove-port=%s/%s" % (port, protocol)
+        self.command(cmd, **dargs)
+        return self.status == 0


### PR DESCRIPTION
During guest boot up, dhcp hand shakes happens between guest and
dnsmasq of host via virtual bridge (virbr0) and this is blocked by
firewalld causing failure of guest boot. This patch permits firewalld
to allow dhcp using firewall-cmd as dhcp using raw sockets which is not
going through iptables.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>