### PR TITLE
utils_test/libvirt: add API `get_machine_types()` to query all machine types

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -32,6 +32,7 @@ from virttest import xml_utils
 from virttest import utils_selinux
 from virttest import test_setup
 from virttest import utils_package
+from virttest.utils_test import libvirt
 from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts, decode_to_text
 
 
@@ -926,20 +927,8 @@ class VM(virt_vm.BaseVM):
         hvm_or_pv = params.get("hvm_or_pv", "hvm")
         # default to 'uname -m' output
         arch_name = params.get("vm_arch_name", platform.machine())
-        capabs = libvirt_xml.CapabilityXML()
-        try:
-            support_machine_type = capabs.guest_capabilities[
-                hvm_or_pv][arch_name]['machine']
-        except KeyError as detail:
-            if detail.args[0] == hvm_or_pv:
-                raise KeyError("No libvirt support for %s virtualization, "
-                               "does system hardware + software support it?"
-                               % hvm_or_pv)
-            elif detail.args[0] == arch_name:
-                raise KeyError("No libvirt support for %s virtualization of "
-                               "%s, does system hardware + software support "
-                               "it?" % (hvm_or_pv, arch_name))
-            raise
+        support_machine_type = libvirt.get_machine_types(arch_name, hvm_or_pv,
+                                                         ignore_status=False)
         logging.debug("Machine types supported for %s/%s: %s",
                       hvm_or_pv, arch_name, support_machine_type)
 

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -64,6 +64,8 @@ from virttest.libvirt_xml import pool_xml
 from virttest.libvirt_xml import nwfilter_xml
 from virttest.libvirt_xml import vol_xml
 from virttest.libvirt_xml import secret_xml
+from virttest.libvirt_xml import CapabilityXML
+from virttest.libvirt_xml import base
 from virttest.libvirt_xml.devices import disk
 from virttest.libvirt_xml.devices import hostdev
 from virttest.libvirt_xml.devices import controller
@@ -154,6 +156,37 @@ class LibvirtNetwork(object):
         virsh.net_destroy(self.name)
         if self.persistent:
             virsh.net_undefine(self.name)
+
+
+def get_machine_types(arch, virt_type, virsh_instance=base.virsh, ignore_status=True):
+    """
+    Method to get all supported machine types
+
+    :param arch: architecture of the machine
+    :param virt_type: virtualization type hvm or pv
+    :param virsh_instance: virsh instance object
+    :param ignore_status: False to raise Error, True to ignore
+
+    :return: list of machine types supported
+    """
+    machine_types = []
+    try:
+        capability = CapabilityXML(virsh_instance=virsh_instance)
+        machine_types = capability.guest_capabilities[virt_type][arch]['machine']
+        return machine_types
+    except KeyError as detail:
+        if ignore_status:
+            return machine_types
+        else:
+            if detail.args[0] == virt_type:
+                raise KeyError("No libvirt support for %s virtualization, "
+                               "does system hardware + software support it?"
+                               % virt_type)
+            elif detail.args[0] == arch:
+                raise KeyError("No libvirt support for %s virtualization of "
+                               "%s, does system hardware + software support "
+                               "it?" % (virt_type, arch))
+            raise exceptions.TestError(detail)
 
 
 def cpus_parser(cpulist):


### PR DESCRIPTION
This API can be used to query all the machine types supported by hypervisor
using CapabilityXML() in host or remote host which can be used from tests
and framework.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>