### PR TITLE
nfs.py: use nfs-server instead of nfs

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -162,7 +162,7 @@ class Nfs(object):
             self.nfs_setup = True
             path.find_command("service")
             path.find_command("exportfs")
-            if distro_details.name == 'Ubuntu':
+            if distro_details.name in ('Ubuntu', 'rhel'):
                 self.nfs_service = service.Factory.create_service("nfs-server")
             else:
                 self.nfs_service = service.Factory.create_service("nfs")


### PR DESCRIPTION
nfs-utils package does not provide /usr/lib/systemd/system/nfs.service
any more. So /usr/lib/systemd/system/nfs-server.service is our choice.

Signed-off-by: Dan Zheng <dzheng@redhat.com>