### PR TITLE
Fix filterref ValueError

### DIFF
--- a/virttest/libvirt_xml/devices/filterref.py
+++ b/virttest/libvirt_xml/devices/filterref.py
@@ -1,0 +1,58 @@
+"""
+Network filter support class
+
+https://libvirt.org/formatnwfilter.html#nwfconceptsvars
+"""
+
+from virttest.libvirt_xml import accessors, xcepts
+from virttest.libvirt_xml.devices import base
+
+
+class Filterref(base.base.LibvirtXMLBase):
+    """
+    Interface filterref xml class.
+
+    Properties:
+
+    name:
+    string. filter name
+    parameters:
+    list. parameters element dict list
+    """
+    __slots__ = ("name", "parameters")
+
+    def __init__(self, virsh_instance=base.base.virsh):
+        accessors.XMLAttribute(property_name="name",
+                               libvirtxml=self,
+                               forbidden=None,
+                               parent_xpath='/',
+                               tag_name='filterref',
+                               attribute='filter')
+        accessors.XMLElementList(property_name='parameters',
+                                 libvirtxml=self,
+                                 parent_xpath='/',
+                                 marshal_from=self.marshal_from_parameter,
+                                 marshal_to=self.marshal_to_parameter)
+        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
+        self.xml = '<filterref/>'
+
+    @staticmethod
+    def marshal_from_parameter(item, index, libvirtxml):
+        """Convert a dictionary into a tag + attributes"""
+        del index           # not used
+        del libvirtxml      # not used
+        if not isinstance(item, dict):
+            raise xcepts.LibvirtXMLError("Expected a dictionary of parameter "
+                                         "attributes, not a %s"
+                                         % str(item))
+            # return copy of dict, not reference
+        return ('parameter', dict(item))
+
+    @staticmethod
+    def marshal_to_parameter(tag, attr_dict, index, libvirtxml):
+        """Convert a tag + attributes into a dictionary"""
+        del index                    # not used
+        del libvirtxml               # not used
+        if tag != 'parameter':
+            return None              # skip this one
+        return dict(attr_dict)       # return copy of dict, not reference@

--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -5,7 +5,7 @@ http://libvirt.org/formatdomain.html#elementsNICS
 http://libvirt.org/formatnwfilter.html#nwfconceptsvars
 """
 
-from virttest.libvirt_xml import accessors, xcepts
+from virttest.libvirt_xml import accessors
 from virttest.libvirt_xml.devices import base, librarian
 
 
@@ -78,7 +78,7 @@ class Interface(base.TypedDeviceBase):
         accessors.XMLElementNest("filterref", self,
                                  parent_xpath='/',
                                  tag_name='filterref',
-                                 subclass=Filterref,
+                                 subclass=self.Filterref,
                                  subclass_dargs={
                                      'virsh_instance': virsh_instance})
         accessors.XMLAttribute(property_name="model",
@@ -113,6 +113,8 @@ class Interface(base.TypedDeviceBase):
     # For convenience
     Address = librarian.get('address')
 
+    Filterref = librarian.get('filterref')
+
     def new_bandwidth(self, **dargs):
         """
         Return a new interafce banwidth instance from dargs
@@ -144,7 +146,7 @@ class Interface(base.TypedDeviceBase):
         """
         Return a new interafce filterref instance from dargs
         """
-        new_one = Filterref(virsh_instance=self.virsh)
+        new_one = self.Filterref(virsh_instance=self.virsh)
         for key, value in list(dargs.items()):
             setattr(new_one, key, value)
         return new_one
@@ -196,53 +198,3 @@ class Interface(base.TypedDeviceBase):
                                      tag_name="guest")
             super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = '<driver/>'
-
-
-class Filterref(base.base.LibvirtXMLBase):
-    """
-    Interface filterref xml class.
-
-    Properties:
-
-    name:
-    string. filter name
-    parameters:
-    list. parameters element dict list
-    """
-    __slots__ = ("name", "parameters")
-
-    def __init__(self, virsh_instance=base.base.virsh):
-        accessors.XMLAttribute(property_name="name",
-                               libvirtxml=self,
-                               forbidden=None,
-                               parent_xpath='/',
-                               tag_name='filterref',
-                               attribute='filter')
-        accessors.XMLElementList(property_name='parameters',
-                                 libvirtxml=self,
-                                 parent_xpath='/',
-                                 marshal_from=self.marshal_from_parameter,
-                                 marshal_to=self.marshal_to_parameter)
-        super(self.__class__, self).__init__(virsh_instance=virsh_instance)
-        self.xml = '<filterref/>'
-
-    @staticmethod
-    def marshal_from_parameter(item, index, libvirtxml):
-        """Convert a dictionary into a tag + attributes"""
-        del index           # not used
-        del libvirtxml      # not used
-        if not isinstance(item, dict):
-            raise xcepts.LibvirtXMLError("Expected a dictionary of parameter "
-                                         "attributes, not a %s"
-                                         % str(item))
-            # return copy of dict, not reference
-        return ('parameter', dict(item))
-
-    @staticmethod
-    def marshal_to_parameter(tag, attr_dict, index, libvirtxml):
-        """Convert a tag + attributes into a dictionary"""
-        del index                    # not used
-        del libvirtxml               # not used
-        if tag != 'parameter':
-            return None              # skip this one
-        return dict(attr_dict)       # return copy of dict, not reference@

--- a/virttest/libvirt_xml/devices/librarian.py
+++ b/virttest/libvirt_xml/devices/librarian.py
@@ -12,7 +12,7 @@ DEVICE_TYPES = ['disk', 'filesystem', 'controller', 'lease',
                 'hostdev', 'redirdev', 'smartcard', 'interface', 'input',
                 'hub', 'graphics', 'video', 'parallel', 'serial', 'console',
                 'channel', 'sound', 'watchdog', 'memballoon', 'rng', 'vsock',
-                'seclabel', 'address', 'emulator', 'panic', 'memory']
+                'seclabel', 'address', 'emulator', 'panic', 'memory', 'filterref']
 
 
 def get(name):

--- a/virttest/libvirt_xml/nwfilter_binding.py
+++ b/virttest/libvirt_xml/nwfilter_binding.py
@@ -4,7 +4,7 @@ http://libvirt.org/formatnwfilter.html
 """
 
 from virttest.libvirt_xml import base, accessors
-from virttest.libvirt_xml.devices.interface import Filterref
+from virttest.libvirt_xml.devices.filterref import Filterref
 
 
 class NwfilterBinding(base.LibvirtXMLBase):


### PR DESCRIPTION
This PR is to fix commit d7f91f1, that raised ValueError when assigning value to filterref as
code below:
```
        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
        iface_xml = vmxml.get_devices('interface')[0]
        vmxml.del_device(iface_xml)
        iface_xml.source = {'bridge': br_name}
        iface_xml.filterref = iface_xml.new_filterref(name=nwfilter)
        logging.debug("new interface xml is: %s" % iface_xml)
        vmxml.add_device(iface_xml)
        vmxml.sync()

File "/var/tmp/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/libvirt_xml/accessors.py", line 29, in type_check
    % (name, expected, is_a_name))

ValueError: Instance of Filterref value is not any of [<class 'interface.Filterref'>], it is a <class 'interface.Filterref'>
```

Signed-off-by: Yan Li <yannli@redhat.com>