### PR TITLE
virttest.qemu_monitor: Allow unpickling monitor on py3

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -267,6 +267,12 @@ class Monitor:
         # any representation whatsoever.
         return VM(self.vm.name), self.name, self.filename, True
 
+    def __reduce__(self):
+        """
+        Backward-compatible way to use __getinitargs__ on py3
+        """
+        return self.__class__, (self.__getinitargs__())
+
     def _close_sock(self):
         try:
             self._socket.shutdown(socket.SHUT_RDWR)


### PR DESCRIPTION
Python3 won't call __getinitargs__, instead it uses __reduce__. Let's
use this as backward compatible way to initialize monitor class on both
py2 and py3.

This fixes issue where after test execution Avocado raises tracebacks
like:

Exception ignored in: <bound method Monitor.__del__ of <virttest.qemu_monitor.QMPMonitor object at 0xffffa2425160>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/virttest/qemu_monitor.py", line 227, in __del__
    self._close_sock()
  File "/usr/local/lib/python3.6/site-packages/virttest/qemu_monitor.py", line 272, in _close_sock
    self._socket.shutdown(socket.SHUT_RDWR)
AttributeError: 'QMPMonitor' object has no attribute '_socket'
Exception ignored in: <bound method Monitor.__del__ of <virttest.qemu_monitor.QMPMonitor object at 0xffffa2425128>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/virttest/qemu_monitor.py", line 227, in __del__
    self._close_sock()
  File "/usr/local/lib/python3.6/site-packages/virttest/qemu_monitor.py", line 272, in _close_sock
    self._socket.shutdown(socket.SHUT_RDWR)
AttributeError: 'QMPMonitor' object has no attribute '_socket'

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>