### PR TITLE
env_process: fix screendump timestamp issue

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -215,7 +215,7 @@ class VirtTest(test.Test):
         except Queue.Empty:
             pass
         else:
-            six.reraise(exc[1], None, exc[2])
+            six.reraise(*exc)
 
     def __safe_env_save(self, env):
         """

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1463,28 +1463,24 @@ def _take_screendumps(test, params, env):
                             test.background_errors.put(sys.exc_info())
                     elif inactivity_watcher == 'log':
                         logging.debug(msg)
-                try:
-                    os.link(cache[image_hash], screendump_filename)
-                except OSError:
-                    pass
             else:
                 inactivity[vm.instance] = time.time()
+            cache[image_hash] = screendump_filename
+            try:
                 try:
-                    try:
-                        timestamp = os.stat(temp_filename).st_ctime
-                        image = PIL.Image.open(temp_filename)
-                        image = ppm_utils.add_timestamp(image, timestamp)
-                        image.save(screendump_filename, format="JPEG",
-                                   quality=quality)
-                        cache[image_hash] = screendump_filename
-                    except (IOError, OSError) as error_detail:
-                        logging.warning("VM '%s' failed to produce a "
-                                        "screendump: %s", vm.name, error_detail)
-                        # Decrement the counter as we in fact failed to
-                        # produce a converted screendump
-                        counter[vm.instance] -= 1
-                except NameError:
-                    pass
+                    timestamp = os.stat(temp_filename).st_ctime
+                    image = PIL.Image.open(temp_filename)
+                    image = ppm_utils.add_timestamp(image, timestamp)
+                    image.save(screendump_filename, format="JPEG",
+                               quality=quality)
+                except (IOError, OSError) as error_detail:
+                    logging.warning("VM '%s' failed to produce a "
+                                    "screendump: %s", vm.name, error_detail)
+                    # Decrement the counter as we in fact failed to
+                    # produce a converted screendump
+                    counter[vm.instance] -= 1
+            except NameError:
+                pass
             os.unlink(temp_filename)
 
         if _screendump_thread_termination_event is not None:


### PR DESCRIPTION
id: 1647313

1. always create new screendump no matter VM screen
pauses or not.
2. fix error raising issue.

Signed-off-by: lolyu <lolyu@redhat.com>