### PR TITLE
utils_misc: TLS - increase RSA key bit length to 3072 for SPICE connection

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1369,7 +1369,7 @@ def get_module_params(sys_path, module_name):
 
 
 def create_x509_dir(path, cacert_subj, server_subj, passphrase,
-                    secure=False, bits=1024, days=1095):
+                    secure=False, bits=3072, days=1095):
     """
     Creates directory with freshly generated:
     ca-cart.pem, ca-key.pem, server-cert.pem, server-key.pem,


### PR DESCRIPTION
There is advice to utilize at least 3072 bits to RSA keys.
See [Red Hat documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-hardening_tls_configuration).

Signed-off-by: Radek Duda <rduda@redhat.com>