### PR TITLE
Device should be connected to downstream port bus using device number 0

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1970,7 +1970,7 @@ class QPCISwitchBus(QPCIBus):
         if addr not in self.__downstream_ports:
             _addr = int(addr, 16)
             bus_id = "%s.%s" % (self.busid, _addr)
-            bus = QPCIBus(bus_id, 'PCIE', bus_id)
+            bus = QPCIDownstreamPortBus(bus_id, bus_id)
             self.__downstream_ports["0x%x" % _addr] = bus
             downstream = QDevice(self.__downstream_type,
                                  {'id': bus_id,
@@ -2005,6 +2005,42 @@ class QPCISwitchBus(QPCIBus):
         downstream port.
         """
         self.__downstream_ports['0x%x' % addr[0]].insert(device)
+
+
+class QPCIDownstreamPortBus(QPCIBus):
+
+    """PCIE Switch Downstream Port Bus"""
+
+    def __init__(self, busid, aobject=None):
+        super(QPCIDownstreamPortBus, self).__init__(busid, 'PCIE', busid, length=1)
+
+    def insert(self, device, strict_mode=False):
+        """
+        Insert device into this bus representation.
+
+        :param device: QBaseDevice device
+        :param strict_mode: Use strict mode (set optional params)
+        :return: list of added devices on success,
+                 string indicating the failure on failure.
+        """
+
+        additional_devices = []
+        if not self._check_bus(device):
+            return "BusId"
+        addr_pattern = [0, 0]
+        addr = self.get_free_slot(addr_pattern)
+        if addr is None:
+            return "UsedSlot"
+        elif addr is False:
+            return "BadAddr(%s)" % addr
+        else:
+            additional_devices.extend(self._insert(device,
+                                                   self._addr2stor(addr)))
+        if strict_mode:     # Set full address in strict_mode
+            self._set_device_props(device, addr)
+        else:
+            self._update_device_props(device, addr)
+        return additional_devices
 
 
 class QSCSIBus(QSparseBus):


### PR DESCRIPTION
QPCISwitchBus was designed to hide creation of downstream port from
user. To do that, it first creates a downstream port device and its bus,
connects the downstream port device to upstream port bus (represented by
QPCISwitchBus) at address specified by the device's addr parameter. Then
it connects the device to the downstream port bus (repsented by QPCIBus)
using the same address. This doesn't work when test wants to create a
topology like the following, because the device 2 would be connected to
downstream port 2 using a non-zero addr value, which cause the device
invisible to guest OS (QEMU doens't have a check for this so it starts
up happily).

   root port -> upstream port +-> downstream port 1 -> device 1
                              +-> downstream port 2 -> devive 2

The nature of the issue is the current code reuses device attr value for
two different purposes: the address to connect downstream port to
upstream port bus and the address to connect device to downstream port
bus. These two values are not necessarily same. They actually have to be
different in many cases.

The change fixes this issue by making sure device is always connected to
downstream port bus using device number 0. It does this by introducing a
new QPCIDownstreamPortBus class and provides its own copy of insert(),
which is almost same as QSparseBus's insert() except it hardcodes device
address to [0, 0]. This is not the best way to fix it, but is the
simplest way I can find without changing API of related classes.

Signed-off-by: Huan Xiong <huan.xiong@hxt-semitech.com>