### PR TITLE
Update v2v cmd running timeout value to 5200

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -705,7 +705,7 @@ def v2v_cmd(params):
     vpx_dc = params.get('vpx_dc')
     esx_ip = params.get('esx_ip')
     opts_extra = params.get('v2v_opts')
-    v2v_timeout = params.get('v2v_timeout', 2400)
+    v2v_timeout = params.get('v2v_timeout', 5400)
     rhv_upload_opts = params.get('rhv_upload_opts')
 
     uri_obj = Uri(hypervisor)


### PR DESCRIPTION
For v2v '-o rhv' output, v2v write data to NFS server directly,
so 40min is usually enough, but in some special testing hosts,
if the hosts are plugged in with a telphone line, the transmission
speed will be very slow, 40min may still timeout.

Now v2v implements rhv-upload feature, it copies the data to an
imageio (HTTPS) endpoint, and it usually spends more time. 40 mins
is not enough now.

I tested the value in some different hosts, the time vairies from
20mins to 90min. And developors also said 2 hours is a safe value.

So set the timeout value to 5200s.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>