### PR TITLE
virttest.data_plane: introduce iothread manager classes

### DIFF
--- a/virttest/data_plane.py
+++ b/virttest/data_plane.py
@@ -1,0 +1,396 @@
+"""
+Autotest implementation of iothread manager classes.
+
+These classes represents different iothread allocation scheme.
+"""
+import heapq
+import re
+import threading
+
+from avocado.utils import cpu
+from avocado.utils import process
+
+from virttest.qemu_devices.qdevices import IOThread
+
+
+def get_iothread_supported_devices(qemu_binary):
+    """Return a list of iothread-supported devices."""
+    def _get_supported_devices(devices):
+        for device in devices:
+            out = process.run(cmd=query_command % (qemu_binary, device + ","),
+                              timeout=10, ignore_status=True, shell=True,
+                              verbose=False).stdout_text
+            if "iothread" in out:
+                supported.append(device)
+
+    # get list of qemu devices
+    query_command = "%s --device %s\? 2>&1"
+    out = process.run(cmd=query_command % (qemu_binary, ""), timeout=10,
+                      ignore_status=True, shell=True, verbose=False)
+    devices = re.findall(r'name "([0-9A-Za-z-_]*)"', out.stdout_text)
+
+    # filter out iothread-supported devices
+    # list is thread-safe
+    supported = []
+    N = 5
+    threads = []
+    for i in range(N):
+        threads.append(threading.Thread(target=_get_supported_devices,
+                                        args=(devices[i::N],)))
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    return supported
+
+
+class MinQueue(object):
+    """Min heap."""
+
+    def __init__(self, item_list=None):
+        """Heapify the pool."""
+        if item_list is None:
+            item_list = []
+        self._queue = list(item_list)
+        heapq.heapify(self._queue)
+
+    def __len__(self):
+        """Return the length."""
+        return len(self._queue)
+
+    def __iter__(self):
+        """Return iterator."""
+        return iter(self._queue)
+
+    def __getitem__(self, pos):
+        """heap.__getitem__(pos) <==> heap[pos]"""
+        return self._queue[pos]
+
+    def __setitem__(self, pos, value):
+        """heap.__setitem__(pos, value) <==> heap[pos] = value"""
+        self._queue[pos] = value
+
+    def siftup(self, pos):
+        """Rearrange if item on pos is increased in value."""
+        heapq._siftup(self._queue, pos)
+
+    def siftdown(self, pos, startpos=0):
+        """Rearrange if item on pos is decreased in value."""
+        heapq._siftdown(self._queue, startpos, pos)
+
+    def siftup_item(self, item):
+        """Rearrange item if its value is increased."""
+        try:
+            pos = self._queue.index(item)
+            self.siftup(pos)
+        except ValueError:
+            pass
+
+    def siftdown_item(self, item):
+        """Rearrange item if its value is decreased."""
+        try:
+            pos = self._queue.index(item)
+            self.siftdown(pos)
+        except ValueError:
+            pass
+
+    def push(self, item):
+        """Push item into heap."""
+        heapq.heappush(self._queue, item)
+
+    def pop(self):
+        """Pop out the min item."""
+        return heapq.heappop(self._queue)
+
+    def get_min(self):
+        """Return min item."""
+        return self._queue[0]
+
+    def remove(self, item):
+        """Remove item and re-heapify."""
+        if item not in self._queue:
+            return
+        self._queue.remove(item)
+        heapq.heapify(self._queue)
+
+
+class IOThreadManagerError(Exception):
+    pass
+
+
+class IOThreadNotExistedError(Exception):
+    def __init__(self, iothread_id, manager):
+        msg = "%s not existed in %s." % (iothread_id, manager)
+        super(IOThreadNotExistedError, self).__init__(msg)
+        self.iothread_id = iothread_id
+        self.manager = manager
+
+
+class IOThreadManagerBase(object):
+    """
+    Base class for iothread manager, only responsible for the allocation and
+    deallocation of iothread object.
+
+    To allocate iothread, call IOThreadManagerBase.get_iothread to get next
+    available iothread object.
+    After allocation, call IOThreadManagerBase.sync to update iothread and
+    pool.
+
+    TODO: sync with DevContainer in simple_hotplug and simple_unplug if the
+    device plugged or unplugged is an instance of IOThread.
+    """
+
+    def __init__(self, pool=None):
+        """Constructor."""
+        super(IOThreadManagerBase, self).__init__()
+        pool = pool or []
+        self.iothread_pool = pool
+        self.mapping = {iothread.id: iothread for iothread in pool}
+
+    def __iter__(self):
+        """Return iteractor."""
+        return iter(self.iothread_pool)
+
+    @property
+    def iothread_count(self):
+        """Return iothread count."""
+        return len(self.iothread_pool)
+
+    def get_iothread(self, iothread_id):
+        """Get next iothread to use."""
+        raise NotImplementedError
+
+    def sync(self, dev, iothread_id):
+        """
+        Update iothread.
+
+        :param dev: device attached.
+        :param iothread_id: iothread id to update.
+        """
+        raise NotImplementedError
+
+    def allocate_iothread(self, dev, iothread_id=None):
+        """
+        Update iothread and pool when unplug device.
+
+        :param dev: device to unplug.
+        :param iothread_id: iothread id.
+        """
+        raise NotImplementedError
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=False):
+        """Update iothread when unplug device."""
+        iothread = self.mapping[iothread_id]
+        iothread.detach(dev)
+        if remove is True:
+            self.remove(iothread)
+
+    def push(self, iothread):
+        """Push iothread into manager."""
+        raise NotImplementedError
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        raise NotImplementedError
+
+    def __str__(self):
+        return "%s: [%s]" % (self.__class__.__name__,
+                             ', '.join([str(it) for it in self.iothread_pool]))
+
+
+class PredefinedManager(IOThreadManagerBase):
+    """
+    Predefined iothread allocation based on params, backward support with
+    previous patch that defines iothread objects with 'iothreads=...' and add
+    to device with bus_extra_params and blk_extra_params.
+    """
+
+    def __init__(self, iothreads):
+        """Constructor."""
+        super(PredefinedManager, self).__init__(list(iothreads))
+
+    def get_iothread(self, iothread_id):
+        """Allocate predefined iothread."""
+        if (iothread_id is not None and
+                iothread_id not in self.mapping):
+                raise IOThreadNotExistedError(iothread_id, self)
+        return iothread_id
+
+    def sync(self, dev, iothread_id):
+        """Update iothread with iothread_id."""
+        iothread = self.mapping[iothread_id]
+        iothread.attach(dev)
+        return False, iothread
+
+    def allocate_iothread(self, dev, iothread_id):
+        return self.sync(self.get_iothread(iothread_id), dev)
+
+    def push(self, iothread):
+        """Push iothread to manager."""
+        iothread_id = iothread.id
+        if iothread_id in self.mapping:
+            return
+        self.iothread_pool.append(iothread)
+        self.mapping[iothread_id] = iothread
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        iothread_id = iothread.id
+        if iothread_id not in self.mapping:
+            raise IOThreadNotExistedError(iothread_id, self)
+        IOThread._release_id(iothread_id)
+        del self.mapping[iothread_id]
+        self.iothread_pool.remove(iothread)
+
+
+class RoundRobinManager(IOThreadManagerBase):
+    """
+    Allocate iothread in round robin.
+    Example:
+    'roundrobin3' will create 3 iothreads in manager, and the using of min heap
+    will always choose iothread object with the minimum devices attached.
+    before allocation:  [iothread0 - 0, iothread1 - 0, iothread2 - 0]
+    dev0 --> iothread0: [*iothread0 - 1, iothread1 - 0, iothread2 - 0]
+    dev1 --> iothread1: [iothread0 - 1, *iothread1 - 1, iothread2 - 1]
+    dev2 --> iothread2: [iothread0 - 1, iothread1 - 1, *iothread2 - 1]
+    dev3 --> iothread0: [*iothread0 - 2, iothread1 - 1, iothread2 - 1]
+    dev4 --> iothread1: [iothread0 - 2, *iothread1 - 2, iothread2 - 1]
+    dev5 --> iothread2: [iothread0 - 2, iothread1 - 2, *iothread2 - 2]
+    """
+
+    def __init__(self, count=1):
+        """Constructor."""
+        pool = [IOThread() for i in range(count)]
+        super(RoundRobinManager, self).__init__(MinQueue(pool))
+
+    def get_iothread(self, iothread_id=None):
+        """Get next iothread id to use."""
+        if iothread_id is None:
+            return self.iothread_pool.get_min().id
+        if iothread_id not in self.mapping:
+            raise IOThreadNotExistedError(iothread_id, self)
+        return iothread_id
+
+    def sync(self, dev, iothread_id):
+        """Update iothread and manager, return the synced iothread."""
+        iothread = self.mapping[iothread_id]
+        iothread.attach(dev)
+        self.iothread_pool.siftup_item(iothread)
+        return False, iothread
+
+    def allocate_iothread(self, dev, iothread_id=None):
+        """
+        Get iothread to use.
+
+        param dev: device that requests iothread.
+        param iothread_id: iothread_id to request, ignored.
+        """
+        return self.sync(self.get_iothread(), dev)
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=False):
+        """Update iothread and pool when unplug device."""
+        super(RoundRobinManager, self).update_iothread_in_unplug(dev,
+                                                                 iothread_id,
+                                                                 remove)
+        if remove is False:
+            iothread = self.mapping[iothread_id]
+            self.iothread_pool.siftdown_item(iothread)
+
+    def push(self, iothread):
+        """Push iothread to manager."""
+        iothread_id = iothread.id
+        if iothread_id in self.mapping:
+            return
+        self.iothread_pool.push(iothread)
+        self.mapping[iothread_id] = iothread
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        iothread_id = iothread.id
+        if iothread_id not in self.mapping:
+            raise IOThreadNotExistedError(iothread_id, self)
+        IOThread._release_id(iothread_id)
+        del self.mapping[iothread_id]
+        self.iothread_pool.remove(iothread)
+
+
+class OTOManager(IOThreadManagerBase):
+    """Create iothread for each controller device."""
+
+    def __init__(self):
+        """Constructor."""
+        super(OTOManager, self).__init__()
+
+    def get_iothread(self, iothread_id=None):
+        """Get next iothread id to use."""
+        return IOThread._get_next_id()
+
+    def sync(self, dev, iothread_id):
+        """Instantiate a iothread object with iothread_id."""
+        iothread = IOThread(id=iothread_id)
+        self.mapping[iothread_id] = iothread
+        iothread.attach(dev)
+        self.push(iothread)
+        return True, iothread
+
+    def allocate_iothread(self, dev, iothread_id):
+        return self.sync(self.get_iothread(), dev)
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=True):
+        """Update iothread and pool in unplug, always remove iothread."""
+        super(OTOManager, self).update_iothread_in_unplug(dev, iothread_id,
+                                                          remove)
+
+    def push(self, iothread):
+        """Push iothread to manager."""
+        iothread_id = iothread.id
+        if iothread_id in self.mapping:
+            return
+        self.iothread_pool.append(iothread)
+        self.mapping[iothread_id] = iothread
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        iothread_id = iothread.id
+        if iothread_id not in self.mapping:
+            raise IOThreadNotExistedError(iothread_id, self)
+        IOThread._release_id(iothread_id)
+        del self.mapping[iothread_id]
+        self.iothread_pool.remove(iothread)
+
+
+class OptimalManager(RoundRobinManager):
+    """Dynamically allocate base on min(vpcu, pcpu, device)."""
+
+    def __init__(self, vcpu):
+        """Constructor."""
+        super(OptimalManager, self).__init__(count=0)
+        self.cpu_boundary = min(vcpu, cpu.total_cpus_count())
+
+    def get_iothread(self, iothread_id=None):
+        """Get next iothread id to use."""
+        if len(self.iothread_pool) < self.cpu_boundary:
+            return IOThread._get_next_id()
+        else:
+            return super(OptimalManager, self).get_iothread()
+
+    def sync(self, dev, iothread_id):
+        """Instantiate a new iothread object with iothread_id."""
+        if iothread_id in self.mapping:
+            is_new = False
+            iothread = self.mapping[iothread_id]
+        else:
+            is_new = True
+            iothread = IOThread(id=iothread_id)
+            self.push(iothread)
+        iothread.attach(dev)
+        self.iothread_pool.siftup_item(iothread)
+        return is_new, iothread
+
+    def allocate_iothread(self, dev, iothread_id=None):
+        return self.sync(self.get_iothread(), dev)
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=False):
+        """Update iothread and pool in unplug, never remove iothread."""
+        super(OptimalManager, self).update_iothread_in_unplug(dev, iothread_id,
+                                                              remove)

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -10,6 +10,7 @@ import logging
 import re
 import traceback
 from collections import OrderedDict
+from functools import total_ordering
 
 from virttest import qemu_monitor
 from virttest import utils_misc
@@ -989,6 +990,133 @@ class Dimm(QDevice):
         if dev_id_name not in str(out):
             return True
         return False
+
+
+@total_ordering
+class IOThread(QObject):
+    """
+    iothread representation.
+    attributes of iothread
+    "id", "poll-max-ns", "poll-grow", "poll-shrink"]
+    """
+
+    id = 0
+    id_used = set()
+
+    def __init__(self, id=None, params=None):
+        """Constructor."""
+        if id is None:
+            id = IOThread._get_next_id()
+        if params is None:
+            params = dict()
+        params["id"] = id
+        self.id = id
+        self.__attached_devices = list()
+        kwargs = dict(backend="iothread", params=params)
+        super(IOThread, self).__init__(**kwargs)
+
+    def __len__(self):
+        """Get count of attached devices."""
+        return len(self.__attached_devices)
+
+    def __eq__(self, other):
+        """Equal."""
+        if isinstance(other, IOThread):
+            return (len(self), self.id) == (len(other), other.id)
+        return super(IOThread, self).__eq__(other)
+
+    def __lt__(self, other):
+        """Less than."""
+        return (len(self), self.id) < (len(other), other.id)
+
+    @classmethod
+    def _get_next_id(cls):
+        """Get next usable id."""
+        id = "iothread%d" % cls.id
+        cls.id_used.add(cls.id)
+        while True:
+            cls.id += 1
+            if cls.id not in cls.id_used:
+                break
+        return id
+
+    @classmethod
+    def _release_id(cls, id):
+        """Release id."""
+        try:
+            id = int(re.match("iothread(\d+)", id).group(1))
+            cls.id_used.remove(id)
+        except (KeyError, ValueError, AttributeError):
+            pass
+        else:
+            if id < cls.id:
+                cls.id = id
+
+    @staticmethod
+    def query(monitor):
+        """Get a dictionary of info iothreads."""
+        out = monitor.info("iothreads", debug=False)
+        if isinstance(monitor, qemu_monitor.HumanMonitor):
+            pattern = ("([\w-]+):\s+(thread_id)=(\d+)\s+(poll-max-ns)=(\d+)\s+"
+                       "(poll-grow)=(\d+)\s+(poll-shrink)=(\d+)")
+            result = []
+            for t in re.findall(pattern, out):
+                it_dict = {}
+                it_dict["id"] = t[0]
+                it_dict.update(zip(t[1::2], t[2::2]))
+                result.append(it_dict)
+            return result
+        return out
+
+    def get_children(self):
+        """Get child devices, skip QObject."""
+        return super(QObject, self).get_children()
+
+    def hotplug_qmp(self):
+        """Return hotplug qmp command string."""
+        params = dict(self.params)
+        backend = params.pop("backend")
+        id = params.pop("id")
+        kwargs = {"qom-type": backend, "id": id, "props": params}
+        return "object-add", kwargs
+
+    def verify_hotplug(self, out, monitor):
+        """Verify if it is plugged into VM."""
+        out = IOThread.query(monitor)
+        for iothread in out:
+            if self.id == iothread["id"]:
+                return True
+        return False
+
+    def verify_unplug(self, out, monitor):
+        """Verify if it is unplugged from VM."""
+        return not self.verify_hotplug(out, monitor)
+
+    def is_attached(self, device):
+        """Check if device is using this iothread."""
+        return device in self.__attached_devices
+
+    def unplug_hook(self):
+        """Remove from attached devices' params."""
+        for dev in self.__attached_devices:
+            dev.set_param("iothread", None)
+
+    def unplug_unhook(self):
+        """Reset attached devices' params."""
+        for dev in self.__attached_devices:
+            dev.set_param("iothread", self.id)
+
+    def attach(self, device):
+        """Attach device to this iothread."""
+        if self.is_attached(device):
+            return
+        device.set_param("iothread", self.id)
+        self.__attached_devices.append(device)
+
+    def detach(self, device):
+        """Detach device from this iothread."""
+        self.__attached_devices.remove(device)
+        device.set_param("iothread", None)
 
 
 class CharDevice(QCustomDevice):

--- a/virttest/qemu_devices/utils.py
+++ b/virttest/qemu_devices/utils.py
@@ -73,3 +73,8 @@ def none_or_int(value):
         return int(value)
     else:
         raise TypeError("This parameter has to be int or none")
+
+
+def parse_extra_params(extra_params):
+    """Transform param into dictionary."""
+    return dict(_.split("=", 1) for _ in extra_params.split(",") if _)


### PR DESCRIPTION
This is the implementation of different iothread allocation schemes for
device controllers, which includes the following manager classes:

1. PredefinedManager class, providing backward compatibility. Testcases
with 'iothreads=...' set or no 'iothread_scheme' set will use this
class.

2. RoundRobinManager class, providing iothread allocation in round-robin
way.

3. OTOManager class, always allocate new iothread for controller devices.

4. OptimalManager, will take vpcu and pcpu into consideration.
When device count < min(vcpu, pcpu), this class will allocate new
iothread object as OTOManager does. But when device count >= min(vpu,
pcpu), this class will allocate in round-robin way, since the optimal
iothread count = min(device, vcpu, pcpu).

Other modifications:

1. New IOThread class that subclasses QObjec encapsulates QEMU iothread
to provide hotplug/unplug support.

2. QContainer.get_buses, add extra default argument 'excluded=None' to
get buses without properties listed in excluded.

3. QContainer.images_define_by_variables, change function define_hbas to
 allocate new pci controller with iothread support.

4. add function select_iothread_manager to
virttest.qemu_vm.VM.make_create_command that to initialize iothread
manager to DevContainer instance.
supported schemes:
    'roundrobin_<count>': roundrobin_2 will pre-instantiate two IOThread
    object and allocate it in a round robin way.
    'oto': one controller device to one iothread object.
    'rhv': emulate rhvm that use one iothread for all controllers.
    'optimal': iothread_count = min(pcpu, vcpu, device), but no support
    for unplug scenario.

priority:
    predefined manager with iothreads set > iothread schemes >
    empty predefined manager

5. refactor the code in virttest.qemu_vm.VM.make_create_command to let
 the vcpu initialization precedes the allocation of devices.

Usage example:
	a. predefined
	    --------------------------------------------------
	    iothreads = "iothread0,iothread1,iothread2"
	    images += 'stg0'
	    ...
	    iothread_stg0 = iothread0
	    --------------------------------------------------
	    will enable iothread of the controller device of image stg0.
	b. round robin
	    --------------------------------------------------
	    iothread_scheme = roundrobin_3
	    --------------------------------------------------
	    will create iothread0,iothread1,iothread2 in VM and allocate
	    them in round robin way for controller devices.
	c. one to one
	    --------------------------------------------------
	    iothread_scheme = oto
	    --------------------------------------------------
	    one iothread object for each controller device.
	d. rhv
	    --------------------------------------------------
	    iothread_scheme = rhv
	    --------------------------------------------------
	e. optimal
	    --------------------------------------------------
	    iothread_scheme = optimal
	    --------------------------------------------------
	d. no iothreads and iothread_scheme set
	    disable iothread for controllers.

Signed-off-by: lolyu <lolyu@redhat.com>