### PR TITLE
virttest.data_plane: introduce iothread manager classes

### DIFF
--- a/virttest/data_plane.py
+++ b/virttest/data_plane.py
@@ -1,0 +1,395 @@
+"""
+Autotest implementation of iothread manager classes.
+
+These classes represents different iothread allocation scheme.
+"""
+import heapq
+import re
+
+from avocado.utils import cpu
+from virttest.qemu_devices.qdevices import IOThread
+
+
+class MinQueue(object):
+    """Min heap."""
+
+    def __init__(self, item_list=None):
+        """Heapify the pool."""
+        self._queue = list(item_list or [])
+        heapq.heapify(self._queue)
+
+    def __len__(self):
+        """Return the length."""
+        return len(self._queue)
+
+    def __iter__(self):
+        """Return iterator."""
+        return iter(self._queue)
+
+    def __getitem__(self, pos):
+        """heap.__getitem__(pos) <==> heap[pos]"""
+        return self._queue[pos]
+
+    def __setitem__(self, pos, value):
+        """heap.__setitem__(pos, value) <==> heap[pos] = value"""
+        self._queue[pos] = value
+
+    def siftup(self, pos):
+        """Rearrange if item on pos is increased in value."""
+        heapq._siftup(self._queue, pos)
+
+    def siftdown(self, pos, startpos=0):
+        """Rearrange if item on pos is decreased in value."""
+        heapq._siftdown(self._queue, startpos, pos)
+
+    def siftup_item(self, item):
+        """Rearrange item if its value is increased."""
+        try:
+            pos = self._queue.index(item)
+            self.siftup(pos)
+        except ValueError:
+            pass
+
+    def siftdown_item(self, item):
+        """Rearrange item if its value is decreased."""
+        try:
+            pos = self._queue.index(item)
+            self.siftdown(pos)
+        except ValueError:
+            pass
+
+    def push(self, item):
+        """Push item into heap."""
+        heapq.heappush(self._queue, item)
+
+    def pop(self):
+        """Pop out the min item."""
+        return heapq.heappop(self._queue)
+
+    def get_min(self):
+        """Return min item."""
+        return self._queue[0]
+
+    def remove(self, item):
+        """Remove item and re-heapify."""
+        if item not in self._queue:
+            return
+        self._queue.remove(item)
+        heapq.heapify(self._queue)
+
+
+class IOThreadManagerError(Exception):
+    pass
+
+
+class IOThreadNotExistedError(Exception):
+    def __init__(self, iothread_id, manager):
+        msg = "%s not existed in %s." % (iothread_id, manager)
+        super(IOThreadNotExistedError, self).__init__(msg)
+        self.iothread_id = iothread_id
+        self.manager = manager
+
+
+class IOThreadManagerBase(object):
+    """
+    Base class for iothread manager, only responsible for the allocation and
+    deallocation of iothread object.
+
+    To allocate iothread, call IOThreadManagerBase.get_iothread to get next
+    available iothread object.
+    After allocation, call IOThreadManagerBase.sync to update iothread and
+    pool.
+
+    TODO: sync with DevContainer in simple_hotplug and simple_unplug if the
+    device plugged or unplugged is an instance of IOThread.
+    """
+
+    id_pattern = "iothread%d"
+
+    def __init__(self, pool=None):
+        """Constructor."""
+        super(IOThreadManagerBase, self).__init__()
+        if pool is None:
+            pool = []
+        self.iothread_pool = pool
+        self.mapping = {iothread.id: iothread for iothread in pool}
+        self.id_idx = 0
+        self._loop_till_free()
+
+    def _loop_till_free(self):
+        while True:
+            if self.id_pattern % self.id_idx not in self.mapping.keys():
+                break
+            self.id_idx += 1
+
+    def _get_next_id(self):
+        """Get next usable id."""
+        id = self.id_pattern % self.id_idx
+        return id
+
+    def _release_id(self, id):
+        """Release id."""
+        try:
+            id = int(re.match("iothread(\d+)", id).group(1))
+        except (KeyError, ValueError, AttributeError):
+            pass
+        else:
+            if id < self.id_idx:
+                self.id_idx = id
+
+    def __iter__(self):
+        """Return iteractor."""
+        return iter(self.iothread_pool)
+
+    @property
+    def iothread_count(self):
+        """Return iothread count."""
+        return len(self.iothread_pool)
+
+    def get_iothread(self, iothread_id):
+        """Get next iothread to use."""
+        raise NotImplementedError
+
+    def sync(self, dev, iothread_id):
+        """
+        Update iothread.
+
+        :param dev: device attached.
+        :param iothread_id: iothread id to update.
+        """
+        raise NotImplementedError
+
+    def allocate_iothread(self, dev, iothread_id=None):
+        """
+        Update iothread and pool when unplug device.
+
+        :param dev: device to unplug.
+        :param iothread_id: iothread id.
+        """
+        raise NotImplementedError
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=False):
+        """Update iothread when unplug device."""
+        iothread = self.mapping[iothread_id]
+        iothread.detach(dev)
+        if remove is True:
+            self.remove(iothread)
+
+    def push(self, iothread):
+        """Push iothread into manager."""
+        raise NotImplementedError
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        raise NotImplementedError
+
+    def __str__(self):
+        return "%s: [%s]" % (self.__class__.__name__,
+                             ', '.join([str(it) for it in self.iothread_pool]))
+
+
+class PredefinedManager(IOThreadManagerBase):
+    """
+    Predefined iothread allocation based on params, backward support with
+    previous patch that defines iothread objects with 'iothreads=...' and add
+    to device with bus_extra_params and blk_extra_params.
+    """
+
+    def __init__(self, iothreads):
+        """Constructor."""
+        super(PredefinedManager, self).__init__(list(iothreads))
+
+    def get_iothread(self, iothread_id):
+        """Allocate predefined iothread."""
+        if (iothread_id is not None and
+                iothread_id not in self.mapping):
+            raise IOThreadNotExistedError(iothread_id, self)
+        return iothread_id
+
+    def sync(self, dev, iothread_id):
+        """Update iothread with iothread_id."""
+        iothread = self.mapping[iothread_id]
+        iothread.attach(dev)
+        self._loop_till_free()
+        return False, iothread
+
+    def allocate_iothread(self, dev, iothread_id):
+        return self.sync(self.get_iothread(iothread_id), dev)
+
+    def push(self, iothread):
+        """Push iothread to manager."""
+        iothread_id = iothread.id
+        if iothread_id in self.mapping:
+            return
+        self.iothread_pool.append(iothread)
+        self.mapping[iothread_id] = iothread
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        iothread_id = iothread.id
+        if iothread_id not in self.mapping:
+            raise IOThreadNotExistedError(iothread_id, self)
+        self._release_id(iothread_id)
+        del self.mapping[iothread_id]
+        self.iothread_pool.remove(iothread)
+
+
+class RoundRobinManager(IOThreadManagerBase):
+    """
+    Allocate iothread in round robin.
+    Example:
+    'roundrobin3' will create 3 iothreads in manager, and the using of min heap
+    will always choose iothread object with the minimum devices attached.
+    before allocation:  [iothread0 - 0, iothread1 - 0, iothread2 - 0]
+    dev0 --> iothread0: [*iothread0 - 1, iothread1 - 0, iothread2 - 0]
+    dev1 --> iothread1: [iothread0 - 1, *iothread1 - 1, iothread2 - 0]
+    dev2 --> iothread2: [iothread0 - 1, iothread1 - 1, *iothread2 - 1]
+    dev3 --> iothread0: [*iothread0 - 2, iothread1 - 1, iothread2 - 1]
+    dev4 --> iothread1: [iothread0 - 2, *iothread1 - 2, iothread2 - 1]
+    dev5 --> iothread2: [iothread0 - 2, iothread1 - 2, *iothread2 - 2]
+    """
+
+    def __init__(self, count=1):
+        """Constructor."""
+        pool = [IOThread(self.id_pattern % i) for i in range(count)]
+        super(RoundRobinManager, self).__init__(MinQueue(pool))
+
+    def get_iothread(self, iothread_id=None):
+        """Get next iothread id to use."""
+        if iothread_id is None:
+            return self.iothread_pool.get_min().id
+        if iothread_id in self.mapping:
+            return iothread_id
+        # not existed iothread requested
+        raise IOThreadNotExistedError(iothread_id, self)
+
+    def sync(self, dev, iothread_id):
+        """Update iothread and manager, return the synced iothread."""
+        iothread = self.mapping[iothread_id]
+        iothread.attach(dev)
+        self.iothread_pool.siftup_item(iothread)
+        self._loop_till_free()
+        return False, iothread
+
+    def allocate_iothread(self, dev, iothread_id=None):
+        """
+        Get iothread to use.
+
+        param dev: device that requests iothread.
+        param iothread_id: iothread_id to request, ignored.
+        """
+        return self.sync(self.get_iothread(), dev)
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=False):
+        """Update iothread and pool when unplug device."""
+        super(RoundRobinManager, self).update_iothread_in_unplug(dev,
+                                                                 iothread_id,
+                                                                 remove)
+        if remove is False:
+            iothread = self.mapping[iothread_id]
+            self.iothread_pool.siftdown_item(iothread)
+
+    def push(self, iothread):
+        """Push iothread to manager."""
+        iothread_id = iothread.id
+        if iothread_id in self.mapping:
+            return
+        self.iothread_pool.push(iothread)
+        self.mapping[iothread_id] = iothread
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        iothread_id = iothread.id
+        if iothread_id not in self.mapping:
+            raise IOThreadNotExistedError(iothread_id, self)
+        self._release_id(iothread_id)
+        del self.mapping[iothread_id]
+        self.iothread_pool.remove(iothread)
+
+
+class OTOManager(IOThreadManagerBase):
+    """Create iothread for each controller device."""
+
+    def __init__(self):
+        """Constructor."""
+        super(OTOManager, self).__init__()
+
+    def get_iothread(self, iothread_id=None):
+        """Get next iothread id to use."""
+        return self._get_next_id()
+
+    def sync(self, dev, iothread_id):
+        """Instantiate a iothread object with iothread_id."""
+        iothread = IOThread(id=iothread_id)
+        iothread.attach(dev)
+        self.push(iothread)
+        self._loop_till_free()
+        return True, iothread
+
+    def allocate_iothread(self, dev, iothread_id):
+        return self.sync(self.get_iothread(), dev)
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=True):
+        """Update iothread and pool in unplug, always remove iothread."""
+        super(OTOManager, self).update_iothread_in_unplug(dev, iothread_id,
+                                                          remove)
+
+    def push(self, iothread):
+        """Push iothread to manager."""
+        iothread_id = iothread.id
+        if iothread_id in self.mapping:
+            return
+        self.iothread_pool.append(iothread)
+        self.mapping[iothread_id] = iothread
+
+    def remove(self, iothread):
+        """Remove iothread from manager."""
+        iothread_id = iothread.id
+        if iothread_id not in self.mapping:
+            raise IOThreadNotExistedError(iothread_id, self)
+        self._release_id(iothread_id)
+        del self.mapping[iothread_id]
+        self.iothread_pool.remove(iothread)
+
+
+class OptimalManager(RoundRobinManager):
+    """Dynamically allocate base on min(vpcu, pcpu, device)."""
+
+    def __init__(self, vcpu):
+        """Constructor."""
+        super(OptimalManager, self).__init__(count=0)
+        self.cpu_boundary = min(vcpu, cpu.total_cpus_count())
+
+    def get_iothread(self, iothread_id=None):
+        """Get next iothread id to use."""
+        if len(self.iothread_pool) < self.cpu_boundary:
+            return self._get_next_id()
+        else:
+            return super(OptimalManager, self).get_iothread()
+
+    def sync(self, dev, iothread_id):
+        """Instantiate a new iothread object with iothread_id."""
+        if iothread_id in self.mapping:
+            is_new = False
+            iothread = self.mapping[iothread_id]
+        else:
+            is_new = True
+            iothread = IOThread(id=iothread_id)
+            self.push(iothread)
+        iothread.attach(dev)
+        self.iothread_pool.siftup_item(iothread)
+        self._loop_till_free()
+        return is_new, iothread
+
+    def allocate_iothread(self, dev, iothread_id=None):
+        return self.sync(self.get_iothread(), dev)
+
+    def update_iothread_in_unplug(self, dev, iothread_id, remove=False):
+        """Update iothread and pool in unplug."""
+        iothread = self.mapping[iothread_id]
+        # always remove empty iothread
+        if (remove is False and
+                len(iothread) == 1):
+            remove = True
+        super(OptimalManager, self).update_iothread_in_unplug(dev, iothread_id,
+                                                              remove)

--- a/virttest/data_plane.py
+++ b/virttest/data_plane.py
@@ -72,10 +72,11 @@ class MinQueue(object):
 
     def remove(self, item):
         """Remove item and re-heapify."""
-        if item not in self._queue:
-            return
-        self._queue.remove(item)
-        heapq.heapify(self._queue)
+        try:
+            self._queue.remove(item)
+            heapq.heapify(self._queue)
+        except ValueError:
+            pass
 
 
 class IOThreadManagerError(Exception):
@@ -192,7 +193,9 @@ class PredefinedManager(IOThreadManagerBase):
     """
     Predefined iothread allocation based on params, backward support with
     previous patch that defines iothread objects with 'iothreads=...' and add
-    to device with bus_extra_params and blk_extra_params.
+    to device with "iothread_image0 = iothread0
+    Naming for iothread must follow: r'iothread\d+'.
+    "
     """
 
     def __init__(self, iothreads):

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1815,13 +1815,20 @@ class VM(virt_vm.BaseVM):
             for dev in devices.usbc_by_params(usb_name, usb_params, parent_bus):
                 devices.insert(dev)
 
-        for iothread in params.get("iothreads", "").split():
-            cmd = "-object iothread,"
-            iothread_id = params.get("%s_id" % iothread.strip())
-            if not iothread_id:
-                iothread_id = iothread.strip()
-            cmd += "id=%s" % iothread_id
-            devices.insert(StrDev("IOthread_%s" % iothread_id, cmdline=cmd))
+        # set iothread allocation scheme
+        iothreads = {}
+        props = ["poll_max_ns"]
+        for iothread_id in params.get("iothreads", "").split():
+            iothread_params = params.object_params(iothread_id)
+            iothreads[iothread_id] = {
+                prop.replace("_", "-"): iothread_params[prop]
+                for prop in props if prop in iothread_params
+                }
+        devices.set_iothread_manager(
+            iothreads,
+            params.get("iothread_scheme"),
+            self.cpuinfo
+        )
 
         # Add images (harddrives)
         for image_name in params.objects("images"):

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1552,6 +1552,110 @@ class VM(virt_vm.BaseVM):
         # Additional PCI RC/switch/bridges
         add_pci_controllers(devices, params)
 
+        # Add Memory devices
+        add_memorys(devices, params)
+        smp = int(params.get("smp", 0))
+        mem = int(params.get("mem", 0))
+        vcpu_maxcpus = int(params.get("vcpu_maxcpus", 0))
+        vcpu_sockets = int(params.get("vcpu_sockets", 0))
+        vcpu_cores = int(params.get("vcpu_cores", 0))
+        vcpu_threads = int(params.get("vcpu_threads", 0))
+
+        # Some versions of windows don't support more than 2 sockets of cpu,
+        # here is a workaround to make all windows use only 2 sockets.
+        if (vcpu_sockets and vcpu_sockets > 2 and
+                params.get("os_type") == 'windows'):
+            vcpu_sockets = 2
+
+        amd_vendor_string = params.get("amd_vendor_string")
+        if not amd_vendor_string:
+            amd_vendor_string = "AuthenticAMD"
+        if amd_vendor_string == utils_misc.get_cpu_vendor():
+            # AMD cpu do not support multi threads.
+            if params.get("test_negative_thread", "no") != "yes":
+                vcpu_threads = 1
+                txt = "Set vcpu_threads to 1 for AMD cpu."
+                logging.warn(txt)
+
+        if smp == 0 or vcpu_sockets == 0:
+            vcpu_cores = vcpu_cores or 1
+            vcpu_threads = vcpu_threads or 1
+            if smp and vcpu_sockets == 0:
+                vcpu_sockets = int(smp / (vcpu_cores * vcpu_threads)) or 1
+            else:
+                vcpu_sockets = vcpu_sockets or 1
+            if smp == 0:
+                smp = vcpu_cores * vcpu_threads * vcpu_sockets
+        else:
+            if vcpu_cores == 0:
+                vcpu_threads = vcpu_threads or 1
+                vcpu_cores = int(smp / (vcpu_sockets * vcpu_threads)) or 1
+            else:
+                vcpu_threads = int(smp / (vcpu_cores * vcpu_sockets)) or 1
+
+        self.cpuinfo.smp = smp
+        self.cpuinfo.maxcpus = vcpu_maxcpus or smp
+        self.cpuinfo.cores = vcpu_cores
+        self.cpuinfo.threads = vcpu_threads
+        self.cpuinfo.sockets = vcpu_sockets
+        devices.insert(StrDev('smp', cmdline=add_smp(devices)))
+
+        numa_total_cpus = 0
+        numa_total_mem = 0
+        for numa_node in params.objects("guest_numa_nodes"):
+            numa_params = params.object_params(numa_node)
+            numa_mem = numa_params.get("numa_mem")
+            numa_cpus = numa_params.get("numa_cpus")
+            numa_nodeid = numa_params.get("numa_nodeid")
+            numa_memdev = numa_params.get("numa_memdev")
+            if numa_mem is not None:
+                numa_total_mem += int(numa_mem)
+            if numa_cpus is not None:
+                numa_total_cpus += len(utils_misc.cpu_str_to_list(numa_cpus))
+            cmdline = add_numa_node(devices, numa_memdev,
+                                    numa_mem, numa_cpus, numa_nodeid)
+            devices.insert(StrDev('numa', cmdline=cmdline))
+
+        if params.get("numa_consistency_check_cpu_mem", "no") == "yes":
+            if (numa_total_cpus > int(smp) or numa_total_mem > int(mem) or
+                    len(params.objects("guest_numa_nodes")) > int(smp)):
+                logging.debug("-numa need %s vcpu and %s memory. It is not "
+                              "matched the -smp and -mem. The vcpu number "
+                              "from -smp is %s, and memory size from -mem is"
+                              " %s" % (numa_total_cpus, numa_total_mem, smp,
+                                       mem))
+                raise virt_vm.VMDeviceError("The numa node cfg can not fit"
+                                            " smp and memory cfg.")
+
+        cpu_model = params.get("cpu_model")
+        use_default_cpu_model = True
+        if cpu_model:
+            use_default_cpu_model = False
+            for model in re.split(",", cpu_model):
+                model = model.strip()
+                if model not in support_cpu_model:
+                    continue
+                cpu_model = model
+                break
+            else:
+                cpu_model = model
+                logging.error("Non existing CPU model %s will be passed "
+                              "to qemu (wrong config or negative test)", model)
+
+        if use_default_cpu_model:
+            cpu_model = params.get("default_cpu_model")
+
+        if cpu_model:
+            family = params.get("cpu_family", "")
+            flags = params.get("cpu_model_flags", "")
+            vendor = params.get("cpu_model_vendor", "")
+            self.cpuinfo.model = cpu_model
+            self.cpuinfo.vendor = vendor
+            self.cpuinfo.flags = flags
+            self.cpuinfo.family = family
+            cmd = add_cpu_flags(devices, cpu_model, flags, vendor, family)
+            devices.insert(StrDev('cpu', cmdline=cmd))
+
         # -soundhw addresses are always the lowest after scsi
         soundhw = params.get("soundcards")
         if soundhw:
@@ -1916,110 +2020,6 @@ class VM(virt_vm.BaseVM):
                                         parent_bus=pci_bus)
                 devices.insert(dev_vsock)
                 min_cid = guest_cid + 1
-
-        # Add Memory devices
-        add_memorys(devices, params)
-        smp = int(params.get("smp", 0))
-        mem = int(params.get("mem", 0))
-        vcpu_maxcpus = int(params.get("vcpu_maxcpus", 0))
-        vcpu_sockets = int(params.get("vcpu_sockets", 0))
-        vcpu_cores = int(params.get("vcpu_cores", 0))
-        vcpu_threads = int(params.get("vcpu_threads", 0))
-
-        # Some versions of windows don't support more than 2 sockets of cpu,
-        # here is a workaround to make all windows use only 2 sockets.
-        if (vcpu_sockets and vcpu_sockets > 2 and
-                params.get("os_type") == 'windows'):
-            vcpu_sockets = 2
-
-        amd_vendor_string = params.get("amd_vendor_string")
-        if not amd_vendor_string:
-            amd_vendor_string = "AuthenticAMD"
-        if amd_vendor_string == utils_misc.get_cpu_vendor():
-            # AMD cpu do not support multi threads.
-            if params.get("test_negative_thread", "no") != "yes":
-                vcpu_threads = 1
-                txt = "Set vcpu_threads to 1 for AMD cpu."
-                logging.warn(txt)
-
-        if smp == 0 or vcpu_sockets == 0:
-            vcpu_cores = vcpu_cores or 1
-            vcpu_threads = vcpu_threads or 1
-            if smp and vcpu_sockets == 0:
-                vcpu_sockets = int(smp / (vcpu_cores * vcpu_threads)) or 1
-            else:
-                vcpu_sockets = vcpu_sockets or 1
-            if smp == 0:
-                smp = vcpu_cores * vcpu_threads * vcpu_sockets
-        else:
-            if vcpu_cores == 0:
-                vcpu_threads = vcpu_threads or 1
-                vcpu_cores = int(smp / (vcpu_sockets * vcpu_threads)) or 1
-            else:
-                vcpu_threads = int(smp / (vcpu_cores * vcpu_sockets)) or 1
-
-        self.cpuinfo.smp = smp
-        self.cpuinfo.maxcpus = vcpu_maxcpus or smp
-        self.cpuinfo.cores = vcpu_cores
-        self.cpuinfo.threads = vcpu_threads
-        self.cpuinfo.sockets = vcpu_sockets
-        devices.insert(StrDev('smp', cmdline=add_smp(devices)))
-
-        numa_total_cpus = 0
-        numa_total_mem = 0
-        for numa_node in params.objects("guest_numa_nodes"):
-            numa_params = params.object_params(numa_node)
-            numa_mem = numa_params.get("numa_mem")
-            numa_cpus = numa_params.get("numa_cpus")
-            numa_nodeid = numa_params.get("numa_nodeid")
-            numa_memdev = numa_params.get("numa_memdev")
-            if numa_mem is not None:
-                numa_total_mem += int(numa_mem)
-            if numa_cpus is not None:
-                numa_total_cpus += len(utils_misc.cpu_str_to_list(numa_cpus))
-            cmdline = add_numa_node(devices, numa_memdev,
-                                    numa_mem, numa_cpus, numa_nodeid)
-            devices.insert(StrDev('numa', cmdline=cmdline))
-
-        if params.get("numa_consistency_check_cpu_mem", "no") == "yes":
-            if (numa_total_cpus > int(smp) or numa_total_mem > int(mem) or
-                    len(params.objects("guest_numa_nodes")) > int(smp)):
-                logging.debug("-numa need %s vcpu and %s memory. It is not "
-                              "matched the -smp and -mem. The vcpu number "
-                              "from -smp is %s, and memory size from -mem is"
-                              " %s" % (numa_total_cpus, numa_total_mem, smp,
-                                       mem))
-                raise virt_vm.VMDeviceError("The numa node cfg can not fit"
-                                            " smp and memory cfg.")
-
-        cpu_model = params.get("cpu_model")
-        use_default_cpu_model = True
-        if cpu_model:
-            use_default_cpu_model = False
-            for model in re.split(",", cpu_model):
-                model = model.strip()
-                if model not in support_cpu_model:
-                    continue
-                cpu_model = model
-                break
-            else:
-                cpu_model = model
-                logging.error("Non existing CPU model %s will be passed "
-                              "to qemu (wrong config or negative test)", model)
-
-        if use_default_cpu_model:
-            cpu_model = params.get("default_cpu_model")
-
-        if cpu_model:
-            family = params.get("cpu_family", "")
-            flags = params.get("cpu_model_flags", "")
-            vendor = params.get("cpu_model_vendor", "")
-            self.cpuinfo.model = cpu_model
-            self.cpuinfo.vendor = vendor
-            self.cpuinfo.flags = flags
-            self.cpuinfo.family = family
-            cmd = add_cpu_flags(devices, cpu_model, flags, vendor, family)
-            devices.insert(StrDev('cpu', cmdline=cmd))
 
         # Add cdroms
         for cdrom in params.objects("cdroms"):


### PR DESCRIPTION
1. This is the implementation of different iothread allocation schemes
for device controllers, which includes the following manager classes:

    a. `PredefinedManager`, providing backward compatibility. Testcases with
`iothreads=...` set or no `iothread_scheme` set will use this class.

    b. `RoundRobinManager`, providing iothread allocation in round-robin way.

    c. `OTOManager` class, always allocate new iothread for controller devices.

    d. `OptimalManager`, will take vpcu and pcpu into consideration.
When device count < min(vcpu, pcpu), this class will allocate new
iothread object as `OTOManager` does. But when device count >= min(vpu,
pcpu), this class will allocate in round-robin way, since the optimal
iothread count = min(device, vcpu, pcpu).

2. other modifications:

    a. `virttest.data_plane.MinQueue`, which is a min heap. `RoundRobinManager`
uses it as scheduler.

    b. New `IOThread` class, that subclasses `QObject`, encapsulates QEMU
iothread to provide hotplug/unplug support.

    c. `QContainer.get_buses`, add extra default argument `excluded=None` to
get buses without properties listed in excluded.

    d. `QContainer.images_define_by_variables`, change function `define_hbas` to
 allocate new pci controller with iothread support.

    e. add function `select_iothread_manager` to
`virttest.qemu_vm.VM.make_create_command` that to initialize iothread
manager to `DevContainer` instance.
supported schemes:
    `roundrobin_<count>`: `roundrobin_2` will pre-instantiate two IOThread
    object and allocate it in a round robin way.
    `oto`: one controller device to one iothread object.
    `rhv`: emulate rhvm that use one iothread for all controllers.
    `optimal`: iothread_count = min(pcpu, vcpu, device), but no support
    for unplug scenario.

    f. refactor the code in `virttest.qemu_vm.VM.make_create_command` to let
 the vcpu initialization precedes the allocation of devices.

3. usage example:
Available parameters: `iothreads` and `iothread_schemes`
    a. `predefined`
	    --------------------------------------------------
	    iothreads = "iothread0,iothread1,iothread2"
	    images += 'stg0'
	    ...
	    iothread_stg0 = iothread0
	    --------------------------------------------------
	    will attach iothread to the controller device of image stg0.
	    'iothreads' precedes 'iothread_scheme', if 'iothreads' is
	    set, 'iothread_scheme' will be ignored.
    b. `round robin`
	    --------------------------------------------------
	    iothread_scheme = roundrobin_3
	    --------------------------------------------------
	    will create iothread0,iothread1,iothread2 in VM and allocate
	    them in round robin way for controller devices.
    c. `one to one`
	    --------------------------------------------------
	    iothread_scheme = oto
	    --------------------------------------------------
	    one iothread object for each controller device.
    d. `rhv`
	    --------------------------------------------------
	    iothread_scheme = rhv
	    --------------------------------------------------
    e. `optimal`
	    --------------------------------------------------
	    iothread_scheme = optimal
	    --------------------------------------------------
    d. `no iothreads and iothread_scheme set`
	    disable iothread for controllers.

Signed-off-by: lolyu <lolyu@redhat.com>