### PR TITLE
qemu_vm: Wait for IO channels setting up completely

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2974,6 +2974,10 @@ class VM(virt_vm.BaseVM):
                     output_params=(outfile,))
                 self.logsessions[key].set_log_file(outfile)
 
+            # Wait for IO channels setting up completely,
+            # such as serial console.
+            time.sleep(1)
+
             if params.get("paused_after_start_vm") != "yes":
                 # start guest
                 if self.monitor.verify_status("paused"):


### PR DESCRIPTION
Wait for connecting socket server completely by sleeping 1 second.

ID: 1654102
Signed-off-by: Yongxue Hong <yhong@redhat.com>