### PR TITLE
guest-os: Replace '-rtc-td-hack' with 'driftfix=slew'

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -115,7 +115,7 @@
     timedrift, timerdevice..boot_test:
         # Timedrift compensation on Windows with hpet does not happen
         disable_hpet = yes
-        extra_params += " -rtc-td-hack"
+        rtc_drift = "slew"
         time_command = "echo TIME: %date% %time%"
         time_filter_re = "(?<=TIME: \w\w\w ).{19}(?=\.\d\d)"
         time_format = "%m/%d/%Y %H:%M:%S"


### PR DESCRIPTION
Qemu option '-rtc-td-hack' is for early version. Before, it is
deprecated, and recommend use '-rtc driftfix=slew' instead.
Since QEMU-3.1 (fdaf2d5885209634bf9d9f643cec5323efb4525c), it
is removed completely.

id:  1652815
Signed-off-by: Yanan Fu <yfu@redhat.com>