### PR TITLE
install_package(): Don't raise exception when ignore_status is True

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2834,13 +2834,18 @@ class VM(virt_vm.BaseVM):
         :param name: Name of package to be installed
         """
         session = self.wait_for_login()
-        if not utils_package.package_install(name, session):
-            if not ignore_status:
-                session.close()
+        try:
+            if not utils_package.package_install(name, session):
                 raise virt_vm.VMError("Installation of package %s failed" %
                                       name)
-            logging.error("Installation of package %s failed", name)
-        session.close()
+        except Exception as exception_detail:
+            if ignore_status:
+                logging.error("When install: %s\nError happened: %s\n",
+                              name, exception_detail)
+            else:
+                raise exception_detail
+        finally:
+            session.close()
 
     def remove_package(self, name, ignore_status=False):
         """


### PR DESCRIPTION
When ignore_status=True, test will still be blocked if some
exceptions such as ShellProcessTerminatedError, ShellStatusError
raised. So change the code not to raise exceptions when
ignore_status=True, but just log an error.

Signed-off-by: Yi Sun <yisun@redhat.com>