### PR TITLE
virttest: Rename the firewalld_service and disable it by default

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -682,6 +682,8 @@ inputs = ""
 # Bus type of input device (currently supports virtio)
 #input_dev_bus_type = ""
 
+# Enforce firewalld status enable/disable/none (none = don't change setting)
+# firewalld_service = none
 # firewalld_dhcp_workaround tweaks firewalld setting to allow host-guest
 # communication. Usually this should not be necessary but there are known
 # systems that require this extra setting.

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -682,8 +682,8 @@ inputs = ""
 # Bus type of input device (currently supports virtio)
 #input_dev_bus_type = ""
 
-# firewalld_service param used as global param to abstract the firewalld configuration
-# the framework can control the firewalld settings with this param set/unset, by default
-# firewalld is enabled
-
-# firewalld_service = "yes"
+# firewalld_dhcp_workaround tweaks firewalld setting to allow host-guest
+# communication. Usually this should not be necessary but there are known
+# systems that require this extra setting.
+Host_Ubuntu.m18.u10:
+    firewalld_dhcp_workaround = yes

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -809,17 +809,21 @@ def preprocess(test, params, env):
         firewalld = utils_iptables.Firewalld()
         if firewalld.status():
             firewalld.stop()
+            if firewalld.status():
+                test.log.warning('Failed to stop firewalld')
     else:
         if firewalld_service == 'enable':
             firewalld = utils_iptables.Firewalld()
             if not firewalld.status():
                 firewalld.start()
+                if not firewalld.status():
+                    test.log.warning('Failed to start firewalld')
         # Workaround know issue where firewall blocks dhcp from guest
         # through virbr0
         if params.get('firewalld_dhcp_workaround', "no") == "yes":
             firewall_cmd = utils_iptables.Firewall_cmd()
             if not firewall_cmd.add_service('dhcp', permanent=True):
-                logging.error('Failed to add dhcp service to be permitted')
+                test.log.warning('Failed to add dhcp service to be permitted')
 
     # Start ip sniffing if it isn't already running
     # The fact it has to be started here is so that the test params

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -805,7 +805,7 @@ def preprocess(test, params, env):
                                                 image_name_only)
 
     # firewall blocks dhcp from guest through virbr0
-    if params.get('firewalld_service', "yes") == "yes":
+    if params.get('firewalld_dhcp_workaround', "no") == "yes":
         firewall_cmd = utils_iptables.Firewall_cmd()
         if not firewall_cmd.add_service('dhcp', permanent=True):
             logging.error('Failed to add dhcp service to be permitted')


### PR DESCRIPTION
The recently introduced firewalld_service actually changes the setting
to work well on Ubuntu.18.10, but in reality it's a bug as firewalld
should not prevent that out of the box. Let's rename it to reflect the
fact of being a workaround and only enable it on that particular host
version (search for nftables firewalld libvirt to get more details).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>