### PR TITLE
virttest.qemu_storage: Remove image on filesystem if exists

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -96,6 +96,18 @@ def file_remove(params, filename_path):
         rbd_image_name = "%s.%s" % (image_name.split("/")[-1], image_format)
         return ceph.rbd_image_rm(ceph_monitor, rbd_pool_name, rbd_image_name)
 
+    if params.get("gluster_brick"):
+        # TODO: Add implementation for gluster_brick
+        return
+
+    if params.get('storage_type') in ('iscsi', 'lvm'):
+        # TODO: Add implementation for iscsi/lvm
+        return
+
+    if os.path.exists(filename_path):
+        os.unlink(filename_path)
+        return
+
 
 def get_image_blkdebug_filename(params, root_dir):
     """


### PR DESCRIPTION
When the image already exists qemu-img attempts to get write-lock even
to create it, which fails in case any VM is still using it. Deleting it
first results in the VM using deleted image (until it dies) while
qemu-img happily creating new image in the desired location.

This fixes a real issue where VM from previous test is still running
(either we fail to kill it or keep_between_tests is enabled) and qcow2
image is used with recent-enough qemu and results in:

    qemu-img: .../rhel7devel-64.qcow2: Failed to get "write" lock
    Is another process using the image?

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>