### PR TITLE
Make sure all qemu processes are destroyed on forceful kill

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3226,17 +3226,13 @@ class VM(virt_vm.BaseVM):
             pid = self.process.get_pid()
             logging.debug("Ending VM %s process (killing PID %s)",
                           self.name, pid)
-            utils_misc.kill_process_tree(pid, 9)
-
-            # Wait for the VM to be really dead
-            if utils_misc.wait_for(self.is_dead, 5, 0.5, 0.5):
+            try:
+                utils_misc.kill_process_tree(pid, 9, timeout=60)
                 logging.debug("VM %s down (process killed)", self.name)
-                return
-
-            # If all else fails, we've got a zombie...
-            logging.error("VM %s (PID %s) is a zombie!", self.name,
-                          self.process.get_pid())
-
+            except RuntimeError:
+                # If all else fails, we've got a zombie...
+                logging.error("VM %s (PID %s) is a zombie!", self.name,
+                              self.process.get_pid())
         finally:
             self._cleanup(free_mac_addresses)
 


### PR DESCRIPTION
First commit reuses Avocado implementations of some proces related `virttest.utils_misc`, bringing some fixes and improvements to Avocado-vt's utils and the second commit fixes the issue where forcefully killed qemu process stays alive even when we declared it dead.

This function is only used when qemu refuses to go down. Then when older Avocado is used it adds 10s wait after sending the kill signal. With latest Avocado it really makes sure to wait for all pids to go down.

Note thanks to this PR I noticed the https://github.com/avocado-framework/avocado/pull/2945 is buggy and https://github.com/avocado-framework/avocado/pull/2954 fix is required in order for it to work properly.