### PR TITLE
test_setup: Fix dict keyerror

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2228,9 +2228,9 @@ def remote_session(params):
     :param params: Test params dict for remote machine login details
     :return: remote session object
     """
-    server_ip = params.get("server_ip", params["remote_ip"])
-    server_user = params.get("server_user", params["remote_user"])
-    server_pwd = params.get("server_pwd", params["remote_pwd"])
+    server_ip = params.get("server_ip", params.get("remote_ip"))
+    server_user = params.get("server_user", params.get("remote_user"))
+    server_pwd = params.get("server_pwd", params.get("remote_pwd"))
     return remote.wait_for_login('ssh', server_ip, '22', server_user,
                                  server_pwd, r"[\#\$]\s*$")
 


### PR DESCRIPTION
Python will check the dict default value before checking the 'get' key.
So it will cause KeyError when the key in default value does not exist,
even though the 'get' key has a value if the way with array is used.

Signed-off-by: Dan Zheng <dzheng@redhat.com>