### PR TITLE
Add a backup error image function if the test case is not pass

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -86,6 +86,11 @@ image_chain = ""
 # List of optical device object names
 cdroms = cd1
 
+# To enable saving __all__ images on test failure use:
+# save_image_on_error = yes
+# You can also save only specified (image1) images on failure using:
+# save_image_image1_on_error = yes
+
 # USB controller object names (whitespace separated)
 usbs = usb1
 # USB controller type, run following command to see supported controller.

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -314,6 +314,18 @@ def check_image(test, params, image_name, vm_process_status=None):
                               " Skip the image check.")
                 check_image_flag = False
 
+    # Save the potential bad image when the test is not passed.
+    # It should before image check.
+    if params.get("save_image", "no") == "yes":
+        if vm_process_status == "dead":
+            hsh = utils_misc.generate_random_string(4)
+            name = ("JOB-%s-TEST-%s-%s-%s.%s" % (
+                test.job.unique_id[:7], str(test.name.uid),
+                image_name, hsh, image.image_format))
+            image.save_image(params, name)
+        else:
+            logging.error("Not saving images, VM is not stopped.")
+
     if check_image_flag:
         try:
             if clone_master is None:


### PR DESCRIPTION
Using a `save_image_{image_tag}_on_error` param to save any specified
image under JOB-{job_id}-TEST-{case_num}-{image_name} naming convention.

If use `save_image_on_error = yes`, it will save all the images in
the `params["images"]`, image created outside `params["images"]`
will not be saved.
You can choose which image to save, by adding an image tag.
`save_image_{image_tag}_on_error`, eg: `save_image_image1_on_error`.

Refactor backup image for code reuse and efficiency.

id: 1543282
Signed-off-by: Haotong Chen <hachen@redhat.com>