### PR TITLE
Generate gcov code coverage report for qemu in postprocess

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -697,6 +697,25 @@ rpmbuild_path = "/root/rpmbuild/"
 sysprep_required = no
 sysprep_options = "--operations machine-id"
 
+# Enable Code Coverage report
+# prerequisite: qemu build test is run with --enable-gcov
+#               configure option and preserve_srcdir = yes
+#               and qemu build dir is available
+# Enable/disable gcov for qemu, default: disable
+gcov_qemu = no
+# Enable/disable to reset the code coverage report
+# generated/collected by previous test
+gcov_qemu_reset = yes
+# Additional command options for gcovr
+# E:g:- "--html-details --html --exclude-directories=capstone"
+# above options will be required to collect detailed html
+# reports for individial source files and exclude "capstone"
+# directory from code coverage report generation
+# default: --html
+gcov_qemu_collect_cmd_opts = "--html"
+# Enable/disable to compress code coverage report
+gcov_qemu_compress = no
+
 Linux:
     # param for installing stress tool from repo
     stress_install_from_repo = "no"


### PR DESCRIPTION
This patch enables the gcov code coverage report
generation as part of test postprocess if suitable
params are enabled and prerequisite as mentioned in
base.cfg are satisfied.

This would be helpful in case of code debugging and new
test scenarios development.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>