### PR TITLE
qcontainer: fix arm64-pci machine bus type

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -63,6 +63,7 @@ variants:
         # Only virtio-gpu-pci supported for now
         vga = virtio
         vir_domain_undefine_nvram = yes
+        pcie_extra_root_port = 2
     - riscv64-mmio:
         only riscv64
         # USB subsystem not available

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -993,7 +993,7 @@ class DevContainer(object):
                                                   child_bus=bus,
                                                   aobject="virtio-mmio-bus"))
             # And this is the pcie bus
-            bus = (qdevices.QPCIBus('pcie.0', 'PCIE', 'pci.0'),
+            bus = (qdevices.QPCIEBus('pcie.0', 'PCIE', root_port_type, 'pci.0'),
                    qdevices.QStrictCustomBus(None, [['chassis'], [256]],
                                              '_PCI_CHASSIS', first_port=[1]),
                    qdevices.QStrictCustomBus(None, [['chassis_nr'], [256]],

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -981,24 +981,14 @@ class DevContainer(object):
                           % aavmf_vars)
             devices.append(qdevices.QStringDevice('AAVMF_VARS',
                                                   cmdline=aavmf_vars))
-            # Add virtio-bus
-            # TODO: Currently this uses QNoAddrCustomBus and does not
-            # set the device's properties. This means that the qemu qtree
-            # and autotest's representations are completelly different and
-            # can't be used.
-            bus = qdevices.QNoAddrCustomBus('bus', [['addr'], [32]],
-                                            'virtio-mmio-bus', 'virtio-bus',
-                                            'virtio-mmio-bus')
-            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
-                                                  child_bus=bus,
-                                                  aobject="virtio-mmio-bus"))
-            # And this is the pcie bus
+
             bus = (qdevices.QPCIEBus('pcie.0', 'PCIE', root_port_type, 'pci.0'),
                    qdevices.QStrictCustomBus(None, [['chassis'], [256]],
                                              '_PCI_CHASSIS', first_port=[1]),
                    qdevices.QStrictCustomBus(None, [['chassis_nr'], [256]],
                                              '_PCI_CHASSIS_NR', first_port=[1]))
-            devices.append(qdevices.QStringDevice('pci.0', child_bus=bus,
+            devices.append(qdevices.QStringDevice('machine', cmdline=cmd,
+                                                  child_bus=bus,
                                                   aobject="pci.0"))
             devices.append(qdevices.QStringDevice('gpex-root',
                                                   {'addr': 0, 'driver': 'gpex-root'},


### PR DESCRIPTION
I made two changes:

- change machine's bus type to pcie
- remove virtio-mmio-bus. 

While virt machine type on aarch64 always creates some virtio-mmio buses for connecting on-board devices, I don't think they are useful in tests on 'arm64-pci' configuration. So I remove it. Please correct me if I'm wrong.

I verified the patch with a few tests and it worked fine in my experiments.