### PR TITLE
libvirt: Fix server_ip missing

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1386,7 +1386,8 @@ def postprocess(test, params, env):
 
     # cleanup migration presetup in post process
     if migration_setup:
-        dest_uri = libvirt_vm.complete_uri(params["server_ip"])
+        dest_uri = libvirt_vm.complete_uri(params.get("server_ip",
+                                                      params.get("remote_ip")))
         migrate_setup = utils_test.libvirt.MigrationTest()
         migrate_setup.migrate_pre_setup(dest_uri, params, cleanup=True)
 

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1356,9 +1356,9 @@ class MigrationTest(object):
                 # SMT for Power8 machine is turned off for local machine during
                 # test setup
             else:
-                server_ip = params.get("server_ip")
-                server_user = params.get("server_user", "root")
-                server_pwd = params.get("server_pwd")
+                server_ip = params.get("server_ip", params.get("remote_ip"))
+                server_user = params.get("server_user", params.get("remote_user"))
+                server_pwd = params.get("server_pwd", params.get("remote_pwd"))
                 server_session = remote.wait_for_login('ssh', server_ip, '22',
                                                        server_user, server_pwd,
                                                        r"[\#\$]\s*$")


### PR DESCRIPTION
Sometimes 'server_*' parameters may be missing, so we need use "remote_*"
as default.

Signed-off-by: Dan Zheng <dzheng@redhat.com>