### PR TITLE
unattended_install: `reboot` parameter in kickstart file doesn't work

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -721,3 +721,9 @@ Host_Ubuntu.m18.u10:
 
 # temporarily disable monitor QEMU vm exit status
 vm_monitor_exit_status = no
+
+# Bug `reboot` param from the kickstart is not actually restarts
+# the VM instead it shutsoff and fails the test even after successful
+# installation this is temporary workaround for the test to proceed by
+# setting it to "yes"
+kickstart_reboot_bug = "no"


### PR DESCRIPTION
`reboot` parameter in kickstart file supposed to restart the VM on
successful post installation without prompt, but instead VM shutsoff
and test fails. This bug is reported, but for our test to proceed
have a workaround with the param set `kickstart_reboot_bug = "yes"`

Bug-id: RH1663430
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>