### PR TITLE
unattended_install: support url unattended guest installation for Ubuntu1810 using preseed file

### DIFF
--- a/shared/cfg/guest-os/Linux/Ubuntu/18.10.ppc64le.cfg
+++ b/shared/cfg/guest-os/Linux/Ubuntu/18.10.ppc64le.cfg
@@ -1,0 +1,9 @@
+- 18.10.ppc64le:
+    image_name += -18.10-ppc64le
+    vm_arch_name = ppc64le
+    os_variant = linux
+    kernel_params = "locale=en_US passwd/make-user=false priority=critical noprompt"
+    unattended_install.url:
+        unattended_file_kernel_param_name = "url"
+        unattended_file = "unattended/Ubuntu-18.10-ppc64le.preseed"
+        url = "http://us.ports.ubuntu.com/ubuntu-ports/dists/cosmic/main/installer-ppc64el"

--- a/shared/unattended/Ubuntu-18.10-ppc64le.preseed
+++ b/shared/unattended/Ubuntu-18.10-ppc64le.preseed
@@ -1,0 +1,64 @@
+debconf debconf/priority string critical
+unknown debconf/priority string critical
+d-i debconf/priority string critical
+d-i localechooser/languagelist select en
+d-i debian-installer/locale string en_US
+d-i console-tools/archs select at
+d-i keyboard-configuration/layoutcode string us
+d-i keyboard-configuration/layout select English (US)
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string en
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string unassigned-hostname
+d-i netcfg/get_domain string unassigned-domain
+d-i netcfg/wireless_wep string
+
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Eastern
+
+d-i partman-auto/method string regular
+d-i partman-auto/choose_recipe select atomic
+d-i partman/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-auto/disk string /dev/sda
+
+d-i passwd/root-login boolean true
+d-i passwd/user-fullname string Ubuntu User
+d-i passwd/username string ubuntu
+d-i passwd/user-password password 12345678
+d-i passwd/user-password-again password 12345678
+d-i user-setup/allow-password-weak boolean true
+
+d-i passwd/root-password password 12345678
+d-i passwd/root-password-again password 12345678
+d-i passwd/root-password-weak boolean true
+
+d-i mirror/http/mirror select us.archive.ubuntu.com
+d-i mirror/udeb/components multiselect main, restricted, universe, multiverse
+
+tasksel tasksel/first multiselect standard
+
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i debian-installer/add-kernel-opts string console=tty0 console=ttyS0,115200
+
+d-i apt-setup/security_host string
+base-config apt-setup/security-updates boolean false
+
+ubiquity ubiquity/summary note
+ubiquity ubiquity/reboot boolean true
+
+d-i finish-install/reboot_in_progress note
+d-i debian-installer/exit/halt boolean false
+d-i debian-installer/exit/poweroff boolean false
+d-i preseed/late_command string \
+echo "start on stopped rc or RUNLEVEL=[2345]" > /target/etc/init/ttyS0.conf; \
+echo "stop on runlevel [!2345]" >> /target/etc/init/ttyS0.conf; \
+echo "respawn exec /sbin/getty -L 115200 ttyS0 vt102" >> /target/etc/init/ttyS0.conf; \
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /target/etc/default/grub; \
+sed -i "s/ alias/ #alias/g" /target/root/.bashrc; in-target update-grub

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -653,12 +653,12 @@ class UnattendedInstallConfig(object):
 
     def setup_unattended_http_server(self):
         '''
-        Setup a builtin http server for serving the kickstart file
+        Setup a builtin http server for serving the kickstart/preseed file
 
-        Does nothing if unattended file is not a kickstart file
+        Does nothing if unattended file is not a kickstart/preseed file
         '''
-        if self.unattended_file.endswith('.ks'):
-            # Red Hat kickstart install
+        if self.unattended_file.endswith('.ks') or self.unattended_file.endswith('.preseed'):
+            # Red Hat kickstart install or Ubuntu preseed install
             dest_fname = 'ks.cfg'
 
             answer_path = os.path.join(self.tmpdir, dest_fname)


### PR DESCRIPTION
- unattended_install: add Ubuntu1810 url variant and its preseed file 
support guest installation of Ubuntu1810 with url method and
unattended file using preseed file.


- unattended_install: allow preseed to be served from builtin http server 
similar to kickstart file, preseed file can also be served to kernel
param during installation by `url=http://localhost:8000/ubuntu.preseed`,
include preseed file to be served from builtin http server.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>