### PR TITLE
Add vm name to vm_ip_dict in ping_vm() after migration

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1240,6 +1240,7 @@ class MigrationTest(object):
             server_ip = params.get("server_ip")
             src_uri = "qemu:///system"
             vm.connect_uri = uri
+            vm_ip[vm.name] = vm.get_address()
             server_pwd = params.get("server_pwd")
             server_user = params.get("server_user")
             server_session = remote.wait_for_login('ssh', server_ip, '22',


### PR DESCRIPTION
Vm name may change after migration if --dname is used. So we also
need to add vm name to vm_ip_dict after migration, or ping_vm()
will fail after migraiton.

Signed-off-by: Fangge Jin <fjin@redhat.com>