### PR TITLE
Enable output guest dmesg log

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -468,6 +468,9 @@ guest_dmesg_level = 3
 # Whether to fail the testcase, default is to fail incase of error
 guest_dmesg_ignore = False
 
+# Whether to dump guest dmesg output to console
+guest_dmesg_dump_console = no
+
 # Screendump thread params
 convert_ppm_files_to_png = no
 keep_ppm_files = no

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1084,6 +1084,8 @@ def postprocess(test, params, env):
         for vm in living_vms:
             guest_dmesg_log_file += ".%s" % vm.name
             try:
+                if params.get("guest_dmesg_dump_console") == "yes":
+                    guest_dmesg_log_file = None
                 vm.verify_dmesg(dmesg_log_file=guest_dmesg_log_file)
             except exceptions.TestFail as details:
                 err += ("\n: Guest %s dmesg verification failed: %s"


### PR DESCRIPTION
Guest dmesg log will benefit the analysis of guest dmesg
So just enable it output to console.

Signed-off-by: chunfuwen <chwen@redhat.com>