### PR TITLE
finish.bat: Add optional step to accomplish windows updates

### DIFF
--- a/shared/deps/finish/finish.bat
+++ b/shared/deps/finish/finish.bat
@@ -1,18 +1,24 @@
 taskkill /IM serialport.exe /F
 
-:check_net
-if [%2]==[] goto check_process
+if [%~3]==[-AccomplishWinUpdates] (
+    set has_update=1
+) else (
+    set has_update=0
+)
 
-set ping_host=%2
+:check_net
+if [%~2]==[] goto check_process
+
+set ping_host=%~2
 echo Check network status > COM1
 ping %ping_host%
 
 if errorlevel 1 goto check_net
 
 :check_process
-if [%1]==[] goto end
+if [%~1]==[] goto end
 
-set process=%1
+set process=%~1
 echo Check %process% status >  COM1
 tasklist /FO List>  C:\log
 type C:\log|find "%process%"
@@ -30,4 +36,9 @@ reg add "HKLM\System\CurrentControlSet\Control\CrashControl" /v AlwaysKeepMemory
 reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\Windows Error Reporting" /v Disabled /d 1 /t REG_DWORD /f
 reg add "HKLM\SYSTEM\CurrentControlSet\Services\vds" /v Start /t REG_DWORD /d 3 /f
 
-for /L %%i in (1,1,3) do (echo Post set up finished> COM1)
+if [%has_update%]==[1] (
+    reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce" /v PostSetupEvent /d "cmd /c """for %%i in ^(1,1,5^) do ^(echo Post set up finished^> COM1^)"" /t REG_SZ /f
+    shutdown /r /f /t 0
+) else (
+    for /L %%i in (1,1,3) do (echo Post set up finished> COM1)
+)

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -168,6 +168,10 @@ class UnattendedInstallConfig(object):
         for a in self.attributes:
             setattr(self, a, params.get(a, ''))
 
+        # Make finish.bat work well with positional arguments
+        if not self.process_check.strip():  # pylint: disable=E0203
+            self.process_check = '""'       # pylint: disable=E0203
+
         # Will setup the virtio attributes
         v_attributes = ['virtio_floppy', 'virtio_scsi_path',
                         'virtio_storage_path', 'virtio_network_path',


### PR DESCRIPTION
Sometimes, we would install windows updates for our guests, and these
updates may require a reboot to accomplish themselves.

In order to achieve this requirement, add an optional step to perform
the operation (by setting the string `-AccomplishWinUpdates` as the
third argument of `finish.bat`.)

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1601309