### PR TITLE
Fix unsupported operand type for += between 'NoneType' and 'str'

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1082,10 +1082,11 @@ def postprocess(test, params, env):
         guest_dmesg_log_file = utils_misc.get_path(test.debugdir, guest_dmesg_log_file)
         living_vms = [vm for vm in env.get_all_vms() if (vm.is_alive() and not vm.is_paused())]
         for vm in living_vms:
-            guest_dmesg_log_file += ".%s" % vm.name
+            if params.get("guest_dmesg_dump_console") == "yes":
+                guest_dmesg_log_file = None
+            else:
+                guest_dmesg_log_file += ".%s" % vm.name
             try:
-                if params.get("guest_dmesg_dump_console") == "yes":
-                    guest_dmesg_log_file = None
                 vm.verify_dmesg(dmesg_log_file=guest_dmesg_log_file)
             except exceptions.TestFail as details:
                 err += ("\n: Guest %s dmesg verification failed: %s"


### PR DESCRIPTION
Previously guest_dmesg_log_file=None will bring the value to next loop,
therefore it cause unsupported operand type error

Signed-off-by: chunfuwen <chwen@redhat.com>