### PR TITLE
virttest/utils_test: fixes to virtio serial file transfer

### DIFF
--- a/shared/deps/serial/VirtIoChannel_guest_send_receive.py
+++ b/shared/deps/serial/VirtIoChannel_guest_send_receive.py
@@ -50,7 +50,7 @@ class VirtIoChannel:
         self.ack_format = "3s"
         self.ack_msg = b"ACK"
         self.hi_format = "2s"
-        self.hi_msg = "HI"
+        self.hi_msg = b"HI"
         if self.is_windows:
             vport_name = '\\\\.\\Global\\' + device_name
             from windows_support import WinBufferedReadFile
@@ -85,7 +85,7 @@ class VirtIoChannel:
             self.send(self.hi_msg)
             txt = self.receive(hi_msg_len)
             out = struct.unpack(self.hi_format, txt)[0]
-            if out != "HI":
+            if out != b"HI":
                 raise ShakeHandError("Fail to get HI from guest.")
             size_s = struct.pack("q", size)
             self.send(size_s)
@@ -101,7 +101,6 @@ class VirtIoChannel:
                 raise ShakeHandError("Fail to get HI from guest.")
             self.send(txt)
             size = self.receive(8)
-            print("xxxx size = %s" % size)
             if size:
                 size = struct.unpack("q", size)[0]
                 txt = struct.pack(self.ack_format, self.ack_msg)
@@ -180,7 +179,7 @@ def receive(device, filename, p_size=1024):
             txt = vio.receive(p_size)
             md5_value.update(txt)
             file_no.write(txt)
-            recv_size += p_size
+            recv_size += len(txt)
     finally:
         file_no.close()
         if vio:

--- a/shared/deps/serial/serial_host_send_receive.py
+++ b/shared/deps/serial/serial_host_send_receive.py
@@ -98,19 +98,19 @@ def shake_hand(connect, size=0, action="receive"):
         connect.send(hi_str)
         txt = connect.recv(hi_str_len)
         hi_str = struct.unpack("2s", txt)[0]
-        if hi_str != "HI":
+        if hi_str != b"HI":
             raise ShakeHandError("Fail to get HI from guest.")
         size_str = struct.pack("q", size)
         connect.send(size_str)
         txt = connect.recv(3)
         ack_str = struct.unpack("3s", txt)[0]
-        if ack_str != "ACK":
+        if ack_str != b"ACK":
             raise ShakeHandError("Guest did not ACK the file size message.")
         return size
     elif action == "receive":
         txt = connect.recv(hi_str_len)
         hi_str = struct.unpack("2s", txt)[0]
-        if hi_str != "HI":
+        if hi_str != b"HI":
             raise ShakeHandError("Fail to get HI from guest.")
         connect.send(hi_str)
         size = connect.recv(8)

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -433,6 +433,12 @@ def find_python(session, try_binaries=('python3', 'python2', 'python')):
         if session.cmd_status("which %s" % python) == 0:
             return python
 
+def find_host_python(try_binaries=('python3', 'python2', 'python')):
+    for python in try_binaries:
+        out = process.run("which %s" % python, shell=True)
+        if out.exit_status == 0:
+            return python
+
 
 @error_context.context_aware
 def get_image_version(qemu_image):
@@ -742,6 +748,7 @@ def run_virtio_serial_file_transfer(test, params, env, port_name=None,
 
     host_data_file = os.path.join(dir_name,
                                   "tmp-%s" % utils_misc.generate_random_string(8))
+    session.cmd("mkdir -p %s" % tmp_dir)
     guest_data_file = os.path.join(tmp_dir,
                                    "tmp-%s" % utils_misc.generate_random_string(8))
 
@@ -775,14 +782,22 @@ def run_virtio_serial_file_transfer(test, params, env, port_name=None,
     host_script = params.get("host_script", "serial_host_send_receive.py")
     host_script = os.path.join(data_dir.get_root_dir(), "shared", "deps",
                                "serial", host_script)
-    host_cmd = "python %s -s %s -f %s -a %s" % (host_script, host_device,
-                                                host_data_file, action)
+
+    host_python = find_host_python()
+    if host_python is None:
+        logging.error("Python not found on host.")
+    host_cmd = "%s %s -s %s -f %s -a %s" % (host_python, host_script,
+                                            host_device, host_data_file, action)
     guest_script = params.get("guest_script",
                               "VirtIoChannel_guest_send_receive.py")
     guest_script = os.path.join(guest_path, guest_script)
 
-    guest_cmd = "python %s -d %s -f %s -a %s" % (guest_script, port_name,
-                                                 guest_data_file, guest_action)
+    guest_python = find_python(session)
+    if guest_python is None:
+        logging.error("Python not found on guest.")
+    guest_cmd = "%s %s -d %s -f %s -a %s" % (guest_python, guest_script,
+                                             port_name, guest_data_file,
+                                             guest_action)
     n_time = int(params.get("repeat_times", 1))
     txt += " for %s times" % n_time
     try:


### PR DESCRIPTION
The run_virtio_serial_file_transfer() function runs python scripts
on (usually) both guest and host to test serial communication. It
assumes Python 2 is installed on both side, which is not always
true. So this change ensure it uses the python binary (python3 preferred)
available. It was added the find_host_python() function which is
used to find the python binary on host.

This change also contain some misc fixes:
a) Ensure proper comparisons of byte type with Python 3.
b) Ensure the working directory is created on the guest.
c) Fix the calculation of received bytes by the guest script.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>