### PR TITLE
docs: Add note where to download virtio-win drivers  ISO

### DIFF
--- a/docs/source/DownloadableImages.rst
+++ b/docs/source/DownloadableImages.rst
@@ -39,6 +39,15 @@ That's basically a collection of files useful for windows testing. If you want
 to update that file, you'll have to pick that iso file, extract it to a directory,
 make changes, remaster the iso and upload back to the main location.
 
+
+Windows virtio drivers ISO
+==========================
+
+In Avocado we mainly use fedora/RHEL based windows virtio drivers ISO that
+can be obtained from:
+
+https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html
+
 JeOS image
 ==========
 

--- a/docs/source/InstallWinVirtio.rst
+++ b/docs/source/InstallWinVirtio.rst
@@ -95,10 +95,10 @@ SHA1 sum of it matches.
 #. Execute the ``get_started.py`` script (see the `get started documentation <../GetStartedGuide>`.
    It will create the directories where we expect the cd files to be
    available. You don't need to download the Fedora 14 DVD, but you do
-   need to download the winutils.iso cd (on the example below, I have
-   skipped the download because I do have the file, so I can copy it to
-   the expected location, which is in this case
-   ``/tmp/kvm_autotest_root/isos/windows``). Please, do read the
+   need to download the winutils.iso. Our configuration is based on
+   RHEL/Fedora based version that can be obtained from `here <https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html>` and
+   need to be placed in ``/tmp/kvm_autotest_root/isos/windows``).
+   Please, do read the
    documentation mentioned on the script to avoid missing packages
    installed and other misconfiguration.
 #. Create a windows dir under ``/tmp/kvm_autotest_root/isos``


### PR DESCRIPTION
This ISO is used for windows testing, it makes sense to add information
where to download it to our docs.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>