### PR TITLE
qemu_vm: add vsock device

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -694,3 +694,6 @@ inputs = ""
 # systems that require this extra setting.
 Host_Ubuntu.m18.u10:
     firewalld_dhcp_workaround = yes
+
+# Add vsock device
+# vsocks = vhost_vsock0

--- a/virttest/arch.py
+++ b/virttest/arch.py
@@ -38,6 +38,8 @@ if ARCH in ('ppc64', 'ppc64le'):
     NLMSG_ERROR = 2
     # From linux/socket.h
     AF_PACKET = 17
+    # From linux/vhost.h
+    VHOST_VSOCK_SET_GUEST_CID = 0x8008af60
 else:
     # From include/linux/sockios.h
     SIOCSIFHWADDR = 0x8924
@@ -72,6 +74,8 @@ else:
     NLMSG_ERROR = 2
     # From linux/socket.h
     AF_PACKET = 17
+    # From linux/vhost.h
+    VHOST_VSOCK_SET_GUEST_CID = 0x4008af60
 
 
 def get_kvm_module_list():

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1839,7 +1839,7 @@ class QPCIEBus(QPCIBus):
         :param device: the QBaseDevice object
         :return: bool value for directly plug or not.
         """
-        pcie_devices = ["virtio-net-pci", "virtio-blk-pci",
+        pcie_devices = ["virtio-net-pci", "virtio-blk-pci", "vhost-vsock-pci"
                         "virtio-scsi-pci", "virtio-balloon-pci",
                         "virtio-serial-pci", "virtio-rng-pci",
                         "e1000e", "virtio-gpu-device", "qemu-xhci"]


### PR DESCRIPTION
1. The cmd line: -device vhost-vsock-pci,id=vhost-vsock0,guest-cid=3
2. guest-cid is between '3' and '0xffffffff - 1'(unsigned 32-bit
 integer. 0-2 and 0xffffffff are reserved)
3. It is a virtio device so should be a pcie device

id: 1665845
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>