### PR TITLE
Allow for absolute paths to additional virtual tests

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -330,7 +330,8 @@ class VirtTest(test.Test):
 
         other_subtests_dirs = params.get("other_tests_dirs", "")
         for d in other_subtests_dirs.split():
-            d = os.path.join(*d.split("/"))
+            # If d starts with a "/" an absolute path will be assumed
+            # else the relative path will be searched in the bin_dir
             subtestdir = os.path.join(self.bindir, d, "tests")
             if not os.path.isdir(subtestdir):
                 raise exceptions.TestError("Directory %s does not "

--- a/virt.py
+++ b/virt.py
@@ -104,8 +104,8 @@ class virt(test.test):
                     bin_dir = self.bindir
 
                     for d in other_subtests_dirs.split():
-                        # Replace split char.
-                        d = os.path.join(*d.split("/"))
+                        # If d starts with a "/" an absolute path will be assumed
+                        # else the relative path will be searched in the bin_dir
                         subtestdir = os.path.join(bin_dir, d, "tests")
                         if not os.path.isdir(subtestdir):
                             raise exceptions.TestError("Directory %s not"


### PR DESCRIPTION
Some test suites would prefer to place their tests outside of and
not relative to the default folder with virtual tests.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>