### PR TITLE
Add various parameter manipulation functionality to the param utils

### DIFF
--- a/selftests/unit/test_utils_params.py
+++ b/selftests/unit/test_utils_params.py
@@ -3,6 +3,7 @@
 import unittest
 import os
 import sys
+from collections import OrderedDict
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -85,6 +86,64 @@ class TestParams(unittest.TestCase):
 
     def testGetItem(self):
         self.assertEqual(self.params['image_size'], "10G")
+
+    def testGetBoolean(self):
+        self.params["foo1"] = "yes"
+        self.params["foo2"] = "no"
+        self.params["foo3"] = "on"
+        self.params["foo4"] = "off"
+        self.params["foo5"] = "true"
+        self.params["foo6"] = "false"
+        self.assertEqual(True, self.params.get_boolean('foo1'))
+        self.assertEqual(False, self.params.get_boolean('foo2'))
+        self.assertEqual(True, self.params.get_boolean('foo3'))
+        self.assertEqual(False, self.params.get_boolean('foo4'))
+        self.assertEqual(True, self.params.get_boolean('foo5'))
+        self.assertEqual(False, self.params.get_boolean('foo6'))
+        self.assertEqual(False, self.params.get_boolean('notgiven'))
+
+    def testGetNumeric(self):
+        self.params["something"] = "7"
+        self.params["foobar"] = 11
+        self.params["barsome"] = 13.0
+        self.assertEqual(7, self.params.get_numeric('something'))
+        self.assertEqual(11, self.params.get_numeric('foobar'))
+        self.assertEqual(11.0, self.params.get_numeric('foobar'), float)
+        self.assertEqual(13, self.params.get_numeric('barsome'))
+        self.assertEqual(13.0, self.params.get_numeric('barsome'), float)
+        self.assertEqual(17, self.params.get_numeric('joke', 17))
+        self.assertEqual(17.0, self.params.get_numeric('joke', 17), float)
+
+    def testGetList(self):
+        self.params["primes"] = "7 11 13 17"
+        self.params["dashed"] = "7-11-13"
+        self.assertEqual(["7", "11", "13", "17"], self.params.get_list('primes'))
+        self.assertEqual([7, 11, 13, 17], self.params.get_list('primes', "1 2 3", " ", int))
+        self.assertEqual([1, 2, 3], self.params.get_list('missing', "1 2 3", " ", int))
+        self.assertEqual([7, 11, 13], self.params.get_list('dashed', "1 2 3", "-", int))
+
+    def testGetDict(self):
+        self.params["dummy"] = "name1=value1 name2=value2"
+        self.assertEqual({"name1": "value1", "name2": "value2"}, self.params.get_dict('dummy'))
+        result_dict = self.params.get_dict('dummy', need_order=True)
+        right_dict, wrong_dict = OrderedDict(), OrderedDict()
+        right_dict["name1"] = "value1"
+        right_dict["name2"] = "value2"
+        wrong_dict["name2"] = "value2"
+        wrong_dict["name1"] = "value1"
+        self.assertEqual(right_dict, result_dict)
+        self.assertNotEqual(wrong_dict, result_dict)
+
+    def dropDictInternals(self):
+        self.params["a"] = "7"
+        self.params["b"] = "11"
+        self.params["_b"] = "13"
+        pruned = self.params.drop_dict_internals()
+        self.assertIn("a", pruned.keys())
+        self.assertEqual(pruned["a"], self.params["a"])
+        self.assertIn("b", pruned.keys())
+        self.assertEqual(pruned["b"], self.params["b"])
+        self.assertNotIn("_b", pruned.keys())
 
 
 if __name__ == "__main__":

--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -3,6 +3,7 @@ try:
     from collections import UserDict as IterableUserDict
 except ImportError:
     from UserDict import IterableUserDict
+from collections import OrderedDict
 
 from avocado.core import exceptions
 
@@ -104,3 +105,91 @@ class Params(IterableUserDict):
             if self.get(key):
                 new_dict[key] = self.get(key)
         return new_dict
+
+    def get_boolean(self, key, default=False):
+        """
+        Check if a config option is set to a default affirmation or not.
+
+        :param key: config option key
+        :type key: str
+        :param bool default: whether to assume "yes" or "no" if param
+                             does not exist (defaults to False/"no").
+        :return whether option is set to 'yes'
+        :rtype: bool
+        """
+        value = self.get(key, "yes" if default else "no")
+        if value in ("yes", "on", "true"):
+            return True
+        if value in ("no", "off", "false"):
+            return False
+        raise ValueError("Cannot get boolean parameter value for %s: %s", key, value)
+
+    def get_numeric(self, key, default=0, target_type=int):
+        """
+        Get numeric value converting to integer if necessary.
+
+        :param str key: config option key
+        :param int default: default numeric value
+        :param type target_type: numeric type to return like int or float
+        :return numerical type `target_type` converted parameter value
+        :rtype: int or float
+        """
+        return target_type(self.get(key, default))
+
+    def get_list(self, key, default="", delimiter=' ', target_type=str):
+        """
+        Get a parameter value that is a character delimited list.
+
+        :param str key: parameter whose value is list
+        :param str default: default list value
+        :param str delimiter: character to split list items
+        :param type target_type: type of each item, default is string
+        :returns: empty list if if the key is not in the parameters
+        :rtype: [str]
+
+        .. note:: This an extension to the :py:func:`Params.objects` method as
+          it allows for delimiters other than white space.
+        .. seealso:: :py:func:`param_dict`
+        """
+        param_string = self.get(key, default)
+        if not param_string:
+            return []
+        else:
+            return [target_type(entry) for entry in param_string.split(delimiter)]
+
+    def get_dict(self, key, default="", delimiter=' ', need_order=False):
+        """
+        Get a param value that has the form 'name1=value1 name2=value2 ...'.
+
+        :param str key: parameter whose value is dict
+        :param str default: default dict value
+        :param str delimiter: character to split list items
+        :param bool need_order: whether to return an OrderedDict instead of
+                                a regular dict
+        :returns: empty dict if if the key is not in the parameters, a dict
+                  or an ordered dictionary if the item order is important
+        :rtype: {str: str}
+
+        This uses :py:meth:`get_list` to convert the list entries to dict.
+        """
+        if need_order:
+            result = OrderedDict()
+        else:
+            result = dict()
+        for entry in self.get_list(key, default, delimiter):
+            index = entry.find('=')
+            if index == -1:
+                raise ValueError('failed to find "=" in "{0}" (value for {1})'
+                                 .format(entry, key))
+            result[entry[:index]] = entry[index+1:]
+        return result
+
+    def drop_dict_internals(self):
+        """
+        Drop internal keys which are not of our concern and
+        return the modified params.
+
+        :returns: parameters without the internal keys
+        :rtype: {str, str}
+        """
+        return Params({key: value for key, value in self.items() if not key.startswith("_")})


### PR DESCRIPTION
This includes custom key checking, list and dictionary parameter
retrieval, advanced object parameter manipulation, etc.

The only additional change other than pure copying from our downstream
code was done in order to adapt to object method access rather than module
function one:

index 40b21f63..b61e5864 100644
@@ -139,21 +139,21 @@ class Params(IterableUserDict):
         :returns: empty dict if if the key is not in the parameters, a dict
                   or an ordered dictionary if the item order is important
         :rtype: {str: str}

         This uses :py:meth:`get_list` to convert the list entries to dict.
         """
         if need_order:
             result = OrderedDict()
         else:
             result = dict()
-        for entry in get_list(self, key, default, delimiter):
+        for entry in self.get_list(key, default, delimiter):
             index = entry.find('=')
             if index == -1:
                 raise ValueError('failed to find "=" in "{0}" (value for {1})'
                                  .format(entry, key))
             result[entry[:index]] = entry[index+1:]
         return result

     def get_multi_param(self, name):
         """
         Get multiple parameters by appending a number

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>