### PR TITLE
Do not refer to not fully reconstructed (unpickled) vm object

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -340,8 +340,9 @@ class Monitor:
         :param extra_str: Extra string would be printed in log.
         """
         if self.debug_log or debug:
+            vm_name = "" if not hasattr(self.vm, "name") else self.vm.name
             logging.debug("(monitor %s.%s) Sending command '%s' %s",
-                          self.vm.name, self.name, cmd, extra_str)
+                          vm_name, self.name, cmd, extra_str)
 
     def _log_lines(self, log_str):
         """


### PR DESCRIPTION
There is a recursion in the assumption of constructed objects
where unpickling a vm also requires unpickling its monitors which
in turn assumes the vm is already unpickled.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>