### PR TITLE
Enable machine_type get correct value from runtime

### DIFF
--- a/backends/libvirt/cfg/tests.cfg
+++ b/backends/libvirt/cfg/tests.cfg
@@ -6,8 +6,6 @@ variants:
         virt_install_binary = /usr/bin/virt-install
         qemu_img_binary = /usr/bin/qemu-img
         hvm_or_pv = hvm
-        # Allow os_type + os_variant to choose this automatically
-        machine_type =
         use_os_variant = yes
         use_os_type = yes
         only qcow2


### PR DESCRIPTION
Here machine_type reset to empty, and override the correct value defined
in machines.cfg, the machine_type value benefit to get correct runtime
guest machine type.

Signed-off-by: chunfuwen <chwen@redhat.com>