### PR TITLE
Add 'alias' element for 'Serial' device

### DIFF
--- a/virttest/libvirt_xml/devices/serial.py
+++ b/virttest/libvirt_xml/devices/serial.py
@@ -11,7 +11,7 @@ from virttest.libvirt_xml.devices.character import CharacterBase
 class Serial(CharacterBase):
 
     __slots__ = ('protocol_type', 'target_port', 'target_type',
-                 'target_model', 'sources', 'address')
+                 'target_model', 'sources', 'alias', 'address')
 
     def __init__(self, type_name='pty', virsh_instance=base.virsh):
         # Additional attribute for protocol type (raw, telnet, telnets, tls)
@@ -26,6 +26,8 @@ class Serial(CharacterBase):
         accessors.XMLElementList('sources', self, parent_xpath='/',
                                  marshal_from=self.marshal_from_sources,
                                  marshal_to=self.marshal_to_sources)
+        accessors.XMLElementDict('alias', self, parent_xpath='/',
+                                 tag_name='alias')
         accessors.XMLElementDict('address', self, parent_xpath='/',
                                  tag_name='address')
         super(Serial, self).__init__(device_tag='serial', type_name=type_name,


### PR DESCRIPTION
Add 'alias' element for 'Serial' device

Signed-off-by: Jing Yan <jiyan@redhat.com>