### PR TITLE
virttest.utils_test: fix logging.warn on setup_runlevel()

### DIFF
--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -257,7 +257,7 @@ def setup_runlevel(params, session):
         tmp_runlevel = session.cmd(cmd)
         tmp_runlevel = tmp_runlevel.split()[-1]
         if tmp_runlevel != expect_runlevel:
-            logging.warn("Changing runlevel from %s to %s failed (%s)!" %
+            logging.warn("Changing runlevel from %s to %s failed (%s)!",
                          ori_runlevel, expect_runlevel, tmp_runlevel)
 
 


### PR DESCRIPTION
The arguments of logging.warn call on setup_runlevel() are incorrect
formatted, resulting in error:
"TypeError: not enough arguments for format string"

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>