### PR TITLE
virt_vm: make sure libvirt connect uri doesn't break the test

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2477,7 +2477,7 @@ class VM(virt_vm.BaseVM):
             state = self.state()
             if state != 'paused':
                 virsh.suspend(
-                    self.name, uri=self.connect_uri, ignore_statues=False)
+                    self.name, uri=self.connect_uri, ignore_status=False)
             return True
         except Exception:
             logging.error("VM %s failed to suspend", self.name)

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3477,6 +3477,10 @@ def verify_dmesg(dmesg_log_file=None, ignore_result=False, level_check=3,
                         4 - emerg,alert,crit,err
                         5 - emerg,alert,crit,err,warn
     :param session: session object to guest
+    :param return: if ignore_result=True, return True if no errors/crash
+                   observed, False otherwise.
+    :param raise: if ignore_result=False, raise TestFail exception on
+                  observing errors/crash
     """
     cmd = "dmesg -T -l %s|grep ." % ",".join(map(str, xrange(0, int(level_check))))
     if session:
@@ -3504,6 +3508,8 @@ def verify_dmesg(dmesg_log_file=None, ignore_result=False, level_check=3,
             process.system("dmesg -C", ignore_status=True)
         if not ignore_result:
             raise exceptions.TestFail(err)
+        return False
+    return True
 
 
 def add_ker_cmd(kernel_cmdline, kernel_param, remove_similar=False):


### PR DESCRIPTION
In migration tests, verify_dmesg can be used to check the guest
after migration where connect uri would be changed. API should
ensure to hold the `vm.connect_uri` in the test flow when it is
used multiple times, this fix resume the original connect_uri
once verifying dmesg.

utils_misc: let verify_dmesg() return bool if `ignore_result=True`

If ignore_result=True, let verify_dmesg() return bool, True if no
errors/crash and False otherwise which would help proceed the test
based on the return value.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>