### PR TITLE
Add a fix for android (x86) devices on recent (2.10+) qemu

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1120,6 +1120,12 @@ class DevContainer(object):
                              'i440FX')
                 devices = machine_i440FX(False)
 
+        if params.get("vm_pci_hole64_fix"):
+            if machine_type.startswith('pc'):
+                devices.append(qdevices.QGlobal("i440FX-pcihost", "x-pci-hole64-fix", "off"))
+            if machine_type.startswith('q35'):
+                devices.append(qdevices.QGlobal("q35-pcihost", "x-pci-hole64-fix", "off"))
+
         # reserve pci.0 addresses
         pci_params = params.object_params('pci.0')
         reserved = pci_params.get('reserved_slots', '').split()


### PR DESCRIPTION
Some test suites are using android-x86 machines for testing functionality related to Android devices.

More details on the issue can be found here:

https://bugs.launchpad.net/qemu/+bug/1778350?comments=all

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>