### PR TITLE
utils_net: Fix `get_structure` doesn't get the interface dir correctly

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1008,7 +1008,8 @@ class Bridge(object):
         result = dict()
         for br_iface in os.listdir(sysfs_path):
             br_iface_path = os.path.join(sysfs_path, br_iface)
-            if "bridge" not in os.listdir(br_iface_path):
+            if (not os.path.isdir(br_iface_path) or
+                    "bridge" not in os.listdir(br_iface_path)):
                 continue
             result[br_iface] = dict()
             # Get stp_state


### PR DESCRIPTION
Sometimes there are not only directories in `/sys/class/net`. For example, when we `modprobe bonding`, a file named `bonding_masters` will be created in this directory. Make it get the interface directory correctly.

ID: 1638680
Signed-off-by: Yihuang Yu <yihyu@redhat.com>