### PR TITLE
virttest.libvirt_vm: Fix machine_type assessment

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -961,7 +961,10 @@ class VM(virt_vm.BaseVM):
         # Add the VM's name
         virt_install_cmd += add_name(help_text, name)
 
-        machine_type = params.get("machine_type")
+        # The machine_type format is [avocado-type:]machine_type
+        # where avocado-type is optional part and is used in
+        # tp-qemu to use different devices. Use only the second part
+        machine_type = params.get("machine_type").split(':', 1)[-1]
         if machine_type:
             if machine_type in support_machine_type:
                 virt_install_cmd += add_machine_type(help_text, machine_type)


### PR DESCRIPTION
For quite a while the "machine_type" can optionally include avocado-vt
machine type, which is used for example on arm to use either mmio or pci
devices. This was not implemented in libvirt provider and was hidden
until 7d37e0a07e5e803b7a64490032baf2063feab72c which actually enabled
machine_type selection there. Since then all arm jobs are being skipped
because it's machine_type is "arm64-pci:virt".

Let's adjust the "machine_type" assessment to reflect the optional
values.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>