### PR TITLE
unattended_install.nfs: To create image_dir before being used

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -247,11 +247,6 @@ class UnattendedInstallConfig(object):
                 os.makedirs(os.path.dirname(self.floppy))
 
         self.image_path = os.path.dirname(self.kernel)
-        if not os.path.isdir(self.image_path):
-            # To prevent errors
-            if os.path.isfile(self.image_path):
-                os.unlink(self.image_path)
-            os.makedirs(self.image_path)
 
         # Content server params
         # lookup host ip address for first nic by interface name
@@ -850,6 +845,8 @@ class UnattendedInstallConfig(object):
         """
         error_context.context("Copying vmlinuz and initrd.img from install cdrom %s" %
                               self.cdrom_cd1)
+        if not os.path.isdir(self.image_path):
+            os.makedirs(self.image_path)
 
         if (self.params.get('unattended_delivery_method') in
                 ['integrated', 'url']):
@@ -939,6 +936,8 @@ class UnattendedInstallConfig(object):
         if self.vm_type == 'qemu':
             error_context.context(
                 "downloading vmlinuz/initrd.img from %s" % self.url)
+            if not os.path.exists(self.image_path):
+                os.mkdir(self.image_path)
             os.chdir(self.image_path)
 
             kernel_basename = os.path.basename(self.kernel)

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1012,6 +1012,9 @@ class UnattendedInstallConfig(object):
                  (self.nfs_server, self.nfs_dir, self.nfs_mount))
         process.run(m_cmd, verbose=DEBUG)
 
+        if not os.path.isdir(self.image_path):
+            os.makedirs(self.image_path)
+
         try:
             kernel_fetch_cmd = ("cp %s/%s/%s %s" %
                                 (self.nfs_mount, self.boot_path,


### PR DESCRIPTION
An issue was introduced by https://github.com/avocado-framework/avocado-vt/pull/1927 which cause windows guests failed to be installed successfully.
```
ERROR: [Errno 2] No such file or directory: ''
```
That because windows guests do not have a valid `kernel` set, so let's revert the previous approach and use the first one I sent.

Signed-off-by: Xu Han xuhan@redhat.com

ID: 1668237