### PR TITLE
shared.cfg.guest-os: Add RHEL.8 variant config files

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/8.cfg
@@ -1,0 +1,44 @@
+- 8:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    os_variant = rhel8
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 2048
+    nic_hotplug:
+        modprobe_module =
+    block_hotplug:
+        modprobe_module =
+    no unattended_install..floppy_ks
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_unattended = images/${os_variant}-${vm_arch_name}/ks.iso
+        syslog_server_proto = udp
+    unattended_install, svirt_install:
+        kernel = images/${os_variant}-${vm_arch_name}/vmlinuz
+        initrd = images/${os_variant}-${vm_arch_name}/initrd.img
+        # ARCH dependent things
+        aarch64:
+            grub_file = /boot/grub/grub.conf
+            install_timeout = 7200
+        ppc64le:
+            no guest_s3, guest_s4
+            mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
+            netdev_peer_re = "(.*?): .*?\\\s(.*?):"
+        s390x:
+            grub_file = /boot/grub/grub.conf
+            install_timeout = 7200
+            kernel = images/${os_variant}-${vm_arch_name}/kernel.img
+            unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+                # Anaconda hardcodes headless installation of RHEL.7 on s390x
+                vga = none
+                inactivity_watcher = none
+                take_regular_screendumps = no
+        x86_64:
+            grub_file = /boot/grub2/grub.cfg

--- a/shared/cfg/guest-os/Linux/RHEL/8/8.devel.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/8/8.devel.cfg
@@ -1,0 +1,9 @@
+- devel:
+    # Uses defaults set in 8.cfg
+    # Adding x.y versions should only require changing the kickstart
+    # and adding per-arch image shas.
+    image_name = images/${os_variant}devel-${vm_arch_name}
+    unattended_install.cdrom:
+        cdrom_cd1 = isos/linux/RHEL-8-devel-${vm_arch_name}.iso
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        unattended_file = unattended/RHEL-8-devel.ks


### PR DESCRIPTION
This patch adds RHEL.8 variant which takes whatever
isos/linux/RHEL8-{subverion}-{x86_64,ppc64,aarch64}.iso image exists and
uses it to install RHEL8-like OS.

Signed-off-by: Radek Duda <rduda@redhat.com>