### PR TITLE
env_process: add nested virtualization support to run tests in nested VMs

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1087,8 +1087,10 @@ class AvocadoGuest(object):
                 avocado_cmd += " --vt-no-filter \"%s\"" % self.vt_no_filter
             if self.vt_arch:
                 avocado_cmd += " --vt-arch %s" % self.vt_arch
+            if self.guest_image:
+                avocado_cmd += " --vt-guest-os %s" % self.guest_image
             if self.vt_extra_params:
-                avocado_cmd += " --vt-extra-params \"%s\"" % self.vt_extra_params
+                avocado_cmd += " --vt-extra-params %s" % self.vt_extra_params
         else:
             for test_each in self.testlist:
                 mux = ""


### PR DESCRIPTION
This patch enables existing tests to be run on nested VMs to
multilevels, is supports N * N * N VMs where multiple guests
can be brought up and nested with multilevel and multiple VMs
on every level. The params can be set to the granularity of any
particular VM on any level.

The point here is to dynamically calculate and distribute memory to
higher level VMs based on the available memory in current level
VM/host. It is not neccesary but it is required for VMs to run
test seamlessly on positive scenarios, still negative scenarios
can be tested by overriding the param to perform this distribution.

We handle the test across all the VMs at all the Levels in linear
way as parallelism from here will not have control on the test
flow but configuring different testcases on different VMs at any
level is possible. Parallel test scenarios can be added from testcase
indeed.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>