### PR TITLE
Extend v2v cmd running time

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -705,7 +705,11 @@ def v2v_cmd(params):
     vpx_dc = params.get('vpx_dc')
     esx_ip = params.get('esx_ip')
     opts_extra = params.get('v2v_opts')
-    v2v_timeout = params.get('v2v_timeout', 5400)
+    # Set v2v_timeout to 3 hours, the value can give v2v enough time to execute,
+    # and avoid v2v process be killed by mistake.
+    # the value is bigger than the timeout value in CI, so when some timeout
+    # really happens, CI will still interrupt the v2v process.
+    v2v_timeout = params.get('v2v_timeout', 10800)
     rhv_upload_opts = params.get('rhv_upload_opts')
 
     uri_obj = Uri(hypervisor)


### PR DESCRIPTION
This v2v_timeout argument is used to limit v2v cmd running too long.
But it always cause v2v process be killed unexpected. You can check
below script running log[1].

In the log, v2v cmd starts at 14:39 and be killed at 16:09, and v2v
convertion is almost done(94.37/100%) but it's killed unexpected.

We have to debug those failed scripts every time, it waste our energy.
Now let's extend the timeout value and let CI to break the job when
the job really timeout.

1)https://libvirt-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/v2v/view/RHEL-8.0/job/v2v-RHEL-8.0-runtest-x86_64-acceptance-libvirt/65/testReport/rhel/convert_vm_to_libvirt/esx_vm_5_5_linux_latest6_arch_i386

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>