### PR TITLE
shared.cfg.guest-os: correct cdrom_cd1 ISO filename

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/6.devel/i386.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel/i386.cfg
@@ -7,7 +7,7 @@
         kernel = images/rhel6devel-32/vmlinuz
         initrd = images/rhel6devel-32/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL6-devel-i386.iso
+        cdrom_cd1 = isos/linux/RHEL-6-devel-i386.iso
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel63-64/ks.vfd

--- a/shared/cfg/guest-os/Linux/RHEL/6.devel/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/6.devel/x86_64.cfg
@@ -7,8 +7,8 @@
         kernel = images/rhel6devel-64/vmlinuz
         initrd = images/rhel6devel-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL6-devel-x86_64.iso
+        cdrom_cd1 = isos/linux/RHEL-6-devel-x86_64.iso
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel6-64/ks.vfd
-        cdrom_cd1 = isos/linux/RHEL6-devel-x86_64.iso
+        cdrom_cd1 = isos/linux/RHEL-6-devel-x86_64.iso

--- a/shared/cfg/guest-os/Linux/RHEL/7.devel/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.devel/x86_64.cfg
@@ -7,7 +7,7 @@
         kernel = images/rhel7-64/vmlinuz
         initrd = images/rhel7-64/initrd.img
     unattended_install.cdrom, check_block_size.4096_512, check_block_size.512_512, svirt_install:
-        cdrom_cd1 = isos/linux/RHEL7-devel-x86_64.iso
+        cdrom_cd1 = isos/linux/RHEL-7-devel-x86_64.iso
     unattended_install..floppy_ks:
         floppies = "fl"
         floppy_name = images/rhel7-64/ks.vfd


### PR DESCRIPTION
There was dash missing in cdrom_cd1 ISO filename.

Signed-off-by: Radek Duda <rduda@redhat.com>