### PR TITLE
virttest.qemu_monitor: Use append mode for qmp monitor log

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -356,7 +356,7 @@ class Monitor:
             timestr = time.strftime("%Y-%m-%d %H:%M:%S")
             try:
                 if log not in self.open_log_files:
-                    self.open_log_files[log] = open(log, "w")
+                    self.open_log_files[log] = open(log, "a")
                 for line in log_str.splitlines():
                     self.open_log_files[log].write(
                         "%s: %s\n" % (timestr, line))


### PR DESCRIPTION
The qmp monitor log is re-used by all vms of the same name similarly to
serial-console logs. This is important mainly for migration jobs, where
multiple instances are re-created and therefor the log file get's
re-created. The append mode makes sure we keep all the records.

You can see the difference eg. when using `migrate.default.tcp.default`. Without this patch the `qmpmonitor1-avocado-vt-vm1.log` contains only the qmp logs of the last dst vm while with this patch it contains all of them.