### PR TITLE
guest-hw: Remove variants usb2 from drive format

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -108,11 +108,6 @@ variants:
         only q35
         drive_format=ahci
         cd_format=ahci
-    - usb2:
-        drive_format=usb2
-        cd_format=usb2
-        usbs += " install_ehci"
-        usb_type_install_ehci = ich9-usb-ehci1
     - xenblk:
         # placeholder
 


### PR DESCRIPTION
Since base.cfg defined usb1 as ich9-usb-ehci1 controller by default,
while usb2 defined another ich9-usb-ehci1 controller install_ehci,
usbc_by_variables() allocate a fixed address '1d.7' for ich9-usb-ehci1
which causes the address conflit when there are 2 ehci controller.

Considering:
1. There should be only 1 echi controller exists
2. If keep drive format 'usb2' by replace 'usbs += ' with 'usbs =', it
will remove all the other type usb controllers which is not expeceted
3. We usally don't test usb2 as a drive format. Instead of introducing
sepecial conditional processing in current code, we prefer to removing
this variants

id: 1676764
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>