### PR TITLE
Fixup: type cast version info values to string

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -888,7 +888,7 @@ def preprocess(test, params, env):
         kvm_version = "Unknown"
 
     logging.debug("KVM version: %s" % kvm_version)
-    version_info["kvm_version"] = kvm_version
+    version_info["kvm_version"] = str(kvm_version)
 
     # Checking required kernel, if not satisfied, cancel test
     if params.get("required_kernel"):
@@ -923,7 +923,7 @@ def preprocess(test, params, env):
             kvm_userspace_version = "Unknown"
 
     logging.debug("KVM userspace version(qemu): %s" % kvm_userspace_version)
-    version_info["qemu_version"] = kvm_userspace_version
+    version_info["qemu_version"] = str(kvm_userspace_version)
 
     # Checking required qemu, if not satisfied, cancel test
     if params.get("required_qemu"):
@@ -946,7 +946,7 @@ def preprocess(test, params, env):
                 libvirt_ver_cmd, shell=True)).strip()
         except a_process.CmdError:
             libvirt_version = "Unknown"
-        version_info["libvirt_version"] = libvirt_version
+        version_info["libvirt_version"] = str(libvirt_version)
         logging.debug("KVM userspace version(libvirt): %s" % libvirt_version)
 
     # Write it as a keyval


### PR DESCRIPTION
Json read of the version info file fails sometimes when we
have version string with spaces, and causes below failure,

net.sf.json.JSONException: Unquotted string 'u'3.1.50 (v2.8.0-rc0-17028-g3e78ecb378-dirty)''

let's type cast to string to avoid such cases.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>