### PR TITLE
shared: Add RHEL.8 variant

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL/8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/8.cfg
@@ -1,0 +1,48 @@
+- 8:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    os_variant = rhel8
+    unattended_install.url:
+        #Running from http server, RHEL requires more memory
+        mem = 2048
+    nic_hotplug:
+        modprobe_module =
+    block_hotplug:
+        modprobe_module =
+    no unattended_install..floppy_ks
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        cdrom_unattended = images/${os_variant}-${vm_arch_name}/ks.iso
+        syslog_server_proto = udp
+    unattended_install, svirt_install:
+        kernel = images/${os_variant}-${vm_arch_name}/vmlinuz
+        initrd = images/${os_variant}-${vm_arch_name}/initrd.img
+        # ARCH dependent things
+        aarch64:
+            grub_file = /boot/efi/EFI/redhat/grub.cfg
+            install_timeout = 7200
+            kernel_params = "console=ttyAMA0 console=ttyS0 serial"
+        ppc64le:
+            no guest_s3, guest_s4
+            mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
+            netdev_peer_re = "(.*?): .*?\\\s(.*?):"
+            kernel_params = "console=hvc0 serial"
+        s390x:
+            grub_file = /boot/grub/grub.conf
+            install_timeout = 7200
+            kernel = images/${os_variant}-${vm_arch_name}/kernel.img
+            kernel_params = "console=ttysclp0 serial"
+            unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+                # Anaconda hardcodes headless installation of RHEL.7 on s390x
+                vga = none
+                inactivity_watcher = none
+                take_regular_screendumps = no
+        x86_64:
+            grub_file = /boot/grub2/grub.cfg
+            kernel_params = "console=tty0 console=ttyS0"

--- a/shared/cfg/guest-os/Linux/RHEL/8/8.devel.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/8/8.devel.cfg
@@ -1,0 +1,9 @@
+- devel:
+    # Uses defaults set in 8.cfg
+    # Adding x.y versions should only require changing the kickstart
+    # and adding per-arch image shas.
+    image_name = images/${os_variant}devel-${vm_arch_name}
+    unattended_install.cdrom:
+        cdrom_cd1 = isos/linux/RHEL-8-devel-${vm_arch_name}.iso
+    unattended_install, check_block_size.4096_512, check_block_size.512_512, svirt_install:
+        unattended_file = unattended/RHEL-8-devel.ks

--- a/shared/unattended/RHEL-8-devel.ks
+++ b/shared/unattended/RHEL-8-devel.ks
@@ -1,0 +1,111 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+poweroff
+lang en_US.UTF-8
+keyboard us
+network --onboot yes --device eth0 --bootproto dhcp
+rootpw --plaintext 123456
+firstboot --disable
+user --name=test --password=123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+KVM_TEST_LOGGING
+clearpart --all --initlabel
+autopart
+xconfig --startxonboot
+# Additional repositories could be specified in 'kickstart_extra_repos' parameter
+KVM_TEST_REPOS
+
+%packages --ignoremissing
+@base
+@core
+@development
+@additional-devel
+@debugging
+@network-tools
+@gnome-desktop
+@fonts
+@smart-card
+python3-pillow
+python3-six
+python3-pyparsing
+net-tools
+NetworkManager
+dconf
+watchdog
+coreutils
+usbutils
+spice-gtk3
+docbook-utils
+sgml-common
+openjade
+virt-viewer
+pulseaudio-libs-devel
+mesa-libGL-devel
+pygtk2-devel
+libjpeg-turbo-devel
+spice-vdagent
+usbredir
+SDL
+totem
+dmidecode
+alsa-utils
+sg3_utils
+-gnome-initial-setup
+%end
+
+%post
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
+ECHO "OS install is completed"
+case $(arch) in
+    "x86_64")
+        arg="console=tty0 console=ttyS0"
+        ;;
+    "s390x")
+        arg="console=hvc0 serial"
+        ;;
+    "ppc64le")
+        arg="console=hvc0,38400"
+        ;;
+    "aarch64")
+        arg="console=ttyAMA0 console=ttyS0 serial"
+        ;;
+esac
+ECHO "remove rhgb quiet by grubby and add kernel console parameters"
+grubby --remove-args="rhgb quiet" --args="$arg" --update-kernel=$(grubby --default-kernel)
+ECHO "dhclient"
+dhclient
+ECHO "systemctl enable sshd"
+systemctl enable sshd
+ECHO "iptables -F"
+iptables -F
+ECHO "systemctl enable NetworkManager"
+systemctl enable NetworkManager.service
+ECHO "update ifcfg-eth0"
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+ECHO "Disable lock cdrom udev rules"
+sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
+#Workaround for graphical boot as anaconda seems to always instert skipx
+systemctl set-default graphical.target
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-*
+sed -i "s/ONBOOT=no/ONBOOT=yes/" /etc/sysconfig/network-scripts/ifcfg-*
+cat > '/etc/gdm/custom.conf' << EOF
+[daemon]
+AutomaticLogin=test
+AutomaticLoginEnable=True
+EOF
+cat >> '/etc/sudoers' << EOF
+test ALL = NOPASSWD: /sbin/shutdown -r now,/sbin/shutdown -h now
+EOF
+cat >> '/home/test/.bashrc' << EOF
+alias shutdown='sudo shutdown'
+EOF
+ECHO 'Post set up finished'
+%end


### PR DESCRIPTION
This patch adds RHEL.8 variant for following aritectures: x86_64,
ppc64le, aarch64 and s390x. It contains RHEL-8 kickstart file as
well.

Signed-off-by: Radek Duda rduda@redhat.com