### PR TITLE
fix vcpupin_output format got from vcpupin

### DIFF
--- a/virttest/utils_hotplug.py
+++ b/virttest/utils_hotplug.py
@@ -152,7 +152,7 @@ def affinity_from_vcpupin(vm):
     host_cpu_count = utils.total_cpus_count()
     result = virsh.vcpupin(vm.name)
     for vcpu in results_stdout_52lts(result).strip().split('\n')[2:]:
-        vcpupin_output[int(vcpu.split(":")[0])] = vcpu.split(":")[1]
+        vcpupin_output[int(vcpu.split(":")[0])] = vcpu.split(":")[1].strip()
     for vcpu in vcpupin_output:
         vcpupin_affinity[vcpu] = libvirt.cpus_string_to_affinity_list(
             vcpupin_output[vcpu], host_cpu_count)


### PR DESCRIPTION
in affinity_from_vcpupin(), the value of vcpupin_output is got from
command "virsh vcpupin". The right vcpupin result such as " 0-1,3-7 "
will be thought to be a not a supported format without being stripped
as follows:

L0231 DEBUG| Cpus_string= 0-1,3-7 is not a supported format for cpu_list.

Signed-off-by: Jin Li <jil@redhat.com>