### PR TITLE
virttest.utils_logging: introduce QemuProcessTermHandler

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2874,12 +2874,11 @@ class VM(virt_vm.BaseVM):
                 logging.info("Running qemu command (reformatted):\n%s",
                              qemu_command.replace(" -", " \\\n    -"))
                 self.qemu_command = qemu_command
-                self.process = aexpect.run_tail(qemu_command,
-                                                None,
-                                                logging.info,
-                                                "[qemu output] ",
-                                                auto_close=False,
-                                                pass_fds=pass_fds)
+                self.process = aexpect.run_tail(
+                    qemu_command, None, logging.info,
+                    "[%s qemu process output] " % self.name,
+                    auto_close=False, pass_fds=pass_fds
+                    )
 
             logging.info("Created qemu process with parent PID %d",
                          self.process.get_pid())

--- a/virttest/utils_logging.py
+++ b/virttest/utils_logging.py
@@ -1,0 +1,50 @@
+"""logging related classes and functions."""
+import logging
+import re
+
+from virttest import virt_vm
+
+
+class QemuProcessTermHandler(logging.Handler):
+    """
+    This handler sends exception to a queue if qemu process exited with
+    none-zero status.
+    https://github.com/python/cpython/blob/master/Lib/logging/handlers.py
+    """
+
+    def __init__(self, queue):
+        """
+        Initialize an instance, using the passed queue.
+
+        :param queue: passed event queue.
+        :type queue: an instance of queue.Queue.
+        """
+        logging.Handler.__init__(self)
+        self.queue = queue
+
+    def enqueue(self, event):
+        """Enqueue an event, non-blocking."""
+        self.queue.put_nowait(event)
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Writes (VMExitStatusError, VMExitStatusError(vm, status), None) to
+        queue if qemu process is exited with non-zero status.
+        """
+        message = self.format(record)
+        pattern = (r"\[(?P<vm>[a-zA-Z0-9-_]+) qemu process output\]"
+                   r" \(Process terminated with status (?P<exit_status>\d+)\)")
+        match = re.search(pattern, message)
+        if match:
+            vm, exit_status = match.group("vm", "exit_status")
+            if int(exit_status) != 0:
+                try:
+                    self.enqueue(
+                        (virt_vm.VMExitStatusError,
+                         virt_vm.VMExitStatusError(vm, exit_status, message),
+                         None)
+                        )
+                except Exception:
+                    self.handleError(record)

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -29,6 +29,15 @@ class VMError(Exception):
         Exception.__init__(self, *args)
 
 
+class VMExitStatusError(VMError):
+
+    def __init__(self, vm, exit_status, msg=None):
+        msg = msg or "vm %s exited with status %s" % (vm, exit_status)
+        super(VMExitStatusError, self).__init__(msg)
+        self.vm = vm
+        self.exit_status = exit_status
+
+
 class VMCreateError(VMError):
 
     def __init__(self, cmd, status, output):


### PR DESCRIPTION
id: 1219379
1. add virttest.utils_logging.QemuProcessTermHandler to monitor log
records, if qemu output is detected and the exit status is non-zero, a
VMExitStatusError is pushed into the bg error queue.
2. add virttest.virt_vm.VMExitStatusError to represent un-zero exit
error.
3. change the prefix of qemu process logs in virttest.qemu_vm.create to
include the vm name.
4. change virttest.env_process._take_screendump to only push one
VMScreenInactiveError into background error queue instead of flooding
with repeated errors.
5. support new param 'enable_qemu_proc_log_watcher' to enable error
reporting for non-zero exit of qemu process, default off.
6. change avocado_vt.test.VirtTest.verify_background_errors to put all
errors in the bg error queue into logs.

Signed-off-by: lolyu <lolyu@redhat.com>