### PR TITLE
avocado_vt: Allow to run variants filtered by tests.cfg

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -479,12 +479,25 @@ class VirtTestOptionsProcess(object):
 
         if self.options.vt_config:
             cfg = os.path.abspath(self.options.vt_config)
-
-        if not self.options.vt_config:
+            self.cartesian_parser.parse_file(cfg)
+        elif self.options.vt_filter_default_filters:
+            cfg = data_dir.get_backend_cfg_path(self.options.vt_type,
+                                                'tests-shared.cfg')
+            self.cartesian_parser.parse_file(cfg)
+            for arg in ('no_9p_export', 'no_virtio_rng', 'no_pci_assignable',
+                        'smallpages', 'default_bios', 'bridge'):
+                if arg not in self.options.vt_filter_default_filters:
+                    self.cartesian_parser.only_filter(arg)
+            if 'image_backend' not in self.options.vt_filter_default_filters:
+                self.cartesian_parser.only_filter('(image_backend='
+                                                  'filesystem)')
+            if 'multihost' not in self.options.vt_filter_default_filters:
+                self.cartesian_parser.no_filter('multihost')
+        else:
             cfg = data_dir.get_backend_cfg_path(self.options.vt_type,
                                                 'tests.cfg')
+            self.cartesian_parser.parse_file(cfg)
 
-        self.cartesian_parser.parse_file(cfg)
         if self.options.vt_type != 'lvsb':
             self._process_general_options()
 

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -81,6 +81,16 @@ def add_basic_vt_options(parser):
                         dest="vt_only_filter", default="", help="List of space"
                         " separated 'only' filters to be passed to the config "
                         "parser.  Default: '%(default)s'")
+    parser.add_argument("--vt-filter-default-filters", nargs='+',
+                        help="Allows to selectively skip certain default "
+                        "filters. This uses directly 'tests-shared.cfg' and "
+                        "instead of '$provider/tests.cfg' and applies "
+                        "following lists of default filters, unless they are "
+                        "specified as arguments: no_9p_export,no_virtio_rng,"
+                        "no_pci_assignable,smallpages,default_bios,bridge,"
+                        "image_backend,multihost. This can be used to eg. "
+                        "run hugepages tests by filtering 'smallpages' via "
+                        "this option.")
 
 
 def add_qemu_bin_vt_option(parser):


### PR DESCRIPTION
Certain variants are filtered early in tests.cfg that can only be
executed via vt-config. Let's add an "expert" mode where this file is
not parsed and only minimal set of filters is applied.

Note some backend require additional variables and filters, so this
option should only be used after careful evaluation. On the other hand
it allows to perform hugepages, gluster, OVMF or other kinds of
variants usually available only in vt-config world.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>