### PR TITLE
Enable dmesg white list

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -506,6 +506,10 @@ guest_dmesg_ignore = False
 # Whether to dump guest dmesg output to console
 guest_dmesg_dump_console = no
 
+# Guest dmesg white list that need to be ignored in case, multiple item can be seperated by ';'
+# For examples: hardware has not undergone testing by Red Hat and might not be certified;xx" 
+guest_dmesg_white_list = "this hardware has not undergone testing by Red Hat and might not be certified"
+
 # Screendump thread params
 convert_ppm_files_to_png = no
 keep_ppm_files = no

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -985,6 +985,7 @@ class BaseVM(object):
         """
         level = self.params.get("guest_dmesg_level", 3)
         ignore_result = self.params.get("guest_dmesg_ignore", "no") == "yes"
+        guest_dmesg_white_list = self.params.get("guest_dmesg_white_list").split(';')
         serial_login = self.params.get("serial_login", "no") == "yes"
         if serial_login:
             self.session = self.wait_for_serial_login()
@@ -994,7 +995,7 @@ class BaseVM(object):
         return utils_misc.verify_dmesg(dmesg_log_file=dmesg_log_file,
                                        ignore_result=ignore_result,
                                        level_check=level,
-                                       session=self.session)
+                                       session=self.session, dmesg_white_list=guest_dmesg_white_list)
 
     def verify_bsod(self, scrdump_file):
         # For windows guest


### PR DESCRIPTION
In some case, some dmesg from Vm is expected due to specific hardware,
but it still throw exception and fail the case. By adding one white list,
it will ignore exception throw if white list is enabled

Signed-off-by: chunfuwen <chwen@redhat.com>