### PR TITLE
qemu_storage: remove duplicate 'backup_image' step in 'check_image'

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -565,10 +565,6 @@ class QemuImg(storage.QemuImg):
                                               " during image check. No data "
                                               "integrity problem was found "
                                               "though. (%s)" % image_filename)
-
-                # Just handle normal operation
-                if params.get("backup_image", "no") == "yes":
-                    self.backup_image(params, root_dir, "backup", True, True)
         else:
             if not storage.file_exists(params, image_filename):
                 logging.debug("Image file %s not found, skipping check",


### PR DESCRIPTION
'check_image' will backup image only if these two conditions are met:
1. check_image pass('img_check_failed' is null)
2. 'backup_image = yes'

In such conditions, image will be backed up during postprocess too.
so, remove the 'backup_image' step in 'check_image'.

id: 1683557
Signed-off-by: Yanan Fu <yfu@redhat.com>