### PR TITLE
qemu_monitor&qemu_vm : add check_event praramter in balloon() function

### DIFF
--- a/virttest/1
+++ b/virttest/1
@@ -4710,9 +4710,9 @@ class VM(virt_vm.BaseVM):
         cmd = "balloon"
         qmp_event = "BALLOON_CHANGE"
         # Look for BALLOON QMP events
-        if check_event and self.params.get("monitor_type") == "qmp":
+        if check_event:
             # Clear the event list of QMP monitors
-            self.monitor.clear_event(qmp_event)
+            self.clear_event(qmp_event)
             if not utils_misc.wait_for(lambda: self.monitor.get_event(qmp_event), 120):
                 raise QMPEventError(cmd, qmp_event, self.name, self.monitor.name)
             logging.info("%s QMP event received" % qmp_event)

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -2558,16 +2558,9 @@ class QMPMonitor(Monitor):
         :param size: int type values.
         """
         cmd = "balloon"
-        qmp_event = "BALLOON_CHANGE"
         self.verify_supported_cmd(cmd)
-        # Clear the event list of QMP monitors
-        self.clear_event(qmp_event)
         # Send a balloon monitor command
         self.send_args_cmd("%s value=%s" % (cmd, size))
-        # Look for BALLOON QMP events
-        if not utils_misc.wait_for(lambda: self.get_event(qmp_event), 120):
-            raise QMPEventError(cmd, qmp_event, self.vm.name, self.name)
-        logging.info("%s QMP event received" % qmp_event)
 
     def set_migrate_capability(self, state, capability):
         """


### PR DESCRIPTION
Add check_event parameter to decide whether check balloon qmp event, the default value is true.

ID: 1669959

Signed-off-by: Li Jin <lijin@redhat.com>