### PR TITLE
qemu_monitor: add pid of vm to the monitor log file name

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -212,7 +212,10 @@ class Monitor:
         self._passfd = None
         self._supported_cmds = []
         self.debug_log = False
-        self.log_file = "%s-%s.log" % (name, vm.name)
+        vm_pid = vm.get_pid()
+        if vm_pid is None:
+            vm_pid = 'unknown'
+        self.log_file = "%s-%s-pid-%s.log" % (name, vm.name, vm_pid)
         self.open_log_files = {}
 
         try:


### PR DESCRIPTION
Some cases boot vm for not only one time but with same 'vm.name',
if we use 'log_file = "%s-%s.log" % (name, vm.name)", two different
processes will use same file name to save monitor log, and the log
for the first one will be overwritten by the second one.
So, add pid to the log file name to save all of the log.

id: 1685134

Signed-off-by: Yanan Fu <yfu@redhat.com>