### PR TITLE
Alternate for cloning multiple guests

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -592,6 +592,7 @@ netdev_peer_re = "\s{2,}(.*?): .*?\\\s(.*?):"
 #kvm_ver_cmd = "modinfo kvm | grep vermagic | awk '{print $2}'"
 #kvm_userspace_ver_cmd = "grep -q el5 /proc/version && rpm -q kvm || rpm -q qemu-kvm"
 
+qemu_img_command = 'qemu-img create -f qcow2 -o backing_file=%s %s'
 image_clone_command = 'cp --reflink=auto %s %s'
 image_remove_command = 'rm -rf %s'
 

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -534,8 +534,12 @@ class QemuImg(object):
                 force_clone = params.get("force_image_clone", "no")
                 if not os.path.exists(image_fn) or force_clone == "yes":
                     logging.info("Clone master image for vms.")
-                    process.run(params.get("image_clone_command") %
-                                (m_image_fn, image_fn))
+                    if params.get("images_with_backingfile", "no") == "yes":
+                        process.run(params.get("qemu_img_command") %
+                                    (m_image_fn, image_fn))
+                    else:
+                        process.run(params.get("image_clone_command") %
+                                    (m_image_fn, image_fn))
             params["image_name_%s" % vm_name] = vm_image_name
             params["image_name_%s_%s" % (image_name, vm_name)] = vm_image_name
 


### PR DESCRIPTION
Currently, tests using multiple guests use the copy (cp) command to
clone the qcow2 images which consume both time and space. In this patch
I have enabled an alternative to clone qcow2 images using
"qemu-img create --backingfile", the backing file will be the original
qcow2 image. New guests created will be backed by the original qcow2 image,
the new images will record only the differences from backing_file.
Each guest can operate independently.

Patch improves execution time and storage used on the disk to clone.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>