### PR TITLE
utils_time: remove "re.A" which is not supported by python2

### DIFF
--- a/virttest/utils_time.py
+++ b/virttest/utils_time.py
@@ -81,7 +81,7 @@ def verify_timezone_win(session):
         match_pattern = "(?:\(UTC([+|-]\d{2}:\d{2})?)(?:.*\n)(\w+.*(?:\s\w+)*)"
         timezone_sets = []
         for para in re.split("(?:\r?\n){2,}", timezone_list.strip()):
-            result = re.match(match_pattern, para, re.M | re.A)
+            result = re.match(match_pattern, para, re.M)
             if not result:
                 continue
             code, name = result.groups()


### PR DESCRIPTION
1. python2 don't support "re.A"
2. only for python3, "re.A" is used for ASCII-only matching instead of full Unicode matching. We need to match non-ASCII letters here if it have (such as Chinese character)

id: 1677189
Signed-off-by: Yanan Fu <yfu@redhat.com>