### PR TITLE
test_setup: Set param for huge pages to integer

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -597,7 +597,7 @@ class HugePageConfig(object):
         """
         Set number of pages of certain page size under given numa node.
 
-        :param num: string or int, number of pages
+        :param num: int, number of pages
         :param node: string or int, node number
         :param pagesize: string or int, page size in kB
         """
@@ -607,7 +607,7 @@ class HugePageConfig(object):
             raise ValueError("%s page size nr_hugepages file of node %s did "
                              "not exist" % (pagesize, node))
         process.system("echo %s > %s" % (num, node_page_path), shell=True)
-        if int(num) != self.get_node_num_huge_pages(node, pagesize):
+        if num != self.get_node_num_huge_pages(node, pagesize):
             raise ValueError("Cannot set %s hugepages on node %s, please check"
                              " if the node has enough memory" % (num, node))
 
@@ -667,7 +667,7 @@ class HugePageConfig(object):
                       self.target_hugepages)
         if self.target_nodes:
             for node, num in six.iteritems(self.target_node_num):
-                self.set_node_num_huge_pages(num, node, self.hugepage_size)
+                self.set_node_num_huge_pages(int(num), node, self.hugepage_size)
         else:
             self.set_hugepages()
         self.mount_hugepage_fs()


### PR DESCRIPTION
Hello, my hotplug_memory.during.vm_system_reset.hotplug tests are failing due to huge pages parameter is floating point number

```
2019-03-07 10:53:44,050 test_setup       L0656 DEBUG| Number of VMs this test will use: 1
2019-03-07 10:53:44,050 test_setup       L0657 DEBUG| Amount of memory used by each vm: 4096
2019-03-07 10:53:44,050 test_setup       L0659 DEBUG| System setting for large memory page size: 2048
2019-03-07 10:53:44,050 test_setup       L0661 DEBUG| Number of large memory pages needed for this test: 2112
2019-03-07 10:53:44,050 process          L0560 INFO | Running 'echo 2112.0 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages'
2019-03-07 10:53:44,054 process          L0392 DEBUG| [stderr] /bin/sh: line 0: echo: write error: Invalid argument
2019-03-07 10:53:44,055 process          L0648 INFO | Command 'echo 2112.0 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages' finished with 1 after 0.00124001502991s
```
Passing with this change
```
# avocado run type_specific.io-github-autotest-qemu.hotplug_memory.during.vm_system_reset.hotplug
JOB ID     : 64577a1046c52f0310713cdc38a49513411d215b
JOB LOG    : /root/avocado/job-results/job-2019-03-07T13.39-64577a1/job.log
 (1/4) type_specific.io-github-autotest-qemu.hotplug_memory.during.vm_system_reset.hotplug.backend_ram.policy_default.two.default: PASS (88.88 s)
 (2/4) type_specific.io-github-autotest-qemu.hotplug_memory.during.vm_system_reset.hotplug.backend_ram.policy_bind.two.default: PASS (44.63 s)
 (3/4) type_specific.io-github-autotest-qemu.hotplug_memory.during.vm_system_reset.hotplug.backend_file.policy_default.two.default: PASS (52.21 s)
 (4/4) type_specific.io-github-autotest-qemu.hotplug_memory.during.vm_system_reset.hotplug.backend_file.policy_bind.two.default: PASS (55.45 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 247.17 s
#
```