### PR TITLE
monitor qemu process non-zero exit

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -29,6 +29,15 @@ class VMError(Exception):
         Exception.__init__(self, *args)
 
 
+class VMExitStatusError(VMError):
+
+    def __init__(self, vm, exit_status, msg=None):
+        msg = msg or "vm %s exited with non-zero status %s" % (vm, exit_status)
+        super(VMExitStatusError, self).__init__(msg)
+        self.vm = vm
+        self.exit_status = exit_status
+
+
 class VMCreateError(VMError):
 
     def __init__(self, cmd, status, output):


### PR DESCRIPTION
1. virt_vm.VMExitStatusError to represent QEMU process non-zero exit
error.
2. qemu_vm.monitor_qemu_process_term, will be used as callback function
to aexpect.Tail to monitor QEMU non-zero exit.
3. new param "qemu_term_watcher", with value either "log" or "error".
"error" to push an instance of VMExitStatusError to global error bus.
"log" to log this event at level logging.DEBUG.

Signed-off-by: lolyu <lolyu@redhat.com>