### PR TITLE
monitor qemu process non-zero exit

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -718,3 +718,6 @@ Host_Ubuntu.m18.u10:
 # further vcpus if guest have will be left as default
 #
 # vcpu_cputune = "0-2 N 1,3"
+
+# temporarily disable monitor QEMU vm exit status
+vm_monitor_exit_status = no

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -11,6 +11,7 @@ import logging
 import fcntl
 import re
 import random
+import sys
 
 from functools import partial
 
@@ -35,6 +36,7 @@ from virttest import arch
 from virttest import storage
 from virttest import error_context
 from virttest import utils_vsock
+from virttest import error_event
 from virttest.compat_52lts import decode_to_text
 from virttest.qemu_devices import qdevices, qcontainer
 from virttest.qemu_devices.utils import DeviceError
@@ -90,6 +92,24 @@ def clean_tmp_files():
 
 CREATE_LOCK_FILENAME = os.path.join(data_dir.get_tmp_dir(),
                                     'avocado-vt-vm-create.lock')
+
+
+def qemu_proc_term_handler(vm, monitor_exit_status, exit_status):
+    """Monitors qemu process unexpected exit.
+
+    Callback function to detect QEMU process non-zero exit status and
+    push VMExitStatusError to background error bus.
+
+    :param vm: VM name.
+    :param monitor_exit_status: True to push VMUnexpectedExitError instance
+        with calltrace to global error event bus.
+    :param exit_status: QEMU process exit status.
+    """
+    if exit_status != 0 and monitor_exit_status:
+        try:
+            raise virt_vm.VMUnexpectedExitError(vm, exit_status)
+        except virt_vm.VMUnexpectedExitError:
+            error_event.error_events_bus.put(sys.exc_info())
 
 
 class VM(virt_vm.BaseVM):
@@ -2896,12 +2916,14 @@ class VM(virt_vm.BaseVM):
                 logging.info("Running qemu command (reformatted):\n%s",
                              qemu_command.replace(" -", " \\\n    -"))
                 self.qemu_command = qemu_command
-                self.process = aexpect.run_tail(qemu_command,
-                                                None,
-                                                logging.info,
-                                                "[qemu output] ",
-                                                auto_close=False,
-                                                pass_fds=pass_fds)
+                monitor_exit_status = \
+                    params.get("vm_monitor_exit_status", "yes") == "yes"
+                self.process = aexpect.run_tail(
+                    qemu_command,
+                    partial(qemu_proc_term_handler, self.name,
+                            monitor_exit_status),
+                    logging.info, "[qemu output] ",
+                    auto_close=False, pass_fds=pass_fds)
 
             logging.info("Created qemu process with parent PID %d",
                          self.process.get_pid())

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -29,6 +29,24 @@ class VMError(Exception):
         Exception.__init__(self, *args)
 
 
+class VMUnexpectedExitError(VMError):
+
+    def __init__(self, vm, exit_status=None):
+        super(VMUnexpectedExitError, self).__init__(vm, exit_status)
+        self.vm = vm
+        self.exit_status = exit_status
+        self.msg = None
+
+    def __str__(self):
+        if self.msg is None:
+            self.msg = "vm %s is exited unexpectedly%s."
+            if self.exit_status is None:
+                self.msg %= (self.vm, "")
+            else:
+                self.msg %= (self.vm, ", exit status: %s" % self.exit_status)
+        return self.msg
+
+
 class VMCreateError(VMError):
 
     def __init__(self, cmd, status, output):


### PR DESCRIPTION
id: 1219379
1. virt_vm.VMUnexpectedExitError to represent vm's unexpected exit
status error.
2. qemu_vm.qemu_proc_term_handler, will be used as callback function
to aexpect.Tail to monitor QEMU non-zero exit.
3. new param "monitor_exit_status", with value either "on" or "off",
"on" to enable pushing an instance of `VMExitStatusError` to global
error event bus.

Signed-off-by: lolyu <lolyu@redhat.com>