### PR TITLE
qdevices: update verify_hotplug and verify_unplug for Dimm

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -977,8 +977,9 @@ class Dimm(QDevice):
         if "unknown command" in out:       # Old qemu don't have info qtree
             return out
         dev_id_name = self.get_qid()
-        if dev_id_name in str(out):
-            return True
+        for item in out:
+            if item['data']['id'] == dev_id_name:
+                return True
         return False
 
     def verify_unplug(self, dev_type, monitor):
@@ -986,9 +987,10 @@ class Dimm(QDevice):
         if "unknown command" in out:       # Old qemu don't have info qtree
             return out
         dev_id_name = self.get_qid()
-        if dev_id_name not in str(out):
-            return True
-        return False
+        for item in out:
+            if item['data']['id'] == dev_id_name:
+                return False
+        return True
 
 
 class CharDevice(QCustomDevice):


### PR DESCRIPTION
The former method has trouble to check Dimms with similar id, e.g.
"dimm-mem1" and "dimm-mem11", causing verify failure. Fix it by
checking the id in the dict other than string.

ID: 1688108
Signed-off-by: Yumei Huang <yuhuang@redhat.com>