### PR TITLE
set mem lower bound for installation excluding RHEL5&6 guests

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -23,3 +23,7 @@
         s390x:
             kernel_params += " console=ttysclp0 debug ignore_loglevel"
             boot_path = images
+        # mem lower bound excluding rhel5 and rhel6
+        # https://access.redhat.com/solutions/3293511
+        !RHEL.5, RHEL.6:
+            vm_mem_minimum = 2G


### PR DESCRIPTION
id: 1671630 
set mem lower bound as 2G for installation cases excluding RHEL5 and
RHEL6 guests, so tests with mem less than 2G will be canceled due to
inefficient mem.

tests affected:
	"unattended_install"
	"check_block_size.4096_512"
	"check_block_size.512_512"
	"svirt_install"
	"with_installation"

Signed-off-by: lolyu <lolyu@redhat.com>