### PR TITLE
Fixup: utils_stress

### DIFF
--- a/virttest/utils_stress.py
+++ b/virttest/utils_stress.py
@@ -23,6 +23,7 @@ class VMStressEvents():
         self.iterations = int(params.get("stress_itrs", 1))
         self.host_iterations = int(params.get("host_event_itrs", 10))
         self.event_sleep_time = int(params.get("event_sleep_time", 10))
+        self.itr_sleep_time = int(params.get("itr_sleep_time", 10))
         self.current_vcpu = params.get("smp", 32)
         self.max_vcpu = params.get("vcpu_maxcpus", 32)
         self.ignore_status = params.get("ignore_status", "no") == "yes"
@@ -171,6 +172,7 @@ class VMStressEvents():
                         libvirt.delete_local_disk(self.disk_type, disk_name)
             else:
                 raise NotImplementedError
+            time.sleep(self.itr_sleep_time)
 
     def host_stress_event(self, event):
         """
@@ -196,3 +198,4 @@ class VMStressEvents():
                 cpu.online(processor)
             else:
                 raise NotImplementedError
+            time.sleep(self.itr_sleep_time)

--- a/virttest/utils_stress.py
+++ b/virttest/utils_stress.py
@@ -27,8 +27,16 @@ class VMStressEvents():
         self.max_vcpu = params.get("vcpu_maxcpus", 32)
         self.ignore_status = params.get("ignore_status", "no") == "yes"
         self.vms = env.get_all_vms()
-        self.events = params.get("stress_events", "reboot").split(',')
-        self.host_events = params.get("host_stress_events", "").split(',')
+        self.events = params.get("stress_events", "reboot")
+        if self.events:
+            self.events = self.events.split(',')
+        else:
+            self.events = []
+        self.host_events = params.get("host_stress_events", "")
+        if self.host_events:
+            self.host_events = self.host_events.split(',')
+        else:
+            self.host_events = []
         self.threads = []
         self.iface_num = params.get("iface_num", '1')
         self.iface_type = params.get("iface_type", "network")


### PR DESCRIPTION

_*Commit 1:*_
**Fixup: validate stress events param before split**

stress events param string is split to convert as list and
when stress events are given as empty string, it does create
list entry with empty string and leads to thread exception, like
below

 [stderr]   File "..../virttest/utils_stress.py", line 165, in vm_stress_events
 [stderr]   File "..../virttest/utils_stress.py", line 165, in vm_stress_events
 [stderr]   File "..../virttest/utils_stress.py", line 190, in host_stress_event
 [stderr]     raise NotImplementedError
 [stderr]     raise NotImplementedError
 [stderr]     raise NotImplementedError
 [stderr] NotImplementedError
 [stderr] NotImplementedError
 [stderr] NotImplementedError

and let's fix it by validating the stress events param before split.

_*Commit 2:*_
**Introduce sleep between each stress events iteration**

Let's introduce a user defined sleep between each
guest and host stress events, as some events like vm suspend
does not allow to guest stress to run as most of the time vm is
suspended during iterations.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>