### PR TITLE
requirements-travis: Use updated inspektor

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,5 +1,8 @@
 Sphinx==1.3b1
-inspektor==0.4.5
+# inspektor (static and style checks)
+pylint==1.9.3; python_version <= '2.7'
+pylint==2.3.0; python_version >= '3.4'
+inspektor==0.5.2
 autotest>=0.16.2; python_version < '3.0'
 aexpect==1.5.1
 simplejson==3.8.0


### PR DESCRIPTION
The updated inspektor contains fixes for the extra lines printed in the
output and the hardcoded pylint versions should avoid new types of fixes
we are not yet ready for (using the same versions as Avocado)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>