### PR TITLE
utils_net: add bridge name as a param for list_iface func

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1026,10 +1026,14 @@ class Bridge(object):
     def list_br(self):
         return list(self.get_structure().keys())
 
-    def list_iface(self):
+    def list_iface(self, br=None):
         """
         Return all interfaces used by bridge.
+
+        :param br: Name of bridge
         """
+        if br:
+            return self.get_structure()[br]['iface']
         interface_list = []
         for br in self.list_br():
             for (value) in self.get_structure()[br]['iface']:


### PR DESCRIPTION
id: 1688577

In some cases, we need to get all the interfaces in a dedicated
bridge. Add a param 'br' to list_iface.

Signed-off-by: Xiyue Wang <xiywang@redhat.com>