### PR TITLE
channel: Add one attribute

### DIFF
--- a/virttest/libvirt_xml/devices/channel.py
+++ b/virttest/libvirt_xml/devices/channel.py
@@ -11,9 +11,11 @@ from virttest.libvirt_xml.devices.character import CharacterBase
 
 class Channel(CharacterBase):
 
-    __slots__ = ('source', 'target', 'alias', 'address')
+    __slots__ = ('source', 'target', 'alias', 'address', 'type')
 
     def __init__(self, type_name='unix', virsh_instance=base.virsh):
+        accessors.XMLAttribute('type', self, parent_xpath='/',
+                               tag_name='channel', attribute='type')
         accessors.XMLElementDict('source', self, parent_xpath='/',
                                  tag_name='source')
         accessors.XMLElementDict('target', self, parent_xpath='/',


### PR DESCRIPTION
As channel in guest xml can have an attribute 'type', this is to add
this attribute in the class in order to access it.

Signed-off-by: Dan Zheng <dzheng@redhat.com>