### PR TITLE
Add cputune support for virt-install

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -702,3 +702,12 @@ Host_Ubuntu.m18.u10:
 
 # Add vsock device
 # vsocks = vhost_vsock0
+
+# Add cputune/vcpupin to guest during import/install below param
+# can be uncommented and modified to match vm vcpu numbers,
+# below value indicates vcpu0 will be pinned to host cpus 0-2,
+# vcpu1 will not be pinned, will be left default, use "N" inorder to skip any vcpu
+# vcpu2 will be pinned to host cpus 1 and 3,
+# further vcpus if guest have will be left as default
+#
+# vcpu_cputune = "0-2 N 1,3"

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -912,6 +912,22 @@ class VM(virt_vm.BaseVM):
                 logging.warning("boot option is not supported")
             return result.rstrip(',')
 
+        def add_cputune(vcpu_cputune=""):
+            """
+            Add cputune for guest
+            """
+            if not vcpu_cputune:
+                return ""
+            cputune_list = vcpu_cputune.split(" ")
+            item = 0
+            cputune_str = " --cputune "
+            for vcpu, cpulist in enumerate(cputune_list):
+                if "N" in cpulist:
+                    continue
+                cputune_str += "vcpupin%s.cpuset=\"%s\",vcpupin%s.vcpu=\"%s\"," % (item, cpulist, item, vcpu)
+                item += 1
+            return cputune_str.rstrip(",")
+
         # End of command line option wrappers
 
         if name is None:
@@ -1069,6 +1085,9 @@ class VM(virt_vm.BaseVM):
                                             model=params.get('virt_cpu_model', ''),
                                             match=params.get('virt_cpu_match', ''),
                                             vendor=params.get('virt_cpu_vendor', False))
+        cputune_list = params.get("vcpu_cputune", "")
+        if cputune_list:
+            virt_install_cmd += add_cputune(cputune_list)
         # TODO: directory location for vmlinuz/kernel for cdrom install ?
         location = None
         if params.get("medium") == 'url':


### PR DESCRIPTION
Add cputune param support for virt-install, which would
help us to define guest cputune configuration during guest
install/import itself.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>