### PR TITLE
tpm.py: For create tpm dev xml

### DIFF
--- a/virttest/libvirt_xml/devices/librarian.py
+++ b/virttest/libvirt_xml/devices/librarian.py
@@ -13,7 +13,7 @@ DEVICE_TYPES = ['disk', 'filesystem', 'controller', 'lease',
                 'hub', 'graphics', 'video', 'parallel', 'serial', 'console',
                 'channel', 'sound', 'watchdog', 'memballoon', 'rng', 'vsock',
                 'seclabel', 'address', 'emulator', 'panic', 'memory', 'filterref',
-                'iommu']
+                'iommu', 'tpm']
 
 
 def get(name):

--- a/virttest/libvirt_xml/devices/tpm.py
+++ b/virttest/libvirt_xml/devices/tpm.py
@@ -1,0 +1,60 @@
+"""
+tpm device support class(es)
+
+http://libvirt.org/formatdomain.html#elementsTpm
+"""
+
+from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml.devices import base
+
+
+class Tpm(base.UntypedDeviceBase):
+
+    __slots__ = ('tpm_model', 'backend')
+
+    def __init__(self, virsh_instance=base.base.virsh):
+        accessors.XMLAttribute('tpm_model', self,
+                               parent_xpath='/',
+                               tag_name='tpm',
+                               attribute='model')
+        accessors.XMLElementNest('backend', self, parent_xpath='/',
+                                 tag_name='backend', subclass=self.Backend,
+                                 subclass_dargs={
+                                     'virsh_instance': virsh_instance})
+        super(Tpm, self).__init__(
+            device_tag='tpm', virsh_instance=virsh_instance)
+
+    class Backend(base.base.LibvirtXMLBase):
+
+        """
+        Tpm backend xml class.
+
+        Properties:
+
+        type:
+            string. backend type
+        version:
+            string. backend version
+        path:
+            string. device_path
+        """
+        __slots__ = ('backend_type', 'backend_version', 'device_path')
+
+        def __init__(self, virsh_instance=base.base.virsh):
+            accessors.XMLAttribute(property_name="backend_type",
+                                   libvirtxml=self,
+                                   parent_xpath='/',
+                                   tag_name='backend',
+                                   attribute='type')
+            accessors.XMLAttribute(property_name="backend_version",
+                                   libvirtxml=self,
+                                   parent_xpath='/',
+                                   tag_name='backend',
+                                   attribute='version')
+            accessors.XMLAttribute(property_name="device_path",
+                                   libvirtxml=self,
+                                   parent_xpath='/',
+                                   tag_name='device',
+                                   attribute='path')
+            super(self.__class__, self).__init__(virsh_instance=virsh_instance)
+            self.xml = '<backend/>'


### PR DESCRIPTION
tpm.py is used to create tpm device xml, for testing tpm function
in tp-libvirt. Also modify librarian.py to permit use.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>