### PR TITLE
blockdev: Support blockdev

### DIFF
--- a/virttest/qemu_capabilities.py
+++ b/virttest/qemu_capabilities.py
@@ -1,0 +1,49 @@
+"""
+Module for defining the capabilities of vm.
+
+Available class:
+- Flags: Enumerate of the flags of VM capabilities.
+- Capabilities: Representation of VM capabilities.
+"""
+
+from itertools import count
+
+ID_COUNTER = count()
+
+
+def _auto_value():
+    return next(ID_COUNTER)
+
+
+class Flags(object):
+    """ Enumerate the flags of VM capabilities. """
+
+    BLOCKDEV = _auto_value()
+
+
+class Capabilities(object):
+    """ Representation of VM capabilities. """
+
+    def __init__(self):
+        self._flags = set()
+
+    def set_flag(self, flag):
+        """
+        Set the flag.
+
+        :param flag: The name of flag.
+        :type flag: Flags
+        """
+        self._flags.add(flag)
+
+    def clear_flag(self, flag):
+        """
+        Clear the flag.
+
+        :param flag: The name of flag.
+        :type flag: Flags
+        """
+        self._flags.remove(flag)
+
+    def __contains__(self, flag):
+        return flag in self._flags


### PR DESCRIPTION
    qdevices: New classes to support blockdev options
    1. New a class QBlockdevNode to represent the "-blockdev" qemu object.
    2. New classes to represent the type of format blockdev node.
       2.1 QBlockdevFormatNode represents the format blockdev node.
       2.2 QBlockdevFormatQcow2 represents the format qcow2 blockdev node.
       2.3 QBlockdevFormatRaw represents the format raw blockdev node.
       2.4 QBlockdevFormatLuks represents the format lusk blockdev node.
    3. New classes to represent the type of protocol blockdev node.
       3.1 QBlockdevProtocol represents the protocol blockdev node.
       3.2 QBlockdevProtocolFile represents the protocol file blockdev node.
       3.3 QBlockdevProtocolNullCo represents the protocol null-co blockdev
           node.
       3.4 QBlockdevProtocolHostDevice represents the protocol host_device
           blockdev node.
       3.5 QBlockdevProtocolBlkdebug represents the protocol blddebug blockdev
           node.
       3.6 QBlockdevProtocolHostCdrom represents the protocol host_cdrom
           blockdev node.

    qemu_capabilities: Add qemu_capabilities module
    This module is to define the capabilities of vm.
    Available class:
    1. Flags: Enumerate the flags of VM capabilities.
    2. Capabilities: Representation of VM capabilities.

    qcontainer: Support blockdev in class DevContainer
    1. Add a cache_map dict to map the cache option between blockdev and drive
       options.
    2. Add a parameter capabilities to pass the capabilities of vm.
    3. Add a method get_qdev_id that get the qdev id of the specify device.
    4. Add support blockdev that unplug blockdev nodes in the method simple_unplug.
    5. Add support blockdev options in the method images_define_by_variables.

    qemu_vm: Support blockdev in class VM
    1. Add a protected attribute _caps to represents the vm capabilities.
    2. Add a protected method _probe_capabilities to probe whether
       the vm sets the capabilities.
    3. Add a public method check_capability to check whether the given
       capability is set in the vm capabilities.
    4. Add a argument capabilities for calling the qcontainer.DevContainer.
    5. Add support blockdev in the method get_block_old.
    6. Add support blockdev in the method eject_cdrom.
    7. Add support blockdev in the method change_media.

    qemu_monitor: Support blockdev in class Monitor
    1. Add a protected attribute _enable_blockdev.
    2. Add support blockdev in the method _parse_info_block_qmp.

ID: 1543687

Signed-off-by: Yongxue Hong yhong@redhat.com