### PR TITLE
virttest.env_process: Keep vm.instance throughout the workflow

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1496,10 +1496,11 @@ def _take_screendumps(test, params, env):
 
     while True:
         for vm in env.get_all_vms():
-            if vm.instance not in list(counter.keys()):
-                counter[vm.instance] = 0
-            if vm.instance not in list(inactivity.keys()):
-                inactivity[vm.instance] = time.time()
+            instance = vm.instance
+            if instance not in list(counter.keys()):
+                counter[instance] = 0
+            if instance not in list(inactivity.keys()):
+                inactivity[instance] = time.time()
             if not vm.is_alive():
                 continue
             vm_pid = vm.get_pid()
@@ -1525,13 +1526,13 @@ def _take_screendumps(test, params, env):
                 os.makedirs(screendump_dir)
             except OSError:
                 pass
-            counter[vm.instance] += 1
-            filename = "%04d.jpg" % counter[vm.instance]
+            counter[instance] += 1
+            filename = "%04d.jpg" % counter[instance]
             screendump_filename = os.path.join(screendump_dir, filename)
             vm.verify_bsod(screendump_filename)
             image_hash = crypto.hash_file(temp_filename)
             if image_hash in cache:
-                time_inactive = time.time() - inactivity[vm.instance]
+                time_inactive = time.time() - inactivity[instance]
                 if time_inactive > inactivity_treshold:
                     msg = (
                         "%s screen is inactive for more than %d s (%d min)" %
@@ -1543,12 +1544,12 @@ def _take_screendumps(test, params, env):
                         except virt_vm.VMScreenInactiveError:
                             logging.error(msg)
                             # Let's reset the counter
-                            inactivity[vm.instance] = time.time()
+                            inactivity[instance] = time.time()
                             test.background_errors.put(sys.exc_info())
                     elif inactivity_watcher == 'log':
                         logging.debug(msg)
             else:
-                inactivity[vm.instance] = time.time()
+                inactivity[instance] = time.time()
             cache[image_hash] = screendump_filename
             try:
                 try:
@@ -1562,7 +1563,7 @@ def _take_screendumps(test, params, env):
                                     "screendump: %s", vm.name, error_detail)
                     # Decrement the counter as we in fact failed to
                     # produce a converted screendump
-                    counter[vm.instance] -= 1
+                    counter[instance] -= 1
             except NameError:
                 pass
             os.unlink(temp_filename)


### PR DESCRIPTION
We use the vm.instance as a key to our screendump status dict, but the
instance number might change during our evaluation. Let's get the
instance at the beginning of our workflow and keep it everywhere to
avoid assigning to non-existing keys.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>