### PR TITLE
virttest.qemu_monitor: Automatic fallback to "x-" mig capability

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1476,10 +1476,10 @@ class HumanMonitor(Monitor):
 
         :param parameter: the parameter which need to get
         """
-        parameter_info = self.query("migrate_parameters")
-        parameter_info = parameter_info.split(" ")
-        value = parameter_info[parameter_info.index("parameter") + 1]
-        return value
+        for line in self.query("migrate_parameters").splitlines():
+            split = line.split(':', 1)
+            if split[0] == parameter:
+                return split[1].lstrip()
 
     def migrate_start_postcopy(self):
         """

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -195,7 +195,8 @@ class VM(object):
         self.name = name
 
 
-class Monitor:
+class Monitor(object):
+
     """
     Common code for monitor classes.
     """
@@ -676,7 +677,7 @@ class HumanMonitor(Monitor):
                 docstring.
         """
         try:
-            Monitor.__init__(self, vm, name, filename)
+            super(HumanMonitor, self).__init__(vm, name, filename)
 
             self.protocol = "human"
 
@@ -1546,7 +1547,7 @@ class QMPMonitor(Monitor):
                 fails.  See cmd()'s docstring.
         """
         try:
-            Monitor.__init__(self, vm, name, filename)
+            super(QMPMonitor, self).__init__(vm, name, filename)
 
             self.protocol = "qmp"
             self._greeting = None

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3908,7 +3908,7 @@ class VM(virt_vm.BaseVM):
                 for parameter, value in migrate_parameters[0].items():
                     self.monitor.set_migrate_parameter(parameter, value)
                     s = self.monitor.get_migrate_parameter(parameter)
-                    if s != value:
+                    if str(s) != str(value):
                         msg = ("Migrate parameter '%s' should be '%s', "
                                "but actual result is '%s' on source guest"
                                % (parameter, value, s))
@@ -3922,7 +3922,7 @@ class VM(virt_vm.BaseVM):
                 for parameter, value in migrate_parameters[1].items():
                     clone.monitor.set_migrate_parameter(parameter, value)
                     s = clone.monitor.get_migrate_parameter(parameter)
-                    if s != value:
+                    if str(s) != str(value):
                         msg = ("Migrate parameter '%s' should be '%s', "
                                "but actual result is '%s' on destination guest"
                                % (parameter, value, s))

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -123,6 +123,10 @@ class VM(virt_vm.BaseVM):
     # By default we inherit all timeouts from the base VM class except...
     CLOSE_SESSION_TIMEOUT = 30
     MIGRATE_TIMEOUT = 2000
+    #: By default translate standard and experimental (prefixed with x-)
+    #: options according to supported parameters/capabilities. To turn this
+    #: off enable this option
+    DISABLE_AUTO_X_MIG_OPTS = False
 
     def __init__(self, name, params, root_dir, address_cache, state=None):
         """
@@ -3887,14 +3891,18 @@ class VM(virt_vm.BaseVM):
                     "Set migrate capabilities.", logging.info)
                 for key, value in list(migrate_capabilities.items()):
                     state = value == "on"
-                    self.monitor.set_migrate_capability(state, key)
-                    s = self.monitor.get_migrate_capability(key)
+                    self.monitor.set_migrate_capability(state, key,
+                                                        self.DISABLE_AUTO_X_MIG_OPTS)
+                    s = self.monitor.get_migrate_capability(key,
+                                                            self.DISABLE_AUTO_X_MIG_OPTS)
                     if s != state:
                         msg = ("Migrate capability '%s' should be '%s', "
                                "but actual result is '%s'" % (key, state, s))
                         raise exceptions.TestError(msg)
-                    clone.monitor.set_migrate_capability(state, key)
-                    s = clone.monitor.get_migrate_capability(key)
+                    clone.monitor.set_migrate_capability(state, key,
+                                                         self.DISABLE_AUTO_X_MIG_OPTS)
+                    s = clone.monitor.get_migrate_capability(key,
+                                                             self.DISABLE_AUTO_X_MIG_OPTS)
                     if s != state:
                         msg = ("Migrate capability '%s' should be '%s', "
                                "but actual result is '%s' on destination guest"
@@ -3906,10 +3914,12 @@ class VM(virt_vm.BaseVM):
                 logging.info("Set source migrate parameters before migration: "
                              "%s", str(migrate_parameters[0]))
                 for parameter, value in migrate_parameters[0].items():
-                    if parameter == "x-multifd-page-count":
+                    if (parameter == "x-multifd-page-count" and
+                            not self.DISABLE_AUTO_X_MIG_OPTS):
                         try:
                             self.monitor.set_migrate_parameter(parameter,
-                                                               value, True)
+                                                               value, True,
+                                                               self.DISABLE_AUTO_X_MIG_OPTS)
                         except qemu_monitor.MonitorNotSupportedError:
                             # x-multifd-page-count was dropped without
                             # replacement, ignore this param
@@ -3918,8 +3928,11 @@ class VM(virt_vm.BaseVM):
                                          "newer qemu, not setting it.")
                             continue
                     else:
-                        self.monitor.set_migrate_parameter(parameter, value)
-                    s = self.monitor.get_migrate_parameter(parameter)
+                        self.monitor.set_migrate_parameter(parameter, value,
+                                                           False,
+                                                           self.DISABLE_AUTO_X_MIG_OPTS)
+                    s = self.monitor.get_migrate_parameter(parameter,
+                                                           self.DISABLE_AUTO_X_MIG_OPTS)
                     if str(s) != str(value):
                         msg = ("Migrate parameter '%s' should be '%s', "
                                "but actual result is '%s' on source guest"
@@ -3932,10 +3945,12 @@ class VM(virt_vm.BaseVM):
                              "%s", str(migrate_parameters[1]))
                 # target qemu migration parameters configuration
                 for parameter, value in migrate_parameters[1].items():
-                    if parameter == "x-multifd-page-count":
+                    if (parameter == "x-multifd-page-count" and
+                            not self.DISABLE_AUTO_X_MIG_OPTS):
                         try:
                             clone.monitor.set_migrate_parameter(parameter,
-                                                                value, True)
+                                                                value, True,
+                                                                False)
                         except qemu_monitor.MonitorNotSupportedError:
                             logging.warn("Parameter x-multifd-page-count "
                                          "not supported on dst, probably "
@@ -3944,8 +3959,11 @@ class VM(virt_vm.BaseVM):
                             # replacement, ignore this param
                             continue
                     else:
-                        clone.monitor.set_migrate_parameter(parameter, value)
-                    s = clone.monitor.get_migrate_parameter(parameter)
+                        clone.monitor.set_migrate_parameter(parameter, value,
+                                                            False,
+                                                            self.DISABLE_AUTO_X_MIG_OPTS)
+                    s = clone.monitor.get_migrate_parameter(parameter,
+                                                            self.DISABLE_AUTO_X_MIG_OPTS)
                     if str(s) != str(value):
                         msg = ("Migrate parameter '%s' should be '%s', "
                                "but actual result is '%s' on destination guest"


### PR DESCRIPTION
In order to support various qemu versions, let's always try using "x-"
or non "x-" variant of the migration capability.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>