### PR TITLE
utils_net: support shell command for param netdst_nic

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2831,6 +2831,12 @@ class ParamsNet(VMNet):
                 except IndexError:
                     existing_value = None
                 nic_dict[propertea] = nic_params.get(propertea, existing_value)
+                if propertea == "netdst" and "shell:" in nic_dict[propertea]:
+                    nic_dict[propertea] = process.getoutput(
+                        nic_dict[propertea].split(':', 1)[1])
+                    if not nic_dict[propertea]:
+                        raise exceptions.TestError(
+                            "netdst is null, please check the shell command")
             result_list.append(nic_dict)
         VMNet.__init__(self, self.container_class, result_list)
 


### PR DESCRIPTION
In different kernel, the network interface will be unpredictable
changed, wen can use shell command to get the network interface
name for param netdst_nic

Signed-off-by: Wenli Quan <wquan@redhat.com>

id: 1692276