### PR TITLE
vsock: Correct parent bus issue

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1839,7 +1839,7 @@ class QPCIEBus(QPCIBus):
         :param device: the QBaseDevice object
         :return: bool value for directly plug or not.
         """
-        pcie_devices = ["virtio-net-pci", "virtio-blk-pci", "vhost-vsock-pci"
+        pcie_devices = ["virtio-net-pci", "virtio-blk-pci", "vhost-vsock-pci",
                         "virtio-scsi-pci", "virtio-balloon-pci",
                         "virtio-serial-pci", "virtio-rng-pci",
                         "e1000e", "virtio-gpu-device", "qemu-xhci"]

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1912,7 +1912,8 @@ class VM(virt_vm.BaseVM):
                 elif params.get('machine_type').startswith("s390"):
                     dev_vsock = QDevice("vhost-vsock-ccw", vsock_params)
                 else:
-                    dev_vsock = QDevice('vhost-vsock-pci', vsock_params)
+                    dev_vsock = QDevice('vhost-vsock-pci', vsock_params,
+                                        parent_bus=pci_bus)
                 devices.insert(dev_vsock)
                 min_cid = guest_cid + 1
 


### PR DESCRIPTION
1.  qemu_vm: add parent_bus for vsock pci device
    It will not have bus automatically, so no address being issued,
     therefor will hit error when add extra pcie-root-port for pcie bus

2.  qdevices: add missed comma in pcie_devices list
    Miss a ',' after "vhost-vsock-pci", which will lead all components
    after it be treated as pcie device, be plugged into pcie.0 directly

id: 1694901
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>