### PR TITLE
Support -it vddk for virt-v2v

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -156,7 +156,8 @@ def handle_prompts(session, username, password, prompt, timeout=10,
                  r"[Cc]onnection.*closed", r"[Cc]onnection.*refused",
                  r"[Pp]lease wait", r"[Ww]arning", r"[Ee]nter.*username",
                  r"[Ee]nter.*password", r"[Cc]onnection timed out", prompt,
-                 r"Escape character is.*"],
+                 r"Escape character is.*",
+                 r"Command>"],
                 timeout=timeout, internal_timeout=0.5)
             output += text
             if match == 0:  # "Are you sure you want to continue connecting"
@@ -211,6 +212,15 @@ def handle_prompts(session, username, password, prompt, timeout=10,
             elif match == 13:  # console prompt
                 logging.debug("Got console prompt, send return to show login")
                 session.sendline()
+            elif match == 14:  # VMware vCenter command prompt
+                # Some old vsphere version (e.x. 6.0.0) needs to enable first.
+                cmd = 'shell.set --enabled True'
+                logging.debug(
+                    "Got VMware VCenter prompt, send '%s' to enable shell first" % cmd)
+                session.sendline(cmd)
+                logging.debug(
+                    "Got VMware VCenter prompt, send 'shell' to launch bash")
+                session.sendline('shell')
         except aexpect.ExpectTimeoutError as e:
             # sometimes, linux kernel print some message to console
             # the message maybe impact match login pattern, so send


### PR DESCRIPTION
1) Handle interactive operation with VMware Vcenter to lauch 'Bash'
2) Autoset vddk_libdir and vddk_thumbprint if not set by user
3) Use user's value of vddk_libdir and vddk_thumbprint if set
4) Autoclean mount records after v2v command finishes

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>