### PR TITLE
utils_test: fix the return format of `get_loss_ratio()`

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1566,7 +1566,7 @@ def get_loss_ratio(output):
     :param output: Ping output.
     """
     try:
-        return int(re.findall('(\d+)%.*loss', output)[0])
+        return float(re.findall(r'(\d*\.?\d+)%.*loss', output)[0])
     except IndexError:
         logging.warn("Invaild output of ping command: %s" % output)
     return -1


### PR DESCRIPTION
Packet loss ratio may not be an integer, modify the return format of
`get_loss_ratio()` to handle it.

ID: 1696100
Signed-off-by: Yihuang Yu <yihyu@redhat.com>