### PR TITLE
Support VMX uri with vddk

### DIFF
--- a/backends/v2v/cfg/convert_source.cfg
+++ b/backends/v2v/cfg/convert_source.cfg
@@ -12,6 +12,7 @@ variants:
         # ESX host and dc info
         hypervisor = esx
         vpx_password = VPX_PASSWORD_V2V_EXAMPLE
+        esxi_password = ESXI_PASSWORD_V2V_EXAMPLE
         variants:
             - esx_55:
                 vpx_hostname = VPX_55_HOSTNAME_V2V_EXAMPLE


### PR DESCRIPTION
Support convertion vmware guest by esx:// with vddk

Example:
virt-v2v -ic esx://root@xxx/?no_verify=1 -it vddk xxx

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>