### PR TITLE
qemu_vm: Delete all guest ports correctly when destroying guest

### DIFF
--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -299,6 +299,10 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
 
     def del_port(self, br_name, port_name):
         self.ovs_vsctl(["del-port", br_name, port_name])
+        if utils_misc.wait_for(lambda: port_name in self.list_ports(br_name),
+                               timeout=5, first=0.5):
+            logging.warning("Failed to delete %s from %s" % (port_name,
+                                                             br_name))
 
     def add_port_tag(self, port_name, tag):
         self.ovs_vsctl(["set", "Port", port_name, "tag=%s" % tag])

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2408,10 +2408,10 @@ class VM(virt_vm.BaseVM):
                 if nic.vhostfds:
                     for i in nic.vhostfds.split(':'):
                         os.close(int(i))
-                if nic.ifname and nic.ifname not in utils_net.get_net_if():
-                    _, br_name = utils_net.find_current_bridge(nic.ifname)
+                if nic.ifname:
+                    br_mgr, br_name = utils_net.find_current_bridge(nic.ifname)
                     if br_name == nic.netdst:
-                        utils_net.del_from_bridge(nic.ifname, nic.netdst)
+                        br_mgr.del_port(nic.netdst, nic.ifname)
         except TypeError:
             pass
 
@@ -2758,9 +2758,10 @@ class VM(virt_vm.BaseVM):
 
                     if nic.ifname in utils_net.get_net_if():
                         self.virtnet.generate_ifname(nic.nic_name)
-                    elif (utils_net.find_current_bridge(nic.ifname)[1] ==
-                          nic.netdst):
-                        utils_net.del_from_bridge(nic.ifname, nic.netdst)
+                    else:
+                        br_mgr, br_name = utils_net.find_current_bridge(nic.ifname)
+                        if br_name == nic.netdst:
+                            br_mgr.del_port(nic.netdst, nic.ifname)
 
                     if nic.nettype in ['bridge', 'network', 'macvtap']:
                         self._nic_tap_add_helper(nic)
@@ -3199,10 +3200,10 @@ class VM(virt_vm.BaseVM):
             if nic.nettype == 'macvtap':
                 tap = utils_net.Macvtap(nic.ifname)
                 tap.delete()
-            elif nic.ifname and nic.ifname not in utils_net.get_net_if():
-                _, br_name = utils_net.find_current_bridge(nic.ifname)
+            elif nic.ifname:
+                br_mgr, br_name = utils_net.find_current_bridge(nic.ifname)
                 if br_name == nic.netdst:
-                    utils_net.del_from_bridge(nic.ifname, nic.netdst)
+                    br_mgr.del_port(nic.netdst, nic.ifname)
 
     def destroy(self, gracefully=True, free_mac_addresses=True):
         """

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1128,6 +1128,10 @@ class Bridge(object):
         """
         try:
             self._br_ioctl(arch.SIOCBRDELIF, brname, ifname)
+            if utils_misc.wait_for(lambda: ifname in self.list_iface(brname),
+                                   timeout=5, first=0.5):
+                logging.warning("Failed to delete %s from %s" % (ifname,
+                                                                 brname))
         except IOError as details:
             raise BRDelIfError(ifname, brname, details)
 


### PR DESCRIPTION
The current method sometimes cannot delete all ports of guest
accurately. Such as openvswitch backend, ovs takes some time to process
ports to be deleted. So we should not check the port status via 'ip
link'(get_net_if), we need to check if it exists in the bridge to decide
whether to delete it.

ID: 1701815
Signed-off-by: Yihuang Yu <yihyu@redhat.com>