### PR TITLE
test_setup and env_process: Track and handle host surplus hugepage

### DIFF
--- a/virttest/staging/utils_memory.py
+++ b/virttest/staging/utils_memory.py
@@ -141,6 +141,14 @@ def get_num_huge_pages_rsvd(session=None):
     return read_from_meminfo('HugePages_Rsvd', session=session)
 
 
+def get_num_huge_pages_surp(session=None):
+    """
+    Method to get surplus hugepage pages
+    :param session: ShellSession Object of remote host / guest
+    """
+    return read_from_meminfo('HugePages_Surp', session=session)
+
+
 def get_num_anon_huge_pages(pid=0, session=None):
     """
     Method to get total no of anon hugepages


### PR DESCRIPTION
1. Add a function to get total surplus hugepages.
2. Add a param to set number of overcommit hugepages, and we can test it in the future.
3. Handle existing surplus hugepages, make `self.target_hugepages` correct.
4. Tracking existing huge page before and after testing

ID: 1701853
Signed-off-by: Yihuang Yu <yihyu@redhat.com>
