### PR TITLE
Avoid configure firewalld in ubuntu

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -846,6 +846,10 @@ def preprocess(test, params, env):
                 firewalld.start()
                 if not firewalld.status():
                     test.log.warning('Failed to start firewalld')
+
+        if distro.detect().name == 'Ubuntu':
+            params['firewalld_dhcp_workaround'] = "no"
+
         # Workaround know issue where firewall blocks dhcp from guest
         # through virbr0
         if params.get('firewalld_dhcp_workaround', "no") == "yes":

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -424,7 +424,8 @@ class NFSClient(object):
             self.mkdir_mount_remote = True
 
         if self.params.get("firewall_to_permit_nfs", "yes") == "yes":
-            self.firewall_to_permit_nfs()
+            if distro.detect().name != "Ubuntu":
+                self.firewall_to_permit_nfs()
 
         self.mount_src = "%s:%s" % (self.nfs_server_ip, self.mount_src)
         logging.debug("Mount %s to %s" % (self.mount_src, self.mount_dir))

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1365,7 +1365,7 @@ class MigrationTest(object):
         :param cleanup: if True revert back to default setting, used to cleanup
         :param ports: ports used for allowing migration
         """
-        use_firewall_cmd = True
+        use_firewall_cmd = distro.detect().name != "Ubuntu"
         try:
             utils_path.find_command("firewall-cmd")
         except utils_path.CmdNotFoundError:


### PR DESCRIPTION
Ubuntu doesn't support firewalld, so avoid using firewall-cmd and
configure/install firewalld to prevent test/framework to break
in ubuntu

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>