### PR TITLE
RHEL.ks: use text mode in kickstart for unattended install

### DIFF
--- a/shared/unattended/RHEL-7-devel.ks
+++ b/shared/unattended/RHEL-7-devel.ks
@@ -1,6 +1,6 @@
 install
 KVM_TEST_MEDIUM
-GRAPHICAL_OR_TEXT
+text
 poweroff
 lang en_US.UTF-8
 keyboard us

--- a/shared/unattended/RHEL-7-series.ks
+++ b/shared/unattended/RHEL-7-series.ks
@@ -1,6 +1,6 @@
 install
 KVM_TEST_MEDIUM
-GRAPHICAL_OR_TEXT
+text
 poweroff
 lang en_US.UTF-8
 keyboard us

--- a/shared/unattended/RHEL-8-devel.ks
+++ b/shared/unattended/RHEL-8-devel.ks
@@ -1,6 +1,6 @@
 install
 KVM_TEST_MEDIUM
-GRAPHICAL_OR_TEXT
+text
 poweroff
 lang en_US.UTF-8
 keyboard us


### PR DESCRIPTION
Installation fails to start by prompting for text/graphical
input during unattended install test, use text mode in kickstart
file for the test for proceed.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>