### PR TITLE
Log warning for unreadable serial console in case of IOError

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -931,7 +931,7 @@ class BaseVM(object):
         panic_re = "|".join(panic_re)
         if self.serial_console:
             data = self.serial_console.get_output()
-            if not data:
+            if data is None:
                 logging.warn("Unable to read serial console")
                 return
             match = re.search(panic_re, data, re.DOTALL | re.MULTILINE | re.I)
@@ -991,7 +991,7 @@ class BaseVM(object):
         """
         if self.serial_console is not None:
             data = self.serial_console.get_output()
-            if not data:
+            if data is None:
                 logging.warn("Unable to read serial console")
                 return
             match = re.findall(r".*trap invalid opcode.*\n", data,


### PR DESCRIPTION
In some cases the file is open just fine but the serial console
prints no output. Not being able to find kernel panic or other
messages in an empty output should be equivalent to good output
or otherwise this will spawn lots of warnings throughout the run.

For instance, a recent check for these warnings for our runs got:

grep -r "Unable to read serial" * |wc -l
-> 9774

Empty output is not the same as no output.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>