### PR TITLE
DevContainer.str_bus_long: wrong header string

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -373,7 +373,7 @@ class DevContainer(object):
 
     def str_bus_long(self):
         """ Long representation of all buses """
-        out = "Devices of %s:\n  " % self.vmname
+        out = "Buses of %s:\n  " % self.vmname
         for bus in self.__buses:
             out += bus.str_long().replace('\n', '\n  ')
         return out[:-3]


### PR DESCRIPTION
the header string should be "Buses of" instead of "Devices of".

Signed-off-by: lolyu <lolyu@redhat.com>