### PR TITLE
SLES: Make SLES.11 use legacy virtio

### DIFF
--- a/shared/cfg/guest-os/Linux/SLES.cfg
+++ b/shared/cfg/guest-os/Linux/SLES.cfg
@@ -17,3 +17,6 @@
     block_hotplug, pci_hotplug:
         modprobe_module = acpiphp
         no block_scsi
+    11:
+        virtio_dev_disable_legacy = off
+        virtio_dev_disable_modern = on


### PR DESCRIPTION
SLES.11 doesn't support virtio1.0, make it use legacy mode.

id: 1704547
Signed-off-by: Yanan Fu <yfu@redhat.com>