### PR TITLE
Fixup: Emulatorpin does not need to iterate for vcpus

### DIFF
--- a/virttest/utils_stress.py
+++ b/virttest/utils_stress.py
@@ -88,13 +88,11 @@ class VMStressEvents():
                     if not self.ignore_status:
                         libvirt.check_exit_status(result)
             elif "emulatorpin" in event:
-                for vcpu in range(int(self.current_vcpu)):
-                    result = virsh.emulatorpin(vm.name,
-                                               random.choice(
-                                                   self.host_cpu_list),
-                                               **dargs)
-                    if not self.ignore_status:
-                        libvirt.check_exit_status(result)
+                result = virsh.emulatorpin(vm.name,
+                                           random.choice(self.host_cpu_list),
+                                           **dargs)
+                if not self.ignore_status:
+                    libvirt.check_exit_status(result)
             elif "suspend" in event:
                 result = virsh.suspend(vm.name, **dargs)
                 if not self.ignore_status:


### PR DESCRIPTION
Emulator pin does not depend on vcpu number, and it
has to be assigned once per Guest VM, let's fix it.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>