### PR TITLE
RFC: Fixup: Test hung

### DIFF
--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -200,7 +200,7 @@ class Sniffer(object):
         if self._remote_opts:
             self._start_remote()
         else:
-            self._process = aexpect.run_tail(
+            self._process = aexpect.run_bg(
                 command=cmd,
                 output_func=self._output_logger_handler)
 


### PR DESCRIPTION
Seeing tp-libvirt test cases runs in RHEL 8 host hung at the
preprocess stage itself, rootcaused the issue seems
to be in the below place

	env.start_ip_sniffing(params)
		self._sniffer.start()
			aexpect.run_tail(...) --> indefinitely hung here

Changing it to aexpect.run_bg(...) seems to be working fine,

 (1/1) powerkvm-qemu.reboot: PASS (132.85 s)

But have looked around change of code, no new change in any of
the places.

Avocado-vt version: 69.0+(6579028d)
Aexpect version: 1.5.1

Though this patch fixes the issue, need to understand better
why suddenly, we started seeing this issue and is this proper
fix.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>