### PR TITLE
qemu_vm: Find port sequentially

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2821,7 +2821,7 @@ class VM(virt_vm.BaseVM):
 
             # Find available VNC port, if needed
             if params.get("display") == "vnc":
-                self.vnc_port = utils_misc.find_free_port(5900, 6900)
+                self.vnc_port = utils_misc.find_free_port(5900, 6900, sequent=True)
 
             # Find random UUID if specified 'uuid = random' in config file
             if params.get("uuid") == "random":


### PR DESCRIPTION
To find port sequentially is in order to know of the number
of running guests on the host, so it could help us to debug some issues,
such as checking whether the environment of the host was pure, there are not
others non-automation guests were running at that time if the host was released.


ID: 1712230
Signed-off-by: Yongxue Hong <yhong@redhat.com>