### PR TITLE
utils_net: `arping_cmd` can timeout causing TestWarn

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3175,7 +3175,7 @@ def verify_ip_address_ownership(ip, macs, timeout=60.0, devs=None,
             arping_cmd = "%s -f -c3 -w%d -I %s %s" % (arping_bin, int(timeout),
                                                       dev, ip)
         try:
-            o = func(arping_cmd, timeout=timeout, **dargs)
+            o = func(arping_cmd, **dargs)
         except (process.CmdError, aexpect.ShellError):
             return False
         return bool(regex.search(o))


### PR DESCRIPTION
Test can cause timeout `process.getoutput()` for `arping_cmd` and
framework tries to kill it with signal.SIGKILL and switches on
TestWarn. Instead wait till the `arping_cmd` completes to finish
the test gracefully.

Issue-Id: https://github.com/avocado-framework/avocado-vt/issues/2089
Reported-by: Yanan Fu <yfu@redhat.com>
Suggested-by: Yanan Fu <yfu@redhat.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>