### PR TITLE
virttest: Resolve the circular import between utils modules

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -147,10 +147,10 @@ def umount(src, dst, fstype=None, verbose=False, session=None):
     """
     mounted = is_mount(src, dst, fstype, verbose=verbose, session=session)
     if mounted:
-        from . import utils_package
+        from virttest.utils_package import package_install
         package = "psmisc"
         # check package is available, if not try installing it
-        if not utils_package.package_install(package):
+        if not package_install(package):
             logging.error("%s is not available/installed for fuser", package)
         fuser_cmd = "fuser -km %s" % dst
         umount_cmd = "umount %s" % dst

--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -8,7 +8,7 @@ from avocado.core import exceptions
 from avocado.utils import software_manager
 from six import string_types
 
-from virttest import utils_misc
+from virttest.utils_misc import wait_for
 from virttest import vt_console
 
 PACKAGE_MANAGERS = ['apt-get',
@@ -219,7 +219,7 @@ def package_install(pkg, session=None, timeout=300):
     :return: True if all packages installed, False if any error
     """
     mgr = package_manager(session, pkg)
-    return utils_misc.wait_for(mgr.install, timeout)
+    return wait_for(mgr.install, timeout)
 
 
 def package_remove(pkg, session=None, timeout=300):
@@ -232,4 +232,4 @@ def package_remove(pkg, session=None, timeout=300):
     :return: True if all packages removed, False if any error
     """
     mgr = package_manager(session, pkg)
-    return utils_misc.wait_for(mgr.remove, timeout)
+    return wait_for(mgr.remove, timeout)


### PR DESCRIPTION
There is circular import between utils_disk, utils_misc and
utils_package, resolve it by replacing importing modules with
importing functions

id: 1714428
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>