### PR TITLE
virttest.qemu_vm: Support VGA on non-default s390x machine_type

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1177,7 +1177,7 @@ class VM(virt_vm.BaseVM):
                 if vga == 'virtio' and not devices.has_device(vga_dev):
                     # Arm doesn't usually supports 'virtio-vga'
                     vga_dev = 'virtio-gpu-pci'
-            elif machine_type == 's390-ccw-virtio':
+            elif machine_type.startswith('s390-ccw-virtio'):
                 if vga == 'virtio':
                     vga_dev = 'virtio-gpu-ccw'
                     parent_bus = None


### PR DESCRIPTION
Currently we require full-match on s390x machine type, but it is
possible to use different machine types requiring the same hacks (eg.
s390-ccw-virtio-2.6). Let's use startwith.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>