### PR TITLE
virttest.qemu_vm: Improve migration postprocess on failure

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4305,6 +4305,7 @@ class VM(virt_vm.BaseVM):
             # If we're doing remote migration and it's completed successfully,
             # self points to a dead VM object
             if not not_wait_for_migration:
+                clone.destroy(gracefully=False)
                 if self.is_alive() and self.is_paused():
                     # For short period of time the status can be "inmigrate"
                     # for example when using external program
@@ -4321,7 +4322,6 @@ class VM(virt_vm.BaseVM):
                     except qemu_monitor.MonitorError:
                         utils_misc.log_last_traceback('Fail to resume qemu '
                                                       'after migration:')
-                clone.destroy(gracefully=False)
                 if env:
                     env.unregister_vm("%s_clone" % self.name)
 


### PR DESCRIPTION
In case of post-copy migration the VM ends-up in "postcopy-paused"
state, that is a special case of the "paused" state. Our finally block
in migration function resumes the VM in such case which results in
exception as it is not possible to resume such VM.

This patch ignores monitor exceptions for the "resume" operation. This
should be fairly safe as different status would raise a different
exception (still we can fail to send "cont" for a different reason, but
then we should fail to interact with the VM and detect the failure
later)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>