### PR TITLE
unattended_install: Avoid crash on missing unattended file

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1296,14 +1296,18 @@ def run(test, params, env):
                 # Bug `reboot` param from the kickstart is not actually restarts
                 # the VM instead it shutsoff this is temporary workaround
                 # for the test to proceed
-                if "reboot" in open(unattended_install_config.unattended_file).read():
-                    if kickstart_reboot_bug and not vm.is_alive():
+                if unattended_install_config.unattended_file:
+                    with open(unattended_install_config.unattended_file) as unattended_fd:
+                        reboot_in_unattended = "reboot" in unattended_fd.read()
+                    if (reboot_in_unattended and kickstart_reboot_bug and not
+                            vm.is_alive()):
                         try:
                             vm.start()
                             break
                         except:
-                            logging.warn("Failed to start unattended install image "
-                                         "workaround reboot kickstart parameter bug")
+                            logging.warn("Failed to start unattended install "
+                                         "image workaround reboot kickstart "
+                                         "parameter bug")
 
                 # Print out the original exception before copying images.
                 logging.error(e)


### PR DESCRIPTION
Some OSes (JeOS) don't have unattended file associated and attempt to
open "None" crashes. Let's not apply the workaround in such case.

While on it also correctly open/close the unattended_file via with.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>