### PR TITLE
Optional vm persistence

### DIFF
--- a/avocado_vt/conf.d/vt.conf
+++ b/avocado_vt/conf.d/vt.conf
@@ -4,11 +4,15 @@ backup_image_before_test = True
 # Restore image after testing (if backup present)
 restore_image_after_test = True
 # Keep guest running between tests (faster, but unsafe)
-keep_guest_running=False
+keep_guest_running = False
 
 [vt.common]
 # Data dir path. If none specified, the default virt-test data dir will be used
 data_dir =
+# Make the temporary dir path persistent across jobs if needed.
+# By default the data in the temporary directory will be wiped after each test
+# in some cases and after each job in others.
+tmp_dir =
 # Enable only type specific tests. Shared tests will not be tested
 type_specific_only = False
 # RAM dedicated to the main VM

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -126,6 +126,7 @@ class VirtTestLoader(loader.TestLoader):
         _add_if_not_exist('vt_log_level', 'debug')
         _add_if_not_exist('vt_console_level', 'debug')
         _add_if_not_exist('vt_datadir', data_dir.get_data_dir())
+        _add_if_not_exist('vt_tmp_dir', '')
         _add_if_not_exist('vt_config', None)
         _add_if_not_exist('vt_arch', None)
         _add_if_not_exist('vt_machine_type', None)

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -76,6 +76,8 @@ class VirtTestOptionsProcess(object):
         # common section
         self.options.vt_data_dir = settings.get_value(
             'vt.common', 'data_dir', default=None)
+        self.options.vt_tmp_dir = settings.get_value(
+            'vt.common', 'tmp_dir', default='')
         self.options.vt_type_specific = settings.get_value(
             'vt.common', 'type_specific_only', key_type=bool,
             default=False)

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -395,17 +395,14 @@ class VirtTest(test.Test):
             test_modules[t_type] = imp.load_module(t_type, f, p, d)
             f.close()
 
-        # TODO: the environment file is deprecated code, and should be removed
-        # in future versions. Right now, it's being created on an Avocado temp
-        # dir that is only persisted during the runtime of one job, which is
-        # different from the original idea of the environment file (which was
-        # persist information accross virt-test/avocado-vt job runs)
+        # Open the environment file
         env_filename = os.path.join(data_dir.get_tmp_dir(),
                                     params.get("env", "env"))
         env = utils_env.Env(env_filename, self.env_version)
-        self.runner_queue.put({"func_at_exit": cleanup_env,
-                               "args": (env_filename, self.env_version),
-                               "once": True})
+        if params.get_boolean("job_env_cleanup", "yes"):
+            self.runner_queue.put({"func_at_exit": cleanup_env,
+                                   "args": (env_filename, self.env_version),
+                                   "once": True})
 
         test_passed = False
         t_type = None

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 
 from avocado.core import data_dir
+from avocado.core.settings import settings
 from avocado.utils import distro
 from avocado.utils import path as utils_path
 
@@ -208,6 +209,10 @@ def get_tmp_dir(public=True):
 
     :param public: If public for all users' access
     """
+    persistent_dir = settings.get_value('vt.common', 'tmp_dir',
+                                        default="")
+    if persistent_dir != "":
+        return persistent_dir
     tmp_dir = None
     # apparmor deny /tmp/* /var/tmp/* and cause failure across tests
     # it is better to handle here


### PR DESCRIPTION
Adding optional vm persistence throughout tests/jobs is an old behavior in virt-test that seems to be missing in avocado-vt but is highly appreciated when it comes to improved performance due to no vm rebooting as well as setup reuse through qcow2 vm snapshots. The only way this can be possible is if the vms are not immediately destroyed and the environment/sockets/address_pool cleaned up, all in turn requiring a persistent temporary location that is not regenerated for each job. This branch is doing exactly this, keeping the cleaner (but less efficient) default behavior while making such new behavior optional.