### PR TITLE
Fixup: Avoid skipping postprocess due to failure in verify_dmesg

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1124,7 +1124,7 @@ def postprocess(test, params, env):
                 guest_dmesg_log_file += ".%s" % vm.name
             try:
                 vm.verify_dmesg(dmesg_log_file=guest_dmesg_log_file)
-            except exceptions.TestFail as details:
+            except Exception as details:
                 err += ("\n: Guest %s dmesg verification failed: %s"
                         % (vm.name, details))
 


### PR DESCRIPTION
vm.verify_dmesg() method in postprocess was catching only
test fail exception and rest it slipped through the postprocess
try block, resulting in tests not executing rest of postprocess
steps like cleaning up the VMs in environment, leaving further
tests to fail, this patch address it by adding vm.verify_dmesg()
under try block that covers all exceptions.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>