### PR TITLE
Fix delete port problem on linux bridge backend

### DIFF
--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -299,10 +299,6 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
 
     def del_port(self, br_name, port_name):
         self.ovs_vsctl(["del-port", br_name, port_name])
-        if utils_misc.wait_for(lambda: port_name in self.list_ports(br_name),
-                               timeout=5, first=0.5):
-            logging.warning("Failed to delete %s from %s" % (port_name,
-                                                             br_name))
 
     def add_port_tag(self, port_name, tag):
         self.ovs_vsctl(["set", "Port", port_name, "tag=%s" % tag])

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -12,6 +12,7 @@ import fcntl
 import re
 import random
 import sys
+import math
 
 from functools import partial
 
@@ -2262,6 +2263,11 @@ class VM(virt_vm.BaseVM):
 
         return devices, spice_options
 
+    def _del_port_from_bridge(self, nic):
+        br_mgr, br_name = utils_net.find_current_bridge(nic.ifname)
+        if br_name == nic.netdst:
+            br_mgr.del_port(nic.netdst, nic.ifname)
+
     def _nic_tap_add_helper(self, nic):
         if nic.nettype == 'macvtap':
             macvtap_mode = self.params.get("macvtap_mode", "vepa")
@@ -2295,9 +2301,10 @@ class VM(virt_vm.BaseVM):
                     for i in nic.vhostfds.split(':'):
                         os.close(int(i))
                 if nic.ifname:
-                    br_mgr, br_name = utils_net.find_current_bridge(nic.ifname)
-                    if br_name == nic.netdst:
-                        br_mgr.del_port(nic.netdst, nic.ifname)
+                    deletion_time = max(5, math.ceil(int(nic.queues) / 8))
+                    if utils_misc.wait_for(lambda: nic.ifname not in utils_net.get_net_if(),
+                                           deletion_time):
+                        self._del_port_from_bridge(nic)
         except TypeError:
             pass
 
@@ -2625,9 +2632,7 @@ class VM(virt_vm.BaseVM):
                     if nic.ifname in utils_net.get_net_if():
                         self.virtnet.generate_ifname(nic.nic_name)
                     else:
-                        br_mgr, br_name = utils_net.find_current_bridge(nic.ifname)
-                        if br_name == nic.netdst:
-                            br_mgr.del_port(nic.netdst, nic.ifname)
+                        self._del_port_from_bridge(nic)
 
                     if nic.nettype in ['bridge', 'network', 'macvtap']:
                         self._nic_tap_add_helper(nic)
@@ -3039,14 +3044,24 @@ class VM(virt_vm.BaseVM):
             for nic_index in xrange(0, len(self.virtnet)):
                 self.free_mac_address(nic_index)
 
+        port_mapping = {}
         for nic in self.virtnet:
             if nic.nettype == 'macvtap':
                 tap = utils_net.Macvtap(nic.ifname)
                 tap.delete()
             elif nic.ifname:
-                br_mgr, br_name = utils_net.find_current_bridge(nic.ifname)
-                if br_name == nic.netdst:
-                    br_mgr.del_port(nic.netdst, nic.ifname)
+                port_mapping[nic.ifname] = nic
+
+        if port_mapping:
+            queues_num = sum([int(_.queues) for _ in port_mapping.values()])
+            deletion_time = max(5, math.ceil(queues_num / 8))
+            utils_misc.wait_for(lambda: set(port_mapping.keys()).isdisjoint(
+                utils_net.get_net_if()), deletion_time)
+            for inactive_port in set(port_mapping.keys()).difference(utils_net.get_net_if()):
+                nic = port_mapping.pop(inactive_port)
+                self._del_port_from_bridge(nic)
+            for active_port in port_mapping.keys():
+                logging.warning("Deleting %s failed during tap cleanup" % active_port)
 
     def destroy(self, gracefully=True, free_mac_addresses=True):
         """

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1050,15 +1050,15 @@ class Bridge(object):
         result = dict()
         for br_iface in os.listdir(sysfs_path):
             br_iface_path = os.path.join(sysfs_path, br_iface)
-            if os.path.isdir(br_iface_path):
-                try:
-                    if "bridge" not in os.listdir(br_iface_path):
-                        continue
-                except OSError as e:
-                    if e.errno == errno.ENOENT:
-                        continue
-                    else:
-                        raise e
+            try:
+                if (not os.path.isdir(br_iface_path) or
+                        "bridge" not in os.listdir(br_iface_path)):
+                    continue
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    continue
+                else:
+                    raise e
 
             result[br_iface] = dict()
             # Get stp_state
@@ -1132,10 +1132,6 @@ class Bridge(object):
         """
         try:
             self._br_ioctl(arch.SIOCBRDELIF, brname, ifname)
-            if utils_misc.wait_for(lambda: ifname in self.list_iface(brname),
-                                   timeout=5, first=0.5):
-                logging.warning("Failed to delete %s from %s" % (ifname,
-                                                                 brname))
         except IOError as details:
             raise BRDelIfError(ifname, brname, details)
 


### PR DESCRIPTION
The current code can delete the ovs port correctly, but for linux bridge
backend, qemu will delete all guest ports after it quit, so sometimes
_cleanup() will delete a port which has been deleted.

ID: 1701815
Signed-off-by: Yihuang Yu <yihyu@redhat.com>