### PR TITLE
Add support for user defined vm info collection

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -341,9 +341,14 @@ screendump_delay = 5
 # Encode video from vm screenshots
 encode_video_files = yes
 
-# Record vm register information during each test
-vm_register_delay = 5
-store_vm_register = yes
+# Record user defined vm moniter info during each test in regular interval.
+# To enable multiple info cmds just use comma seperated cmds
+# E:g:- vm_info_cmds = "registers,cpus,pic"
+# let's keep default value as "registers"
+# Note: It works for both vm_types(qemu, libvirt)
+vm_info_delay = 5
+store_vm_info = yes
+vm_info_cmds = "registers"
 
 # Set boot order
 boot_order = cdn


### PR DESCRIPTION
Add support for user defined vm information for both
qemu and libvirt tests from vm monitor during the test
in regular intervals, this comes handy while debugging.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>