### PR TITLE
Use current Avocado loader discovery mode definitions

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -179,12 +179,12 @@ class VirtTestLoader(loader.TestLoader):
 
     @staticmethod
     def _report_bad_discovery(name, reason, which_tests):
-        if which_tests is loader.ALL:
+        if which_tests is loader.DiscoverMode.ALL:
             return [(NotAvocadoVTTest, {"name": "%s: %s" % (name, reason)})]
         else:
             return []
 
-    def discover(self, url, which_tests=loader.DEFAULT):
+    def discover(self, url, which_tests=loader.DiscoverMode.DEFAULT):
         try:
             cartesian_parser = self._get_parser()
         except Exception as details:
@@ -199,7 +199,7 @@ class VirtTestLoader(loader.TestLoader):
             # the other test plugins to handle the URL.
             except cartesian_config.ParserError as details:
                 return self._report_bad_discovery(url, details, which_tests)
-        elif which_tests is loader.DEFAULT and not self.args.vt_config:
+        elif which_tests is loader.DiscoverMode.DEFAULT and not self.args.vt_config:
             # By default don't run anythinig unless vt_config provided
             return []
         # Create test_suite
@@ -223,7 +223,7 @@ class VirtTestLoader(loader.TestLoader):
             test_parameters = {'name': test_name,
                                'vt_params': params}
             test_suite.append((VirtTest, test_parameters))
-        if which_tests is loader.ALL and not test_suite:
+        if which_tests is loader.DiscoverMode.ALL and not test_suite:
             return self._report_bad_discovery(url, "No matching tests",
                                               which_tests)
         return test_suite


### PR DESCRIPTION
Commit e286c127533fc05eab5c9083386d645917878f4b on Avocado dropped the
deprecated (compatibility) definitions of the loader modes.  The
current interface was introduced in version 63.0, so users could adapt
from 63.0 all the way to 69.0.

Reference: https://trello.com/c/k90E1kdg/1357-loader-remove-compatibility-aliases
Reference: https://github.com/avocado-framework/avocado/issues/3163
Signed-off-by: Cleber Rosa <crosa@redhat.com>