### PR TITLE
avocado_vt: Get loader mode from DiscoverMode

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -32,6 +32,14 @@ from .options import VirtTestOptionsProcess
 from .test import VirtTest
 
 
+if hasattr(loader, "DiscoverMode"):
+    LOADER_DEFAULT = loader.DiscoverMode.DEFAULT
+    LOADER_ALL = loader.DiscoverMode.ALL
+else:
+    LOADER_DEFAULT = loader.DEFAULT
+    LOADER_ALL = loader.ALL
+
+
 LOG = logging.getLogger("avocado.app")
 
 
@@ -179,12 +187,12 @@ class VirtTestLoader(loader.TestLoader):
 
     @staticmethod
     def _report_bad_discovery(name, reason, which_tests):
-        if which_tests is loader.ALL:
+        if which_tests is LOADER_ALL:
             return [(NotAvocadoVTTest, {"name": "%s: %s" % (name, reason)})]
         else:
             return []
 
-    def discover(self, url, which_tests=loader.DEFAULT):
+    def discover(self, url, which_tests=LOADER_DEFAULT):
         try:
             cartesian_parser = self._get_parser()
         except Exception as details:
@@ -199,7 +207,7 @@ class VirtTestLoader(loader.TestLoader):
             # the other test plugins to handle the URL.
             except cartesian_config.ParserError as details:
                 return self._report_bad_discovery(url, details, which_tests)
-        elif which_tests is loader.DEFAULT and not self.args.vt_config:
+        elif which_tests is LOADER_DEFAULT and not self.args.vt_config:
             # By default don't run anythinig unless vt_config provided
             return []
         # Create test_suite
@@ -223,7 +231,7 @@ class VirtTestLoader(loader.TestLoader):
             test_parameters = {'name': test_name,
                                'vt_params': params}
             test_suite.append((VirtTest, test_parameters))
-        if which_tests is loader.ALL and not test_suite:
+        if which_tests is LOADER_ALL and not test_suite:
             return self._report_bad_discovery(url, "No matching tests",
                                               which_tests)
         return test_suite


### PR DESCRIPTION
Recently Avocado dropped the deprecated DEFAULT/AVAILABLE/ALL variables,
let's add the compatibility bits to Avocado-vt to allow running with
old-ish Avocado as well as with master.

Fixes: https://github.com/avocado-framework/avocado/issues/3163