### PR TITLE
 Update libvirt_vm.py with aarch support to undefine similar to vm_xml.py

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -291,6 +291,11 @@ class VM(virt_vm.BaseVM):
         Undefine the VM.
         """
         try:
+            if "aarch" in platform.machine():
+                if options is None:
+                    options = "--nvram"
+                if "--nvram" not in options:
+                    options += " --nvram"
             virsh.undefine(self.name, options=options, uri=self.connect_uri,
                            ignore_status=False)
         except process.CmdError as detail:


### PR DESCRIPTION
When running multivm stress, I notice the VMs were not being undefined which cause the subsequent test failures. Lifted this patch from vm_xml.py. Just wondering if it is the right thing to do?