### PR TITLE
Update libvirt_vm.py with aarch support undefine with --nvram

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -291,6 +291,11 @@ class VM(virt_vm.BaseVM):
         Undefine the VM.
         """
         try:
+            if "aarch" in platform.machine():
+                if options is None:
+                    options = "--nvram"
+                if "--nvram" not in options:
+                    options += " --nvram"
             virsh.undefine(self.name, options=options, uri=self.connect_uri,
                            ignore_status=False)
         except process.CmdError as detail:


### PR DESCRIPTION
Mirroring earlier change in "Deal with guest undefine in aarch",  undefine should use --nvram for aarch64.

See 24edfaed8c00866fce7a2f777856f4b149fbe5f3