### PR TITLE
drive/utils_misc: Update get drive id in wait_for function

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2757,7 +2757,8 @@ def get_winutils_vol(session, label="WIN_UTILS"):
 
     :return: volume ID.
     """
-    return get_win_disk_vol(session, condition="VolumeName='%s'" % label)
+    return wait_for(lambda: get_win_disk_vol(session,
+                    condition="VolumeName='%s'" % label), 240)
 
 
 def set_winutils_letter(session, cmd, label="WIN_UTILS"):

--- a/virttest/utils_windows/drive.py
+++ b/virttest/utils_windows/drive.py
@@ -3,12 +3,15 @@ Windows drive utilities
 """
 
 from . import wmic
+from virttest import utils_misc
 
 
 def _logical_disks(session, cond=None, props=None):
     cmd = wmic.make_query("LogicalDisk", cond, props,
                           get_swch=wmic.FMT_TYPE_LIST)
-    return wmic.parse_list(session.cmd(cmd, timeout=120))
+    out = utils_misc.wait_for(lambda: wmic.parse_list(session.cmd(cmd,
+                              timeout=120)), 240)
+    return out if out else []
 
 
 def get_hard_drive_letter(session, label):


### PR DESCRIPTION
Sometimes, the cdrom is identified delay in guest,
that caused get the cdrom drive letter will fail sometimes.
Add get cdrom drive letter function to wait_for function,
that will try getting letter cycle in 240 secs.
If getted, return the value. if not, return None.

id: 1685924
Signed-off-by: Peixiu Hou <phou@redhat.com>