### PR TITLE
Fixup: Improper initialization of vmcpu_xml

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -790,8 +790,8 @@ class VMXML(VMXMLBase):
                                          'threads': threads}
                 vmxml['cpu'] = vmcpu_xml
             try:
+                vmcpu_xml = vmxml['cpu']
                 if update_numa and vmxml.cpu.numa_cell:
-                    vmcpu_xml = vmxml['cpu']
                     no_numa_cell = len(vmxml.cpu.numa_cell)
                     if vcpus >= no_numa_cell:
                         vcpus_num = vcpus // no_numa_cell


### PR DESCRIPTION
In some scenarios, we would hit below issue due to vmcpu_xml
is not initialized in proper place, this patch tries to fix it.

UnboundLocalError: local variable 'vmcpu_xml' referenced before assignment

Reported-by: Junxiang Li <junli@redhat.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>