### PR TITLE
qemu_vm.py: Empty self.virtio_ports before fill it

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1528,6 +1528,7 @@ class VM(virt_vm.BaseVM):
                 devices.insert(pvpanic_dev)
 
         # Add serial console redirection
+        self.virtio_ports = []
         serials = params.objects('serials')
         if serials:
             self.serial_session_device = serials[0]


### PR DESCRIPTION
'state' is not always None when initialize class VM, especially
when the test case is in non-first place of the test run. The list
will be superimposed in one loop since the parameter 'state' will
record it and reuse previous list. So need to empty it before
fill it again

Signed-off-by: Qianqian Zhu <qizhu@redhat.com>