### PR TITLE
storage: allow VM specific master image to be cloned

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1065,8 +1065,8 @@ def preprocess(test, params, env):
 
             vm_params = params.object_params(vm_name)
             for image in vm_params.get("master_images_clone").split():
-                image_obj = qemu_storage.QemuImg(params, base_dir, image)
-                image_obj.clone_image(params, vm_name, image, base_dir)
+                image_obj = qemu_storage.QemuImg(vm_params, base_dir, image)
+                image_obj.clone_image(vm_params, vm_name, image, base_dir)
 
     # Preprocess all VMs and images
     if params.get("not_preprocess", "no") == "no":

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -33,8 +33,8 @@ def preprocess_images(bindir, params, env):
             vm.destroy(free_mac_addresses=False)
         vm_params = params.object_params(vm_name)
         for image in vm_params.get("master_images_clone").split():
-            image_obj = QemuImg(params, bindir, image)
-            image_obj.clone_image(params, vm_name, image, bindir)
+            image_obj = QemuImg(vm_params, bindir, image)
+            image_obj.clone_image(vm_params, vm_name, image, bindir)
 
 
 def preprocess_image_backend(bindir, params, env):
@@ -50,8 +50,8 @@ def postprocess_images(bindir, params):
     for vm in params.get("vms").split():
         vm_params = params.object_params(vm)
         for image in vm_params.get("master_images_clone").split():
-            image_obj = QemuImg(params, bindir, image)
-            image_obj.rm_cloned_image(params, vm, image, bindir)
+            image_obj = QemuImg(vm_params, bindir, image)
+            image_obj.rm_cloned_image(vm_params, vm, image, bindir)
 
 
 def file_exists(params, filename_path):
@@ -522,7 +522,13 @@ class QemuImg(object):
                 image_params = params.object_params(image_name)
                 image_params["image_name"] = vm_image_name
 
-                m_image_fn = get_image_filename(params, root_dir)
+                master_image = params.get("master_image_name")
+                if master_image:
+                    image_format = params.get("image_format", "qcow2")
+                    m_image_fn = "%s.%s" % (master_image, image_format)
+                    m_image_fn = utils_misc.get_path(root_dir, m_image_fn)
+                else:
+                    m_image_fn = get_image_filename(params, root_dir)
                 image_fn = get_image_filename(image_params, root_dir)
 
                 # If image is not available/corrupted in nfs share location


### PR DESCRIPTION
In MultiVM environment, every VM can have different master image
to support different OS distributions and this patch provide option
for it.

Param `master_image_name_<VM name>` can be used to clone VM specific
master image and param `image_name_<VM name>` can be used to provide
name of the cloned image for VM to use.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>