### PR TITLE
env_process: avoid changing the param `image_name` for nfs

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -825,8 +825,6 @@ def preprocess(test, params, env):
             seLinuxBool.setup()
 
         image_name_only = os.path.basename(params["image_name"])
-        params['image_name'] = os.path.join(image_nfs.mount_dir,
-                                            image_name_only)
         for image_name in params.objects("images"):
             name_tag = "image_name_%s" % image_name
             if params.get(name_tag):

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1195,8 +1195,9 @@ class VM(virt_vm.BaseVM):
             base_dir = image_params.get("images_base_dir",
                                         data_dir.get_data_dir())
 
+            basename = params.get("storage_type") == "nfs"
             filename = storage.get_image_filename(image_params,
-                                                  base_dir)
+                                                  base_dir, basename=basename)
             if image_params.get("use_storage_pool") == "yes":
                 filename = None
                 virt_install_cmd += add_drive(help_text,
@@ -1873,6 +1874,9 @@ class VM(virt_vm.BaseVM):
         params = self.params
         root_dir = self.root_dir
 
+        if self.params.get("storage_type") == "nfs":
+            storage.copy_nfs_image(self.params, data_dir.get_data_dir(),
+                                   basename=True)
         # Verify the md5sum of the ISO images
         for cdrom in params.objects("cdroms"):
             if params.get("medium") == "import":

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1200,13 +1200,6 @@ def run(test, params, env):
         process.system(dd_cmd)
     image_name = os.path.basename(dst)
     mount_point = params.get("dst_dir")
-
-    # libvirt import of guest from NFS shared path, then copy image
-    # from image_path to nfs mount dir
-    if(params.get("virt_test_type", "qemu") == "libvirt" and
-       params.get("storage_type") == "nfs"):
-        storage.copy_nfs_image(params, image_name, vt_data_dir)
-
     if mount_point and src:
         funcatexit.register(env, params.get("type"), copy_file_from_nfs, src,
                             dst, mount_point, image_name)


### PR DESCRIPTION
changing the param during runtime affects the test from different
places, avoid changing the param `image_name` for vm.create() to
use nfs mounted path. Instead make use of `images_base_dir` param
to provide nfs mounted path as base path for VM to be created.

Also remove copying VM image from data_dir to nfs mounted path
from multiple places and call it from vm.create() in libvirt_vm
to avoid redundant code and simpicity.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>