### PR TITLE
virttest.qemu_vm: add a qemu_stop param for -S

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -730,3 +730,6 @@ vm_monitor_exit_status = no
 # installation this is temporary workaround for the test to proceed by
 # setting it to "yes"
 kickstart_reboot_bug = "no"
+
+# Add -S  to qemu by default, if you don't need it, pls set it off.
+qemu_stop = on

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1419,7 +1419,9 @@ class VM(virt_vm.BaseVM):
         devices.insert(StrDev('PREFIX', cmdline=cmd))
         # Add the qemu binary
         devices.insert(StrDev('qemu', cmdline=qemu_binary))
-        devices.insert(StrDev('-S', cmdline="-S"))
+        qemu_stop = params.get("qemu_stop", "on")
+        if qemu_stop == "on":
+            devices.insert(StrDev('-S', cmdline="-S"))
         # Add the VM's name
         devices.insert(StrDev('vmname', cmdline=add_name(name)))
 


### PR DESCRIPTION
For some cases, e.g., timer device, -S needs to be removed in
 qemu.

bug id: 1694657
Signed-off-by: yama <yama@redhat.com>