### PR TITLE
set hugepage param in respective config section

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -196,6 +196,7 @@ variants:
 variants:
     - @smallpages:
     - hugepages:
+        hugepage = yes
         setup_hugepages = yes
         # In some special conditions, such as low mem PPC systems, you might
         # want to define how many large memory pages you want to set directly.


### PR DESCRIPTION
Enable hugepage param in respective hugepages
config section so that it get's honored by filter
while using `only hugepages` for libvirt tests.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>