### PR TITLE
Fix trying failed problem in get_driver_info

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -774,12 +774,12 @@ class WindowsVMCheck(VMCheck):
         while count > 0:
             logging.debug('%d times remaining for getting driver info' % count)
             try:
+                # Clean up output
+                self.session.cmd('cls')
                 output = self.session.cmd_output(cmd)
             except Exception as detail:
                 logging.error(detail)
                 count -= 1
-                # Clean up output
-                self.session.cmd('cls')
             else:
                 break
         if not output:


### PR DESCRIPTION
The problem is 5 times tring for getting driver info, but only did once and then script exit.

2019-07-14 01:56:00,248 utils_v2v        L0777 DEBUG| 5 times remaining for getting driver info
2019-07-14 01:56:00,248 client           L1126 DEBUG| Sending command: DRIVERQUERY /SI
2019-07-14 01:57:00,309 utils_v2v        L0781 ERROR| Timeout expired while waiting for shell command to complete: 'DRIVERQUERY /SI'    (output: '')
2019-07-14 01:57:00,309 client           L1126 DEBUG| Sending command: cls
2019-07-14 01:58:00,689 ovirt            L0319 INFO | Shutdown VM esx6.7-win10-x86_64LhT

Fix:
Move the self.session.cmd('cls') to into try..except clause, because when it
also raise an exception, the uncaught exception will break the while loop.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>