### PR TITLE
Fixup: Validate session before close

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -867,7 +867,7 @@ def session_handler(func):
                 self.session = self.get_session()
             return func(self)
         finally:
-            if self.vm or self.remote_host:
+            if (self.vm or self.remote_host) and self.session:
                 self.session.close()
     return manage_session
 


### PR DESCRIPTION
Let's validate the session object before attempt
to close it to avoid below issue
```
Traceback (most recent call last):
  File "/root/smfci/tests/data/avocado-vt/test-providers.d/downloads/io-github-autotest-qemu/generic/tests/avocado_guest.py", line 35, in run
    ignore_result=False)
  File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-70.0-py2.7.egg/virttest/utils_test/__init__.py", line 942, in __init__
    if not self.env_check():
  File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-70.0-py2.7.egg/virttest/utils_test/__init__.py", line 871, in manage_session
    self.session.close()
AttributeError: 'NoneType' object has no attribute 'close'
```
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>