### PR TITLE
virttest.libvirt_vm: Add support for virtqueues while guest boot

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -73,6 +73,13 @@ netdst = virbr0
 #advanced network configuration of the host
 #host_ip_addr = ""
 
+# For enabling virt queues in tests uncomment below two params and
+# modify based on need, net_driver value can either be vhost or qemu
+# vhost - use host kernel, qemu - userspace, bydefault it is vhost if
+# kernel supports
+# queues = 10
+# net_driver = vhost
+
 # Set this parameter to 'yes' inorder to get IP from
 # any network interface incase of multiple interface
 # present in VM, default is 'no'

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -856,6 +856,8 @@ class VM(virt_vm.BaseVM):
             nettype = nic_params.get('nettype')
             netdst = nic_params.get('netdst')
             nic_model = nic_params.get('nic_model')
+            nic_queues = nic_params.get('queues')
+            nic_driver = nic_params.get('net_driver')
             if nettype:
                 result = " --network=%s" % nettype
             else:
@@ -875,6 +877,10 @@ class VM(virt_vm.BaseVM):
                     result += ",model=%s" % nic_model
                 if nettype and mac:
                     result += ',mac=%s' % mac
+                if nettype and nic_queues and has_sub_option('network', 'driver_queues'):
+                    result += ',driver_queues=%s' % nic_queues
+                    if nic_driver and has_sub_option('network', 'driver_name'):
+                        result += ',driver_name=%s' % nic_driver
                 elif mac:  # possible to specify --mac w/o --network
                     result += " --mac=%s" % mac
             logging.debug("vm.make_create_command.add_nic returning: %s",

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2444,7 +2444,7 @@ class VirtIface(propcan.PropCan, object):
     """
 
     __slots__ = ['nic_name', 'g_nic_name', 'mac', 'nic_model', 'ip',
-                 'nettype', 'netdst']
+                 'nettype', 'netdst', 'queues', 'net_driver']
     # Using MA-S assignment here, that means we can have at most 4096 unique
     # identifiers (MAC addresses) on the same job instance. We may consider
     # using bigger blocks for large-scale deployment, such as microVM


### PR DESCRIPTION
Let's add support for virt-queues during guest boot
in virt-install commandline, queues and net_driver
params to be set accordingly in-order to use this support.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>