### PR TITLE
Increase the flexibility of parameter type converting methods

### DIFF
--- a/selftests/unit/test_utils_params.py
+++ b/selftests/unit/test_utils_params.py
@@ -105,14 +105,18 @@ class TestParams(unittest.TestCase):
     def testGetNumeric(self):
         self.params["something"] = "7"
         self.params["foobar"] = 11
-        self.params["barsome"] = 13.0
+        self.params["barsome"] = 13.17
         self.assertEqual(7, self.params.get_numeric('something'))
+        self.assertEqual(7, self.params.get_numeric('something'), int)
+        self.assertEqual(7.0, self.params.get_numeric('something'), float)
         self.assertEqual(11, self.params.get_numeric('foobar'))
+        self.assertEqual(11, self.params.get_numeric('something'), int)
         self.assertEqual(11.0, self.params.get_numeric('foobar'), float)
         self.assertEqual(13, self.params.get_numeric('barsome'))
-        self.assertEqual(13.0, self.params.get_numeric('barsome'), float)
+        self.assertEqual(13, self.params.get_numeric('barsome'), int)
+        self.assertEqual(13.17, self.params.get_numeric('barsome'), float)
         self.assertEqual(17, self.params.get_numeric('joke', 17))
-        self.assertEqual(17.0, self.params.get_numeric('joke', 17), float)
+        self.assertEqual(17.13, self.params.get_numeric('joke', 17.13), float)
 
     def testGetList(self):
         self.params["primes"] = "7 11 13 17"

--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -136,13 +136,14 @@ class Params(IterableUserDict):
         """
         return target_type(self.get(key, default))
 
-    def get_list(self, key, default="", delimiter=' ', target_type=str):
+    def get_list(self, key, default="", delimiter=None, target_type=str):
         """
         Get a parameter value that is a character delimited list.
 
         :param str key: parameter whose value is list
         :param str default: default list value
-        :param str delimiter: character to split list items
+        :param delimiter: character to split list items
+        :type delimiter: str or None
         :param type target_type: type of each item, default is string
         :returns: empty list if if the key is not in the parameters
         :rtype: [str]
@@ -157,13 +158,14 @@ class Params(IterableUserDict):
         else:
             return [target_type(entry) for entry in param_string.split(delimiter)]
 
-    def get_dict(self, key, default="", delimiter=' ', need_order=False):
+    def get_dict(self, key, default="", delimiter=None, need_order=False):
         """
         Get a param value that has the form 'name1=value1 name2=value2 ...'.
 
         :param str key: parameter whose value is dict
         :param str default: default dict value
         :param str delimiter: character to split list items
+        :type delimiter: str or None
         :param bool need_order: whether to return an OrderedDict instead of
                                 a regular dict
         :returns: empty dict if if the key is not in the parameters, a dict
@@ -181,7 +183,7 @@ class Params(IterableUserDict):
             if index == -1:
                 raise ValueError('failed to find "=" in "{0}" (value for {1})'
                                  .format(entry, key))
-            result[entry[:index]] = entry[index+1:]
+            result[entry[:index].strip()] = entry[index+1:].strip()
         return result
 
     def drop_dict_internals(self):


### PR DESCRIPTION
We allow the user more flexibility when it comes to white spaces
and overall Cartesian configuration formatting.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>