### PR TITLE
get_vcpu_pids: Modify method of getting vcpus info from monitor

### DIFF
--- a/selftests/unit/unittest_data/testcfg.huge/base.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/base.cfg
@@ -175,10 +175,6 @@ monitors = hmp1
 #monitor_type_hmp1 = human
 # Default monitor type (protocol), if multiple types to be used
 monitor_type = human
-# Pattern to get vcpu threads from monitor.
-#    human monitor: thread_id=(\d+)
-#    qmp monitor: u'thread_id':\s+(\d+)
-vcpu_thread_pattern = "thread_id=(\d+)"
 
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc

--- a/selftests/unit/unittest_data/testcfg.huge/subtests.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/subtests.cfg
@@ -1468,13 +1468,11 @@ variants:
         type = qmp_basic
         monitors = qmp1
         monitor_type = qmp
-        vcpu_thread_pattern = "u'thread_id':\s+(\d+)"
     - qmp_basic_rhel6: install setup image_copy unattended_install.cdrom
         virt_test_type = qemu
         type = qmp_basic_rhel6
         monitors = qmp1
         monitor_type = qmp
-        vcpu_thread_pattern = "u'thread_id':\s+(\d+)"
     - rv_connect:
         virt_test_type = qemu
         no JeOS

--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -304,8 +304,6 @@ monitor_type = qmp
 # VmRegister and ScreenDump threads.
 catch_monitor = catch_monitor
 #monitor_type_catch_monitor = qmp
-# Pattern to get vcpu threads from monitor.both support
-vcpu_thread_pattern = "thread_id.?[:|=]\s*(\d+)"
 
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc


### PR DESCRIPTION
1. Use 'query-cpus-fast' instead of 'query-cpus' for new qemu build (
beginning with 2.12.0)
2. qemu_vm: Add a method `get_vcpus_info()` to get vcpus info
3. Deprecate 'vcpu_thread_pattern'

ID: 1731777
Signed-off-by: Yihuang Yu <yihyu@redhat.com>