### PR TITLE
qemu_vm: Name serial by index if there is prefix defined

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -144,6 +144,13 @@ q35, arm64-pci, arm64-mmio:
 # virtio_port_name_prefix = "com.redhat.spice."
 # By default the port name is used (vc1)
 # virtio_port_name_prefix_vc1 = ""
+# If there is prefix defined, will replace serial_name to
+# 'prefix+(the device index of the virtio_ports list)', e.g.
+# serials = "serial0 vs1"
+# serial_type = "isa-serial"
+# serial_type_vs1 = virtserialport
+# virtio_port_name_prefix_vs1 = "com.redhat.spice."
+# Then the serial_name of "vs1" will be "com.redhat.spice.0"
 
 serials = "serial0"
 serial_type = "isa-serial"

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1807,22 +1807,12 @@ class DevContainer(object):
             else:
                 controller_suffix = 'pci'
             bus_type = 'virtio-serial-%s' % controller_suffix
-
-        prefix = params.get('virtio_port_name_prefix')
-        name = prefix + serial_id if prefix else serial_id
         chardev_id = 'chardev_%s' % serial_id
         chardev_device = self.chardev_define_by_params(chardev_id, params, file_name)
-        serial_devices = self.serials_define_by_variables(serial_id,
-                                                          serial_type,
-                                                          chardev_id,
-                                                          bus_type=bus_type,
-                                                          serial_name=name,
-                                                          bus=params.get(
-                                                              "serial_bus"),
-                                                          nr=params.get(
-                                                              "serial_nr"),
-                                                          reg=params.get(
-                                                              "serial_reg"))
+        serial_devices = self.serials_define_by_variables(
+            serial_id, serial_type, chardev_id, bus_type=bus_type,
+            serial_name=params.get("serial_name"), bus=params.get("serial_bus"),
+            nr=params.get("serial_nr"), reg=params.get("serial_reg"))
 
         return [chardev_device] + serial_devices
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1553,6 +1553,10 @@ class VM(virt_vm.BaseVM):
             if backend in ['udp', 'tcp_socket']:
                 serial_params['chardev_host'] = host
                 serial_params['chardev_port'] = free_ports[index]
+            prefix = serial_params.get('virtio_port_name_prefix')
+            serial_name = prefix + str(len(self.virtio_ports))\
+                if prefix else serial
+            serial_params['serial_name'] = serial_name
             serial_devices = devices.serials_define_by_params(
                 serial, serial_params, serial_filename)
 


### PR DESCRIPTION
Fix issue: https://github.com/avocado-framework/avocado-vt/commit/9c82ef693d6a7d5f7835b04d76505f945731fd11#commitcomment-34427735

Signed-off-by: Qianqian Zhu <qizhu@redhat.com>