### PR TITLE
libvirt_xml/vm_xml: Add --nvram flag for guests with nvram

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -4,7 +4,6 @@ http://libvirt.org/formatdomain.html
 """
 
 import logging
-import platform
 
 from .. import xml_utils
 from .. import utils_misc
@@ -634,8 +633,12 @@ class VMXML(VMXMLBase):
 
     def undefine(self, options=None, virsh_instance=base.virsh):
         """Undefine this VM with libvirt retaining XML in instance"""
-        # add --nvram in undefine for aarch64
-        if "aarch" in platform.machine():
+	try:
+		nvram = getattr(getattr(self, "os"), "nvram")
+	except xcepts.LibvirtXMLNotFoundError:
+		nvram = None
+
+	if nvram:
             if options is None:
                 options = "--nvram"
             if "--nvram" not in options:


### PR DESCRIPTION
Guests with nvram will fail with "ERROR: Failed to undefine " since
the --nvram flag is only added for the aarch platform. Instead, add the
--nvram for any guest with nvram.

Signed-off-by: John Allen john.allen@amd.com