### PR TITLE
utils_test: timeout was hardcoded

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -2922,7 +2922,7 @@ class RemoteVMManager(object):
                                           password=self.remote_pwd)
 
     def setup_ssh_auth(self, vm_ip, vm_pwd, vm_user="root",
-                       port=22, timeout=10):
+                       port=22, timeout=20):
         """
         Setup SSH passwordless access between remote host
         and VM, which is on the remote host.
@@ -2948,7 +2948,7 @@ class RemoteVMManager(object):
                             r"lost connection", r"]#"]
             try:
                 index, text = session.read_until_last_line_matches(
-                    matched_strs, timeout=20,
+                    matched_strs, timeout=timeout,
                     internal_timeout=0.5)
             except (aexpect.ExpectTimeoutError,
                     aexpect.ExpectProcessTerminatedError) as e:


### PR DESCRIPTION
The value of 'timeout' in RemoteVMManager.setup_ssh_auth is not
used. Fix the hard-code issue and update the default value to 20s
which works for many cases for now.

Signed-off-by: Yingshun Cui <yicui@redhat.com>