### PR TITLE
 Add sysprep option before cloning master image

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -687,6 +687,13 @@ enable_remote_host_sosreport = "no"
 # libvirt installer default options
 rpmbuild_path = "/root/rpmbuild/"
 
+# params "sysprep_required" & "sysprep_options": using which 
+# users can provide required customization to prepare master 
+# disk image, like "truncating machine-id" or any other tweaks 
+# supported by virt-sysprep tool, followed by cloning process.
+sysprep_required = no
+sysprep_options = "--operations machine-id"
+
 Linux:
     # param for installing stress tool from repo
     stress_install_from_repo = "no"

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -32,6 +32,7 @@ from virttest import test_setup
 from virttest import virt_vm
 from virttest import utils_misc
 from virttest import storage
+from virttest import utils_libguestfs
 from virttest import qemu_storage
 from virttest import utils_libvirtd
 from virttest import remote
@@ -1082,6 +1083,14 @@ def preprocess(test, params, env):
         process_command(test, params, env, params.get("pre_command"),
                         int(params.get("pre_command_timeout", "600")),
                         params.get("pre_command_noncritical") == "yes")
+
+    # Sysprep the master image if requested, to customize image before cloning
+    if params.get("sysprep_required", "no") == "yes":
+        logging.info("Syspreping the image as requested before cloning.")
+        image_filename = storage.get_image_filename(params, base_dir)
+        sysprep_options = params.get("sysprep_options", "--operations machine-id")
+        utils_libguestfs.virt_sysprep_cmd(
+            image_filename, options=sysprep_options, ignore_status=False)
 
     # Clone master image from vms.
     if params.get("master_images_clone"):


### PR DESCRIPTION
During multivm tests, there might be scenarios where we
need to reset/tweak few parameters on master  disk image
before we start using that to clone disks for usage with vms.

This commit introduces params "sysprep_required" &
"sysprep_options", using which users can provide required customization
to prepare master disk image, like "truncating machine-id" or any other
tweaks supported by virt-sysprep tool, followed by cloning process.

Usecase example: Recent distros not only depend on the unique mac
address to determine IP but also the machine-id. If the cloned images
have same machine-id, then all cloned guests end up getting same IP.
Using this commit user can reset machine-id in the master disk image so that
multivms using cloned disks would get unique ip addresses later.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>