### PR TITLE
virttest: Add input_send_key/btn_event funcs in qemu_monitor.py

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -3235,3 +3235,22 @@ class QMPMonitor(Monitor):
                     "data": key
                 }}}]}
         return self.cmd(cmd, args)
+
+    def input_send_event(self, events, device=None, head=None):
+        """
+        Send input event(s) to guest.
+
+        :param device: display device to send event(s) to.
+        :param head: head to send event(s) to, in case the
+                     display device supports multiple scanouts.
+        :param events: List of InputEvent union.
+        """
+        cmd = "input-send-event"
+        self.verify_supported_cmd(cmd)
+        arguments = dict()
+        if device:
+            arguments["device"] = device
+        if head:
+            arguments["head"] = int(head)
+        arguments["events"] = events
+        return self.cmd(cmd, arguments)


### PR DESCRIPTION
input_send_key_event() is used to send keys on keyboard from qemu monitor.
input_send_btn_event() is used to send button on mouse from qemu monitor.

id: 1735508
Signed-off-by: Peixiu Hou <phou@redhat.com>