### PR TITLE
Specify bus/addr and fix vector issue during hotplug nic device

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3438,7 +3438,7 @@ class VM(virt_vm.BaseVM):
             nic.netdev_id = self.add_netdev(**dict(nic))
         nic.set_if_none('nic_model', params['nic_model'])
         nic.set_if_none('queues', params.get('queues', '1'))
-        if params.get("enable_msix_vectors") == "yes":
+        if params.get("enable_msix_vectors") == "yes" and int(nic.queues) > 1:
             nic.set_if_none('vectors', 2 * int(nic.queues) + 2)
         return nic
 
@@ -3561,8 +3561,8 @@ class VM(virt_vm.BaseVM):
         if nic['nic_model'] == 'virtio-net-pci':
             if int(nic['queues']) > 1:
                 device_add_cmd += ",mq=on"
-            if 'vectors' in nic:
-                device_add_cmd += ",vectors=%s" % nic.vectors
+                if 'vectors' in nic:
+                    device_add_cmd += ",vectors=%s" % nic.vectors
         device_add_cmd += nic.get('nic_extra_params', '')
         if 'romfile' in nic:
             device_add_cmd += ",romfile=%s" % nic.romfile

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2849,8 +2849,6 @@ class ParamsNet(VMNet):
         default_params['netdev_extra_params'] = ''
         nic_name_list = self.params.objects('nics')
         default_params['vlan'] = str(nic_name_list.index(nic_name))
-        if nic_params.get('enable_misx_vectors') == 'yes':
-            default_params['vectors'] = 2 * 1 + 2
         for key, val in list(default_params.items()):
             nic_params.setdefault(key, val)
 


### PR DESCRIPTION
1. automatically specify bus and addr for hot plugged nic device
2. drop the default vector because it is meaningless
3. vectors are added only when there are multiqueue during hotplug

ID: 1512424 1736784

Signed-off-by: Yihuang Yu <yihyu@redhat.com>