### PR TITLE
minor fix for id_rsa already exists issue

### DIFF
--- a/virttest/utils_conn.py
+++ b/virttest/utils_conn.py
@@ -622,7 +622,7 @@ class SSHConnection(ConnectionBase):
                 raise ConnToolNotFoundError(tool_name,
                                             "executable not set or found on path,")
 
-        if os.path.exists("/root/.ssh/id_rsa"):
+        if not client_session.cmd_status("ls /root/.ssh/id_rsa"):
             pass
         else:
             cmd = "%s -t rsa -f /root/.ssh/id_rsa -N '' " % (ssh_keygen)


### PR DESCRIPTION
It reports 'id_rsa already exists' error while generating key pairs.
Update to check the key on client host before run ssh-keygen to make
sure it checked correct host.

Signed-off-by: Yingshun Cui <yicui@redhat.com>