### PR TITLE
Introduce option to remove backup files

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -441,6 +441,20 @@ class QemuImg(object):
                 continue
             backup_func(src, dst)
 
+    def rm_backup_image(self):
+        """
+        Remove backup image
+        """
+        backup_dir = utils_misc.get_path(self.root_dir,
+                                         self.params.get("backup_dir", ""))
+        image_name = os.path.join(backup_dir, "%s.backup" %
+                                  os.path.basename(self.image_filename))
+        logging.debug("Removing image file %s as requested", image_name)
+        if os.path.exists(image_name):
+            os.unlink(image_name)
+        else:
+            logging.warning("Image file %s not found", image_name)
+
     def save_image(self, params, filename, root_dir=None):
         """
         Save images to a path for later debugging.


### PR DESCRIPTION
Currently after backup/restore of any image would leave .backup file behind.
This would have been done to reuse backup when next time there is a call for
backup function, but there can be scenarios where user would like to remove
backup once original image is restored.
This commit introduces an option to allow users to remove backup images
by providing a flag.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>