### PR TITLE
Add support for job configuration as a dictionary

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -28,6 +28,7 @@ from virttest import cartesian_config
 from virttest import data_dir
 from virttest import standalone_test
 from virttest import storage
+from virttest.compat import get_opt, set_opt
 
 from .options import VirtTestOptionsProcess
 from .test import VirtTest
@@ -48,7 +49,7 @@ def guest_listing(options):
     """
     List available guest os and info about image availability
     """
-    if options.vt_type == 'lvsb':
+    if get_opt(options, 'vt_type') == 'lvsb':
         raise ValueError("No guest types available for lvsb testing")
     LOG.debug("Using %s for guest images\n",
               os.path.join(data_dir.get_data_dir(), 'images'))
@@ -57,7 +58,8 @@ def guest_listing(options):
     for params in guest_name_parser.get_dicts():
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())
         image_name = storage.get_image_filename(params, base_dir)
-        name = params['name'].replace('.%s' % options.vt_machine_type, '')
+        machine_type = get_opt(options, 'vt_machine_type')
+        name = params['name'].replace('.%s' % machine_type, '')
         if os.path.isfile(image_name):
             out = name
         else:
@@ -71,14 +73,16 @@ def arch_listing(options):
     """
     List available machine/archs for given guest os
     """
-    if options.vt_guest_os:
-        extra = " for guest os \"%s\"" % options.vt_guest_os
+    guest_os = get_opt(options, 'vt_guest_os')
+    if guest_os is not None:
+        extra = " for guest os \"%s\"" % guest_os
     else:
         extra = ""
     LOG.info("Available arch profiles%s", extra)
     guest_name_parser = standalone_test.get_guest_name_parser(options)
+    machine_type = get_opt(options, 'vt_machine_type')
     for params in guest_name_parser.get_dicts():
-        LOG.debug(params['name'].replace('.%s' % options.vt_machine_type, ''))
+        LOG.debug(params['name'].replace('.%s' % machine_type, ''))
     LOG.debug("")
 
 
@@ -112,15 +116,17 @@ class VirtTestLoader(loader.TestLoader):
         if vt_extra_params:
             # We don't want to override the original args
             self.args = copy.deepcopy(self.args)
-            if getattr(self.args, 'vt_extra_params', None) is not None:
-                self.args.vt_extra_params += vt_extra_params
+            extra = get_opt(self.args, 'vt_extra_params')
+            if extra is not None:
+                extra += vt_extra_params
             else:
-                self.args.vt_extra_params = vt_extra_params
+                extra = vt_extra_params
+            set_opt(self.args, 'vt_extra_params', extra)
 
     def _fill_optional_args(self):
         def _add_if_not_exist(arg, value):
-            if not hasattr(self.args, arg):
-                setattr(self.args, arg, value)
+            if not get_opt(self.args, arg):
+                set_opt(self.args, arg, value)
         _add_if_not_exist('vt_config', None)
         _add_if_not_exist('vt_verbose', True)
         _add_if_not_exist('vt_log_level', 'debug')
@@ -159,15 +165,15 @@ class VirtTestLoader(loader.TestLoader):
         return options_processor.get_parser()
 
     def get_extra_listing(self):
-        if self.args.vt_list_guests:
+        if get_opt(self.args, 'vt_list_guests'):
             args = copy.copy(self.args)
-            args.vt_config = None
-            args.vt_guest_os = None
+            set_opt(args, 'vt_config', None)
+            set_opt(args, 'vt_guest_os', None)
             guest_listing(args)
-        if self.args.vt_list_archs:
+        if get_opt(self.args, 'vt_list_archs'):
             args = copy.copy(self.args)
-            args.vt_machine_type = None
-            args.vt_arch = None
+            set_opt(args, 'vt_machine_type', None)
+            set_opt(args, 'vt_arch', None)
             arch_listing(args)
 
     @staticmethod
@@ -212,7 +218,7 @@ class VirtTestLoader(loader.TestLoader):
             # the other test plugins to handle the URL.
             except cartesian_config.ParserError as details:
                 return self._report_bad_discovery(url, details, which_tests)
-        elif which_tests is LOADER_DEFAULT and not self.args.vt_config:
+        elif which_tests is LOADER_DEFAULT and not get_opt(self.args, 'vt_config'):
             # By default don't run anythinig unless vt_config provided
             return []
         # Create test_suite
@@ -220,9 +226,9 @@ class VirtTestLoader(loader.TestLoader):
         for params in (_ for _ in cartesian_parser.get_dicts()):
             # Evaluate the proper avocado-vt test name
             test_name = None
-            if self.args.vt_config:
+            if get_opt(self.args, 'vt_config'):
                 test_name = params.get("shortname")
-            elif self.args.vt_type == "spice":
+            elif get_opt(self.args, 'vt_type') == "spice":
                 short_name_map_file = params.get("_short_name_map_file")
                 if "tests-variants.cfg" in short_name_map_file:
                     test_name = short_name_map_file["tests-variants.cfg"]

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -27,6 +27,7 @@ from virttest import cartesian_config
 from virttest import data_dir
 from virttest import defaults
 from virttest import standalone_test
+from virttest.compat import get_opt, set_opt
 from virttest.standalone_test import SUPPORTED_DISK_BUSES
 from virttest.standalone_test import SUPPORTED_IMAGE_TYPES
 from virttest.standalone_test import SUPPORTED_LIBVIRT_DRIVERS
@@ -54,64 +55,68 @@ class VirtTestOptionsProcess(object):
         # that don't quite make sense for avocado (avocado implements a
         # better version of the virt-test feature).
         # So let's just inject some values into options.
-        self.options.vt_verbose = False
-        self.options.vt_log_level = logging.DEBUG
-        self.options.vt_console_level = logging.DEBUG
-        self.options.vt_no_downloads = False
-        self.options.vt_selinux_setup = False
+        set_opt(self.options, 'vt_verbose', False)
+        set_opt(self.options, 'vt_log_level', logging.DEBUG)
+        set_opt(self.options, 'vt_console_level', logging.DEBUG)
+        set_opt(self.options, 'vt_no_downloads', False)
+        set_opt(self.options, 'vt_selinux_setup', False)
 
         # Here we'll inject values from the config file.
         # Doing this makes things configurable yet the number of options
         # is not overwhelming.
         # setup section
-        self.options.vt_backup_image_before_test = settings.get_value(
-            'vt.setup', 'backup_image_before_test', key_type=bool,
-            default=True)
-        self.options.vt_restore_image_after_test = settings.get_value(
-            'vt.setup', 'restore_image_after_test', key_type=bool,
-            default=True)
-        self.options.vt_keep_guest_running = settings.get_value(
-            'vt.setup', 'keep_guest_running', key_type=bool,
-            default=False)
+        set_opt(self.options, 'vt_backup_image_before_test',
+                settings.get_value('vt.setup', 'backup_image_before_test',
+                                   key_type=bool, default=True))
+        set_opt(self.options, 'vt_restore_image_after_test',
+                settings.get_value('vt.setup', 'restore_image_after_test',
+                                   key_type=bool, default=True))
+        set_opt(self.options, 'vt_keep_guest_running',
+                settings.get_value('vt.setup', 'keep_guest_running',
+                                   key_type=bool, default=False))
         # common section
-        self.options.vt_data_dir = settings.get_value(
-            'vt.common', 'data_dir', default=None)
-        self.options.vt_tmp_dir = settings.get_value(
-            'vt.common', 'tmp_dir', default='')
-        self.options.vt_type_specific = settings.get_value(
-            'vt.common', 'type_specific_only', key_type=bool,
-            default=False)
-        self.options.vt_mem = settings.get_value(
-            'vt.common', 'mem', key_type=int, default=None)
-        self.options.vt_nettype = settings.get_value(
-            'vt.common', 'nettype', default=None)
-        self.options.vt_netdst = settings.get_value(
-            'vt.common', 'netdst', default='virbr0')
+        set_opt(self.options, 'vt_data_dir',
+                settings.get_value('vt.common', 'data_dir', default=None))
+        set_opt(self.options, 'vt_tmp_dir',
+                settings.get_value('vt.common', 'tmp_dir', default=''))
+        set_opt(self.options, 'vt_type_specific',
+                settings.get_value('vt.common', 'type_specific_only',
+                                   key_type=bool, default=False))
+        set_opt(self.options, 'vt_mem',
+                settings.get_value('vt.common', 'mem', key_type=int,
+                                   default=None))
+        set_opt(self.options, 'vt_nettype',
+                settings.get_value('vt.common', 'nettype', default=None))
+        set_opt(self.options, 'vt_netdst',
+                settings.get_value('vt.common', 'netdst', default='virbr0'))
         # qemu section
-        self.options.vt_accel = settings.get_value(
-            'vt.qemu', 'accel', default='kvm')
-        self.options.vt_vhost = settings.get_value(
-            'vt.qemu', 'vhost', default='off')
-        self.options.vt_monitor = settings.get_value(
-            'vt.qemu', 'monitor', default=None)
-        self.options.vt_smp = settings.get_value(
-            'vt.qemu', 'smp', default='2')
-        self.options.vt_image_type = settings.get_value(
-            'vt.qemu', 'image_type', default='qcow2')
-        self.options.vt_nic_model = settings.get_value(
-            'vt.qemu', 'nic_model', default='virtio_net')
-        self.options.vt_disk_bus = settings.get_value(
-            'vt.qemu', 'disk_bus', default='virtio_blk')
-        self.options.vt_qemu_sandbox = settings.get_value(
-            'vt.qemu', 'sandbox', default='on')
-        self.options.vt_qemu_defconfig = settings.get_value(
-            'vt.qemu', 'defconfig', default='yes')
-        self.options.vt_malloc_perturb = settings.get_value(
-            'vt.qemu', 'malloc_perturb', default='yes')
+        set_opt(self.options, 'vt_accel',
+                settings.get_value('vt.qemu', 'accel', default='kvm'))
+        set_opt(self.options, 'vt_vhost',
+                settings.get_value('vt.qemu', 'vhost', default='off'))
+        set_opt(self.options, 'vt_monitor',
+                settings.get_value('vt.qemu', 'monitor', default=None))
+        set_opt(self.options, 'vt_smp',
+                settings.get_value('vt.qemu', 'smp', default='2'))
+        set_opt(self.options, 'vt_image_type',
+                settings.get_value('vt.qemu', 'image_type', default='qcow2'))
+        set_opt(self.options, 'vt_nic_model',
+                settings.get_value('vt.qemu', 'nic_model',
+                                   default='virtio_net'))
+        set_opt(self.options, 'vt_disk_bus',
+                settings.get_value('vt.qemu', 'disk_bus',
+                                   default='virtio_blk'))
+        set_opt(self.options, 'vt_qemu_sandbox',
+                settings.get_value('vt.qemu', 'sandbox', default='on'))
+        set_opt(self.options, 'vt_qemu_defconfig',
+                settings.get_value('vt.qemu', 'defconfig', default='yes'))
+        set_opt(self.options, 'vt_malloc_perturb',
+                settings.get_value('vt.qemu', 'malloc_perturb', default='yes'))
 
         # debug section
-        self.options.vt_no_cleanup = settings.get_value(
-            'vt.debug', 'no_cleanup', key_type=bool, default=False)
+        set_opt(self.options, 'vt_no_cleanup',
+                settings.get_value('vt.debug', 'no_cleanup',
+                                   key_type=bool, default=False))
 
         self.cartesian_parser = None
 
@@ -121,13 +126,15 @@ class VirtTestOptionsProcess(object):
         """
         qemu_bin_setting = ('option --vt-qemu-bin or '
                             'config vt.qemu.qemu_bin')
-        if self.options.vt_config and self.options.vt_qemu_bin is None:
+        if (get_opt(self.options, 'vt_config') and
+                get_opt(self.options, 'vt_qemu_bin') is None):
             logging.info("Config provided and no %s set. Not trying "
                          "to automatically set qemu bin.", qemu_bin_setting)
         else:
             (qemu_bin_path, qemu_img_path, qemu_io_path,
              qemu_dst_bin_path) = standalone_test.find_default_qemu_paths(
-                self.options.vt_qemu_bin, self.options.vt_dst_qemu_bin)
+                 get_opt(self.options, 'vt_qemu_bin'),
+                 get_opt(self.options, 'vt_dst_qemu_bin'))
             self.cartesian_parser.assign("qemu_binary", qemu_bin_path)
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
             self.cartesian_parser.assign("qemu_io_binary", qemu_io_path)
@@ -141,141 +148,143 @@ class VirtTestOptionsProcess(object):
         """
         qemu_img_setting = ('option --vt-qemu-img or '
                             'config vt.qemu.qemu_img')
-        if self.options.vt_config and self.options.vt_qemu_bin is None:
+        if (get_opt(self.options, 'vt_config') and
+                get_opt(self.options, 'vt_qemu_bin') is None):
             logging.info("Config provided and no %s set. Not trying "
                          "to automatically set qemu bin", qemu_img_setting)
         else:
             (_, qemu_img_path,
              _, _) = standalone_test.find_default_qemu_paths(
-                self.options.vt_qemu_bin, self.options.vt_dst_qemu_bin)
+                 get_opt(self.options, 'vt_qemu_bin'),
+                 get_opt(self.options, 'vt_dst_qemu_bin'))
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
 
     def _process_qemu_accel(self):
         """
         Puts the value of the qemu bin option in the cartesian parser command.
         """
-        if self.options.vt_accel == 'tcg':
+        if get_opt(self.options, 'vt_accel') == 'tcg':
             self.cartesian_parser.assign("disable_kvm", "yes")
 
     def _process_bridge_mode(self):
         nettype_setting = 'config vt.qemu.nettype'
-        if not self.options.vt_config:
+        if not get_opt(self.options, 'vt_config'):
             # Let's select reasonable defaults depending on vt_type
-            if not self.options.vt_nettype:
-                if self.options.vt_type == 'qemu':
-                    self.options.vt_nettype = ("bridge" if os.getuid() == 0
-                                               else "user")
-                elif self.options.vt_type == 'spice':
-                    self.options.vt_nettype = "none"
+            if not get_opt(self.options, 'vt_nettype'):
+                if get_opt(self.options, 'vt_type') == 'qemu':
+                    set_opt(self.options, 'vt_nettype',
+                            ("bridge" if os.getuid() == 0 else "user"))
+                elif get_opt(self.options, 'vt_type') == 'spice':
+                    set_opt(self.options, 'vt_nettype', "none")
                 else:
-                    self.options.vt_nettype = "bridge"
+                    set_opt(self.options, 'vt_nettype', "bridge")
 
-            if self.options.vt_nettype not in SUPPORTED_NET_TYPES:
+            if get_opt(self.options, 'vt_nettype') not in SUPPORTED_NET_TYPES:
                 raise ValueError("Invalid %s '%s'. "
                                  "Valid values: (%s)" %
                                  (nettype_setting,
-                                  self.options.vt_nettype,
+                                  get_opt(self.options, 'vt_nettype'),
                                   ", ".join(SUPPORTED_NET_TYPES)))
-            if self.options.vt_nettype == 'bridge':
+            if get_opt(self.options, 'vt_nettype') == 'bridge':
                 if os.getuid() != 0:
                     raise ValueError("In order to use %s '%s' you "
                                      "need to be root" % (nettype_setting,
-                                                          self.options.vt_nettype))
+                                                          get_opt(self.options, 'vt_nettype')))
                 self.cartesian_parser.assign("nettype", "bridge")
-                self.cartesian_parser.assign("netdst", self.options.vt_netdst)
-            elif self.options.vt_nettype == 'user':
+                self.cartesian_parser.assign("netdst", get_opt(self.options, 'vt_netdst'))
+            elif get_opt(self.options, 'vt_nettype') == 'user':
                 self.cartesian_parser.assign("nettype", "user")
         else:
             logging.info("Config provided, ignoring %s", nettype_setting)
 
     def _process_monitor(self):
-        if not self.options.vt_config:
-            if not self.options.vt_monitor:
+        if not get_opt(self.options, 'vt_config'):
+            if not get_opt(self.options, 'vt_monitor'):
                 pass
-            elif self.options.vt_monitor == 'qmp':
+            elif get_opt(self.options, 'vt_monitor') == 'qmp':
                 self.cartesian_parser.assign("monitor_type", "qmp")
-            elif self.options.vt_monitor == 'human':
+            elif get_opt(self.options, 'vt_monitor') == 'human':
                 self.cartesian_parser.assign("monitor_type", "human")
         else:
             logging.info("Config provided, ignoring monitor setting")
 
     def _process_smp(self):
         smp_setting = 'config vt.qemu.smp'
-        if not self.options.vt_config:
-            if self.options.vt_smp == '1':
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_smp') == '1':
                 self.cartesian_parser.only_filter("up")
-            elif self.options.vt_smp == '2':
+            elif get_opt(self.options, 'vt_smp') == '2':
                 self.cartesian_parser.only_filter("smp2")
             else:
                 try:
                     self.cartesian_parser.only_filter("up")
                     self.cartesian_parser.assign(
-                        "smp", int(self.options.vt_smp))
+                        "smp", int(get_opt(self.options, 'vt_smp')))
                 except ValueError:
                     raise ValueError("Invalid %s '%s'. Valid value: (1, 2, "
-                                     "or integer)" % self.options.vt_smp)
+                                     "or integer)" % get_opt(self.options, 'vt_smp'))
         else:
             logging.info("Config provided, ignoring %s", smp_setting)
 
     def _process_arch(self):
         arch_setting = "option --vt-arch or config vt.common.arch"
-        if self.options.vt_arch is None:
+        if get_opt(self.options, 'vt_arch') is None:
             pass
-        elif not self.options.vt_config:
-            self.cartesian_parser.only_filter(self.options.vt_arch)
+        elif not get_opt(self.options, 'vt_config'):
+            self.cartesian_parser.only_filter(get_opt(self.options, 'vt_arch'))
         else:
             logging.info("Config provided, ignoring %s", arch_setting)
 
     def _process_machine_type(self):
         machine_type_setting = ("option --vt-machine-type or config "
                                 "vt.common.machine_type")
-        if not self.options.vt_config:
-            if self.options.vt_machine_type is None:
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_machine_type') is None:
                 # TODO: this is x86-specific, instead we can get the default
                 # arch from qemu binary and run on all supported machine types
-                if ((self.options.vt_arch is None) and
-                        (self.options.vt_guest_os is None)):
+                if ((get_opt(self.options, 'vt_arch') is None) and
+                        (get_opt(self.options, 'vt_guest_os') is None)):
                     self.cartesian_parser.only_filter(
                         defaults.DEFAULT_MACHINE_TYPE)
             else:
-                self.cartesian_parser.only_filter(self.options.vt_machine_type)
+                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_machine_type'))
         else:
             logging.info("Config provided, ignoring %s", machine_type_setting)
 
     def _process_image_type(self):
         image_type_setting = 'config vt.qemu.image_type'
-        if not self.options.vt_config:
-            if self.options.vt_image_type in SUPPORTED_IMAGE_TYPES:
-                self.cartesian_parser.only_filter(self.options.vt_image_type)
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_image_type') in SUPPORTED_IMAGE_TYPES:
+                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_image_type'))
             else:
                 self.cartesian_parser.only_filter("raw")
                 # The actual param name is image_format.
                 self.cartesian_parser.assign("image_format",
-                                             self.options.vt_image_type)
+                                             get_opt(self.options, 'vt_image_type'))
         else:
             logging.info("Config provided, ignoring %s", image_type_setting)
 
     def _process_nic_model(self):
         nic_model_setting = 'config vt.qemu.nic_model'
-        if not self.options.vt_config:
-            if self.options.vt_nic_model in SUPPORTED_NIC_MODELS:
-                self.cartesian_parser.only_filter(self.options.vt_nic_model)
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_nic_model') in SUPPORTED_NIC_MODELS:
+                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_nic_model'))
             else:
                 self.cartesian_parser.only_filter("nic_custom")
                 self.cartesian_parser.assign(
-                    "nic_model", self.options.vt_nic_model)
+                    "nic_model", get_opt(self.options, 'vt_nic_model'))
         else:
             logging.info("Config provided, ignoring %s", nic_model_setting)
 
     def _process_disk_buses(self):
         disk_bus_setting = 'config vt.qemu.disk_bus'
-        if not self.options.vt_config:
-            if self.options.vt_disk_bus in SUPPORTED_DISK_BUSES:
-                self.cartesian_parser.only_filter(self.options.vt_disk_bus)
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_disk_bus') in SUPPORTED_DISK_BUSES:
+                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_disk_bus'))
             else:
                 raise ValueError("Invalid %s '%s'. Valid values: %s" %
                                  (disk_bus_setting,
-                                  self.options.vt_disk_bus,
+                                  get_opt(self.options, 'vt_disk_bus'),
                                   SUPPORTED_DISK_BUSES))
         else:
             logging.info("Config provided, ignoring %s", disk_bus_setting)
@@ -283,43 +292,43 @@ class VirtTestOptionsProcess(object):
     def _process_vhost(self):
         nettype_setting = 'config vt.qemu.nettype'
         vhost_setting = 'config vt.qemu.vhost'
-        if not self.options.vt_config:
-            if self.options.vt_nettype == "bridge":
-                if self.options.vt_vhost == "on":
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_nettype') == "bridge":
+                if get_opt(self.options, 'vt_vhost') == "on":
                     self.cartesian_parser.assign("vhost", "on")
-                elif self.options.vt_vhost == "force":
+                elif get_opt(self.options, 'vt_vhost') == "force":
                     self.cartesian_parser.assign("netdev_extra_params",
                                                  '",vhostforce=on"')
                     self.cartesian_parser.assign("vhost", "on")
             else:
-                if self.options.vt_vhost in ["on", "force"]:
+                if get_opt(self.options, 'vt_vhost') in ["on", "force"]:
                     raise ValueError("%s '%s' is incompatible with %s '%s'"
                                      % (nettype_setting,
-                                        self.options.vt_nettype,
+                                        get_opt(self.options, 'vt_nettype'),
                                         vhost_setting,
-                                        self.options.vt_vhost))
+                                        get_opt(self.options, 'vt_vhost')))
         else:
             logging.info("Config provided, ignoring %s", vhost_setting)
 
     def _process_qemu_sandbox(self):
         sandbox_setting = 'config vt.qemu.sandbox'
-        if not self.options.vt_config:
-            if self.options.vt_qemu_sandbox == "off":
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_qemu_sandbox') == "off":
                 self.cartesian_parser.assign("qemu_sandbox", "off")
         else:
             logging.info("Config provided, ignoring %s", sandbox_setting)
 
     def _process_qemu_defconfig(self):
         defconfig_setting = 'config vt.qemu.sandbox'
-        if not self.options.vt_config:
-            if self.options.vt_qemu_defconfig == "no":
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_qemu_defconfig') == "no":
                 self.cartesian_parser.assign("defconfig", "no")
         else:
             logging.info("Config provided, ignoring %s", defconfig_setting)
 
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
-                                     self.options.vt_malloc_perturb)
+                                     get_opt(self.options, 'vt_malloc_perturb'))
 
     def _process_qemu_specific_options(self):
         """
@@ -343,62 +352,63 @@ class VirtTestOptionsProcess(object):
         """
         Calls for processing all options specific to lvsb test
         """
-        self.options.no_downloads = True
+        set_opt(self.options, 'no_downloads', True)
 
     def _process_libvirt_specific_options(self):
         """
         Calls for processing all options specific to libvirt test.
         """
         uri_setting = 'config vt.libvirt.connect_uri'
-        if self.options.vt_connect_uri:
+        if get_opt(self.options, 'vt_connect_uri'):
             driver_found = False
             for driver in SUPPORTED_LIBVIRT_DRIVERS:
-                if self.options.vt_connect_uri.count(driver):
+                if get_opt(self.options, 'vt_connect_uri').count(driver):
                     driver_found = True
                     self.cartesian_parser.only_filter(driver)
             if not driver_found:
                 raise ValueError("Unsupported %s '%s'"
-                                 % (uri_setting, self.options.vt_connect_uri))
+                                 % (uri_setting, get_opt(self.options, 'vt_connect_uri')))
         else:
             self.cartesian_parser.only_filter("qemu")
 
     def _process_guest_os(self):
         guest_os_setting = 'option --vt-guest-os'
 
-        if self.options.vt_type == 'spice':
+        if get_opt(self.options, 'vt_type') == 'spice':
             logging.info("Ignoring predefined OS: %s", guest_os_setting)
             return
 
-        if not self.options.vt_config:
+        if not get_opt(self.options, 'vt_config'):
             if len(standalone_test.get_guest_name_list(self.options)) == 0:
                 raise ValueError("%s '%s' is not on the known guest os for "
                                  "arch '%s' and machine type '%s'. (see "
                                  "--vt-list-guests)"
-                                 % (guest_os_setting, self.options.vt_guest_os,
-                                    self.options.vt_arch,
-                                    self.options.vt_machine_type))
+                                 % (guest_os_setting,
+                                    get_opt(self.options, 'vt_guest_os'),
+                                    get_opt(self.options, 'vt_arch'),
+                                    get_opt(self.options, 'vt_machine_type')))
             self.cartesian_parser.only_filter(
-                self.options.vt_guest_os or defaults.DEFAULT_GUEST_OS)
+                get_opt(self.options, 'vt_guest_os') or defaults.DEFAULT_GUEST_OS)
         else:
             logging.info("Config provided, ignoring %s", guest_os_setting)
 
     def _process_restart_vm(self):
-        if not self.options.vt_config:
-            if not self.options.vt_keep_guest_running:
+        if not get_opt(self.options, 'vt_config'):
+            if not get_opt(self.options, 'vt_keep_guest_running'):
                 self.cartesian_parser.assign("kill_vm", "yes")
 
     def _process_restore_image(self):
-        if not self.options.vt_config:
-            if self.options.vt_backup_image_before_test:
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_backup_image_before_test'):
                 self.cartesian_parser.assign("backup_image_before_testing",
                                              "yes")
-            if self.options.vt_restore_image_after_test:
+            if get_opt(self.options, 'vt_restore_image_after_test'):
                 self.cartesian_parser.assign("restore_image_after_testing",
                                              "yes")
 
     def _process_mem(self):
-        if not self.options.vt_config:
-            mem = self.options.vt_mem
+        if not get_opt(self.options, 'vt_config'):
+            mem = get_opt(self.options, 'vt_mem')
             if mem is not None:
                 self.cartesian_parser.assign("mem", mem)
 
@@ -417,24 +427,24 @@ class VirtTestOptionsProcess(object):
             self.cartesian_parser.assign("run_tcpdump", "no")
 
     def _process_no_filter(self):
-        if self.options.vt_no_filter:
-            for item in self.options.vt_no_filter.split(' '):
+        if get_opt(self.options, 'vt_no_filter'):
+            for item in get_opt(self.options, 'vt_no_filter').split(' '):
                 self.cartesian_parser.no_filter(item)
 
     def _process_only_filter(self):
-        if self.options.vt_only_filter:
-            for item in self.options.vt_only_filter.split(' '):
+        if get_opt(self.options, 'vt_only_filter'):
+            for item in get_opt(self.options, 'vt_only_filter').split(' '):
                 self.cartesian_parser.only_filter(item)
 
     def _process_extra_params(self):
-        if getattr(self.options, "vt_extra_params", False):
-            for param in self.options.vt_extra_params:
+        if get_opt(self.options, "vt_extra_params"):
+            for param in get_opt(self.options, "vt_extra_params"):
                 key, value = param.split('=', 1)
                 self.cartesian_parser.assign(key, value)
 
     def _process_only_type_specific(self):
-        if not self.options.vt_config:
-            if self.options.vt_type_specific:
+        if not get_opt(self.options, 'vt_config'):
+            if get_opt(self.options, 'vt_type_specific'):
                 self.cartesian_parser.only_filter("(subtest=type_specific)")
 
     def _process_general_options(self):
@@ -462,7 +472,7 @@ class VirtTestOptionsProcess(object):
         """
         # We can call here for self._process_qemu_specific_options()
         # to process some --options, but let SpiceQA tests will be independent
-        self.options.no_downloads = True
+        set_opt(self.options, 'no_downloads', True)
 
     def _process_options(self):
         """
@@ -471,52 +481,55 @@ class VirtTestOptionsProcess(object):
         cfg = None
         vt_type_setting = 'option --vt-type'
         vt_config_setting = 'option --vt-config'
-        if (not self.options.vt_type) and (not self.options.vt_config):
+
+        vt_type = get_opt(self.options, 'vt_type')
+        vt_config = get_opt(self.options, 'vt_config')
+
+        if (not vt_type) and (not vt_config):
             raise ValueError("No %s or %s specified" %
                              (vt_type_setting, vt_config_setting))
 
-        if self.options.vt_type:
-            if self.options.vt_type not in SUPPORTED_TEST_TYPES:
+        if vt_type:
+            if vt_type not in SUPPORTED_TEST_TYPES:
                 raise ValueError("Invalid %s %s. Valid values: %s. "
                                  % (vt_type_setting,
-                                    self.options.vt_type,
+                                    vt_type,
                                     " ".join(SUPPORTED_TEST_TYPES)))
 
         self.cartesian_parser = cartesian_config.Parser(debug=False)
 
-        if self.options.vt_config:
-            cfg = os.path.abspath(self.options.vt_config)
+        if vt_config:
+            cfg = os.path.abspath(vt_config)
             self.cartesian_parser.parse_file(cfg)
-        elif self.options.vt_filter_default_filters:
-            cfg = data_dir.get_backend_cfg_path(self.options.vt_type,
+        elif get_opt(self.options, 'vt_filter_default_filters'):
+            cfg = data_dir.get_backend_cfg_path(vt_type,
                                                 'tests-shared.cfg')
             self.cartesian_parser.parse_file(cfg)
             for arg in ('no_9p_export', 'no_virtio_rng', 'no_pci_assignable',
                         'smallpages', 'default_bios', 'bridge'):
-                if arg not in self.options.vt_filter_default_filters:
+                if arg not in get_opt(self.options, 'vt_filter_default_filters'):
                     self.cartesian_parser.only_filter(arg)
-            if 'image_backend' not in self.options.vt_filter_default_filters:
+            if 'image_backend' not in get_opt(self.options, 'vt_filter_default_filters'):
                 self.cartesian_parser.only_filter('(image_backend='
                                                   'filesystem)')
-            if 'multihost' not in self.options.vt_filter_default_filters:
+            if 'multihost' not in get_opt(self.options, 'vt_filter_default_filters'):
                 self.cartesian_parser.no_filter('multihost')
         else:
-            cfg = data_dir.get_backend_cfg_path(self.options.vt_type,
-                                                'tests.cfg')
+            cfg = data_dir.get_backend_cfg_path(vt_type, 'tests.cfg')
             self.cartesian_parser.parse_file(cfg)
 
-        if self.options.vt_type != 'lvsb':
+        if vt_type != 'lvsb':
             self._process_general_options()
 
-        if self.options.vt_type == 'qemu':
+        if vt_type == 'qemu':
             self._process_qemu_specific_options()
-        elif self.options.vt_type == 'lvsb':
+        elif vt_type == 'lvsb':
             self._process_lvsb_specific_options()
-        elif self.options.vt_type == 'openvswitch':
+        elif vt_type == 'openvswitch':
             self._process_qemu_specific_options()
-        elif self.options.vt_type == 'libvirt':
+        elif vt_type == 'libvirt':
             self._process_libvirt_specific_options()
-        elif self.options.vt_type == 'spice':
+        elif vt_type == 'spice':
             self._process_spice_specific_options()
 
         self._process_extra_params()

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -12,7 +12,6 @@
 # Copyright: Red Hat Inc. 2015
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-import argparse
 import sys
 import logging
 
@@ -97,18 +96,14 @@ class VTBootstrap(CLICmd):
                             help=("The architecture of the distro to be used when "
                                   "generating the host configuration entry."))
 
-    def run(self, args):
+    def run(self, config):
         # Enable root logger as some Avocado-vt libraries use that
         handler = logging.StreamHandler()
         handler.setLevel(logging.DEBUG)
         logging.getLogger("").addHandler(handler)
 
-        # Compatibility with nrunner Avocado
-        if isinstance(args, dict):
-            args = argparse.Namespace(**args)
-
         try:
-            bootstrap.bootstrap(options=args, interactive=True)
+            bootstrap.bootstrap(options=config, interactive=True)
             sys.exit(0)
         except process.CmdError as ce:
             if ce.result.interrupted:

--- a/virttest/compat.py
+++ b/virttest/compat.py
@@ -1,0 +1,28 @@
+import argparse
+
+
+def get_opt(opt, name):
+    """
+    Compatibility handler for options in either argparse.Namespace or dict
+
+    :param opt: either an argpase.Namespace instance or a dict
+    :param name: the name of the attribute or key
+    """
+    if isinstance(opt, argparse.Namespace):
+        return getattr(opt, name, None)
+    else:
+        return opt.get(name)
+
+
+def set_opt(opt, name, value):
+    """
+    Compatibility handler for options in either argparse.Namespace or dict
+
+    :param opt: either an argpase.Namespace instance or a dict
+    :param name: the name of the attribute or key
+    :param value: the value to be set
+    """
+    if isinstance(opt, argparse.Namespace):
+        setattr(opt, name, value)
+    else:
+        opt[name] = value

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -4,6 +4,7 @@ from avocado.utils import path as utils_path
 
 from . import data_dir
 from . import cartesian_config
+from .compat import get_opt
 
 GUEST_NAME_LIST = None
 TAG_INDEX = {}
@@ -105,18 +106,18 @@ def get_cartesian_parser_details(cartesian_parser):
 
 def get_guest_name_parser(options):
     cartesian_parser = cartesian_config.Parser()
-    machines_cfg_path = data_dir.get_backend_cfg_path(options.vt_type,
+    machines_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt_type'),
                                                       'machines.cfg')
-    guest_os_cfg_path = data_dir.get_backend_cfg_path(options.vt_type,
+    guest_os_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt_type'),
                                                       'guest-os.cfg')
     cartesian_parser.parse_file(machines_cfg_path)
     cartesian_parser.parse_file(guest_os_cfg_path)
-    if options.vt_arch:
-        cartesian_parser.only_filter(options.vt_arch)
-    if options.vt_machine_type:
-        cartesian_parser.only_filter(options.vt_machine_type)
-    if options.vt_guest_os:
-        cartesian_parser.only_filter(options.vt_guest_os)
+    if get_opt(options, 'vt_arch'):
+        cartesian_parser.only_filter(get_opt(options, 'vt_arch'))
+    if get_opt(options, 'vt_machine_type'):
+        cartesian_parser.only_filter(get_opt(options, 'vt_machine_type'))
+    if get_opt(options, 'vt_guest_os'):
+        cartesian_parser.only_filter(get_opt(options, 'vt_guest_os'))
     return cartesian_parser
 
 


### PR DESCRIPTION
Which is part of the "Job API enabler" work, while keeping
compatibility with previous Avocado version that supply an
argparse.Namespace instance.

Reference: https://github.com/avocado-framework/avocado/pull/3248
Signed-off-by: Cleber Rosa <crosa@redhat.com>