### PR TITLE
avocado_vt: Add compatibility with nrunner Avocado

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -16,6 +16,7 @@
 Avocado VT plugin
 """
 
+import argparse
 import copy
 import logging
 import os
@@ -103,6 +104,9 @@ class VirtTestLoader(loader.TestLoader):
            of this plugins "self.args" (extends the --vt-extra-params)
         """
         vt_extra_params = extra_params.pop("avocado_vt_extra_params", None)
+        # Compatibility with nrunner Avocado
+        if isinstance(args, dict):
+            args = argparse.Namespace(**args)
         super(VirtTestLoader, self).__init__(args, extra_params)
         self._fill_optional_args()
         if vt_extra_params:

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -16,6 +16,7 @@
 Avocado VT plugin
 """
 
+import argparse
 import logging
 import os
 
@@ -44,7 +45,11 @@ class VirtTestOptionsProcess(object):
         """
         Parses options and initializes attributes.
         """
-        self.options = options
+        # Compatibility with nrunner Avocado
+        if isinstance(options, dict):
+            self.options = argparse.Namespace(**options)
+        else:
+            self.options = options
         # There are a few options from the original virt-test runner
         # that don't quite make sense for avocado (avocado implements a
         # better version of the virt-test feature).

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -12,6 +12,7 @@
 # Copyright: Red Hat Inc. 2015
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import argparse
 import sys
 import logging
 
@@ -101,6 +102,10 @@ class VTBootstrap(CLICmd):
         handler = logging.StreamHandler()
         handler.setLevel(logging.DEBUG)
         logging.getLogger("").addHandler(handler)
+
+        # Compatibility with nrunner Avocado
+        if isinstance(args, dict):
+            args = argparse.Namespace(**args)
 
         try:
             bootstrap.bootstrap(options=args, interactive=True)

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -51,7 +51,7 @@ class VTJobLock(Pre, Post):
     name = 'vt-joblock'
     description = 'Avocado-VT Job Lock/Unlock'
 
-    def __init__(self, args=None):
+    def __init__(self, **kwargs):
         self.log = logging.getLogger("avocado.app")
         self.lock_dir = os.path.expanduser(settings.get_value(
             section="plugins.vtjoblock",


### PR DESCRIPTION
Avocado with nrunner uses dict instead of argparse.Namespace object for
args. Let's "downgrade" the dict to argparce.Namespace as a hotfix,
before all places are tackled and we could switch to the dict-like
access.

This is a hotfix that should be easier to review than the original https://github.com/avocado-framework/avocado-vt/pull/2194 but it should not replace the need for the proper fix (update vs. downgrade)