### PR TITLE
Improve CI checks with Avocado + Avocado-VT (using Cirrus CI)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,23 @@
+smoke_task:
+    env:
+       CIRRUS_CLONE_DEPTH: 10
+    setup_script:
+       - dnf -y install python3 git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
+       - python3 -m pip install $AVOCADO_SOURCE
+       - python3 -m pip install -r requirements.txt
+       - python3 setup.py develop --user
+    bootstrap_script:
+       - python3 -m avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
+    list_script:
+       - python3 -m avocado list
+    dry_run_script:
+       - python3 -m avocado --show all run --dry-run -- boot
+    container:
+        matrix:
+          - image: fedora:30
+          - image: fedora:29
+    env:
+        matrix:
+          - AVOCADO_SOURCE: avocado-framework==69.1
+          - AVOCADO_SOURCE: avocado-framework==70.0
+          - AVOCADO_SOURCE: -e git+https://github.com/avocado-framework/avocado#egg=avocado_framework

--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -38,7 +38,7 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 70.0
-Release: 0%{?gitrel}%{?dist}
+Release: 1%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -49,9 +49,11 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.g
 # old way of retrieving snapshot sources
 #Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}/%{srcname}-%{version}-%{shortcommit}.tar.gz
 %endif
-BuildRequires: python2-devel, python2-setuptools
+BuildRequires: python2-devel, python2-setuptools, python-six
+Requires: python-six
 %if %{with_python3}
-BuildRequires: python3-devel, python3-setuptools
+BuildRequires: python3-devel, python3-setuptools, python3-six
+Requires: python3-six
 %endif
 BuildArch: noarch
 Requires: autotest-framework, xz, tcpdump, iproute, iputils, gcc, glibc-headers, nc, git
@@ -162,6 +164,9 @@ Xunit output, among others.
 
 
 %changelog
+* Tue Aug 13 2019 Cleber Rosa <cleber@redhat.com> - 70.0-1
+- Added six requirement
+
 * Wed Jun 26 2019 Cleber Rosa <cleber@redhat.com> - 70.0-0
 - New release
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ aexpect>1.5.0
 simplejson>=3.5.3
 netaddr>=0.7.18
 netifaces>=0.10.5
+six


### PR DESCRIPTION
This adds an initial set of Avocado + Avocado-VT basic set of checks on Fedora 29 and 30.
    
Because Avocado-VT should work with LTS and non-LTS version, this uses two released versions (one LTS, one regular release) and also adds a compatibility check with Avocado's master.
    
This initial version is also limited to Python 2 (and given the Python 2 lifetime, will probably remain like that).