### PR TITLE
env_process: update params image_name keys with vm_params

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1108,6 +1108,8 @@ def preprocess(test, params, env):
             for image in vm_params.get("master_images_clone").split():
                 image_obj = qemu_storage.QemuImg(vm_params, base_dir, image)
                 image_obj.clone_image(vm_params, vm_name, image, base_dir)
+            params["image_name_%s" % vm_name] = vm_params["image_name_%s" % vm_name]
+            params["image_name_%s_%s" % (image, vm_name)] = vm_params["image_name_%s_%s" % (image, vm_name)]
 
     # Preprocess all VMs and images
     if params.get("not_preprocess", "no") == "no":


### PR DESCRIPTION
from commit 281e7990, vm_params is used for cloning image to
support multiple images on multiple vms, but clone_image()
updates image_name_* in vm_params but not in global params.
This fix gives backward compatibility to use vm clone with
or without vm specific `master_image_name` and `image_name`.

Reported-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>
Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>