### PR TITLE
Only initiate libvirtd installation helper when really needed

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1036,7 +1036,7 @@ def preprocess(test, params, env):
     # Write it as a keyval
     test.write_test_keyval(version_info)
 
-    libvirtd_inst = utils_libvirtd.Libvirtd()
+    libvirtd_inst = None
 
     # If guest is configured to be backed by hugepages, setup hugepages in host
     if params.get("hugepage") == "yes":
@@ -1050,6 +1050,8 @@ def preprocess(test, params, env):
         if suggest_mem is not None:
             params['mem'] = suggest_mem
         if vm_type == "libvirt":
+            if libvirtd_inst is None:
+                libvirtd_inst = utils_libvirtd.Libvirtd()
             libvirtd_inst.restart()
 
     if params.get("setup_thp") == "yes":
@@ -1080,6 +1082,8 @@ def preprocess(test, params, env):
                 logging.error(str(e))
             except Exception as e:
                 logging.error("Unexpected error: '%s'" % str(e))
+            if libvirtd_inst is None:
+                libvirtd_inst = utils_libvirtd.Libvirtd()
             libvirtd_inst.restart()
 
     # Execute any pre_commands
@@ -1358,6 +1362,8 @@ def postprocess(test, params, env):
             h = test_setup.HugePageConfig(params)
             h.cleanup()
             if vm_type == "libvirt":
+                if libvirtd_inst is None:
+                    libvirtd_inst = utils_libvirtd.Libvirtd()
                 libvirtd_inst.restart()
         except Exception as details:
             err += "\nHP cleanup: %s" % str(details).replace('\\n', '\n  ')
@@ -1394,6 +1400,8 @@ def postprocess(test, params, env):
             try:
                 pol = test_setup.LibvirtPolkitConfig(params)
                 pol.cleanup()
+                if libvirtd_inst is None:
+                    libvirtd_inst = utils_libvirtd.Libvirtd()
                 libvirtd_inst.restart()
             except test_setup.PolkitConfigCleanupError as e:
                 err += "\nPolkit cleanup: %s" % str(e).replace('\\n', '\n  ')


### PR DESCRIPTION
This lazy initialization is motivated by the fact that on some
container based testing scenarios, we don't want to even touch the
service manager utility code, which breaks when trying to determine if
this "system" is SysV or systemd based (and is neither).

Signed-off-by: Cleber Rosa <crosa@redhat.com>