### PR TITLE
Make sure postprocess cleans up libvirt VM properly

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -474,6 +474,9 @@ kill_timeout = 60
 # Undefines vm from libvirt environment if set
 kill_vm_libvirt = no
 
+# VM Undefine options during postprocess if kill_vm_libvirt is enabled
+kill_vm_libvirt_options = '--managed-save'
+
 # Cleans up the env if set
 env_cleanup = no
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -497,7 +497,7 @@ def postprocess_vm(test, params, env, name):
             utils_misc.wait_for(vm.is_dead, kill_vm_timeout, 0, 1)
         vm.destroy(gracefully=params.get("kill_vm_gracefully") == "yes")
         if params.get("kill_vm_libvirt") == "yes" and params.get("vm_type") == "libvirt":
-            vm.undefine()
+            vm.undefine(options=params.get('kill_vm_libvirt_options'))
 
     if params.get("enable_strace") == "yes":
         strace = test_setup.StraceQemu(test, params, env)


### PR DESCRIPTION
Sometimes libvirt refuses to undefine VM properly even
`kill_vm_libvirt` is set due to issue in managed-save etc.,
So, let's use user defined param, `kill_vm_libvirt_opions`
to give additional undefine params, it is bydefault set to
clear if any managed state file, but it can be customized many
other usecases, like remove storage, clear snanpshot metadata.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>