### PR TITLE
virttest.qemu_devices: Allow cache='' in images definition

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1622,7 +1622,7 @@ class DevContainer(object):
         if Flags.BLOCKDEV in self.__caps:
             devices[-2].set_param('filename', filename)
             for dev in (devices[-1], devices[-2]):
-                if cache is None:
+                if not cache:
                     direct, no_flush = (None, None)
                 else:
                     direct, no_flush = (self.cache_map[cache]['cache.direct'],
@@ -1735,7 +1735,7 @@ class DevContainer(object):
         if Flags.BLOCKDEV in self.__caps:
             if isinstance(devices[-3], qdevices.QBlockdevProtocolHostDevice):
                 self.cache_map[cache]['write-cache'] = None
-            write_cache = None if cache is None else self.cache_map[cache]['write-cache']
+            write_cache = None if not cache else self.cache_map[cache]['write-cache']
             devices[-1].set_param('write-cache', write_cache)
             if 'scsi-generic' == fmt:
                 rerror, werror = (None, None)


### PR DESCRIPTION
The newly introduced cache_map 7a685934dda4d0de05e3aec31ea330384d5eb816 only works with valid values or None, but
these params are often specified in cart config and might result in
empty string instead of None. Even we set it to "" on line 2018 in
cdroms_define_by_params in case of aio == threads.

Instead of fixing our value let's treat any empty string the same as
None as users might want to get the default from cart config.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>