### PR TITLE
Add Fedora 30 x86_64 and aarch64 guest and assets definitions

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/30.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/30.cfg
@@ -1,0 +1,49 @@
+- 30:
+    variants:
+        - x86_64:
+            vm_arch_name = x86_64
+        - aarch64:
+            vm_arch_name = aarch64
+    image_name = images/f30-${vm_arch_name}
+    os_variant = fedora30
+    # default boot path is set in ../Fedora.cfg: boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel = images/f30-${vm_arch_name}/vmlinuz
+        initrd = images/f30-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/Fedora-30.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            # Unless overridden use secondary url, because it's the most common one
+            url = https://download.fedoraproject.org/pub/fedora/linux/releases/30/Server/${vm_arch_name}/os/
+        x86_64:
+            kernel_params = "console=tty0 console=ttyS0"
+            unattended_install.cdrom:
+                cdrom_cd1 = isos/linux/Fedora-Server-dvd-x86_64-30-1.2.iso
+                md5sum_cd1 = a24d2fed6440df75bd49d531f71a2b84
+                md5sum_1m_cd1 = 07c58a0139b02d178ed2e88eb20f5ca7
+            unattended_install.url:
+                sha1sum_vmlinuz = 89f9019a03b49a2c8a4aa8617710e3e1563dc6d6
+                sha1sum_initrd = b3451ed1214c284fca180e0678b0c46549e5325e
+        aarch64:
+            unattended_install, svirt_install:
+                unattended_file = unattended/Fedora-30.aarch64.ks
+            kernel_params = "console=ttyAMA0 console=ttyS0 serial"
+            unattended_install.cdrom:
+                cdrom_cd1 = isos/linux/Fedora-Server-dvd-aarch64-30-1.2.iso
+                md5sum_cd1 = 171fc8c60f08beba41b3d83c6ebda1b0
+                md5sum_1m_cd1 = a14b71cb518f2e5a1717ca2daf3c6dfa
+            unattended_install.url:
+                sha1sum_vmlinuz = bf1247d61743575f03f8e8fcbb9aa8335b1e72b1
+                sha1sum_initrd = 227b9756fd458a4bf877e2653d23c1bc66a28f51
+        # Shared specific setting
+        unattended_install.url:
+            kernel_params += " inst.repo=${url}"
+        extra_cdrom_ks:
+            kernel_params += " ks=cdrom"
+            cdrom_unattended = images/f30-${vm_arch_name}/ks.iso
+        syslog_server_proto = tcp
+        kernel_params += " nicdelay=60 inst.sshd"

--- a/shared/downloads/fedora-30-aarch64.ini
+++ b/shared/downloads/fedora-30-aarch64.ini
@@ -1,0 +1,4 @@
+[fedora-30-aarch64]
+title = Fedora 30 aarch64
+url = https://download.fedoraproject.org/pub/fedora/linux/releases/30/Server/aarch64/iso/Fedora-Server-dvd-aarch64-30-1.2.iso
+destination = isos/linux/Fedora-Server-dvd-aarch64-30-1.2.iso

--- a/shared/downloads/fedora-30-x86_64.ini
+++ b/shared/downloads/fedora-30-x86_64.ini
@@ -1,0 +1,4 @@
+[fedora-30-x86_64]
+title = Fedora 30 x86_64
+url = https://download.fedoraproject.org/pub/fedora/linux/releases/30/Server/x86_64/iso/Fedora-Server-dvd-x86_64-30-1.2.iso
+destination = isos/linux/Fedora-Server-dvd-x86_64-30-1.2.iso

--- a/shared/unattended/Fedora-30.aarch64.ks
+++ b/shared/unattended/Fedora-30.aarch64.ks
@@ -1,0 +1,36 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+part /boot/efi --size=200 --ondisk=sda --fstype=efi
+part / --fstype=ext4 --grow --asprimary --size=1
+
+%packages --ignoremissing
+@minimal-environment
+%end
+
+%post
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+sed -i -e "s,^GRUB_TIMEOUT=.*,GRUB_TIMEOUT=0," /etc/default/grub
+grub2-mkconfig > /etc/grub2.cfg
+ECHO 'Post set up finished'
+%end

--- a/shared/unattended/Fedora-30.ks
+++ b/shared/unattended/Fedora-30.ks
@@ -1,0 +1,35 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+reboot
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+part / --fstype=ext4 --grow --asprimary --size=1
+
+%packages --ignoremissing
+@minimal-environment
+%end
+
+%post
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+sed -i -e "s,^GRUB_TIMEOUT=.*,GRUB_TIMEOUT=0," /etc/default/grub
+grub2-mkconfig > /etc/grub2.cfg
+ECHO 'Post set up finished'
+%end


### PR DESCRIPTION
This is currently limited to the primary architectures, that is,
the non "alternative" or "secondary" ones.

For those intending to use a non-aarch64 platform to install/use
this guest, the following command line can be helpful:

   avocado run --vt-qemu-bin=/usr/bin/qemu-system-aarch64 \
      --vt-arch=aarch64 --vt-machine-type=arm64-pci \
      --vt-guest-os=Guest.Linux.Fedora.30.aarch64 \
      --vt-extra-params 'enable_kvm=no' 'cpu_model=cortex-a53' 'machine_type_extra_params=' \
      -- io-github-autotest-qemu.unattended_install.cdrom.extra_cdrom_ks.default_install.aio_threads

Signed-off-by: Cleber Rosa <crosa@redhat.com>