### PR TITLE
CI: add smoke checks based on containers and Cirrus CI [v2]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,41 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+fedora_30_task:
+  env:
+    PYTHON: python3
+  container:
+    image: quay.io/avocado-framework/avocado-vt-ci-fedora-30
+  setup_script:
+    - $PYTHON --version
+    - $PYTHON -m pip install $AVOCADO_SRC
+    - $PYTHON -m pip install -r requirements.txt
+    - $PYTHON setup.py develop --user
+  bootstrap_script:
+    - $PYTHON -m avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
+  list_script:
+    - $PYTHON -m avocado list
+  dry_run_script:
+    - $PYTHON -m avocado --show all run --dry-run -- boot
+  env:
+    matrix:
+      - AVOCADO_SRC: avocado-framework<70.0
+      - AVOCADO_SRC: -e git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+
+centos_7_task:
+  env:
+    PYTHON: python2
+    AVOCADO_SRC: avocado-framework<70.0
+  container:
+    image: quay.io/avocado-framework/avocado-vt-ci-centos-7
+  setup_script:
+    - $PYTHON --version
+    - $PYTHON -m pip install $AVOCADO_SRC
+    - $PYTHON -m pip install -r requirements.txt
+    - $PYTHON setup.py develop --user
+  bootstrap_script:
+    - $PYTHON -m avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
+  list_script:
+    - $PYTHON -m avocado list
+  dry_run_script:
+    - $PYTHON -m avocado --show all run --dry-run -- boot

--- a/contrib/containers/ci/README
+++ b/contrib/containers/ci/README
@@ -1,0 +1,1 @@
+These containers are used in CI checks, such as the Cirrus-CI checks.

--- a/contrib/containers/ci/centos-7.docker
+++ b/contrib/containers/ci/centos-7.docker
@@ -1,0 +1,5 @@
+FROM centos:7.6.1810
+LABEL description "CentOS 7 image used on integration checks, such as cirrus-ci"
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum -y install git tcpdump nc iproute gcc python-devel qemu-kvm qemu-img python2-pip
+RUN yum -y clean all

--- a/contrib/containers/ci/fedora-30.docker
+++ b/contrib/containers/ci/fedora-30.docker
@@ -1,0 +1,4 @@
+FROM fedora:30
+LABEL description "Fedora image used on integration checks, such as cirrus-ci"
+RUN dnf -y install git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
+RUN dnf -y clean all


### PR DESCRIPTION
This adds an initial set of Avocado + Avocado-VT basic set of
checks on Fedora and CentOS.

Because Avocado-VT should work with Avocado's LTS and non-LTS version,
this uses the latest LTS release and Avocado's latest master.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---
Changes from v1 (#2199):
 * Added/built/hosted container images for Fedora 30 and CentOS 7, to improve stability of the environment and keep just the right pieces "moving"
 * Added testing for both Python 2 and 3
 * Set clone depth to 1
