### PR TITLE
CI: add smoke checks based on containers and Cirrus CI [v3]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,63 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+fedora_30_task:
+  container:
+    image: quay.io/avocado-framework/avocado-vt-ci-fedora-30
+  env:
+    PYTHON: python3
+    matrix:
+      - AVOCADO_SRC: avocado-framework<70.0
+      - AVOCADO_SRC: -e git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+    matrix:
+      - SETUP: setup.py develop --user
+      - SETUP: -m pip install .
+  setup_script: &setup_scr
+    - $PYTHON --version
+    - $PYTHON -m pip install $AVOCADO_SRC
+    - $PYTHON -m pip install -r requirements.txt
+    - $PYTHON $SETUP
+  bootstrap_script: &bootstrap_scr
+    - $PYTHON -m avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
+  list_script: &list_scr
+    - $PYTHON -m avocado list
+  dry_run_script: &dry_run_scr
+    - $PYTHON -m avocado --show all run --dry-run -- boot
+
+rhel_8_task:
+  container:
+    image: quay.io/avocado-framework/avocado-vt-ci-rhel-8
+  env:
+    PYTHON: python3
+    matrix:
+      - AVOCADO_SRC: avocado-framework<70.0
+      # When installing from source, pip tries to install at
+      # /usr/local/lib/python3.6/site-packages/ and fails with:
+      # [Errno 2] No such file or directory: '/usr/local/lib/python3.6/site-packages/test-easy-install-78.write-test'
+      # workaround is to add "--prefix /"
+      - AVOCADO_SRC: --prefix / -e git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+    matrix:
+      - SETUP: setup.py develop --user
+      - SETUP: -m pip install .
+  setup_script:
+    *setup_scr
+  plugin_script:
+    - $PYTHON -m avocado plugins 2>/dev/null | grep vt-bootstrap
+
+centos_7_task:
+  env:
+    PYTHON: python2
+    AVOCADO_SRC: avocado-framework<70.0
+    matrix:
+      - SETUP: setup.py develop --user
+      - SETUP: -m pip install .
+  container:
+    image: quay.io/avocado-framework/avocado-vt-ci-centos-7
+  setup_script:
+    *setup_scr
+  bootstrap_script:
+    *bootstrap_scr
+  list_script:
+    *list_scr
+  dry_run_script:
+    *dry_run_scr

--- a/contrib/containers/ci/README
+++ b/contrib/containers/ci/README
@@ -1,0 +1,1 @@
+These containers are used in CI checks, such as the Cirrus-CI checks.

--- a/contrib/containers/ci/centos-7.docker
+++ b/contrib/containers/ci/centos-7.docker
@@ -1,0 +1,5 @@
+FROM centos:7.6.1810
+LABEL description "CentOS 7 image used on integration checks, such as cirrus-ci"
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum -y install git tcpdump nc iproute gcc python-devel qemu-kvm qemu-img python2-pip
+RUN yum -y clean all

--- a/contrib/containers/ci/fedora-30.docker
+++ b/contrib/containers/ci/fedora-30.docker
@@ -1,0 +1,4 @@
+FROM fedora:30
+LABEL description "Fedora image used on integration checks, such as cirrus-ci"
+RUN dnf -y install git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
+RUN dnf -y clean all

--- a/contrib/containers/ci/rhel-8.docker
+++ b/contrib/containers/ci/rhel-8.docker
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi8/ubi
+LABEL description "RHEL 8 image used on integration checks, such as cirrus-ci"
+RUN dnf -y install git xz nc iproute iputils gcc python3-devel
+RUN dnf -y clean all


### PR DESCRIPTION
This adds an initial set of Avocado + Avocado-VT basic set of
checks on:
  - latest Fedora (30)
  - CentOS 7
  - RHEL 8

Because Avocado-VT should work with Avocado's LTS and non-LTS version,
this uses the latest LTS release and Avocado's latest master.

The RHEL 8 checks are simpler, and only involve checking the presence
of the Avocado-VT plugins, instead of doing the full bootstrap, list
and dry-run, because of package limitations.  This could be improved
in the future with some moking of the required packages and binaries.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---
Changes from v2 (#2219):
 * Used YAML anchors/references to reduce repetition (thanks @ldoktor)
 * Introduced RHEL 8 checks and container

Changes from v1 (#2199):
 * Added/built/hosted container images for Fedora 30 and CentOS 7, to improve stability of the environment and keep just the right pieces "moving"
 * Added testing for both Python 2 and 3
 * Set clone depth to 1
