### PR TITLE
qemu_vm: include internet protocol version in migration incoming uri

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2785,8 +2785,15 @@ class VM(virt_vm.BaseVM):
             elif migration_mode == "exec":
                 if migration_exec_cmd is None:
                     self.migration_port = utils_misc.find_free_port(5200, 6000)
-                    qemu_command += (' -incoming "exec:nc -l %s"' %
-                                     self.migration_port)
+                    # check whether ip version supported by nc
+                    if process.system("nc -h | grep -E '\-4 | \-6'",
+                                      shell=True, ignore_status=True) == 0:
+                        qemu_command += (' -incoming "exec:nc -l -%s %s"' %
+                                         (self.ip_version[-1],
+                                          self.migration_port))
+                    else:
+                        qemu_command += (' -incoming "exec:nc -l %s"' %
+                                         self.migration_port)
                 else:
                     qemu_command += (' -incoming "exec:%s"' %
                                      migration_exec_cmd)


### PR DESCRIPTION
ncat works appropriately with internet protocol version specified
for migration to succeed, otherwise connection get refused.

13:50:33 INFO | Migrating to "exec:nc localhost 4444"
13:50:33 DEBUG| (monitor avocado-vt-vm1.qmpmonitor1) Sending command 'migrate'
13:50:33 DEBUG| Send command: {'execute': 'migrate', 'arguments': {'uri': 'exec:nc localhost 4444', 'blk': False, 'inc': False}, 'id': 'ZQGotJkl'}
13:50:33 INFO | [qemu output] close: Bad file descriptor
13:50:33 INFO | [qemu output] Ncat: Connection reset by peer.
13:50:33 INFO | [qemu output] qemu-system-ppc64: Unable to write to command: Broken pipe

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>