### PR TITLE
Add vendor variant to host-os config

### DIFF
--- a/backends/libvirt/cfg/tests-shared.cfg
+++ b/backends/libvirt/cfg/tests-shared.cfg
@@ -12,7 +12,7 @@ connect_uri = default
 # Include the base config files.
 include base.cfg
 include subtests.cfg
-include host-os.cfg
+include host.cfg
 include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg

--- a/backends/qemu/cfg/tests-shared.cfg
+++ b/backends/qemu/cfg/tests-shared.cfg
@@ -13,7 +13,7 @@ connect_uri = default
 include base.cfg
 include machines.cfg
 include subtests.cfg
-include host-os.cfg
+include host.cfg
 include guest-os.cfg
 include guest-hw.cfg
 include cdkeys.cfg


### PR DESCRIPTION
Rename host-os.cfg to host.cfg to better fit further additions to it.
Add vendor variant to host config inorder to refine tests to be choosen.

For example, there is a test specific to Power9 HW, and
we do not need to run on Power8 HW provided, this will help
in those cases, test uses filter like `only HostCpuFamily.power9`
and similarly for intel, broadwell family file like
`only HostCpuFamily.broadwell` etc.

Today we do such checks inside the test and skip, which is
unnecessary and takes additional test run time, with this change
we do skip the test before even it starts, to be presice the test
will not be even selected to run in those environment.

Usage examples in test configs:
only HostCpuFamily.power9
only HostCpuFamily.power8
no HostCpuFamily.power8
only HostCpuFamily.power9.2.1 => DD2.1 Power9 HW
only HostCpuFamily.power9.2.3 => DD2.3 Power9 HW
only HostCpuFamily.power8
only HostCpuFamily.broadwell
only HostCpuFamily.broadwell.i5-5300U
only HostCpuVendor.amd
only HostCpuVendor.intel

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>