### PR TITLE
utils_net: Remove unhelpful log message

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3313,8 +3313,7 @@ def verify_ip_address_ownership(ip, macs, timeout=60.0, devs=None,
         return bool(utils_misc.wait_for(lambda: verify_func(ip, macs, dev,
                                                             timeout,
                                                             session=session, **dargs),
-                                        timeout,
-                                        text="Retry verifying IP address"))
+                                        timeout))
 
 
 def generate_mac_address_simple():


### PR DESCRIPTION
When running tests with windows guest, the following message would
flood the main log stream.

  Retry verifying IP address (0.000007 secs)

However, it isn't helpful since it only tells user what it will do
rather than give the detail of errors. Let's remove it then.

Signed-off-by: Xu Han <xuhan@redhat.com>