### PR TITLE
Add smp 'dies' option support and optimize parameter calculation

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -176,6 +176,9 @@ smp = 1
 #vcpu_cores = 1
 #vcpu_threads = 1
 #vcpu_sockets = 1
+#vcpu_dies = 1
+! x86_64, i386:
+    vcpu_dies = INVALID
 
 # Configure cpu mode and model
 # possible values: host-model, host-passthrough, custom, default:''

--- a/virttest/qemu_capabilities.py
+++ b/virttest/qemu_capabilities.py
@@ -19,6 +19,7 @@ class Flags(object):
     """ Enumerate the flags of VM capabilities. """
 
     BLOCKDEV = _auto_value()
+    SMP_DIES = _auto_value()
 
 
 class Capabilities(object):

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -63,6 +63,7 @@ class DevContainer(object):
                             'cache.no-flush': 'on'}}
 
     BLOCKDEV_VERSION_SCOPE = '[2.12.0, )'
+    SMP_DIES_VERSION_SCOPE = '[4.1.0, )'
 
     def __init__(self, qemu_binary, vmname, strict_mode="no",
                  workaround_qemu_qmp_crash="no", allow_hotplugged_vm="yes"):
@@ -159,6 +160,9 @@ class DevContainer(object):
         if (self.has_option('blockdev') and
                 ver in VersionInterval(self.BLOCKDEV_VERSION_SCOPE)):
             self.caps.set_flag(Flags.BLOCKDEV)
+        # -smp dies=?
+        if ver in VersionInterval(self.SMP_DIES_VERSION_SCOPE):
+            self.caps.set_flag(Flags.SMP_DIES)
 
     def __getitem__(self, item):
         """

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -459,17 +459,18 @@ class CpuInfo(object):
     """
 
     def __init__(self, model=None, vendor=None, flags=None, family=None,
-                 smp=0, maxcpus=0, sockets=0, cores=0, threads=0):
+                 smp=0, maxcpus=0, cores=0, threads=0, dies=0, sockets=0):
         """
         :param model: CPU Model of VM (use 'qemu -cpu ?' for list)
         :param vendor: CPU Vendor of VM
         :param flags: CPU Flags of VM
-        :param flags: CPU Family of VM
+        :param family: CPU Family of VM
         :param smp: set the number of CPUs to 'n' [default=1]
         :param maxcpus: maximum number of total cpus, including
                         offline CPUs for hotplug, etc
-        :param cores: number of CPU cores on one socket
+        :param cores: number of CPU cores on one socket (for PC, it's on one die)
         :param threads: number of threads on one CPU core
+        :param dies: number of CPU dies on one socket (for PC only)
         :param sockets: number of discrete sockets in the system
         """
         self.model = model
@@ -478,9 +479,10 @@ class CpuInfo(object):
         self.family = family
         self.smp = smp
         self.maxcpus = maxcpus
-        self.sockets = sockets
         self.cores = cores
         self.threads = threads
+        self.dies = dies
+        self.sockets = sockets
 
 
 def session_handler(func):


### PR DESCRIPTION
1. Add smp 'dies=*' option support
2. Optimize missing parameter calculation

Reference to: [vl.c: Add -smp, dies=* command line support and update doc](https://git.qemu.org/?p=qemu.git;a=commitdiff;h=1b45842203540943b1e22fc30764456c035d8637)
Reference to: [compute missing values, prefer sockets over cores over threads](https://github.com/qemu/qemu/blob/f3b8f18ebf344ab359e8f79f6ed777e740dae77c/hw/i386/pc.c#L1561-L1586)
Signed-off-by: Yihuang Yu <yihyu@redhat.com>