### PR TITLE
virttest.utils_test: Replace "iteritems" with "items"

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -953,7 +953,7 @@ class AvocadoGuest(object):
         Check prerequisites
         """
         # TODO: Try installing the prerequisites
-        for _, packages in self.prerequisites.iteritems():
+        for _, packages in self.prerequisites.items():
             pacman = utils_package.package_manager(self.session, packages)
             if not pacman.install(timeout=self.timeout):
                 logging.error("Failed to install - %s", packages)


### PR DESCRIPTION
On py2 this will result in insignificant memory overhead (the list will
be very small) and on py3 it will actually work.

Fixes https://github.com/avocado-framework/avocado-vt/issues/2232

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>