### PR TITLE
Add vcpu device support

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -127,6 +127,8 @@ pseries:
     usb_controller = xhci
     usb_type = nec-usb-xhci
     usb_type_usb1 = nec-usb-xhci
+    # Configure cpu_driver_type
+    cpu_driver_type = spapr-cpu-core
 #use qemu-xchi as the default controller for q35 and aarch64 platforms.
 q35, arm64-pci, arm64-mmio:
     usb_controller = xhci
@@ -528,6 +530,12 @@ used_mem = 512
 # Cpu model params
 auto_cpu_model = "yes"
 cpu_model_flags = ""
+
+# Configure cpu driver type
+x86_64:
+    cpu_driver_type = x86_64-cpu
+i386:
+    cpu_driver_type = i386-cpu
 
 # Port redirections
 redirs = remote_shell

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -991,11 +991,19 @@ def preprocess(test, params, env):
             vm.destroy()
             del env[key]
 
-    if (params.get("auto_cpu_model") == "yes" and
-            vm_type == "qemu"):
+    if params.get("auto_cpu_model") == "yes" and vm_type == "qemu":
         if not env.get("cpu_model"):
             env["cpu_model"] = utils_misc.get_qemu_best_cpu_model(params)
+            if params["machine_type"].startswith('pseries'):
+                env["cpu_model"] = 'host'
+
         params["cpu_model"] = env.get("cpu_model")
+
+        if not params.get("cpu_driver_type"):
+            cpu_model = params["cpu_model"]
+            for cpu_driver in utils_misc.get_qemu_cpu_driver(params):
+                if cpu_driver.startswith(cpu_model):
+                    params['cpu_driver_type'] = cpu_driver.replace('%s-' % cpu_model, '')
 
     version_info = {}
     # Get the KVM kernel module version

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2211,3 +2211,19 @@ class DevContainer(object):
             logging.warn("'%s' is not supported by your qemu", driver)
 
         return devices
+
+    def vcpu_device_define_by_params(self, params, parent_bus=None):
+        """
+        Create vcpu device by params.
+        :param params: vpcu device params.
+        :param parent_bus: Parent bus.
+        """
+        vcpu_driver = params['driver']
+        if not self.has_device(vcpu_driver):
+            raise exceptions.TestSkipError("Unsupported cpu driver: %s"
+                                           % vcpu_driver)
+        if parent_bus is None:
+            parent_bus = {'aobject': vcpu_driver}
+        vcpu_dev = qdevices.QCPUDevice(vcpu_type=vcpu_driver, params=params,
+                                       parent_bus=parent_bus)
+        return vcpu_dev

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -2223,6 +2223,10 @@ class QMPMonitor(Monitor):
         """
         return self.info(what, debug)
 
+    def query_cpus_fast(self, debug=True):
+        """ Query cpus-fast info """
+        return self.query('cpus-fast', debug)
+
     def screendump(self, filename, debug=True):
         """
         Request a screendump.

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2229,6 +2229,16 @@ def get_qemu_cpu_models(qemu_binary):
     return extract_qemu_cpu_models(results_stdout_52lts(result))
 
 
+def get_qemu_cpu_driver(params):
+    """Get listing of CPU device driver supported by QEMU
+    Filter list of CPU device driver by parsing the output of <qemu> -device '?'
+    """
+    qemu_binary = get_qemu_binary(params)
+    cmd = qemu_binary + " -device '?'"
+    result = process.run(cmd, verbose=False)
+    return re.findall(r'name "(\S+-cpu\S*)"', results_stdout_52lts(result), re.M)
+
+
 def _get_backend_dir(params):
     """
     Get the appropriate backend directory. Example: backends/qemu.


### PR DESCRIPTION
- qemu_monitor:
  1. Add a method 'query_cpus_fast' for QMPMonitor to distinguish 'query/info cpus'
- qdevices:
  1. Add class 'QCPUDevice' to support define a vcpu device, it supports all cpu properties
  2. Add class 'QCPUBus' to manage all vcpu, include fixed vcpu and vcpu device
- qcontainer:
 1. Add a method 'vcpu_device_define_by_params' to define vcpu device using params
- utils_misc:
  1. Add a method to get all cpu driver supported by qemu
- base.cfg：
  1. Add cpu_driver_type parameter for different arch
- env_process:
  1. Define cpu_driver_type if not set
  2. Set 'cpu_model = host' for pseries machine type
- qemu_vm:
  1. Support add vcpu devices when create qemu command
  2. Add a method to get all vcpu devices that support hot plug/unplug
  3. Add 2 methods to hotplug hotunplug vcpu device

Depends on: https://github.com/avocado-framework/avocado-vt/pull/2236
Signed-off-by: Yihuang Yu <yihyu@redhat.com>