### PR TITLE
Fix background test start failed on 32bit windows guests issue

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -355,9 +355,9 @@
         client_path_win = "c:\\"
     with_stress:
         timeout = 600
-        autostress = no
+        !virtual_nic:
+            autostress = no
         stress_test = win_heavyload
-        install_path = "C:\Program Files (x86)\JAM Software\HeavyLoad"
         config_cmd = 'setx -m path "%PATH%;${install_path};"'
         install_cmd = "start /wait DRIVE:\HeavyLoadSetup.exe /verysilent"
         check_cmd = 'tasklist | findstr /I  "heavyload.exe"'


### PR DESCRIPTION
Add "!virtual_nic" to Windows.cfg, It should not use
"autostress = no" for virtual_nic.cfg

Signed-off-by: Yu Wang <wyu@redhat.com>

id:1749260