### PR TITLE
Add Fedora 30 x86_64 and aarch64 guest and assets definitions [v2]

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -34,7 +34,7 @@
         kernel = images/f28-${vm_arch_name}/vmlinuz
         initrd = images/f28-${vm_arch_name}/initrd.img
         # Unattended-file does not require any changes
-        unattended_file = unattended/Fedora-25.ks
+        unattended_file = unattended/Fedora.ks
         unattended_install.url:
             # Installation works fine with mem=1024 on methods such as cdrom
             # but fails ("No space left on device") with methods such as url.

--- a/shared/cfg/guest-os/Linux/Fedora/30.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/30.cfg
@@ -1,0 +1,49 @@
+- 30:
+    variants:
+        - x86_64:
+            vm_arch_name = x86_64
+        - aarch64:
+            vm_arch_name = aarch64
+    image_name = images/f30-${vm_arch_name}
+    os_variant = fedora30
+    # default boot path is set in ../Fedora.cfg: boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel = images/f30-${vm_arch_name}/vmlinuz
+        initrd = images/f30-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/Fedora.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            # Unless overridden use secondary url, because it's the most common one
+            url = https://download.fedoraproject.org/pub/fedora/linux/releases/30/Server/${vm_arch_name}/os/
+        x86_64:
+            kernel_params = "console=tty0 console=ttyS0"
+            unattended_install.cdrom:
+                cdrom_cd1 = isos/linux/Fedora-Server-dvd-x86_64-30-1.2.iso
+                md5sum_cd1 = a24d2fed6440df75bd49d531f71a2b84
+                md5sum_1m_cd1 = 07c58a0139b02d178ed2e88eb20f5ca7
+            unattended_install.url:
+                sha1sum_vmlinuz = 89f9019a03b49a2c8a4aa8617710e3e1563dc6d6
+                sha1sum_initrd = b3451ed1214c284fca180e0678b0c46549e5325e
+        aarch64:
+            unattended_install, svirt_install:
+                unattended_file = unattended/Fedora.ks
+            kernel_params = "console=ttyAMA0 console=ttyS0 serial"
+            unattended_install.cdrom:
+                cdrom_cd1 = isos/linux/Fedora-Server-dvd-aarch64-30-1.2.iso
+                md5sum_cd1 = 171fc8c60f08beba41b3d83c6ebda1b0
+                md5sum_1m_cd1 = a14b71cb518f2e5a1717ca2daf3c6dfa
+            unattended_install.url:
+                sha1sum_vmlinuz = bf1247d61743575f03f8e8fcbb9aa8335b1e72b1
+                sha1sum_initrd = 227b9756fd458a4bf877e2653d23c1bc66a28f51
+        # Shared specific setting
+        unattended_install.url:
+            kernel_params += " inst.repo=${url}"
+        extra_cdrom_ks:
+            kernel_params += " ks=cdrom"
+            cdrom_unattended = images/f30-${vm_arch_name}/ks.iso
+        syslog_server_proto = tcp
+        kernel_params += " nicdelay=60 inst.sshd"

--- a/shared/downloads/fedora-30-aarch64.ini
+++ b/shared/downloads/fedora-30-aarch64.ini
@@ -1,0 +1,4 @@
+[fedora-30-aarch64]
+title = Fedora 30 aarch64
+url = https://download.fedoraproject.org/pub/fedora/linux/releases/30/Server/aarch64/iso/Fedora-Server-dvd-aarch64-30-1.2.iso
+destination = isos/linux/Fedora-Server-dvd-aarch64-30-1.2.iso

--- a/shared/downloads/fedora-30-x86_64.ini
+++ b/shared/downloads/fedora-30-x86_64.ini
@@ -1,0 +1,4 @@
+[fedora-30-x86_64]
+title = Fedora 30 x86_64
+url = https://download.fedoraproject.org/pub/fedora/linux/releases/30/Server/x86_64/iso/Fedora-Server-dvd-x86_64-30-1.2.iso
+destination = isos/linux/Fedora-Server-dvd-x86_64-30-1.2.iso

--- a/shared/unattended/Fedora.ks
+++ b/shared/unattended/Fedora.ks
@@ -1,0 +1,48 @@
+install
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+autopart
+
+%packages --ignoremissing
+@standard
+@c-development
+@development-tools
+python
+net-tools
+sg3_utils
+%end
+
+%post
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+chkconfig sshd on
+iptables -F
+systemctl mask tmp.mount
+echo 0 > /selinux/enforce
+sed -i "/^HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth0
+# if package groups were missing from main installation repo
+# try again from installed system
+dnf -y groupinstall c-development development-tools
+# include avocado: allows using this machine with remote runner
+dnf -y install python2-avocado
+ECHO 'Post set up finished'
+%end


### PR DESCRIPTION
This is currently limited to the primary architectures, that is,
the non "alternative" or "secondary" ones.

It brings back a unattended (kickstart file) that was removed in
595befdf3f7df9e3b1c5f1a8bc6e7e909144bd40, but names it generically
"Fedora.ks".

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#2214):
 * Brought back older (Fedora 28, previously named as 25) kickstart file
 * Simplified commit message