### PR TITLE
Add funcs for gluster backend disk oprations

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1511,6 +1511,46 @@ def check_isfile(file_name, session=None):
         return os.path.isfile(file_name)
 
 
+def make_symlink(target, link_name, session=None):
+    """
+    Create symlink in local/remote host/VM
+
+    :param target: Target to be linked
+    :param link_name: Link name of symbolic link
+    :param session: ShellSession object of VM/remote host
+    """
+    if is_symlink(link_name, session):
+        rm_link(link_name, session)
+    if session:
+        return session.cmd_status("ln -s {} {}".format(target, link_name)) == 0
+    return os.symlink(target, link_name)
+
+
+def rm_link(link_name, session=None):
+    """
+    Remove symlink in local/remote host/VM
+
+    :param link_name: Link name to be removed
+    :param session: ShellSession object of VM/remote host
+    """
+    if session:
+        return session.cmd_status("unlink %s" % link_name) == 0
+    return os.unlink(link_name)
+
+
+def is_symlink(link_name, session=None):
+    """
+    Check if it's symlink in local/remote host/VM
+
+    :param link_name: Link name to be checked
+    :param session: ShellSession object of VM/remote host
+    """
+    if session:
+        cmd = "file %s | grep -q 'symbolic link to'" % link_name
+        return session.cmd_status(cmd) == 0
+    return os.path.islink(link_name)
+
+
 class NumaInfo(object):
 
     """

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3386,21 +3386,25 @@ def get_ip_address_by_interface(ifname, ip_ver="ipv4", linklocal=False):
         return None
 
 
-def get_host_ip_address(params, ip_ver="ipv4", linklocal=False):
+def get_host_ip_address(params=None, ip_ver="ipv4", linklocal=False):
     """
     Returns ip address of host specified in host_ip_addr parameter if provided.
     Otherwise ip address on interface specified in netdst parameter is returned.
     In case of "nettype == user" "netdst" parameter is left empty, then the
     default interface of the system is used.
+
     :param params
     :param ip_ver: Host IP version, ipv4 or ipv6.
     :param linklocal: Whether ip address is local or remote
+    :raise: TestFail when failed to fetch IP address
     """
-    host_ip = params.get('host_ip_addr', None)
-    if host_ip:
-        logging.debug("Use IP address at config %s=%s", 'host_ip_addr', host_ip)
-        return host_ip
-    net_dev = params.get("netdst")
+    net_dev = ""
+    if params:
+        host_ip = params.get('host_ip_addr', None)
+        if host_ip:
+            logging.debug("Use IP address at config %s=%s", 'host_ip_addr', host_ip)
+            return host_ip
+        net_dev = params.get("netdst")
     if not net_dev:
         net_dev = get_host_default_gateway(iface_name=True)
     logging.warning("No IP address of host was provided, using IP address"

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -507,76 +507,6 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
     return ""
 
 
-def get_host_ipv4_addr():
-    """
-    Get host ipv4 addr
-    """
-    if_up = utils_net.get_net_if(state="UP")
-    for i in if_up:
-        ipv4_value = utils_net.get_net_if_addrs(i)["ipv4"]
-        logging.debug("ipv4_value is %s", ipv4_value)
-        if ipv4_value != []:
-            ip_addr = ipv4_value[0]
-            break
-    if ip_addr is not None:
-        logging.info("ipv4 address is %s", ip_addr)
-    else:
-        raise exceptions.TestFail("Fail to get ip address")
-    return ip_addr
-
-
-def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
-                             file_path="/etc/glusterfs/glusterd.vol", **kwargs):
-    """
-    Set up or clean up glusterfs environment on localhost
-    :param is_setup: Boolean value, true for setup, false for cleanup
-    :param vol_name: gluster created volume name
-    :param brick_path: Dir for create glusterfs
-    :param kwargs: Other parameters that need to set for gluster
-    :return: ip_addr or nothing
-    """
-    try:
-        utils_path.find_command("gluster")
-    except utils_path.CmdNotFoundError:
-        raise exceptions.TestSkipError("Missing command 'gluster'")
-    if not brick_path:
-        tmpdir = data_dir.get_tmp_dir()
-        brick_path = os.path.join(tmpdir, pool_name)
-
-    # Check gluster server apply or not
-    ip_addr = kwargs.get("gluster_server_ip", "")
-    session = None
-    if ip_addr != "":
-        remote_user = kwargs.get("gluster_server_user")
-        remote_pwd = kwargs.get("gluster_server_pwd")
-        remote_identity_file = kwargs.get("gluster_identity_file")
-        session = remote.remote_login("ssh", ip_addr, "22",
-                                      remote_user, remote_pwd, "#",
-                                      identity_file=remote_identity_file)
-    if is_setup:
-        if ip_addr == "":
-            ip_addr = get_host_ipv4_addr()
-            gluster.add_rpc_insecure(file_path)
-            gluster.glusterd_start()
-            logging.debug("finish start gluster")
-            logging.debug("The contents of %s: \n%s", file_path, open(file_path).read())
-
-        gluster.gluster_vol_create(vol_name, ip_addr, brick_path, True, session)
-        gluster.gluster_allow_insecure(vol_name, session)
-        gluster.gluster_nfs_disable(vol_name, session)
-        logging.debug("finish vol create in gluster")
-        if session:
-            session.close()
-        return ip_addr
-    else:
-        gluster.gluster_vol_stop(vol_name, True, session)
-        gluster.gluster_vol_delete(vol_name, session)
-        gluster.gluster_brick_delete(brick_path, session)
-        if session:
-            session.close()
-        return ""
-
-
 def define_pool(pool_name, pool_type, pool_target, cleanup_flag, **kwargs):
     """
     To define a given type pool(Support types: 'dir', 'netfs', logical',
@@ -649,8 +579,8 @@ def define_pool(pool_name, pool_type, pool_target, cleanup_flag, **kwargs):
         gluster_vol_number = kwargs.get('gluster_vol_number')
 
         # Prepare gluster service and create volume
-        hostip = setup_or_cleanup_gluster(True, gluster_source_name,
-                                          pool_name=pool_name, **kwargs)
+        hostip = gluster.setup_or_cleanup_gluster(True, gluster_source_name,
+                                                  pool_name=pool_name, **kwargs)
         logging.debug("hostip is %s", hostip)
         # create image in gluster volume
         file_path = "gluster://%s/%s" % (hostip, gluster_source_name)
@@ -926,8 +856,8 @@ class PoolVolumeTest(object):
                 if os.path.exists(pool_target):
                     shutil.rmtree(pool_target)
             if pool_type == "gluster" or source_format == 'glusterfs':
-                setup_or_cleanup_gluster(False, source_name,
-                                         pool_name=pool_name, **kwargs)
+                gluster.setup_or_cleanup_gluster(False, source_name,
+                                                 pool_name=pool_name, **kwargs)
 
     def pre_pool(self, pool_name, pool_type, pool_target, emulated_image,
                  **kwargs):
@@ -1007,8 +937,9 @@ class PoolVolumeTest(object):
             if not os.path.exists(pool_target):
                 os.mkdir(pool_target)
             if source_format == 'glusterfs':
-                hostip = setup_or_cleanup_gluster(True, source_name,
-                                                  pool_name=pool_name, **kwargs)
+                hostip = gluster.setup_or_cleanup_gluster(True, source_name,
+                                                          pool_name=pool_name,
+                                                          **kwargs)
                 logging.debug("hostip is %s", hostip)
                 extra = "--source-host %s --source-path %s" % (hostip,
                                                                source_name)
@@ -1088,8 +1019,9 @@ class PoolVolumeTest(object):
         elif pool_type == "gluster":
             source_path = kwargs.get('source_path')
             logging.info("source path is %s" % source_path)
-            hostip = setup_or_cleanup_gluster(True, source_name,
-                                              pool_name=pool_name, **kwargs)
+            hostip = gluster.setup_or_cleanup_gluster(True, source_name,
+                                                      pool_name=pool_name,
+                                                      **kwargs)
             logging.debug("Gluster host ip address: %s", hostip)
             extra = "--source-host %s --source-path %s --source-name %s" % \
                     (hostip, source_path, source_name)
@@ -2610,7 +2542,8 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
                                'source_host_port': disk_src_port}
     elif disk_src_protocol == 'gluster':
         # Setup gluster.
-        host_ip = setup_or_cleanup_gluster(True, brick_path=brick_path, **params)
+        host_ip = gluster.setup_or_cleanup_gluster(True, brick_path=brick_path,
+                                                   **params)
         logging.debug("host ip: %s " % host_ip)
         dist_img = "gluster.%s" % disk_format
 


### PR DESCRIPTION
This adds some functions to manage the glusterfs backend disk

1. Add functions to mount/umount/check status of glusterfs
2. Add functions to create/remove/check symlink
3. Move setup_or_cleanup_gluster from libvirt.py to gluster.py
    and move get_host_ipv4_addr to utils_net due to cyclic import

This PR is required by migration cases which need to migrate
with gluster backend disk.

Signed-off-by: Yingshun Cui <yicui@redhat.com>