### PR TITLE
shared: Force anaconda output to serial console

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -16,10 +16,10 @@
         aarch64:
             kernel_params += " earlyprintk=pl011,0x9000000 console=ttyAMA0 debug ignore_loglevel rootwait"
         ppc64, ppc64le:
-            kernel_params += " console=hvc0,38400 console=tty0"
+            kernel_params += " console=hvc0"
             boot_path = ppc/ppc64
         x86_64, i386:
-            kernel_params += " console=ttyS0,115200 console=tty0"
+            kernel_params += " console=tty0 console=ttyS0,115200"
         s390x:
             kernel_params += " console=ttysclp0 debug ignore_loglevel"
             boot_path = images


### PR DESCRIPTION
With multiple console outputs Anaconda runs usually on the later and on
some archs not even there. Let's modify our "console=" lines to make it
always produce the output to serial console, which is captured in nice
format.

The only cons is that on ppc64 some messages will go only to serial
console and not to VGA output. This only affects some kernel messages
and not the graphical installation itself.

Note: We are already using this on Fedora and RHEL8 and it works better
than the previous implementation with output to tty0.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>