### PR TITLE
virttest.utils_net: Avoid failing test when port already removed

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1133,7 +1133,9 @@ class Bridge(object):
         try:
             self._br_ioctl(arch.SIOCBRDELIF, brname, ifname)
         except IOError as details:
-            raise BRDelIfError(ifname, brname, details)
+            # Avoid failing the test when port not present in br
+            if ifname in self.list_iface(brname):
+                raise BRDelIfError(ifname, brname, details)
 
     def add_bridge(self, brname):
         """


### PR DESCRIPTION
Quite often I see a failure related to port removal, when the port is
already removed (either doulbe-removal, or "ip link delete ..."). Let's
be a bit more lenient and only fail the "del_port" when the port is
still present in the bridge (as that is the purpose of this method)

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>