### PR TITLE
boot_options_default: remove default values of boot options

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -363,6 +363,8 @@ boot_order = cdn
 boot_once = c
 # Enable/Disable boot menu
 boot_menu = off
+# Enable/Disable strict boot
+boot_strict = off
 
 
 #### SPICE related options valid if display == spice,

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2093,10 +2093,10 @@ class VM(virt_vm.BaseVM):
 
         if devices.has_option("boot"):
             boot_opts = {}
-            boot_opts["order"] = params.get("boot_order", "cdn")
-            boot_opts["once"] = params.get("boot_once", "c")
-            boot_opts["menu"] = params.get("boot_menu", "off")
-            boot_opts["strict"] = params.get("boot_strict", "off")
+            boot_opts["menu"] = params.get("boot_menu")
+            boot_opts["order"] = params.get("boot_order")
+            boot_opts["once"] = params.get("boot_once")
+            boot_opts["strict"] = params.get("boot_strict")
             boot_opts["reboot-timeout"] = params.get("boot_reboot_timeout")
             cmd = add_boot(devices, boot_opts)
             devices.insert(StrDev('bootmenu', cmdline=cmd))


### PR DESCRIPTION
Remove the default values of boot options to add ability to
test each option separately.

ID: 1752360

Signed-off-by: ybduan <yduan@redhat.com>