### PR TITLE
utils_misc: Fix cmd_status_output() for command failing on remote

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -150,7 +150,7 @@ class InterruptedThread(threading.Thread):
 
 
 def cmd_status_output(cmd, shell=False, ignore_status=True, verbose=True,
-                      timeout=None, session=None):
+                      timeout=60, session=None):
     """
     common wrapper method of `def cmd_status_output()` that could
     support 52lts in local system and with ShellSession object for
@@ -168,7 +168,7 @@ def cmd_status_output(cmd, shell=False, ignore_status=True, verbose=True,
     stdout = None
     try:
         if session:
-            status, output = session.cmd_status_output(cmd, timeout=timeout)
+            status, stdout = session.cmd_status_output(cmd, timeout=timeout)
 
         else:
             cmd_obj = process.run(cmd, shell=shell, ignore_status=ignore_status,


### PR DESCRIPTION
1. The default value of timeout is None which makes it raise exception,
so update to '60'.
2. update the command output to 'stdout'

Signed-off-by: Yingshun Cui <yicui@redhat.com>