### PR TITLE
HOTFIX: Makefile: Fix "make install" after the pip changes

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -10,7 +10,7 @@ install:
 	if [ "$$($(PYTHON) --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1)" == "2" ]; then \
 		$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE); \
 	else \
-		$(PYTHON) -m pip install --prefix $(DESTDIR) .; \
+		$(PYTHON) -m pip install --prefix $(DESTDIR) --upgrade .; \
 	fi
 
 srpm: source

--- a/Makefile.include
+++ b/Makefile.include
@@ -7,7 +7,7 @@ source-release: clean
 	git archive --prefix="$(ARCHIVE_BASE_NAME)-$(VERSION)/" -o "SOURCES/$(ARCHIVE_BASE_NAME)-$(VERSION).tar.gz" $(VERSION)
 
 install:
-	$(PYTHON) -m pip install --root $(DESTDIR) .
+	$(PYTHON) -m pip install --prefix $(DESTDIR) .
 
 srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi

--- a/Makefile.include
+++ b/Makefile.include
@@ -7,7 +7,11 @@ source-release: clean
 	git archive --prefix="$(ARCHIVE_BASE_NAME)-$(VERSION)/" -o "SOURCES/$(ARCHIVE_BASE_NAME)-$(VERSION).tar.gz" $(VERSION)
 
 install:
-	$(PYTHON) -m pip install --prefix $(DESTDIR) .
+	if [ "$$($(PYTHON) --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1)" == "2" ]; then \
+		$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE); \
+	else \
+		$(PYTHON) -m pip install --prefix $(DESTDIR) .; \
+	fi
 
 srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 autotest>=0.16.2; python_version < '3.0'
+aexpect>1.5.0
+simplejson>=3.5.3
+netaddr>=0.7.18
+netifaces>=0.10.5


### PR DESCRIPTION
There are some issues with pip installation. First the "--root" doesn't work as expected on py3 and the "pip install" puts shared files into the incorrect location on py2.

---

Resending https://github.com/avocado-framework/avocado-vt/pull/2203 to make it go through the new CI checks.