### PR TITLE
utils_test: python3 doesn't support iteritems()

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -953,7 +953,7 @@ class AvocadoGuest(object):
         Check prerequisites
         """
         # TODO: Try installing the prerequisites
-        for _, packages in self.prerequisites.iteritems():
+        for _, packages in self.prerequisites.items():
             pacman = utils_package.package_manager(self.session, packages)
             if not pacman.install(timeout=self.timeout):
                 logging.error("Failed to install - %s", packages)


### PR DESCRIPTION
fix to adopt python3 as it doesn't support iteritems() instead
use items().

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'dict' object has no attribute 'iteritems'

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>