### PR TITLE
Refactor qemu capabilities related code

### DIFF
--- a/virttest/utils_qemu.py
+++ b/virttest/utils_qemu.py
@@ -1,0 +1,28 @@
+"""
+QEMU related utility functions.
+"""
+import re
+
+from avocado.utils import process
+
+
+QEMU_VERSION_RE = re.compile(r"QEMU (?:PC )?emulator version\s"
+                             r"([0-9]+\.[0-9]+\.[0-9]+)"
+                             r"(?:\s\((.*?)\))?")
+
+
+def get_qemu_version(bin_path):
+    """
+    Return normalized qemu version and package version
+
+    :param bin_path: Path to qemu binary
+    :raise OSError: If unable to get that
+    :return: A tuple of normalized version and package version
+    """
+    output = process.system_output("%s -version" % bin_path,
+                                   verbose=False,
+                                   ignore_status=True).decode()
+    matches = QEMU_VERSION_RE.match(output)
+    if matches is None:
+        raise OSError('Unable to get the version of qemu')
+    return matches.groups()


### PR DESCRIPTION
Currently, the capabilities of qemu is stored in `VM` and it would
result in some issue, for example, the inconsistency of this
attribute between `VM` and `DevContainer`.

To resolve the issue, as Lukáš suggested we can store the capabilities
only in `DevContainer` and make it to be a public attribute, hence,
it can be used by any context which needs that, and its lifetime will
be managed easily.

CC: Lukáš Doktor <ldoktor@redhat.com>
Signed-off-by: Xu Han <xuhan@redhat.com>