### PR TITLE
virttest.qemu_vm: Properly cleanup src vm on migration

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4141,8 +4141,9 @@ class VM(virt_vm.BaseVM):
 
             # Switch self <-> clone
             temp = self.clone(copy_state=True)
-            self.__dict__ = clone.__dict__
-            clone = temp
+            self.destroy(gracefully=False)      # self is the source dead vm
+            self.__dict__ = clone.__dict__      # self becomes the dst vm
+            clone = temp    # for cleanup purposes keep clone
 
         finally:
             # If we're doing remote migration and it's completed successfully,

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4116,15 +4116,6 @@ class VM(virt_vm.BaseVM):
                 raise virt_vm.VMMigrateFailedError("Migration ended with "
                                                    "unknown status")
 
-            # Switch self <-> clone
-            temp = self.clone(copy_state=True)
-            self.__dict__ = clone.__dict__
-            clone = temp
-
-            # From now on, clone is the source VM that will soon be destroyed
-            # and self is the destination VM that will remain alive.  If this
-            # is remote migration, self is a dead VM object.
-
             error_context.context("after migration")
             if local:
                 time.sleep(1)
@@ -4132,8 +4123,8 @@ class VM(virt_vm.BaseVM):
 
             if local and stable_check:
                 try:
-                    save1 = os.path.join(save_path, "src-" + clone.instance)
-                    save2 = os.path.join(save_path, "dst-" + self.instance)
+                    save1 = os.path.join(save_path, "dst-" + clone.instance)
+                    save2 = os.path.join(save_path, "src-" + self.instance)
                     clone.save_to_file(save1)
                     self.save_to_file(save2)
                     # Fail if we see deltas
@@ -4147,6 +4138,11 @@ class VM(virt_vm.BaseVM):
                             os.remove(save1)
                         if os.path.isfile(save2):
                             os.remove(save2)
+
+            # Switch self <-> clone
+            temp = self.clone(copy_state=True)
+            self.__dict__ = clone.__dict__
+            clone = temp
 
         finally:
             # If we're doing remote migration and it's completed successfully,


### PR DESCRIPTION
Previously we relied on a freshly-produced clone of the src vm to
cleanup the source vm on "finally" stage. This is not enough, because
the source vm (self) contains processes (nc attached to consoles). Let's
explicitly cleanup the source vm (self) just before replacing ourselves
with the destination (clone) vm to make sure all those processes are
cleared. To be super-safe let's keep the updated clone for the "finally"
postprocess.

Without this patch I'm getting about 2 extra aexpect (nc) processes per
ping_pong migration, with this patch it cleans everything properly.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>