### PR TITLE
libvirt_vm: use `nfs_mount_dir` as base_dir for NFS tests

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1197,12 +1197,14 @@ class VM(virt_vm.BaseVM):
                 virt_install_cmd += add_pcidevice(help_text, pci_id)
 
         for image_name in params.objects("images"):
+            basename = False
             image_params = params.object_params(image_name)
 
             base_dir = image_params.get("images_base_dir",
                                         data_dir.get_data_dir())
-
-            basename = params.get("storage_type") == "nfs"
+            if params.get("storage_type") == "nfs":
+                basename = True
+                base_dir = params["nfs_mount_dir"]
             filename = storage.get_image_filename(image_params,
                                                   base_dir, basename=basename)
             if image_params.get("use_storage_pool") == "yes":

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -381,7 +381,7 @@ def copy_nfs_image(params, root_dir, basename=False):
     """
     if params.get("setup_local_nfs", "no") == "yes":
         # check for image availability in NFS shared path
-        base_dir = params.get("images_base_dir", data_dir.get_data_dir())
+        base_dir = params["nfs_mount_dir"]
         dst = get_image_filename(params, base_dir, basename=basename)
         if(not os.path.isfile(dst) or
            utils_misc.get_image_info(dst)['lcounts'].lower() == "true"):


### PR DESCRIPTION
framework picks wrong path from `image_base_dir` or `data_dir` path
for nfs tests causing VM to boot/test with wrong disk path. Instead
use `nfs_mount_dir` for VM to use appropriate image for NFS based
tests.

Fixes: commit 0b463201 and 782cc76a
Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>