### PR TITLE
Fixup: AttributeError("module 'platform' has no attribute 'dist'")

### DIFF
--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -1,12 +1,14 @@
 import ast
 import logging
 import os.path
-import platform
 from six import StringIO
+
 try:
     import configparser as ConfigParser
 except ImportError:
     import ConfigParser
+
+from avocado.utils import distro
 
 
 class ConfigError(Exception):
@@ -437,8 +439,7 @@ class LibvirtdSysConfig(LibvirtConfigCommon):
     """
     Class for sysconfig libvirtd config file.
     """
-    distro = platform.dist()
-    if 'Ubuntu' in distro:
+    if distro.detect().name == 'Ubuntu':
         conf_path = '/etc/default/libvirtd'
     else:
         conf_path = '/etc/sysconfig/libvirtd'


### PR DESCRIPTION
Looks like platform.dist() is removed from python3.8 so the below error

```
Failed to load plugin from module "avocado_vt.plugins.vt": AttributeError("module 'platform' has no attribute 'dist'") :
  File "/usr/local/lib/python3.8/site-packages/avocado_framework-72.0-py3.8.egg/avocado/core/extension_manager.py", line 62, in __init__
    plugin = ep.load()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.8/site-packages/avocado_framework_plugins_vt-72.0-py3.8.egg/avocado_vt/plugins/vt.py", line 39, in <module>
    from ..loader import VirtTestLoader
  File "/usr/local/lib/python3.8/site-packages/avocado_framework_plugins_vt-72.0-py3.8.egg/avocado_vt/loader.py", line 33, in <module>
    from .test import VirtTest
  File "/usr/local/lib/python3.8/site-packages/avocado_framework_plugins_vt-72.0-py3.8.egg/avocado_vt/test.py", line 37, in <module>
    from virttest import env_process
  File "/usr/local/lib/python3.8/site-packages/avocado_framework_plugins_vt-72.0-py3.8.egg/virttest/env_process.py", line 32, in <module>
    from virttest import test_setup
  File "/usr/local/lib/python3.8/site-packages/avocado_framework_plugins_vt-72.0-py3.8.egg/virttest/test_setup.py", line 36, in <module>
    from virttest import utils_config
  File "/usr/local/lib/python3.8/site-packages/avocado_framework_plugins_vt-72.0-py3.8.egg/virttest/utils_config.py", line 434, in <module>
    class LibvirtdSysConfig(LibvirtConfigCommon):
  File "/usr/local/lib/python3.8/site-packages/avocado_framework_plugins_vt-72.0-py3.8.egg/virttest/utils_config.py", line 439, in LibvirtdSysConfig
    distro = platform.dist()
```

Let's handle it by replacing it with avocado utils, distro.detect() method.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>