### PR TITLE
Fix monitor creation for unpickled vms

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -241,6 +241,12 @@ class VM(object):
     def __init__(self, name):
         self.name = name
 
+    def check_capability(self, flag):
+        return False
+
+    def get_pid(self):
+        return None
+
 
 class Monitor(object):
 


### PR DESCRIPTION
The constructor assumes more functionality than the one provided
by dummy vms which avoid recursion when the monitor is unpickled.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>