### PR TITLE
virttest.qemu_vm: Replace qemu_dst_binary on migrate

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3878,6 +3878,7 @@ class VM(virt_vm.BaseVM):
         if self.params.get('qemu_dst_binary', None) is not None:
             clone.params[
                 'qemu_binary'] = utils_misc.get_qemu_dst_binary(self.params)
+            clone.params['qemu_dst_binary'] = self.params['qemu_binary']
         if env:
             env.register_vm("%s_clone" % clone.name, clone)
 


### PR DESCRIPTION
For years we had been claiming ping-pong migration, but in reality we do
ping->pong->pong->pong migrations as the source qemu_binary is only used
once. Let's replace the qemu_dst_binary for qemu_binary of the source VM
in order to start switching between ping and pong binaries.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>