### PR TITLE
Couple fixes to "reboot" when used together with migration

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -789,5 +789,10 @@ vm_monitor_exit_status = no
 # setting it to "yes"
 kickstart_reboot_bug = "no"
 
+# Force go-down method on reset. Supported options are:
+# qmp: use QMP RESET event (if QMP available, usually safest option but
+#      fails when VM object is being replaced (eg. migration))
+force_reset_go_down_check = "qmp"
+
 # Add -S  to qemu by default, if you don't need it, pls set it off.
 qemu_stop = on

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4365,7 +4365,7 @@ class VM(virt_vm.BaseVM):
             """
             try:
                 return bool(self.monitor.get_event("RESET"))
-            except qemu_monitor.MonitorSocketError:
+            except (qemu_monitor.MonitorSocketError, AttributeError):
                 logging.warn("MonitorSocketError while querying for RESET QMP "
                              "event, it might get lost.")
                 return False

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4425,9 +4425,11 @@ class VM(virt_vm.BaseVM):
             utils_net.update_mac_ip_address(self)
 
         if serial:
-            return self.wait_for_serial_login(timeout=(timeout - shutdown_dur))
+            return self.wait_for_serial_login(timeout=(timeout - shutdown_dur),
+                                              status_check=False)
         return self.wait_for_login(nic_index=nic_index,
-                                   timeout=(timeout - shutdown_dur))
+                                   timeout=(timeout - shutdown_dur),
+                                   status_check=False)
 
     def send_key(self, keystr):
         """

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -826,13 +826,13 @@ class BaseVM(object):
                                                      devs=devs,
                                                      session=session,
                                                      timeout=timeout):
-            self.address_cache.drop(mac_pattern % mac)
-
             nic_params = self.params.object_params(nic.nic_name)
             pci_assignable = nic_params.get("pci_assignable") != "no"
 
             if not (pci_assignable or nic.nettype == "macvtap"):
                 raise VMAddressVerificationError(mac, ip_addr)
+
+            self.address_cache.drop(mac_pattern % mac)
 
             # SR-IOV/Macvtap cards may not be in same subnet with the cards
             # used by host by default, so arp checks won't work. Therefore,


### PR DESCRIPTION
This brings back the first commit from https://github.com/avocado-framework/avocado-vt/pull/2081 that was removed before merging, because after couple of months I have many failed cases because of missed events.

The second commit adds a fix to the QMP check when it happens during init when `vm.monitor` is `None`, which also pop-ups pretty frequently in my testing.

@luckyh please re-consider your NACK of the first commit as I am hitting it regularly.

Update: Added 2 commits that are fixing "missing MAC" and "directory not empty" issues I am also regularly hitting and finally got to debug. It's also caused by partially initialized VM during reboot.