### PR TITLE
Add the new Qemu capabilities key to the qcontainer comparison ignorable ones

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -304,8 +304,7 @@ class DevContainer(object):
         qdev2 = qdev2.__dict__
         for key, value in six.iteritems(self.__dict__):
             if key in ("_DevContainer__devices", "_DevContainer__buses",
-                       "_DevContainer__state",
-                       "allow_hotplugged_vm"):
+                       "_DevContainer__state", "caps", "allow_hotplugged_vm"):
                 continue
             if key not in qdev2 or qdev2[key] != value:
                 return False


### PR DESCRIPTION
The vms in our runs are constantly reset using release 72.0 and the
reason is mismatched env configuration within the same vm. The
mismatched params come from no real configuration change but from
a different `qemu_capabilities.Capabilities` instance which is not
relevant to such use cases.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>