### PR TITLE
Add vcpu device support [V2]

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -46,6 +46,7 @@ from virttest import virsh
 from virttest import utils_test
 from virttest import utils_iptables
 from virttest import utils_package
+from virttest import utils_qemu
 from virttest.utils_version import VersionInterval
 from virttest.compat_52lts import decode_to_text
 from virttest.staging import service
@@ -1025,6 +1026,18 @@ def preprocess(test, params, env):
         if not env.get("cpu_model"):
             env["cpu_model"] = cpu.get_qemu_best_cpu_model(params)
         params["cpu_model"] = env.get("cpu_model")
+
+    if params.get("cpu_driver") is None:
+        cpu_model = params.get("cpu_model")
+        if cpu_model:
+            search_pattern = r"%s-\w+-cpu" % cpu_model
+            qemu_path = utils_misc.get_qemu_binary(params)
+            cpu_driver = utils_qemu.find_supported_devices(qemu_path,
+                                                           search_pattern,
+                                                           "CPU")
+            if cpu_driver:
+                env["cpu_driver"] = cpu_driver[0]
+                params["cpu_driver"] = env.get("cpu_driver")
 
     version_info = {}
     # Get the KVM kernel module version

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -14,7 +14,8 @@ import random
 import sys
 import math
 
-from functools import partial
+from functools import partial, reduce
+from operator import mul
 
 import aexpect
 from avocado.core import exceptions
@@ -1537,25 +1538,67 @@ class VM(virt_vm.BaseVM):
                 txt = "Set vcpu_threads to 1 for AMD cpu."
                 logging.warn(txt)
 
-        if smp == 0 or vcpu_sockets == 0:
-            vcpu_dies = vcpu_dies or 1
-            vcpu_cores = vcpu_cores or 1
-            vcpu_threads = vcpu_threads or 1
-            if smp == 0:
-                vcpu_sockets = vcpu_sockets or 1
-                smp = vcpu_cores * vcpu_threads * vcpu_dies * vcpu_sockets
-            else:
-                vcpu_sockets = smp // (vcpu_cores * vcpu_threads * vcpu_dies) or 1
-        elif vcpu_dies == 0:
-            vcpu_cores = vcpu_cores or 1
-            vcpu_threads = vcpu_threads or 1
-            vcpu_dies = smp // (vcpu_sockets * vcpu_cores * vcpu_threads) or 1
-        elif vcpu_cores == 0:
-            vcpu_threads = vcpu_threads or 1
-            vcpu_cores = smp // (vcpu_sockets * vcpu_threads * vcpu_dies) or 1
+        smp_err = ""
+        if vcpu_maxcpus != 0:
+            smp_values = [vcpu_sockets, vcpu_dies, vcpu_cores, vcpu_threads]
+            if smp_values.count(0) == 1:
+                smp_values.remove(0)
+                topology_product = reduce(mul, smp_values)
+                if vcpu_maxcpus < topology_product:
+                    smp_err = ("maxcpus(%d) must be equal to or greater than "
+                               "topological product(%d)" % (vcpu_maxcpus,
+                                                            topology_product))
+                else:
+                    missing_value, cpu_mod = divmod(vcpu_maxcpus, topology_product)
+                    vcpu_maxcpus -= cpu_mod
+                    vcpu_sockets = vcpu_sockets or missing_value
+                    vcpu_dies = vcpu_dies or missing_value
+                    vcpu_cores = vcpu_cores or missing_value
+                    vcpu_threads = vcpu_threads or missing_value
+            elif smp_values.count(0) > 1:
+                if vcpu_maxcpus == 1 and max(smp_values) < 2:
+                    vcpu_sockets = vcpu_dies = vcpu_cores = vcpu_threads = 1
+                else:
+                    smp_err = ("Two or more non-zero parameters are missing to"
+                               " calculate the available SMP topology for VM "
+                               "%s" % self.name)
+
+            hotpluggable_cpus = len(params.objects("vcpu_devices"))
+            if params["machine_type"].startswith("pseries"):
+                hotpluggable_cpus *= vcpu_threads
+            smp = smp or vcpu_maxcpus - hotpluggable_cpus
         else:
-            vcpu_threads = smp // (vcpu_cores * vcpu_sockets * vcpu_dies) or 1
-        vcpu_maxcpus = vcpu_maxcpus or smp
+            if smp == 0 or vcpu_sockets == 0:
+                vcpu_dies = vcpu_dies or 1
+                vcpu_cores = vcpu_cores or 1
+                vcpu_threads = vcpu_threads or 1
+                if smp == 0:
+                    vcpu_sockets = vcpu_sockets or 1
+                    smp = vcpu_cores * vcpu_threads * vcpu_dies * vcpu_sockets
+                else:
+                    vcpu_sockets = smp // (vcpu_cores * vcpu_threads * vcpu_dies) or 1
+            elif vcpu_dies == 0:
+                vcpu_cores = vcpu_cores or 1
+                vcpu_threads = vcpu_threads or 1
+                vcpu_dies = smp // (vcpu_sockets * vcpu_cores * vcpu_threads) or 1
+            elif vcpu_cores == 0:
+                vcpu_threads = vcpu_threads or 1
+                vcpu_cores = smp // (vcpu_sockets * vcpu_threads * vcpu_dies) or 1
+            else:
+                vcpu_threads = smp // (vcpu_cores * vcpu_sockets * vcpu_dies) or 1
+
+            hotpluggable_cpus = len(params.objects("vcpu_devices"))
+            if params["machine_type"].startswith("pseries"):
+                hotpluggable_cpus *= vcpu_threads
+            vcpu_maxcpus = smp
+            smp -= hotpluggable_cpus
+
+        if smp <= 0:
+            smp_err = ("Number of hotpluggable vCPUs(%d) is greater "
+                       "than or equal to the maxcpus(%d)."
+                       % (hotpluggable_cpus, vcpu_maxcpus))
+        if smp_err:
+            raise virt_vm.VMSMPTopologyInvalidError(smp_err)
 
         self.cpuinfo.smp = smp
         self.cpuinfo.maxcpus = vcpu_maxcpus
@@ -1584,13 +1627,13 @@ class VM(virt_vm.BaseVM):
             devices.insert(StrDev('numa', cmdline=cmdline))
 
         if params.get("numa_consistency_check_cpu_mem", "no") == "yes":
-            if (numa_total_cpus > int(smp) or numa_total_mem > int(mem) or
-                    len(params.objects("guest_numa_nodes")) > int(smp)):
+            if (numa_total_cpus > vcpu_maxcpus or numa_total_mem > int(mem) or
+                    len(params.objects("guest_numa_nodes")) > vcpu_maxcpus):
                 logging.debug("-numa need %s vcpu and %s memory. It is not "
                               "matched the -smp and -mem. The vcpu number "
                               "from -smp is %s, and memory size from -mem is"
-                              " %s" % (numa_total_cpus, numa_total_mem, smp,
-                                       mem))
+                              " %s" % (numa_total_cpus, numa_total_mem,
+                                       vcpu_maxcpus, mem))
                 raise virt_vm.VMDeviceError("The numa node cfg can not fit"
                                             " smp and memory cfg.")
 
@@ -1621,8 +1664,30 @@ class VM(virt_vm.BaseVM):
             self.cpuinfo.vendor = vendor
             self.cpuinfo.flags = flags
             self.cpuinfo.family = family
+            cpu_driver = params.get("cpu_driver")
+            if cpu_driver:
+                try:
+                    cpu_driver_items = cpu_driver.split("-")
+                    ctype = cpu_driver_items[cpu_driver_items.index("cpu") - 1]
+                    self.cpuinfo.qemu_type = ctype
+                except ValueError:
+                    logging.warning("Can not assign cpuinfo.type, assign as"
+                                    " 'unknown'")
+                    self.cpuinfo.qemu_type = "unknown"
             cmd = add_cpu_flags(devices, cpu_model, flags, vendor, family)
             devices.insert(StrDev('cpu', cmdline=cmd))
+
+        # Add vcpu devices
+        vcpu_bus = devices.get_buses({'aobject': 'vcpu'})
+        if vcpu_bus and params.get("vcpu_devices"):
+            vcpu_bus = vcpu_bus[0]
+            vcpu_bus.initialize(self.cpuinfo)
+            vcpu_devices = params.objects("vcpu_devices")
+            params["vcpus_count"] = str(vcpu_bus.vcpus_count)
+
+            for vcpu in vcpu_devices:
+                vcpu_dev = devices.vcpu_device_define_by_params(params, vcpu)
+                devices.insert(vcpu_dev)
 
         # -soundhw addresses are always the lowest after scsi
         soundhw = params.get("soundcards")
@@ -3348,6 +3413,21 @@ class VM(virt_vm.BaseVM):
 
         return vcpu_pids
 
+    def _get_hotpluggable_vcpu_qids(self):
+        """
+        :return: list of hotpluggable vcpu ids
+        """
+        vcpu_ids_list = []
+        out = self.monitor.info("hotpluggable-cpus", debug=False)
+        if self.monitor.protocol == "qmp":
+            vcpu_ids_list = [vcpu_info["qom-path"].rsplit("/", 1)[-1]
+                             for vcpu_info in out if "qom-path" in vcpu_info
+                             and "peripheral" in vcpu_info["qom-path"]]
+        elif self.monitor.protocol == "human":
+            vcpu_ids_list = re.findall(r'qom_path: "/\D+/peripheral/(\S+)"',
+                                       out, re.M)
+        return vcpu_ids_list
+
     def get_vhost_threads(self, vhost_thread_pattern):
         """
         Return the list of vhost threads PIDs
@@ -3436,6 +3516,68 @@ class VM(virt_vm.BaseVM):
             return(True, plug_cpu_id)
         else:
             return(False, cmd_output)
+
+    @error_context.context_aware
+    def hotplug_vcpu_device(self, vcpu_id):
+        """
+        Hotplug a vcpu device and verify that this step is successful.
+        :param vcpu_id: the vcpu id you want to hotplug.
+        """
+        try:
+            vcpu_device = self.devices.get_by_qid(vcpu_id)
+            if vcpu_device[0].is_enabled():
+                raise virt_vm.VMDeviceStateError("%s has been enabled"
+                                                 % vcpu_id)
+        except IndexError:
+            raise virt_vm.VMDeviceNotFoundError("Cannot find vcpu device %s"
+                                                % vcpu_id)
+        else:
+            vcpu_device = vcpu_device[0]
+
+        out, ver_out = vcpu_device.enable(self.monitor)
+        if ver_out is False:
+            raise virt_vm.VMDeviceCheckError("Failed to hotplug %s: %s"
+                                             % (vcpu_id, out))
+
+        vcpu_inserted = vcpu_id in self._get_hotpluggable_vcpu_qids()
+        if not vcpu_inserted:
+            out = "Could not find %s in hotpluggable CPUs" % vcpu_id
+            raise virt_vm.VMDeviceCheckError("Failed to hotplug %s: %s"
+                                             % (vcpu_id, out))
+        # Workaround to make vm can be migrated after hotplug.
+        self.params["vcpu_enable_%s" % vcpu_id] = "yes"
+
+    @error_context.context_aware
+    def hotunplug_vcpu_device(self, vcpu_id, verify_timeout=10):
+        """
+        Hotunplug a vcpu device and verify that this step is successful.
+        :param vcpu_id: the vcpu id you want to hotunplug.
+        :param verify_timeout: execution timeout
+        """
+        try:
+            vcpu_device = self.devices.get_by_qid(vcpu_id)
+            if not vcpu_device[0].is_enabled():
+                raise virt_vm.VMDeviceStateError("%s has been disabled"
+                                                 % vcpu_id)
+        except IndexError:
+            raise virt_vm.VMDeviceNotFoundError("Cannot find vcpu device %s"
+                                                % vcpu_id)
+        else:
+            vcpu_device = vcpu_device[0]
+
+        out, ver_out = vcpu_device.disable(self.monitor)
+        if ver_out is False:
+            raise virt_vm.VMDeviceCheckError("Failed to hotunplug %s: %s"
+                                             % (vcpu_id, out))
+
+        if not utils_misc.wait_for(
+                lambda: vcpu_id not in self._get_hotpluggable_vcpu_qids(),
+                verify_timeout):
+            out = "Can still find %s in hotpluggable CPUs" % vcpu_id
+            raise virt_vm.VMDeviceCheckError("Failed to hotunplug %s: %s"
+                                             % (vcpu_id, out))
+        # Workaround to make vm can be migrated after hotunplug.
+        self.params["vcpu_enable_%s" % vcpu_id] = "no"
 
     @error_context.context_aware
     def hotplug_nic(self, **params):

--- a/virttest/utils_qemu.py
+++ b/virttest/utils_qemu.py
@@ -5,10 +5,23 @@ import re
 
 from avocado.utils import process
 
-
 QEMU_VERSION_RE = re.compile(r"QEMU (?:PC )?emulator version\s"
                              r"([0-9]+\.[0-9]+\.[0-9]+)"
                              r"(?:\s\((.*?)\))?")
+
+
+def _get_info(bin_path, options, allow_output_check=None):
+    """
+    Execute a qemu command and return its stdout
+
+    :param bin_path: Path to qemu binary
+    :param options: Command line to run
+    :param allow_output_check: Record the output from stdout/stderr
+    :return: Command stdout
+    """
+    qemu_cmd = "%s %s" % (bin_path, options)
+    return process.run(qemu_cmd, verbose=False, ignore_status=True,
+                       allow_output_check=allow_output_check).stdout_text.strip()
 
 
 def get_qemu_version(bin_path):
@@ -19,10 +32,97 @@ def get_qemu_version(bin_path):
     :raise OSError: If unable to get that
     :return: A tuple of normalized version and package version
     """
-    output = process.system_output("%s -version" % bin_path,
-                                   verbose=False,
-                                   ignore_status=True).decode()
+    output = _get_info(bin_path, "-version")
     matches = QEMU_VERSION_RE.match(output)
     if matches is None:
         raise OSError('Unable to get the version of qemu')
     return matches.groups()
+
+
+def get_machines_info(bin_path):
+    """
+    Return all machines information supported by qemu
+
+    :param bin_path: Path to qemu binary
+    :return: A dict of all machines
+    """
+    output = _get_info(bin_path, r"-machine help", allow_output_check="combined")
+    machines = re.findall(r"^([a-z]\S+)\s+(.*)$", output, re.M)
+    return dict(machines)
+
+
+def get_supported_machines_list(bin_path):
+    """
+    Return all machines supported by qemu
+
+    :param bin_path: Path to qemu binary
+    :return: A list of all machines supported by qemu
+    """
+    return list(get_machines_info(bin_path).keys())
+
+
+def get_devices_info(bin_path, category=None):
+    """
+    Return all devices information supported by qemu
+
+    :param bin_path: Path to qemu binary
+    :param category: device category (e.g. 'USB', 'Network', 'CPU')
+    :return:  A dict of all devices
+    """
+    output = _get_info(bin_path, r"-device help", allow_output_check="combined")
+    qemu_devices = {}
+    for device_info in output.split("\n\n"):
+        device_type = re.match(r"([A-Z]\S+) devices:", device_info).group(1)
+        devs_info = re.findall(r'^name "(\S+)"(.*)', device_info, re.M)
+        qemu_devices[device_type] = {dev[0]: dev[1].replace(", ", "", 1)
+                                     for dev in devs_info}
+    if category:
+        return qemu_devices[category]
+    return {k: v for d in qemu_devices.values() for k, v in d.items()}
+
+
+def get_supported_devices_list(bin_path, category=None):
+    """
+    Return all devices supported by qemu
+
+    :param bin_path: Path to qemu binary
+    :param category: device category (e.g. 'USB', 'Network', 'CPU')
+    :return: A list of all devices supported by qemu
+    """
+    return list(get_devices_info(bin_path, category).keys())
+
+
+def find_supported_devices(bin_path, pattern, category=None):
+    """
+    Use pattern to find all matching devices.
+
+    :param bin_path: Path to qemu binary
+    :param pattern: pattern to search the most suitable device
+    :param category: device category (e.g. 'USB', 'Network', 'CPU')
+    :return: device list
+    """
+    devices = []
+    for device in get_supported_devices_list(bin_path, category):
+        if re.match(pattern, device):
+            devices.append(device)
+    return devices
+
+
+def get_maxcpus_hard_limit(bin_path, machine_type):
+    """
+    Return maximum limit CPUs supported by specified machine type
+
+    :param bin_path: Path to qemu binary
+    :param machine_type: One machine type supported by qemu
+    :raise ValueError: If unable to get that
+    :return: Maximum value of vCPU
+    """
+    invalid_maximum = 0x7fffffff
+    output = _get_info(bin_path, r"-machine %s -smp maxcpus=%d"
+                       % (machine_type, invalid_maximum),
+                       allow_output_check="combined")
+    searches = re.search(r"'%s.*' is (\d+)" % machine_type, output)
+    if searches is None:
+        raise ValueError("Could not get the maximum limit CPUs supported by "
+                         "this machine '%s'" % machine_type)
+    return int(searches.group(1))

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -354,6 +354,18 @@ class VMDeviceNotSupportedError(VMDeviceError):
                 (self.device, self.name))
 
 
+class VMDeviceCheckError(VMDeviceError):
+    pass
+
+
+class VMDeviceNotFoundError(VMDeviceError):
+    pass
+
+
+class VMDeviceStateError(VMDeviceError):
+    pass
+
+
 class VMPCIDeviceError(VMDeviceError):
     pass
 
@@ -452,6 +464,10 @@ class VMLoginError(VMError):
     pass
 
 
+class VMSMPTopologyInvalidError(VMError):
+    pass
+
+
 class CpuInfo(object):
 
     """
@@ -459,12 +475,14 @@ class CpuInfo(object):
     """
 
     def __init__(self, model=None, vendor=None, flags=None, family=None,
-                 smp=0, maxcpus=0, cores=0, threads=0, dies=0, sockets=0):
+                 qemu_type=None, smp=0, maxcpus=0, cores=0, threads=0,
+                 dies=0, sockets=0):
         """
         :param model: CPU Model of VM (use 'qemu -cpu ?' for list)
         :param vendor: CPU Vendor of VM
         :param flags: CPU Flags of VM
         :param family: CPU Family of VM
+        :param qemu_type: cpu driver type of qemu
         :param smp: set the number of CPUs to 'n' [default=1]
         :param maxcpus: maximum number of total cpus, including
                         offline CPUs for hotplug, etc
@@ -477,6 +495,7 @@ class CpuInfo(object):
         self.vendor = vendor
         self.flags = flags
         self.family = family
+        self.qemu_type = qemu_type
         self.smp = smp
         self.maxcpus = maxcpus
         self.cores = cores


### PR DESCRIPTION
- qdevices:
  1. Add class 'QCPUDevice' to support define a vcpu device, it supports all cpu properties
  2. Add class 'QCPUBus' to manage all vcpu, include fixed vcpu and vcpu device
- qcontainer:
  1. Add a method 'vcpu_device_define_by_params' to define vcpu device using params
- utils_qemu:
  1. Add few functions to perform query operations via qemu
- base.cfg：
  1. Specify cpu_model of pseries as host
- env_process:
  1. Define vcpu_driver if not set
- qemu_vm:
  1. Support add vcpu devices when create qemu command
  2. Add a method to get all vcpu devices that support hot plug/unplug

Signed-off-by: Yihuang Yu <yihyu@redhat.com>