### PR TITLE
Fixup: map() returns not an iterable object at add_numa_node()

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1258,7 +1258,7 @@ class VM(virt_vm.BaseVM):
             elif memdev is not None:
                 numa_cmd += ",memdev=%s" % memdev
             if cpus is not None:
-                cpus = map(lambda x: x.strip(), cpus.split(','))
+                cpus = list(map(lambda x: x.strip(), cpus.split(',')))
                 cpus = ','.join(map(lambda x: "cpus=%s" % x, cpus))
                 numa_cmd += ",%s" % cpus
             if nodeid is not None:


### PR DESCRIPTION
On python2, when we invoke `map()`, it will return a list, but on
python3, it returns a class.
e.g: `type(map(int, ["1"]))`
python2: <type 'list'>
python3: <class 'map'>

Signed-off-by: Yihuang Yu <yihyu@redhat.com>