### PR TITLE
Add variable to skip gluster-server remote management if needed.

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -764,12 +764,13 @@ Host_Ubuntu.m18.u10:
 # Add vsock device
 # vsocks = vhost_vsock0
 
-# If no outside gluster server prepared and used for testing, please leave it
-# as "" or comment it
-#gluster_server_ip = ""
-#gluster_server_user = ""
-#gluster_server_pwd = ""
-#gluster_identity_file = ""
+# If no external gluster server has been prepared and is to be used for testing,
+# please don't modify values or leave them commented
+#gluster_server_ip = "" - IP of external gluster server
+#gluster_server_user = "" - ssh (root) user for gluster server management
+#gluster_server_pwd = "" - ssh (root) password for gluster server management
+#gluster_identity_file = "" - ssh (root) identity file for gluster server management
+#remote_gluster_manage = "yes" - If set to "no", gluster server won't be managed by test but only used; default is "yes"
 
 # Add cputune/vcpupin to guest during import/install below param
 # can be uncommented and modified to match vm vcpu numbers,

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -879,8 +879,9 @@ class PoolVolumeTest(object):
                 if os.path.exists(pool_target):
                     shutil.rmtree(pool_target)
             if pool_type == "gluster" or source_format == 'glusterfs':
-                gluster.setup_or_cleanup_gluster(False, source_name,
-                                                 pool_name=pool_name, **kwargs)
+                if kwargs.get("remote_gluster_manage", "yes") == "yes":
+                    gluster.setup_or_cleanup_gluster(False, source_name,
+                                                     pool_name=pool_name, **kwargs)
 
     def pre_pool(self, pool_name, pool_type, pool_target, emulated_image,
                  **kwargs):
@@ -960,9 +961,11 @@ class PoolVolumeTest(object):
             if not os.path.exists(pool_target):
                 os.mkdir(pool_target)
             if source_format == 'glusterfs':
-                hostip = gluster.setup_or_cleanup_gluster(True, source_name,
-                                                          pool_name=pool_name,
-                                                          **kwargs)
+                hostip = kwargs.get("gluster_server_ip", "")
+                if kwargs.get("remote_gluster_manage", "yes") == "yes":
+                    hostip = gluster.setup_or_cleanup_gluster(True, source_name,
+                                                              pool_name=pool_name,
+                                                              **kwargs)
                 logging.debug("hostip is %s", hostip)
                 extra = "--source-host %s --source-path %s" % (hostip,
                                                                source_name)


### PR DESCRIPTION
Added new variable in order to use a static gluster volume instead of
-------------------------------------------------------------------------------------------

managing it in the test.
The default is the previous behavior.
In order to use a static gluster volume use test cfg params
1. remote_gluster_manage = "no"
2. set gluster_server_ip

Changes:
-------------
A. shared/cfg/base.cfg: Add new variables to config (commented)
B. virttest/utils_test/libvirt.py:
B.a. Safeguard test from accessing remote gluster server if remote_gluster_manage = "no"

Testing
---------
I executed these test:
```bash
11:58:20 AM (1/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_internal Result: PASS 101.38 s
12:00:03 PM (2/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no Result: CANCEL: 14.03 s
12:00:18 PM (3/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_none Result: PASS 88.95 s
12:01:48 PM (4/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.current Result: PASS 86.48 s
12:03:16 PM (5/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.no_current Result: PASS 87.53 s
12:04:45 PM (6/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.revert_paused Result: PASS 89.50 s
12:06:16 PM (7/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_internal Result: PASS 89.75 s
12:07:47 PM (8/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no Result: CANCEL: 14.08 s
12:08:02 PM (9/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_none Result: PASS 88.57 s
12:09:32 PM (10/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.current Result: PASS 88.07 s
12:11:01 PM (11/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.no_current Result: PASS 87.52 s
12:12:30 PM (12/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.revert_paused Result: PASS 89.56 s
```