### PR TITLE
Update utils_memory for s390x

### DIFF
--- a/virttest/unittests/test_utils_kernel_module.py
+++ b/virttest/unittests/test_utils_kernel_module.py
@@ -1,0 +1,96 @@
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from virttest import utils_kernel_module
+
+some_module_name = 'skvm'
+some_module_param = 'force_emulation_prefix'
+some_module_val = 'N'
+some_module_config = {some_module_param: 'N',
+                      'halt_poll_ns_shrink': '0'}
+
+getstatusoutput_ok = mock.Mock(return_value=(0, ""))
+
+
+class TestModuleInfo(unittest.TestCase):
+    @mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=False)
+    def test__load_config_module_not_loaded(self, *mocks):
+        kvm_config = utils_kernel_module.KernelModuleHandler._load_config(some_module_name)
+        self.assertIs(None, kvm_config)
+
+    @mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=True)
+    @mock.patch.object(utils_kernel_module.os, 'listdir', return_value=[some_module_param])
+    @mock.patch.object(utils_kernel_module, 'open', mock.mock_open(read_data=some_module_val + '\n'))
+    def test__load_config_module_loaded(self, *mocks):
+        kvm_config = utils_kernel_module.KernelModuleHandler._load_config(some_module_name)
+        self.assertEqual(1, len(kvm_config))
+        first = list(kvm_config.items())[0]
+        self.assertEqual(some_module_param, first[0])
+        self.assertEqual(some_module_val, first[1])
+
+    def test__to_line(self, *mocks):
+        kvm_config = utils_kernel_module.KernelModuleHandler._to_line(some_module_config)
+        self.assertEqual('force_emulation_prefix=N halt_poll_ns_shrink=0', kvm_config)
+
+
+@mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=True)
+@mock.patch.object(utils_kernel_module.os, 'listdir', return_value=[some_module_param])
+@mock.patch.object(utils_kernel_module, 'open', mock.mock_open(read_data=some_module_val + '\n'))
+class TestKernelModuleLoaded(unittest.TestCase):
+
+    def test_instance_backs_up(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        self.assertIsNotNone(handler._config_backup)
+        self.assertTrue(handler._was_loaded)
+        self.assertEqual("force_emulation_prefix=N", handler._config_backup)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_module(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler('skvm')
+        handler.load_module(params="key=value")
+        getstatusoutput_ok.assert_called_with('rmmod skvm; modprobe skvm key=value',
+                                              ignore_status=True, shell=True)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    @mock.patch.object(utils_kernel_module.KernelModuleHandler, '_load_config', return_value=some_module_config)
+    def test_restore(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        handler.load_module(params="key=value")
+        handler.restore()
+        cmd = getstatusoutput_ok.call_args[0][0]
+        self.assertTrue(some_module_param in cmd)
+
+    def tearDown(self):
+        getstatusoutput_ok.reset_mock()
+
+
+@mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=False)
+class TestModuleNotLoaded(unittest.TestCase):
+
+    def test_instance_stores_not_loaded(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        self.assertFalse(handler._was_loaded)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_not_forced(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        handler.load_module(force=False)
+        self.assertFalse(getstatusoutput_ok.assert_not_called())
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_is_forced(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        handler.load_module(params="key1=val1")
+        cmd = getstatusoutput_ok.call_args[0][0]
+        self.assertTrue("key1" in cmd)
+
+    def tearDown(self):
+        getstatusoutput_ok.reset_mock()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/virttest/utils_kernel_module.py
+++ b/virttest/utils_kernel_module.py
@@ -1,0 +1,111 @@
+import os
+import logging
+
+from avocado.utils import process
+from avocado.core import exceptions
+
+"""Handle Linux kernel modules"""
+
+
+class KernelModuleHandler(object):
+    """Class handling Linux kernel modules"""
+
+    def __init__(self, module_name):
+        self._module_name = module_name
+        self._was_loaded = True
+        self._config_backup = ""
+        self._backup_config()
+
+    def load_module(self, force=True, params=""):
+        """
+        Load module with given parameters
+
+        :param force: Force load if currently not loaded. Default is True as restore undoes loading.
+        :param params: Parameters to load with, 'key1=param1 key2=param2 ...'
+        """
+
+        if not force and not self._was_loaded:
+            logging.info("Module %s isn't loaded. Set force=True to force loading." % self._module_name)
+        else:
+            cmd = ""
+            if self._was_loaded:
+                cmd += 'rmmod %s; ' % self._module_name
+            cmd += 'modprobe %s %s' % (self._module_name, params)
+            logging.debug("Loading module: %s" % cmd)
+            status, output = process.getstatusoutput(cmd, shell=True, ignore_status=True)
+            if status:
+                raise exceptions.TestError("Couldn't load module %s: %s" % (
+                    self._module_name, output
+                ))
+
+    def restore(self):
+        """Restore previous module state"""
+
+        if not self._was_loaded:
+            cmd = 'rmmod %s' % self._module_name
+        else:
+            cmd = 'rmmod %s; modprobe %s %s' % (self._module_name, self._module_name,
+                                                self._config_backup)
+        logging.debug("Restoring module state: %s" % cmd)
+        status, output = process.getstatusoutput(cmd, shell=True, ignore_status=True)
+        if status:
+            raise exceptions.TestError("Couldn't restore module %s: %s" % (
+                self._module_name, self._config_backup))
+
+    def _backup_config(self):
+        """
+        Check if self.module_name is loaded and read config
+
+        """
+        config = KernelModuleHandler._load_config(self._module_name)
+        if config:
+            self._config_backup = KernelModuleHandler._to_line(config)
+        else:
+            self._was_loaded = False
+        logging.debug("Backed up %s module state (was_loaded, params)"
+                      "=(%s, %s)" % (self._module_name, self._was_loaded,
+                                     self._config_backup))
+
+    def get_was_loaded(self):
+        """ Read-only property """
+
+        return self._was_loaded
+
+    def get_config_backup(self):
+        """ Read-only property """
+
+        return self._config_backup
+
+    @staticmethod
+    def _to_line(as_dict):
+        """
+        Write dictionary in one line
+
+        :param as_dict: dictionary holding values {key1:value1, key2:value2, ...}
+        :return: string holding values 'key1=value1 key2=value2 ...'
+        """
+        s = ""
+        if as_dict and len(as_dict) > 0:
+            p = " %s=%s"
+            for k in as_dict:
+                s += p % (k, as_dict[k])
+        return s.strip()
+
+    @staticmethod
+    def _load_config(module_name):
+        """
+        Get current kvm module parameters
+
+        :return: Dictionary holding kvm module config {param:value, ...}, None if module not loaded
+        """
+
+        mod_params_path = '/sys/module/%s/parameters/' % module_name
+        if not os.path.exists(mod_params_path):
+            return None
+
+        mod_params = {}
+        params = os.listdir(mod_params_path)
+        for param in params:
+            with open(os.path.join(mod_params_path, param), 'r') as v:
+                mod_params[param] = v.read().strip()
+        return mod_params


### PR DESCRIPTION
On s390x hugepage support is not enabled by default in kvm.
Added helper methods to enable and disable hugepage support so
that memoryBackend/hugepages can be used in libvirt tests.

Added methods in this module because other hugepage related
functions reside there.

New methods were tested indirectly by running updated tp-libvirt tests.