### PR TITLE
qemu_vm: Avoid vnc ports clash on migration

### DIFF
--- a/docs/source/cartesian/CartesianConfigReference-KVM-migration_mode.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-migration_mode.rst
@@ -15,7 +15,7 @@ To start a VM in incoming mode for receiving migration data via tcp:
 
     migration_mode = tcp
 
-A port will be allocated from the range 5200 to 6000.
+A port will be allocated from the range 5200 to 5899.
 
 Defined On
 ----------

--- a/docs/source/cartesian/CartesianConfigReference-KVM-redirs.rst
+++ b/docs/source/cartesian/CartesianConfigReference-KVM-redirs.rst
@@ -16,7 +16,7 @@ Example:
     guest_port_remote_shell = 22
 
 A port will be allocated on the host, usually within the range
-5000-6000, and all traffic to/from this port will be redirect to guest's
+5000-5899, and all traffic to/from this port will be redirect to guest's
 port 22.
 
 Defined On

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1942,7 +1942,7 @@ class VM(virt_vm.BaseVM):
             # Handle port redirections
             redir_names = params.objects("redirs")
             host_ports = utils_misc.find_free_ports(
-                5000, 6000, len(redir_names))
+                5000, 5899, len(redir_names))
             self.redirs = {}
             for i in range(len(redir_names)):
                 redir_params = params.object_params(redir_names[i])

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1690,7 +1690,7 @@ class VM(virt_vm.BaseVM):
             self.serial_session_device = serials[0]
             host = params.get('chardev_host', '127.0.0.1')
             free_ports = utils_misc.find_free_ports(
-                5000, 6000, len(serials), host)
+                5000, 5899, len(serials), host)
             reg_count = 0
         for index, serial in enumerate(serials):
             serial_filename = vm.get_serial_console_filename(serial)
@@ -2619,7 +2619,7 @@ class VM(virt_vm.BaseVM):
             # Handle port redirections
             redir_names = params.objects("redirs")
             host_ports = utils_misc.find_free_ports(
-                5000, 6000, len(redir_names))
+                5000, 5899, len(redir_names))
 
             old_redirs = {}
             if self.redirs:
@@ -2785,7 +2785,7 @@ class VM(virt_vm.BaseVM):
 
             # Add migration parameters if required
             if migration_mode in ["tcp", "rdma", "x-rdma"]:
-                self.migration_port = utils_misc.find_free_port(5200, 6000)
+                self.migration_port = utils_misc.find_free_port(5200, 5899)
                 qemu_command += (" -incoming " + migration_mode +
                                  ":0:%d" % self.migration_port)
             elif migration_mode == "unix":
@@ -2795,7 +2795,7 @@ class VM(virt_vm.BaseVM):
                 qemu_command += " -incoming unix:%s" % self.migration_file
             elif migration_mode == "exec":
                 if migration_exec_cmd is None:
-                    self.migration_port = utils_misc.find_free_port(5200, 6000)
+                    self.migration_port = utils_misc.find_free_port(5200, 5899)
                     # check whether ip version supported by nc
                     if process.system("nc -h | grep -E '\-4 | \-6'",
                                       shell=True, ignore_status=True) == 0:

--- a/virttest/utils_test/qemu/migration.py
+++ b/virttest/utils_test/qemu/migration.py
@@ -933,7 +933,7 @@ class MultihostMigrationFd(MultihostMigration):
         if self.params.get("hostid") == srchost:
             last_port = 5199
             for _ in range(vms_count):
-                last_port = utils_misc.find_free_port(last_port + 1, 6000)
+                last_port = utils_misc.find_free_port(last_port + 1, 5899)
                 mig_ports.append(last_port)
 
         sync = SyncData(self.master_id(), self.hostid,
@@ -1091,7 +1091,7 @@ class MultihostMigrationExec(MultihostMigration):
             if self.params.get("hostid") == dsthost:
                 last_port = 5199
                 for _ in range(vms_count):
-                    last_port = utils_misc.find_free_port(last_port + 1, 6000)
+                    last_port = utils_misc.find_free_port(last_port + 1, 5899)
                     mig_ports.append(last_port)
 
             mig_ports = sync.sync(mig_ports, timeout=120)


### PR DESCRIPTION
The ports 590x are used for VNC (-vnc :0 => 5900) but the port of the
currently processed VM is not yet taken so find_free_port has no chance
on judging whether the port 5900 can be taken. This can happen with any
port depending on the current -vnc index so let's just limit the
available range to 5899 to completely avoid such clashes.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>