### PR TITLE
libvirt_xml.devices: Complement address attribute for vsock and rng

### DIFF
--- a/virttest/libvirt_xml/devices/rng.py
+++ b/virttest/libvirt_xml/devices/rng.py
@@ -5,12 +5,12 @@ http://libvirt.org/formatdomain.html#elementsRng
 """
 
 from virttest.libvirt_xml import accessors, xcepts
-from virttest.libvirt_xml.devices import base
+from virttest.libvirt_xml.devices import base, librarian
 
 
 class Rng(base.UntypedDeviceBase):
 
-    __slots__ = ('rng_model', 'rate', 'backend', 'alias')
+    __slots__ = ('rng_model', 'rate', 'backend', 'alias', 'address')
 
     def __init__(self, virsh_instance=base.base.virsh):
         accessors.XMLAttribute('rng_model', self,
@@ -24,11 +24,26 @@ class Rng(base.UntypedDeviceBase):
                                  tag_name='backend', subclass=self.Backend,
                                  subclass_dargs={
                                      'virsh_instance': virsh_instance})
+        accessors.XMLElementNest('address', self, parent_xpath='/',
+                                 tag_name='address', subclass=self.Address,
+                                 subclass_dargs={'type_name': 'pci',
+                                                 'virsh_instance': virsh_instance})
         accessors.XMLElementDict('alias', self, parent_xpath='/',
                                  tag_name='alias')
         super(Rng, self).__init__(
             device_tag='rng', virsh_instance=virsh_instance)
         self.xml = '<rng/>'
+
+    Address = librarian.get('address')
+
+    def new_rng_address(self, **dargs):
+        """
+        Return a new interface Address instance and set properties from dargs
+        """
+        new_one = self.Address("pci", virsh_instance=self.virsh)
+        for key, value in list(dargs.items()):
+            setattr(new_one, key, value)
+        return new_one
 
     class Backend(base.base.LibvirtXMLBase):
 

--- a/virttest/libvirt_xml/devices/vsock.py
+++ b/virttest/libvirt_xml/devices/vsock.py
@@ -23,6 +23,7 @@ class Vsock(base.UntypedDeviceBase):
         accessors.XMLElementNest('address', self, parent_xpath='/',
                                  tag_name='address', subclass=self.Address,
                                  subclass_dargs={
+                                     'type_name': 'pci',
                                      'virsh_instance': virsh_instance})
         accessors.XMLElementDict('alias', self,
                                  parent_xpath='/',

--- a/virttest/libvirt_xml/devices/vsock.py
+++ b/virttest/libvirt_xml/devices/vsock.py
@@ -31,4 +31,14 @@ class Vsock(base.UntypedDeviceBase):
         super(Vsock, self).__init__(device_tag='vsock',
                                     virsh_instance=virsh_instance)
         self.xml = '<vsock/>'
+
     Address = librarian.get('address')
+
+    def new_vsock_address(self, **dargs):
+        """
+        Return a new interface Address instance and set properties from dargs
+        """
+        new_one = self.Address("pci", virsh_instance=self.virsh)
+        for key, value in list(dargs.items()):
+            setattr(new_one, key, value)
+        return new_one


### PR DESCRIPTION
1. libvirt_xml.devices.vsock: Address requires type_name when initialize
2. libvirt_xml.devices.rng: Add address attribute for rng xml

Signed-off-by: Qianqian Zhu <qizhu@redhat.com>