### PR TITLE
Remove '-ic' option if '-i vmx' is specified in v2v

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -298,6 +298,10 @@ class Target(object):
             if self.input_mode in ['ova', 'disk',
                                    'libvirtxml'] and self.input_file:
                 options = options.replace(self.vm_name, self.input_file)
+
+        # In '-i vmx', '-ic' is not needed
+        if self.input_mode == 'vmx':
+            options = re.sub(r'-ic .*? ', '', options)
         return options
 
     def _get_libvirt_options(self):


### PR DESCRIPTION
'-ic' is optional in '-i vmx' mode.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>