### PR TITLE
Add console target model

### DIFF
--- a/virttest/libvirt_xml/devices/console.py
+++ b/virttest/libvirt_xml/devices/console.py
@@ -10,8 +10,8 @@ from virttest.libvirt_xml.devices.character import CharacterBase
 
 class Console(CharacterBase):
 
-    __slots__ = ('protocol_type', 'target_port', 'target_type', 'sources',
-                 'alias')
+    __slots__ = ('protocol_type', 'target_port', 'target_type', 'target_model',
+                 'sources', 'alias')
 
     def __init__(self, type_name='pty', virsh_instance=base.virsh):
         accessors.XMLAttribute('protocol_type', self, parent_xpath='/',
@@ -20,6 +20,8 @@ class Console(CharacterBase):
                                tag_name='target', attribute='port')
         accessors.XMLAttribute('target_type', self, parent_xpath='/',
                                tag_name='target', attribute='type')
+        accessors.XMLAttribute('target_model', self, parent_xpath='/target',
+                               tag_name='model', attribute='name')
         accessors.XMLElementList('sources', self, parent_xpath='/',
                                  marshal_from=self.marshal_from_sources,
                                  marshal_to=self.marshal_to_sources)


### PR DESCRIPTION
//console/target/model is available since 3.10.0. Added it to make
it available in tp-libvirt/libvirt serial.functional.
https://libvirt.org/formatdomain.html#elementsConsole