### PR TITLE
Fix vt-bootstrap

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -44,9 +44,9 @@ _PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_test_providers_dir(),
 try:
     assert len(os.listdir(_PROVIDERS_DOWNLOAD_DIR)) != 0
 except (OSError, AssertionError):
-    raise EnvironmentError("Bootstrap missing. "
-                           "Execute 'avocado vt-bootstrap' or disable this "
-                           "plugin to get rid of this message")
+    raise ImportError("Bootstrap missing. "
+                      "Execute 'avocado vt-bootstrap' or disable this "
+                      "plugin to get rid of this message")
 
 
 def add_basic_vt_options(parser):


### PR DESCRIPTION
Raising EnvironmentError won't be handled by avocado/core/extension_manager.py anymore since https://github.com/avocado-framework/avocado/commit/c2e30ab980520ab025673a0e60f07de1f32dfa94
Consequence is that if there's no previous avocado installation (/var/lib/avocado)
vt-bootstrap will always fail the first time with
"FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/avocado/data/avocado-vt/test-providers.d/downloads'"
Raising ImportError instead of EnvironmentError to maintain existing
behavior.