### PR TITLE
Fix cannot process flags argument with a compiled pattern

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1062,8 +1062,8 @@ def check_log(params, log):
             line = r'\s*'.join(pattern.split())
             expected = 'expected' if expect else 'not expected'
             logging.info('Searching for %s log: %s' % (expected, pattern))
-            compiled_pattern = re.compile(line)
-            search = re.search(compiled_pattern, log, flags=re.S)
+            compiled_pattern = re.compile(line, flags=re.S)
+            search = re.search(compiled_pattern, log)
             if search:
                 logging.info('Found log: %s', search.group(0))
                 if not expect:


### PR DESCRIPTION
ValueError: cannot process flags argument with a compiled pattern

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>