### PR TITLE
Restrict set of seclabels to be removed

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -518,12 +518,26 @@ class VMXMLBase(base.LibvirtXMLBase):
 
             self.xmltreefile.write()
 
-    def del_seclabel(self):
+    def del_seclabel(self, by_attr=None):
         """
-        Remove the seclabel tag from a domain
+        Remove seclabel tags from a domain. The set of seclabels for removal
+        can be restricted by matching attributes in by_attr.
+        :param by_attr: List of tuples describing the seclabel to be removed,
+        e.g.
+        1. [('model', 'selinux'), ('relabel', 'yes')] removes selinux seclabel
+         only if relabling is enabled.
+        2. [('type', 'dynamic')] removes all seclables that should get unique
+         security labels by libvirt.
+        3. by_attr=None will remove all seclabel tags.
         """
+        tag = "/seclabel"
         try:
-            self.xmltreefile.remove_by_xpath("/seclabel", remove_all=True)
+            if by_attr:
+                for seclabel in self.xmltreefile.findall(tag):
+                    if all(attr in seclabel.items() for attr in by_attr):
+                        self.xmltreefile.remove(seclabel)
+            else:
+                self.xmltreefile.remove_by_xpath(tag, remove_all=True)
         except (AttributeError, TypeError):
             pass  # Element already doesn't exist
         self.xmltreefile.write()

--- a/virttest/unittests/libvirt_xml/test_vm_xml.py
+++ b/virttest/unittests/libvirt_xml/test_vm_xml.py
@@ -1,0 +1,48 @@
+import unittest
+
+from virttest.libvirt_xml import vm_xml, xcepts
+
+XML = """
+<domain type='kvm'>
+  <seclabel type='dynamic' model='selinux' relabel='yes'/>
+  <seclabel type='dynamic' model='dac' relabel='yes'/>
+</domain>
+"""
+
+
+def get_vmxml():
+    vmxml = vm_xml.VMXML()
+    vmxml['xml'] = XML.strip()
+
+    return vmxml
+
+
+class TestVMXMLDelSeclabel(unittest.TestCase):
+
+    def test_del_seclabel_default(self):
+        vmxml = get_vmxml()
+        self.assertEqual(2, len(vmxml.get_seclabel()))
+        vmxml.del_seclabel()
+        with self.assertRaises(xcepts.LibvirtXMLError):
+            vmxml.get_seclabel()
+
+    def test_del_seclabel_with_conditions(self):
+        vmxml = get_vmxml()
+        del_dict = [('model', 'selinux'), ('relabel', 'yes')]
+        self.assertEqual(2, len(vmxml.get_seclabel()))
+        vmxml.del_seclabel(del_dict)
+        seclabels = vmxml.get_seclabel()
+        self.assertEqual(1, len(seclabels))
+        self.assertEqual('dac', seclabels[0]['model'])
+
+    def test_del_seclabel_with_partial_match(self):
+        vmxml = get_vmxml()
+        del_dict = [('model', 'selinux'), ('relabel', 'no')]
+        self.assertEqual(2, len(vmxml.get_seclabel()))
+        vmxml.del_seclabel(del_dict)
+        seclabels = vmxml.get_seclabel()
+        self.assertEqual(2, len(seclabels))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1. del_seclabel:
 a. The function originally deleted all seclabels.
 b. Added new parameter maintaining legacy behavior.
 c. New parameter let's restrict the set of seclables
    to be removed (see docstring).

2. virttest/unittests:
 a. Created new package for unit tests and subpackage to have
    consistent paths in unittests.

3. test_vm_xml.py:
 a. Added test cases to cover previous/default and new behavior.