### PR TITLE
qemu_vm: support shell command for params "device_name"

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2665,15 +2665,21 @@ class VM(virt_vm.BaseVM):
                             net_mask=params.get("net_mask", None),
                             pa_type=pa_type)
 
+                    if nic_params.get("device_name", "").startswith("shell:"):
+                        name = decode_to_text(process.system_output(
+                            nic_params.get("device_name").split(':', 1)[1],
+                            shell=True))
+                    else:
+                        name = nic_params.get("device_name")
                     # Virtual Functions (VF) assignable devices
                     if pa_type == "vf":
                         self.pci_assignable.add_device(device_type=pa_type,
                                                        mac=mac,
-                                                       name=nic_params.get("device_name"))
+                                                       name=name)
                     # Physical NIC (PF) assignable devices
                     elif pa_type == "pf":
                         self.pci_assignable.add_device(device_type=pa_type,
-                                                       name=nic_params.get("device_name"))
+                                                       name=name)
                     else:
                         raise virt_vm.VMBadPATypeError(pa_type)
                 else:


### PR DESCRIPTION
In different kernel, the network interface will be unpredictable
changed, use shell command to get the network interface  name for
param "device_name" in SRIOV tests

Signed-off-by: Wenli Quan <wquan@redhat.com>

id: 1772359