### PR TITLE
Add iscsi and ceph backends support-v3

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -310,6 +310,10 @@ variants image_backend:
         image_raw_device = yes
         storage_type = iscsi
         force_create_image = no
+    - iscsi_direct:
+        storage_type = iscsi-direct
+        enable_iscsi = yes
+        image_raw_device = yes
     - remote_nfs:
         storage_type = nfs
         nfs_mount_dir = /mnt/nfs_images

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -29,6 +29,17 @@ from virttest.compat_52lts import results_stderr_52lts, decode_to_text
 ISCSI_CONFIG_FILE = "/etc/iscsi/initiatorname.iscsi"
 
 
+def get_image_filename(portal, target, lun=0, user=None, password=None):
+    """
+    Form the iscsi image name, now only tcp is supported by qemu
+    e.g. iscsi://10.66.10.26/iqn.2019-09.com.example:zhencliu/0
+    """
+    uri = 'iscsi://{auth}{portal}/{target}/{lun}'
+    auth = '{user}:{password}@'.format(
+        user=user, password=password) if user and password else ''
+    return uri.format(auth=auth, portal=portal, target=target, lun=lun)
+
+
 def restart_iscsid(reset_failed=True):
     """
     Restart iscsid service.

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -24,6 +24,7 @@ from six.moves import xrange
 # Internal imports
 from virttest import utils_qemu
 from virttest import arch, storage, data_dir, virt_vm
+from virttest import qemu_storage
 from virttest.qemu_devices import qdevices
 from virttest.qemu_devices.utils import (DeviceError, DeviceHotplugError,
                                          DeviceInsertError, DeviceRemoveError,
@@ -1341,7 +1342,8 @@ class DevContainer(object):
                                    x_data_plane=None, blk_extra_params=None,
                                    scsi=None, drv_extra_params=None,
                                    num_queues=None, bus_extra_params=None,
-                                   force_fmt=None, image_encryption=None):
+                                   force_fmt=None, image_encryption=None,
+                                   image_access=None):
         """
         Creates related devices by variables
         :note: To skip the argument use None, to disable it use False
@@ -1379,6 +1381,7 @@ class DevContainer(object):
         :param num_queues: performace option for virtio-scsi-pci
         :param bus_extra_params: options want to add to virtio-scsi-pci bus
         :param image_encryption: ImageEncryption object for image
+        :param image_access: The remote image access information object
         """
         def define_hbas(qtype, atype, bus, unit, port, qbus, pci_bus,
                         addr_spec=None, num_queues=None,
@@ -1446,6 +1449,26 @@ class DevContainer(object):
                 devices[-1].set_param("data", secret.data)
             if image_encryption.key_secret:
                 secret_obj = devices[-1]
+
+        iscsi_initiator = None
+        access_secret, secret_type = self._get_access_secret_info(image_access)
+        access_secret_obj = None
+        if access_secret is not None:
+            # create and add secret object: -object secret
+            access_secret_obj = qdevices.QObject('secret')
+            access_secret_obj.set_param("id", access_secret.aid)
+            access_secret_obj.set_param('format', access_secret.data_format)
+
+            if secret_type == 'password':
+                access_secret_obj.set_param("file", access_secret.filename)
+            elif secret_type == 'key':
+                access_secret_obj.set_param("data", access_secret.data)
+
+            devices.append(access_secret_obj)
+
+        if image_access is not None:
+            if image_access.storage_type == 'iscsi-direct':
+                iscsi_initiator = image_access.iscsi_initiator
 
         use_device = self.has_option("device")
         if fmt == "scsi":   # fmt=scsi force the old version of devices
@@ -1578,6 +1601,10 @@ class DevContainer(object):
             protocol_cls = qdevices.QBlockdevProtocolFile
             if not filename:
                 protocol_cls = qdevices.QBlockdevProtocolNullCo
+            elif filename.startswith('iscsi:'):
+                protocol_cls = qdevices.QBlockdevProtocolISCSI
+            elif filename.startswith('rbd:'):
+                protocol_cls = qdevices.QBlockdevProtocolRBD
             elif fmt in ('scsi-generic', 'scsi-block'):
                 protocol_cls = qdevices.QBlockdevProtocolHostDevice
             elif blkdebug is not None:
@@ -1664,7 +1691,21 @@ class DevContainer(object):
         if not filename:
             cache = None
         if Flags.BLOCKDEV in self.caps:
-            devices[-2].set_param('filename', filename)
+            file_opts = qemu_storage.filename_to_file_opts(filename)
+            for key, value in six.iteritems(file_opts):
+                devices[-2].set_param(key, value)
+
+            if access_secret is not None:
+                if secret_type == 'password':
+                    devices[-2].set_param('password-secret',
+                                          access_secret_obj.get_qid())
+                elif secret_type == 'key':
+                    devices[-2].set_param('key-secret',
+                                          access_secret_obj.get_qid())
+
+            if iscsi_initiator is not None:
+                devices[-2].set_param('initiator-name', iscsi_initiator)
+
             for dev in (devices[-1], devices[-2]):
                 if not cache:
                     direct, no_flush = (None, None)
@@ -1682,6 +1723,18 @@ class DevContainer(object):
                 devices[-1].set_param('file', 'blkdebug:%s:%s' % (blkdebug, filename))
             else:
                 devices[-1].set_param('file', filename)
+
+            if access_secret is not None:
+                if secret_type == 'password':
+                    devices[-1].set_param('file.password-secret',
+                                          access_secret_obj.get_qid())
+                elif secret_type == 'key':
+                    devices[-1].set_param('file.key-secret',
+                                          access_secret_obj.get_qid())
+
+            if iscsi_initiator is not None:
+                devices[-1].set_param('file.initiator-name', iscsi_initiator)
+
         if drv_extra_params:
             drv_extra_params = (_.split('=', 1) for _ in
                                 drv_extra_params.split(',') if _)
@@ -1796,6 +1849,25 @@ class DevContainer(object):
 
         return devices
 
+    def _get_access_secret_info(self, image_access):
+        access_secret, secret_type = None, None
+        if image_access is not None:
+            if image_access.auth is not None:
+                access_secret = image_access.auth
+                if image_access.storage_type == 'ceph':
+                    # Now we use 'key-secret' for both -drive and -blockdev,
+                    # but for -drive, 'password-secret' also works, add an
+                    # option in cfg file to enable 'password-secret' in future
+                    secret_type = 'key'
+                elif image_access.storage_type == 'iscsi-direct':
+                    if Flags.BLOCKDEV in self.caps:
+                        # -blockdev: only password-secret is supported
+                        secret_type = 'password'
+                    else:
+                        # -drive: u/p included in the filename
+                        access_secret = None
+        return access_secret, secret_type
+
     def images_define_by_params(self, name, image_params, media=None,
                                 index=None, image_boot=None,
                                 image_bootindex=None,
@@ -1827,6 +1899,10 @@ class DevContainer(object):
                 scsi_hba = "virtio-scsi-ccw"
         image_encryption = storage.ImageEncryption.encryption_define_by_params(
             name, image_params)
+
+        # add storage access secret object for image
+        image_access = storage.retrieve_access_info(name, image_params)
+
         return self.images_define_by_variables(name,
                                                storage.get_image_filename(
                                                    image_params, data_root),
@@ -1884,7 +1960,8 @@ class DevContainer(object):
                                                    "bus_extra_params"),
                                                image_params.get(
                                                    "force_drive_format"),
-                                               image_encryption)
+                                               image_encryption,
+                                               image_access)
 
     def serials_define_by_variables(self, serial_id, serial_type, chardev_id,
                                     bus_type=None, serial_name=None,

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -864,6 +864,16 @@ class QBlockdevProtocolHostCdrom(QBlockdevProtocol):
     TYPE = 'host_cdrom'
 
 
+class QBlockdevProtocolISCSI(QBlockdevProtocol):
+    """ New a protocol iscsi blockdev node. """
+    TYPE = 'iscsi'
+
+
+class QBlockdevProtocolRBD(QBlockdevProtocol):
+    """ New a protocol rbd blockdev node. """
+    TYPE = 'rbd'
+
+
 class QDevice(QCustomDevice):
 
     """

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -26,21 +26,78 @@ from virttest.compat_52lts import (results_stdout_52lts,
                                    decode_to_text)
 
 
+def filename_to_file_opts(filename):
+    """Convert filename into file opts, used by both qemu-img and qemu-kvm"""
+    file_opts = {}
+    if not filename:
+        file_opts = {}
+    elif filename.startswith('iscsi:'):
+        filename_pattern = re.compile(
+            r'iscsi://((?P<user>.+?):(?P<password>.+?)@)?(?P<portal>.+)/(?P<target>.+?)/(?P<lun>\d+)')
+        matches = filename_pattern.match(filename)
+        if matches:
+            if (matches.group('portal') is not None
+                    and matches.group('target') is not None
+                    and matches.group('lun') is not None):
+                # required options for iscsi
+                file_opts = {'driver': 'iscsi',
+                             'transport': 'tcp',
+                             'portal': matches.group('portal'),
+                             'target': matches.group('target'),
+                             'lun': matches.group('lun')}
+                if matches.group('user') is not None:
+                    # optional option
+                    file_opts['user'] = matches.group('user')
+    elif filename.startswith('rbd:'):
+        filename_pattern = re.compile(
+            r'rbd:(?P<pool>.+?)/(?P<image>[^:]+)(:conf=(?P<conf>.+))?')
+        matches = filename_pattern.match(filename)
+        if matches:
+            if (matches.group('pool') is not None
+                    and matches.group('image') is not None):
+                # required options for rbd
+                file_opts = {'driver': 'rbd',
+                             'pool': matches.group('pool'),
+                             'image': matches.group('image')}
+                if matches.group('conf') is not None:
+                    # optional option
+                    file_opts['conf'] = matches.group('conf')
+    else:
+        file_opts = {'driver': 'file', 'filename': filename}
+
+    if not file_opts:
+        raise ValueError("Wrong filename %s" % filename)
+
+    return file_opts
+
+
 def _get_image_meta(image, params, root_dir):
     """Retrieve image meta dict."""
-    image_filename = storage.get_image_filename(params, root_dir)
-    image_format = params.get("image_format", "qcow2")
-    image_encryption = params.get("image_encryption", "off")
     meta = collections.OrderedDict()
-    secret = storage.ImageSecret.image_secret_define_by_params(image, params)
-    if image_format == "qcow2" and image_encryption == "luks":
-        meta["encrypt.key-secret"] = secret.aid
-    meta["driver"] = image_format
     meta["file"] = collections.OrderedDict()
-    meta["file"]["driver"] = "file"
-    meta["file"]["filename"] = image_filename
+
+    filename = storage.get_image_filename(params, root_dir)
+    meta_file = filename_to_file_opts(filename)
+    meta["file"].update(meta_file)
+
+    image_format = params.get("image_format", "qcow2")
+    meta["driver"] = image_format
+
+    secret = storage.ImageSecret.image_secret_define_by_params(image, params)
     if image_format == "luks":
         meta["key-secret"] = secret.aid
+    image_encryption = params.get("image_encryption", "off")
+    if image_format == "qcow2" and image_encryption == "luks":
+        meta["encrypt.key-secret"] = secret.aid
+
+    image_access = storage.ImageAccessInfo.access_info_define_by_params(image,
+                                                                        params)
+    if image_access is not None:
+        if image_access.auth is not None:
+            if image_access.storage_type == 'ceph':
+                # qemu-img needs secret object only for ceph access
+                meta['file']['password-secret'] = image_access.auth.aid
+
     return meta
 
 
@@ -178,6 +235,9 @@ class QemuImg(storage.QemuImg):
     rebase_cmd = ("rebase {secret_object} {image_format} {cache_mode} "
                   "{unsafe!b} {backing_file} {backing_format} "
                   "{image_filename}")
+    dd_cmd = ("dd {secret_object} {image_format} {target_image_format} "
+              "{block_size} {count} {skip} "
+              "if={image_filename} of={target_image_filename}")
 
     def __init__(self, params, root_dir, tag):
         """
@@ -224,6 +284,13 @@ class QemuImg(storage.QemuImg):
                     options.append("%s=%s" % (opt_key.replace("_", "-"),
                                               str(opt_val)))
 
+        access_secret, secret_type = self._get_access_secret_info()
+        if access_secret is not None:
+            if secret_type == 'password':
+                options.append("password-secret=%s" % access_secret.aid)
+            elif secret_type == 'key':
+                options.append("key-secret=%s" % access_secret.aid)
+
         image_extra_params = params.get("image_extra_params")
         if image_extra_params:
             options.append(image_extra_params.strip(','))
@@ -242,6 +309,19 @@ class QemuImg(storage.QemuImg):
         secret_objects = self.encryption_config.image_key_secrets
         secret_obj_str = "--object secret,id={s.aid},data={s.data}"
         return [secret_obj_str.format(s=s) for s in secret_objects]
+
+    @property
+    def _storage_secret_object(self):
+        secret_obj_str = ''
+        access_secret, secret_type = self._get_access_secret_info()
+        if access_secret is not None:
+            if secret_type == 'password':
+                secret_obj_str = "--object secret,id={s.aid},format={s.data_format},file={s.filename}"
+                return secret_obj_str.format(s=access_secret)
+            elif secret_type == 'key':
+                secret_obj_str = "--object secret,id={s.aid},format={s.data_format},data={s.data}"
+                return secret_obj_str.format(s=access_secret)
+        return secret_obj_str
 
     @error_context.context_aware
     def create(self, params, ignore_errors=False):
@@ -308,7 +388,13 @@ class QemuImg(storage.QemuImg):
                     if self.base_format:
                         cmd_dict["backing_format"] = self.base_format
 
-            secret_objects = self._secret_objects
+            secret_objects = []
+            storage_secret_object = self._storage_secret_object
+            if storage_secret_object:
+                secret_objects.append(storage_secret_object)
+            image_secret_objects = self._secret_objects
+            if image_secret_objects:
+                secret_objects.extend(image_secret_objects)
             if secret_objects:
                 cmd_dict["secret_object"] = " ".join(secret_objects)
 
@@ -576,14 +662,17 @@ class QemuImg(storage.QemuImg):
         Remove an image file.
         """
         logging.debug("Removing image file %s", self.image_filename)
-        if os.path.exists(self.image_filename):
-            os.unlink(self.image_filename)
-        else:
-            logging.debug("Image file %s not found", self.image_filename)
-        secret_filename = (self.encryption_config.key_secret and
-                           self.encryption_config.key_secret.filename)
-        if secret_filename and os.path.exists(secret_filename):
-            os.unlink(secret_filename)
+        storage.file_remove(self.params, self.image_filename)
+
+        secret_files = []
+        if self.encryption_config.key_secret:
+            secret_files.append(self.encryption_config.key_secret.filename)
+        access_secret, _ = self._get_access_secret_info()
+        if access_secret is not None:
+            secret_files.append(access_secret.filename)
+        for f in secret_files:
+            if os.path.exists(f):
+                os.unlink(f)
 
     def info(self, force_share=False, output="human"):
         """
@@ -717,9 +806,17 @@ class QemuImg(storage.QemuImg):
                 if self.encryption_config.key_secret:
                     cmd_dict["image_filename"] = "'%s'" % \
                         get_image_json(self.tag, params, root_dir)
-                secret_objects = self._secret_objects
+
+                secret_objects = []
+                storage_secret_object = self._storage_secret_object
+                if storage_secret_object:
+                    secret_objects.append(storage_secret_object)
+                image_secret_objects = self._secret_objects
+                if image_secret_objects:
+                    secret_objects.extend(image_secret_objects)
                 if secret_objects:
                     cmd_dict["secret_object"] = " ".join(secret_objects)
+
                 check_cmd = self.image_cmd + " " + \
                     self._cmd_formatter.format(self.check_cmd, **cmd_dict)
                 cmd_result = process.run(check_cmd, ignore_status=True,
@@ -887,6 +984,59 @@ class QemuImg(storage.QemuImg):
                              self.image_filename])
         cmd_result = process.run(" ".join(cmd_list), ignore_status=True)
         return cmd_result
+
+    def dd(self, output, bs=None, count=None, skip=None):
+        """
+        Qemu image dd wrapper, like dd command, clone the image.
+        Please use convert to convert one format of image to another.
+        :param output: of=output
+        :param bs: bs=bs, the block size in bytes
+        :param count: count=count, count of blocks copied
+        :param skip: skip=skip, count of blocks skipped
+        :return: process.CmdResult object containing the result of the
+                 command
+        """
+        cmd_dict = {
+            "image_filename": self.image_filename,
+            "target_image_filename": output,
+            "image_format": self.image_format,
+            "target_image_format": self.image_format
+        }
+
+        cmd_dict['block_size'] = 'bs=%d' % bs if bs is not None else ''
+        cmd_dict['count'] = 'count=%d' % count if count is not None else ''
+        cmd_dict['skip'] = 'skip=%d' % skip if skip is not None else ''
+
+        # TODO: use raw copy(-f raw -O raw) and ignore image secret and format
+        # for we cannot set secret for the output
+        raw_copy = True if self.encryption_config.key_secret else False
+        if raw_copy:
+            cmd_dict['image_format'] = cmd_dict['target_image_format'] = 'raw'
+
+        # use 'json:{}' instead when accessing storage with auth
+        access_secret, _ = self._get_access_secret_info()
+        meta = _get_image_meta(
+            self.tag, self.params, self.root_dir) if access_secret else None
+        if meta is not None:
+            if raw_copy:
+                # drop image secret from meta
+                for key in ['encrypt.key-secret', 'key-secret']:
+                    if key in meta:
+                        meta.pop(key)
+            meta['driver'] = cmd_dict.pop("image_format")
+            cmd_dict["image_filename"] = "'json:%s'" % json.dumps(meta)
+
+        if self._storage_secret_object:
+            cmd_dict["secret_object"] = self._storage_secret_object
+
+        dd_cmd = self.image_cmd + " " + \
+            self._cmd_formatter.format(self.dd_cmd, **cmd_dict)
+
+        return process.run(dd_cmd, ignore_status=True)
+
+    def copy_data_remote(self, src, dst):
+        bs = 1024 * 1024  # 1M, faster copy
+        self.dd(dst, bs)
 
 
 class Iscsidev(storage.Iscsidev):

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2576,6 +2576,8 @@ class VM(virt_vm.BaseVM):
                 continue
             if cdrom_params.get("enable_ceph") == "yes":
                 continue
+            if cdrom_params.get("enable_iscsi") == "yes":
+                continue
             iso = cdrom_params.get("cdrom")
             if iso:
                 iso = utils_misc.get_path(data_dir.get_data_dir(), iso)

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -18,6 +18,7 @@ from avocado.utils import process
 
 from virttest import iscsi
 from virttest import utils_misc
+from virttest import utils_numeric
 from virttest import virt_vm
 from virttest import gluster
 from virttest import lvm
@@ -74,12 +75,12 @@ def file_exists(params, filename_path):
     if params.get("enable_ceph") == "yes":
         image_name = params.get("image_name")
         image_format = params.get("image_format", "qcow2")
-        ceph_monitor = params["ceph_monitor"]
+        ceph_monitor = params.get("ceph_monitor")
         rbd_pool_name = params["rbd_pool_name"]
         rbd_image_name = "%s.%s" % (image_name.split("/")[-1], image_format)
+        ceph_conf = params.get("ceph_conf")
         return ceph.rbd_image_exist(ceph_monitor, rbd_pool_name,
-                                    rbd_image_name)
-
+                                    rbd_image_name, ceph_conf)
     return os.path.exists(filename_path)
 
 
@@ -92,16 +93,18 @@ def file_remove(params, filename_path):
     if params.get("enable_ceph") == "yes":
         image_name = params.get("image_name")
         image_format = params.get("image_format", "qcow2")
-        ceph_monitor = params["ceph_monitor"]
+        ceph_monitor = params.get("ceph_monitor")
         rbd_pool_name = params["rbd_pool_name"]
         rbd_image_name = "%s.%s" % (image_name.split("/")[-1], image_format)
-        return ceph.rbd_image_rm(ceph_monitor, rbd_pool_name, rbd_image_name)
+        ceph_conf = params.get("ceph_conf")
+        return ceph.rbd_image_rm(ceph_monitor, rbd_pool_name, rbd_image_name,
+                                 ceph_conf)
 
     if params.get("gluster_brick"):
         # TODO: Add implementation for gluster_brick
         return
 
-    if params.get('storage_type') in ('iscsi', 'lvm'):
+    if params.get('storage_type') in ('iscsi', 'lvm', 'iscsi-direct'):
         # TODO: Add implementation for iscsi/lvm
         return
 
@@ -145,20 +148,30 @@ def get_image_filename(params, root_dir, basename=False):
     """
     enable_gluster = params.get("enable_gluster", "no") == "yes"
     enable_ceph = params.get("enable_ceph", "no") == "yes"
+    enable_iscsi = params.get("enable_iscsi", "no") == "yes"
     image_name = params.get("image_name")
+    storage_type = params.get("storage_type")
     if image_name:
+        image_format = params.get("image_format", "qcow2")
+        if enable_iscsi:
+            if storage_type == 'iscsi-direct':
+                portal = params.get('portal_ip')
+                target = params.get('target')
+                lun = params.get('lun', 0)
+                user = params.get('chap_user')
+                password = params.get('chap_passwd')
+                return iscsi.get_image_filename(portal, target, lun,
+                                                user, password)
         if enable_gluster:
-            image_name = params.get("image_name", "image")
-            image_format = params.get("image_format", "qcow2")
             return gluster.get_image_filename(params, image_name, image_format)
         if enable_ceph:
-            image_format = params.get("image_format", "qcow2")
-            ceph_monitor = params["ceph_monitor"]
             rbd_pool_name = params["rbd_pool_name"]
             rbd_image_name = "%s.%s" % (image_name.split("/")[-1],
                                         image_format)
+            ceph_conf = params.get('ceph_conf')
+            ceph_monitor = params.get('ceph_monitor')
             return ceph.get_image_filename(ceph_monitor, rbd_pool_name,
-                                           rbd_image_name)
+                                           rbd_image_name, ceph_conf)
         return get_image_filename_filesytem(params, root_dir, basename=basename)
     else:
         logging.warn("image_name parameter not set.")
@@ -287,6 +300,85 @@ class ImageSecret(object):
         _make_secret_dir()
         with open(self.filename, "w") as fd:
             fd.write(self.data)
+
+
+class StorageAuth(object):
+    """Image storage authentication class"""
+
+    def __init__(self, image, data, data_format, auth_type):
+        self.aid = '%s_access_secret' % image
+        self._auth_type = auth_type
+        self.filename = os.path.join(secret_dir, "%s.secret" % self.aid)
+
+        if self._auth_type == 'chap':
+            self._chap_passwd = data
+        elif self._auth_type == 'cephx':
+            self._ceph_key = data
+        self.data_format = data_format
+
+        if self.data is not None:
+            self.save_to_file()
+
+    @property
+    def data(self):
+        if self._auth_type == 'chap':
+            return self._chap_passwd
+        elif self._auth_type == 'cephx':
+            return self._ceph_key
+        else:
+            return None
+
+    def save_to_file(self):
+        """Save secret data to file."""
+        _make_secret_dir()
+        with open(self.filename, "w") as fd:
+            fd.write(self.data)
+
+
+class ImageAccessInfo(object):
+    """
+    iscsi image access: initiator + StorageAuth(u/p)
+    ceph image access: StorageAuth(u/p)
+    """
+    def __init__(self, image, data, data_format, storage_type, initiator=None):
+        self.image = image
+        self.storage_type = storage_type
+        auth_type = None
+        if self.storage_type == 'iscsi-direct':
+            auth_type = 'chap'
+            self.iscsi_initiator = initiator
+        elif self.storage_type == 'ceph':
+            auth_type = 'cephx'
+        self.auth = StorageAuth(self.image, data, data_format,
+                                auth_type) if data is not None else None
+
+    @classmethod
+    def access_info_define_by_params(cls, image, params):
+        enable_ceph = params.get("enable_ceph", "no") == "yes"
+        enable_iscsi = params.get("enable_iscsi", "no") == "yes"
+        storage_type = params.get("storage_type")
+        access_info = None
+
+        if enable_iscsi:
+            if storage_type == 'iscsi-direct':
+                initiator = params.get('initiator')
+                data = params.get('chap_passwd')
+                data_format = params.get("data_format", "raw")
+                access_info = cls(image, data, data_format, storage_type,
+                                  initiator) if data or initiator else None
+        elif enable_ceph:
+            data = params.get('ceph_key')
+            data_format = params.get("data_format", "base64")
+            access_info = cls(image, data, data_format,
+                              storage_type) if data else None
+        return access_info
+
+
+def retrieve_access_info(image, params):
+    """Create image access info object"""
+    img_params = params.object_params(image)
+    # TODO: get all image access info
+    return ImageAccessInfo.access_info_define_by_params(image, img_params)
 
 
 def retrieve_secrets(image, params):
@@ -436,7 +528,7 @@ class QemuImg(object):
         self.image_blkdebug_filename = get_image_blkdebug_filename(params,
                                                                    root_dir)
         self.remote_keywords = params.get("remote_image",
-                                          "gluster iscsi ceph").split()
+                                          "gluster iscsi rbd").split()
         self.encryption_config = ImageEncryption.encryption_define_by_params(
             tag, params)
         image_chain = params.get("image_chain")
@@ -463,6 +555,19 @@ class QemuImg(object):
                                                               root_dir)
             self.snapshot_format = ss_params.get("image_format")
 
+        self.image_access = retrieve_access_info(self.tag, self.params)
+
+    def _get_access_secret_info(self):
+        access_secret, secret_type = None, None
+        if self.image_access is not None:
+            if self.image_access.auth is not None:
+                if self.image_access.storage_type == 'ceph':
+                    # Only ceph image access requires secret object by
+                    # qemu-img and only 'password-secret' is supported
+                    access_secret = self.image_access.auth
+                    secret_type = 'password'
+        return access_secret, secret_type
+
     def check_option(self, option):
         """
         Check if object has the option required.
@@ -478,7 +583,7 @@ class QemuImg(object):
         """
 
         for keyword in self.remote_keywords:
-            if keyword in self.image_filename:
+            if self.image_filename.startswith(keyword):
                 return True
 
         return False
@@ -536,7 +641,11 @@ class QemuImg(object):
         backup_dir = params.get("backup_dir", "")
         if not os.path.isabs(backup_dir):
             backup_dir = os.path.join(root_dir, backup_dir)
-        if params.get('image_raw_device') == 'yes':
+        if self.is_remote_image():
+            backup_set = get_backup_set(self.image_filename, backup_dir,
+                                        action, good)
+            backup_func = self.copy_data_remote
+        elif params.get('image_raw_device') == 'yes':
             ifmt = params.get("image_format", "qcow2")
             ifilename = utils_misc.get_path(root_dir, ("raw_device.%s" % ifmt))
             backup_set = get_backup_set(ifilename, backup_dir, action, good)
@@ -551,20 +660,25 @@ class QemuImg(object):
             for src, dst in backup_set:
                 if os.path.isfile(src):
                     backup_size += os.path.getsize(src)
+                else:
+                    # TODO: get the size of block/remote images
+                    backup_size += int(float(utils_numeric.normalize_data_size(
+                                             self.size, order_magnitude="B")))
 
-            image_dir = os.path.dirname(self.image_filename)
-            s = os.statvfs(image_dir)
+            s = os.statvfs(backup_dir)
             image_dir_free_disk_size = s.f_bavail * s.f_bsize
-            logging.info("Checking disk size on %s.", image_dir)
+            logging.info("backup image size: %d, available size: %d.",
+                         backup_size, image_dir_free_disk_size)
             if not self.is_disk_size_enough(backup_size,
                                             image_dir_free_disk_size):
                 return
 
         # backup secret file if presented
         if self.encryption_config.key_secret:
-            backup_set.extend(
-                get_backup_set(self.encryption_config.key_secret.filename,
-                               secret_dir, action, good))
+            bk_set = get_backup_set(self.encryption_config.key_secret.filename,
+                                    secret_dir, action, good)
+            for src, dst in bk_set:
+                self.copy_data_file(src, dst)
 
         for src, dst in backup_set:
             if action == 'backup' and skip_existing and os.path.exists(dst):
@@ -600,7 +714,9 @@ class QemuImg(object):
         if root_dir is None:
             root_dir = os.path.dirname(src)
         backup_func = self.copy_data_file
-        if params.get('image_raw_device') == 'yes':
+        if self.is_remote_image():
+            backup_func = self.copy_data_remote
+        elif params.get('image_raw_device') == 'yes':
             ifmt = params.get("image_format", "qcow2")
             src = utils_misc.get_path(root_dir, ("raw_device.%s" % ifmt))
             backup_func = self.copy_data_raw
@@ -608,6 +724,10 @@ class QemuImg(object):
         backup_size = 0
         if os.path.isfile(src):
             backup_size = os.path.getsize(src)
+        else:
+            # TODO: get the size of block/remote images
+            backup_size += int(float(utils_numeric.normalize_data_size(
+                                     self.size, order_magnitude="B")))
         s = os.statvfs(root_dir)
         image_dir_free_disk_size = s.f_bavail * s.f_bsize
         logging.info("Checking disk size on %s.", root_dir)
@@ -629,6 +749,9 @@ class QemuImg(object):
             logging.error("Available disk space is not enough. Skipping...")
             return False
         return True
+
+    def copy_data_remote(self, src, dst):
+        pass
 
     @staticmethod
     def copy_data_raw(src, dst):


### PR DESCRIPTION
1. Support QEMU to access iSCSI resources directly by url:
   scsi://<target-ip>[:<port>]/<target-iqn>/<lun>
2. Support QEMU to access ceph resources directly by uri:
   rbd:{pool-name}/{image-name}
3. Support vm installation on directly accessed iscsi/ceph image

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>