### PR TITLE
Fix local variable 'timestamp' referenced before assignment

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1840,9 +1840,9 @@ def store_vm_info(vm, log_filename, info_cmd='registers',
     :return: Store the vm register information to log file or not
     :rtype: bool
     """
+    timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
     if vmtype == "qemu":
         try:
-            timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
             output = vm.catch_monitor.info(info_cmd, debug=False)
         except qemu_monitor.MonitorError as err:
             logging.warn(err)
@@ -1852,7 +1852,6 @@ def store_vm_info(vm, log_filename, info_cmd='registers',
             return False
     elif vmtype == "libvirt":
         try:
-            timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
             result = virsh.qemu_monitor_command(vm.name,
                                                 "info %s" % info_cmd,
                                                 "--hmp", debug=False)


### PR DESCRIPTION
Fix following UnboundLocalError.

File "/usr/lib64/python2.7/threading.py", line 812, in __bootstrap_inner
  self.run()
File "/usr/lib64/python2.7/threading.py", line 765, in run
  self.__target(*self.__args, **self.__kwargs)
File "/var/tmp/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/env_process.py", line 1922, in _store_vm_info
  stored_log = store_vm_info(vm, vr_filename, cmd, vmtype=vmtype)
File "/var/tmp/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/env_process.py", line 1864, in store_vm_info
  log_filename = "%s_%s" % (log_filename, timestamp)
UnboundLocalError: local variable 'timestamp' referenced before assignment

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>