### PR TITLE
Fix --mac option checking error

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -291,7 +291,7 @@ class Target(object):
             options += input_transport_args[self.input_transport]
             return options
 
-        supported_mac = v2v_supported_option('--mac')
+        supported_mac = v2v_supported_option('--mac <mac:network\|bridge:out>')
         if supported_mac:
             if self.iface_macs:
                 for mac_i in self.iface_macs.split(';'):


### PR DESCRIPTION
'--mac' can match two options in v2v help. Update the patten to
only match '--mac <mac'.

--mac <mac:network|bridge:out>      Map NIC to network or bridge
--machine-readable[=format]         Make output machine readable

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>