### PR TITLE
Handle preseed installations properly

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1080,7 +1080,7 @@ class UnattendedInstallConfig(object):
             raise ValueError("Unexpected installation method %s" %
                              self.medium)
 
-        if self.unattended_file:
+        if self.unattended_file and not self.unattended_file.endswith('.preseed'):
             if self.floppy or self.cdrom_unattended:
                 self.setup_boot_disk()
                 if self.params.get("store_boot_disk") == "yes":


### PR DESCRIPTION
The previous code considers only extra ISO with kickstart file,
bootable kickstart image, or HTTP server providing the kickstart
file, none of which are valid for Debian derivatives where the
initrd is remastered with the kickstart (here preseed) file.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>