### PR TITLE
Supported snapshot for iscsi and ceph images

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -283,12 +283,16 @@ variants image_backend:
         #lvm_reload_cmd = "systemctl reload lvm2-lvmetad.service;"
         #lvm_reload_cmd += "systemctl reload lvm2-monitor.service"
     - ceph:
+        no Windows
         storage_type = ceph
         # Some test case may need images from different backend. Please set up
         # enable_ceph_$image_name to no if the special image is not use ceph
         # server in your test
         enable_ceph = yes
         cmds_installed_host += " rbd"
+        qcow2:
+            # qcow2 is supported since 4.1.0 on ceph
+            required_qemu = [4.1.0,)
         # Please update following parameters based on your test env
         #ceph_monitor = $ceph_monitor_ip
         #rbd_pool_name = $autotest_pool_name
@@ -311,6 +315,7 @@ variants image_backend:
         storage_type = iscsi
         force_create_image = no
     - iscsi_direct:
+        no Windows
         storage_type = iscsi-direct
         enable_iscsi = yes
         image_raw_device = yes


### PR DESCRIPTION
  1. Supported access secrets for images in image_chain
  2. Enhanced qemu_storage.create to create snapshot for remote images

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>