### PR TITLE
shared.machines: Add VSMT workaround for older kernels

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -33,7 +33,10 @@ variants:
         # configuration for power8 on power9(compat mode) remote host
         # enable it by making param as 'yes'
         power9_compat_remote = "no"
-
+        # Uncomment this to use new qemu (>=4.2) on hosts with older kernels
+        # (<4.13). In such case qemu binary reports something like this:
+        #     Failed to set KVM's VSMT mode to 1 (errno -22)
+        # machine_type_extra_params += ",vsmt=8"
         vga = std
         del rtc_drift
         del soundcards


### PR DESCRIPTION
Latest qemu handles VSMT differently, but it requires recent kernels.
Let's add a commented option to run in compatible way (using VSMT=8).
Without this option qemu reports:

    qemu-system-ppc64: Failed to set KVM's VSMT mode to 1 (errno -22)
    On PPC, a VM with 1 threads/core on a host with 8 threads/core
    requires the use of VSMT mode 1.
    This KVM seems to be too old to support VSMT.

This can be tested on RHEL7 host using latest qemu-4.2. Without the extra "vsmt=8" it fails with the message above (unless executed with "-smp 1" or "-smp 8").