### PR TITLE
shared: Force-enable nic on Fedora/RHEL install

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -98,6 +98,7 @@
                 sha1sum_initrd = 0d7bb4b536872954e4c455c87599157b
         # Shared specific setting
         unattended_install.url:
+            # TODO: Remove the "inst.repo" in newer Fedora versions, requiring it was a bug/regression
             kernel_params += " inst.repo=${url}"
         unattended_install.cdrom:
             cdrom_cd1 = isos/linux/Fedora-Server-dvd-${vm_arch_name}-28-1.1.iso
@@ -105,4 +106,4 @@
             kernel_params += " ks=cdrom"
             cdrom_unattended = images/f28-${vm_arch_name}/ks.iso
         syslog_server_proto = tcp
-        kernel_params += " nicdelay=60 inst.sshd"
+        kernel_params += " nicdelay=60 inst.sshd ip=dhcp"

--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -6,7 +6,7 @@
     block_hotplug:
         modprobe_module = acpiphp
     unattended_install, check_block_size, svirt_install, with_installation:
-        kernel_params = "ks=cdrom inst.sshd"
+        kernel_params = "ks=cdrom inst.sshd ip=dhcp"
         # The below config breaks RHEL6 x86, so it's commented out until we figure out a decent
         # solution that works across the board.
         #extra_cdrom_ks:

--- a/shared/cfg/guest-os/Linux/RHEL/8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/8.cfg
@@ -46,4 +46,4 @@
         x86_64:
             grub_file = /boot/grub2/grub.cfg
             kernel_params = "console=tty0 console=ttyS0"
-        kernel_params += " inst.sshd"
+        kernel_params += " inst.sshd ip=dhcp"


### PR DESCRIPTION
Some versions (RHEL8, Fedora>28) don't enable network unless it is
explicitly enabled by ip=... or via dependency (inst.repo=...). Let's
enable it via ip=dhcp.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>