### PR TITLE
utils_qemu: set allow_output_check='combined' in has_device_category

### DIFF
--- a/virttest/utils_qemu.py
+++ b/virttest/utils_qemu.py
@@ -110,7 +110,7 @@ def has_device_category(bin_path, category):
     :param category: device category (e.g. 'USB', 'Network', 'CPU')
     :return: True if device category existed in qemu devices help info
     """
-    out = _get_info(bin_path, "-device help")
+    out = _get_info(bin_path, "-device help", allow_output_check="combined")
     return category in DEVICE_CATEGORY_RE.findall(out)
 
 


### PR DESCRIPTION
The output type of some qemu help information may be different in
different distributions, some are `stdout`, some are `stderr`. Add
allow_output_check='combined' to check them together.

Bugzilla ID: 1781036
Signed-off-by: Yihuang Yu <yihyu@redhat.com>