### PR TITLE
image_boot: use lazy assignment for image_boot

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -81,7 +81,7 @@ variants:
             cd_format=ahci
         # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
         # then kvm_vm will ignore this option.
-        image_boot=yes
+        image_boot~=yes
     - virtio_scsi:
         no WinXP
         # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,


### PR DESCRIPTION
Change to use lazy assignment for variable image_boot to support
modifying its value in case level.

ID: 1781445
Signed-off-by: ybduan <yduan@redhat.com>