### PR TITLE
cartesian_config: Introduce the new operator '~='

### DIFF
--- a/docs/source/CartesianConfig.rst
+++ b/docs/source/CartesianConfig.rst
@@ -570,6 +570,10 @@ Formal definition
       value of <key> in all dicts of the current frame. If a dict lacks
       <key>, it will be created.
 
+   -  A statement of the form <key> ~= <value> sets the value of <key>
+      to <value> in all dicts of the current frame unless the <key> was
+      already defined. Otherwise the original value is preserved.
+
    -  A statement of the form <key> ?= <value> sets the value of <key>
       to <value>, in all dicts of the current frame, but only if <key>
       exists in the dict. The operators ?+= and ?<= are also supported.

--- a/selftests/unit/test_cartesian_config.py
+++ b/selftests/unit/test_cartesian_config.py
@@ -409,6 +409,83 @@ class CartesianConfigTest(unittest.TestCase):
                               ],
                               True)
 
+    def testVariableLazyAssignment(self):
+        self._checkStringDump("""
+            arg1 = ~balabala
+            variants:
+                - base_content:
+                    foo = bar
+                - empty_content:
+            variants:
+                - lazy_set:
+                    foo ~= baz
+                - lazy_set_with_substitution:
+                    foo ~= ${arg1}
+                - lazy_set_with_double_token:
+                    foo ~= ~= foo
+                - dummy_set:
+            foo ~= qux
+            """,
+                              [
+                                  {'_name_map_file': {'<string>': 'lazy_set.base_content'},
+                                   '_short_name_map_file': {'<string>': 'lazy_set.base_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': 'bar',
+                                   'name': 'lazy_set.base_content',
+                                   'shortname': 'lazy_set.base_content'},
+                                  {'_name_map_file': {'<string>': 'lazy_set.empty_content'},
+                                   '_short_name_map_file': {'<string>': 'lazy_set.empty_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': 'baz',
+                                   'name': 'lazy_set.empty_content',
+                                   'shortname': 'lazy_set.empty_content'},
+                                  {'_name_map_file': {'<string>': 'lazy_set_with_substitution.base_content'},
+                                   '_short_name_map_file': {'<string>': 'lazy_set_with_substitution.base_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': 'bar',
+                                   'name': 'lazy_set_with_substitution.base_content',
+                                   'shortname': 'lazy_set_with_substitution.base_content'},
+                                  {'_name_map_file': {'<string>': 'lazy_set_with_substitution.empty_content'},
+                                   '_short_name_map_file': {'<string>': 'lazy_set_with_substitution.empty_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': '~balabala',
+                                   'name': 'lazy_set_with_substitution.empty_content',
+                                   'shortname': 'lazy_set_with_substitution.empty_content'},
+                                  {'_name_map_file': {'<string>': 'lazy_set_with_double_token.base_content'},
+                                   '_short_name_map_file': {'<string>': 'lazy_set_with_double_token.base_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': 'bar',
+                                   'name': 'lazy_set_with_double_token.base_content',
+                                   'shortname': 'lazy_set_with_double_token.base_content'},
+                                  {'_name_map_file': {'<string>': 'lazy_set_with_double_token.empty_content'},
+                                   '_short_name_map_file': {'<string>': 'lazy_set_with_double_token.empty_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': '~= foo',
+                                   'name': 'lazy_set_with_double_token.empty_content',
+                                   'shortname': 'lazy_set_with_double_token.empty_content'},
+                                  {'_name_map_file': {'<string>': 'dummy_set.base_content'},
+                                   '_short_name_map_file': {'<string>': 'dummy_set.base_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': 'bar',
+                                   'name': 'dummy_set.base_content',
+                                   'shortname': 'dummy_set.base_content'},
+                                  {'_name_map_file': {'<string>': 'dummy_set.empty_content'},
+                                   '_short_name_map_file': {'<string>': 'dummy_set.empty_content'},
+                                   'arg1': '~balabala',
+                                   'dep': [],
+                                   'foo': 'qux',
+                                   'name': 'dummy_set.empty_content',
+                                   'shortname': 'dummy_set.empty_content'},
+                              ],
+                              True)
+
     def testCondition(self):
         self._checkStringDump("""
             variants tests [meta1]:


### PR DESCRIPTION
Introduce the new operator `~=` to support variable lazy assignment,
which means a variable will be set only if it has not been defined
in previous frames during configuration parsing. For example, by
given the following configuration, the value of the variable `foo`
should be `"bar"`,

    foo ~= bar

whereas, by given the following configuration, the value of the
variable `foo` would still be `"bar"`.

    foo = bar
    foo ~= foo

This might be useful for generating configuration under uncertain
conditions. For instance, we can set `smp` by using the value of
`vcpu_maxcpus` in the case of `smp` is not being set, otherwise,
let `smp` be what it was.

Signed-off-by: Xu Han <xuhan@redhat.com>