### PR TITLE
Restrict gluster usage by tests

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -766,12 +766,16 @@ Host_Ubuntu.m18.u10:
 # Add vsock device
 # vsocks = vhost_vsock0
 
-# If no outside gluster server prepared and used for testing, please leave it
-# as "" or comment it
+# These parameters determine how a gluster server is used in the pool tests.
+# A. If the gluster server is to be run locally on the test host, don't change
+#    the gluster server access parameters (gluster_server_X and gluster_identity_file)
+# B. If the gluster server is only to be used, e.g. in a pool, but not set or cleaned up
+#    by the test, set 'gluster_managed_by_test = "no"'.
 #gluster_server_ip = ""
 #gluster_server_user = ""
 #gluster_server_pwd = ""
 #gluster_identity_file = ""
+gluster_managed_by_test = "yes"
 
 # Add cputune/vcpupin to guest during import/install below param
 # can be uncommented and modified to match vm vcpu numbers,

--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -460,8 +460,11 @@ def gluster_nfs_disable(vol_name, session=None):
 
 def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
                              file_path="/etc/glusterfs/glusterd.vol", **kwargs):
+    # pylint: disable=E1121
     """
-    Set up or clean up glusterfs environment on localhost or remote
+    Set up or clean up glusterfs environment on localhost or remote. These actions
+    can be skipped by configuration on remote in case where a static gluster instance
+    is used, s. base.cfg. In this case, only the host ip is returned.
 
     :param is_setup: Boolean value, true for setup, false for cleanup
     :param vol_name: gluster created volume name
@@ -469,6 +472,14 @@ def setup_or_cleanup_gluster(is_setup, vol_name, brick_path="", pool_name="",
     :param kwargs: Other parameters that need to set for gluster
     :return: ip_addr or nothing
     """
+    if kwargs.get("gluster_managed_by_test", "yes") != "yes":
+        if not is_setup:
+            return ""
+        gluster_server_ip = kwargs.get("gluster_server_ip")
+        if not gluster_server_ip:
+            return utils_net.get_host_ip_address()
+        return gluster_server_ip
+
     try:
         utils_path.find_command("gluster")
     except utils_path.CmdNotFoundError:


### PR DESCRIPTION
1. base.cfg:
 a. new parameter `gluster_managed_by_test` to determine if the test should manage
    the gluster server or if a static instance managed e.g. manually is to be used.

2. gluster.py:
 a. Have `setup_or_cleanup_gluster` set up or clean up gluster server
    instance only if parameter `gluster_managed_by_test` is `yes`;
    this is default and legacy behavior.
    The function returns local IP or gluster_server_ip to maintain legacy
    behavior.
 b. Suppress pylint E1121 in order to maintain original signature
 c. Support the following use cases (gluster decides if to use local or remote
    gluster server by value of "gluster_server_ip", s. virttest/gluster.py):
    |UC#|Use gluster|Gluster location|Manage setup/cleanup|
    |1  |Yes        |local           |Yes                 |
    |2  |Yes        |remote          |Yes                 |
    |3  |Yes        |local           |No                  |
    |4  |Yes        |remote          |No                  |
    Before this change, only UC#1 and UC#2 were supported.