### PR TITLE
Reform setup_ssh_key function for v2v

### DIFF
--- a/backends/v2v/cfg/tests-shared.cfg
+++ b/backends/v2v/cfg/tests-shared.cfg
@@ -8,6 +8,8 @@ vm_type = v2v
 # The hypervisor uri (default, qemu://hostname/system, etc.)
 # where default or unset means derive from installed system
 connect_uri = default
+# Don't store vm info for v2v
+store_vm_info = no
 
 # Include the base config files.
 include base.cfg


### PR DESCRIPTION
1) Reform v2v_setup_ssh_key_cleanup to be more general
2) Reform the resource cleanup function for setup_ssh_key
3) Disable store_vm_info for v2v to avoid annoying exception reports
during running.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>