### PR TITLE
Add proxy function to delegate to check_result

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1173,6 +1173,31 @@ class PoolVolumeTest(object):
         check_exit_status(ret, False)
 
 
+def check_status_output(status, output='',
+                        expected_fails=None,
+                        skip_if=None,
+                        any_error=False,
+                        expected_match=None):
+    """
+    Proxy function to call check_result for commands run in vm session.
+    :param status: Exit status (used as CmdResult.exit_status)
+    :param output: Stdout and/or stderr
+    :param expected_fails: a string or list of regex of expected stderr patterns.
+                           The check will pass if any of these patterns matches.
+    :param skip_if: a string or list of regex of expected stderr patterns. The
+                    check will raise a TestSkipError if any of these patterns matches.
+    :param any_error: Whether expect on any error message. Setting to True will
+                      will override expected_fails
+    :param expected_match: a string or list of regex of expected stdout patterns.
+                           The check will pass if any of these patterns matches.
+    """
+
+    result = process.CmdResult(stderr=output,
+                               stdout=output,
+                               exit_status=status)
+    check_result(result, expected_fails, skip_if, any_error, expected_match)
+
+
 def check_result(result,
                  expected_fails=[],
                  skip_if=[],


### PR DESCRIPTION
Commands run in vm session don't return process.CmdResult.
In order to increase code reusability of `check_result` add
proxy function to support session typical results.