### PR TITLE
qcow2 was supported by ceph since qemu 4.1.0

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -289,6 +289,9 @@ variants image_backend:
         # server in your test
         enable_ceph = yes
         cmds_installed_host += " rbd"
+        qcow2:
+            # qcow2 is supported since 4.1.0 on ceph
+            required_qemu = [4.1.0,)
         # Please update following parameters based on your test env
         #ceph_monitor = $ceph_monitor_ip
         #rbd_pool_name = $autotest_pool_name


### PR DESCRIPTION
qcow2 was supported by ceph since qemu 4.1.0

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>