### PR TITLE
Add kernel module handler for kvm hugepage support

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -37,6 +37,7 @@ from virttest import data_dir
 from virttest import env_process
 from virttest import funcatexit
 from virttest import utils_env
+from virttest import utils_kernel_module
 from virttest import utils_params
 from virttest import utils_misc
 from virttest import version
@@ -70,8 +71,23 @@ def cleanup_env(env_filename, env_version):
     """
     Pickable function to initialize and destroy the virttest env
     """
+    try_restore_kvm_module_parameters()
     env = utils_env.Env(env_filename, env_version)
     env.destroy()
+
+
+def try_restore_kvm_module_parameters():
+    """Restores original kvm module parameters if modified by last test"""
+
+    try:
+        kvm_module_handler_file = env_process.KVM_MODULE_HANDLER_FILE
+        if os.path.isfile(kvm_module_handler_file):
+            utils_kernel_module.\
+                KernelModuleHandler("kvm", kvm_module_handler_file).restore()
+    except Exception as e:
+        logging.warning("Couldn't restore kvm module configuration."
+                        " You can try to do this manually from %s."
+                        " Error was: %s" % (kvm_module_handler_file, e))
 
 
 class VirtTest(test.Test):

--- a/virttest/unittests/test_utils_kernel_module.py
+++ b/virttest/unittests/test_utils_kernel_module.py
@@ -1,0 +1,174 @@
+import unittest
+import uuid
+import os.path
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from virttest import utils_kernel_module
+
+some_module_name = 'skvm'
+some_module_param = 'force_emulation_prefix'
+some_module_val = 'N'
+some_module_config = {some_module_param: 'N',
+                      'halt_poll_ns_shrink': '0'}
+
+getstatusoutput_ok = mock.Mock(return_value=(0, ""))
+
+
+class TestModuleInfo(unittest.TestCase):
+    @mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=False)
+    def test__load_config_module_not_loaded(self, *mocks):
+        kvm_config = utils_kernel_module.KernelModuleHandler._load_config(some_module_name)
+        self.assertIs(None, kvm_config)
+
+    @mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=True)
+    @mock.patch.object(utils_kernel_module.os, 'listdir', return_value=[some_module_param])
+    @mock.patch.object(utils_kernel_module, 'open', mock.mock_open(read_data=some_module_val + '\n'))
+    def test__load_config_module_loaded(self, *mocks):
+        kvm_config = utils_kernel_module.KernelModuleHandler._load_config(some_module_name)
+        self.assertEqual(1, len(kvm_config))
+        first = list(kvm_config.items())[0]
+        self.assertEqual(some_module_param, first[0])
+        self.assertEqual(some_module_val, first[1])
+
+
+@mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=True)
+@mock.patch.object(utils_kernel_module.os, 'listdir', return_value=[some_module_param])
+@mock.patch.object(utils_kernel_module, 'open', mock.mock_open(read_data=some_module_val + '\n'))
+class TestKernelModuleLoaded(unittest.TestCase):
+
+    def test_instance_backs_up(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        self.assertIsNotNone(handler._config_backup)
+        self.assertTrue(handler._was_loaded)
+        self.assertEqual("force_emulation_prefix=N", handler._config_backup)
+
+    pickle_dump = mock.MagicMock()
+    pickle_load = mock.MagicMock()
+    remove_file = mock.MagicMock()
+
+    @mock.patch.object(utils_kernel_module.pickle, 'dump', pickle_dump)
+    @mock.patch.object(utils_kernel_module.pickle, 'load', pickle_load)
+    @mock.patch.object(utils_kernel_module.os.path, 'isfile', return_value=False)
+    def test_instance_persistence_not_existing(self, *mocks):
+        persistence_file = os.path.join('/tmp/', str(uuid.uuid4()))
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name, persistence_file)
+        self.pickle_load.assert_not_called()
+        handler.save()
+        self.pickle_dump.assert_called_once()
+
+    @mock.patch.object(utils_kernel_module.pickle, 'dump', pickle_dump)
+    @mock.patch.object(utils_kernel_module.pickle, 'load', pickle_load)
+    @mock.patch.object(utils_kernel_module.os.path, 'isfile', return_value=True)
+    def test_instance_persistence_existing(self, *mocks):
+        persistence_file = os.path.join('/tmp/', str(uuid.uuid4()))
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name, persistence_file)
+        self.pickle_load.assert_called_once()
+
+    @mock.patch.object(utils_kernel_module.pickle, 'dump', pickle_dump)
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    @mock.patch.object(utils_kernel_module.os.path, 'isfile', return_value=False)
+    def test_load_module_persists_itself_by_default(self, *mocks):
+        persistence_file = os.path.join('/tmp/', str(uuid.uuid4()))
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name, persistence_file)
+        handler.load_module(params="key=value")
+        self.pickle_dump.assert_called_once()
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_module(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler('skvm')
+        handler.load_module(params="key=value")
+        getstatusoutput_ok.assert_called_with('rmmod skvm; modprobe skvm key=value',
+                                              ignore_status=True, shell=True)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_module_twice_same_params(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler('skvm')
+        handler.load_module(params="key=value")
+        getstatusoutput_ok.reset_mock()
+        handler.load_module(params="key=value")
+        getstatusoutput_ok.assert_not_called()
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_module_twice_different_params(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler('skvm')
+        handler.load_module(params="key=value")
+        getstatusoutput_ok.reset_mock()
+        handler.load_module(params="key=value1")
+        getstatusoutput_ok.assert_called_with('rmmod skvm; modprobe skvm key=value1',
+                                              ignore_status=True, shell=True)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_module_twice_restore(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        handler.load_module(params="key=value")
+        handler.load_module(params="key=value1")
+        handler.restore()
+        cmd = getstatusoutput_ok.call_args[0][0]
+        self.assertTrue(some_module_param in cmd)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    @mock.patch.object(utils_kernel_module.KernelModuleHandler, '_load_config', return_value=some_module_config)
+    def test_restore(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        handler.load_module(params="key=value")
+        handler.restore()
+        cmd = getstatusoutput_ok.call_args[0][0]
+        self.assertTrue(some_module_param in cmd)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    @mock.patch.object(utils_kernel_module.KernelModuleHandler, '_load_config', return_value=some_module_config)
+    def test_restore_only_if_updated_config(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        getstatusoutput_ok.reset_mock()
+        handler.restore()
+        getstatusoutput_ok.assert_not_called()
+
+    @mock.patch.object(utils_kernel_module.pickle, 'dump', pickle_dump)
+    @mock.patch.object(utils_kernel_module.pickle, 'load', pickle_load)
+    @mock.patch.object(utils_kernel_module.os.path, 'isfile', return_value=True)
+    @mock.patch.object(utils_kernel_module.os, 'remove', remove_file)
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    @mock.patch.object(utils_kernel_module.KernelModuleHandler, '_load_config', return_value=some_module_config)
+    def test_restore_removes_persistence_file_per_default(self, *mocks):
+        persistence_file = os.path.join('/tmp/', str(uuid.uuid4()))
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name, persistence_file)
+        handler._loaded_config = "key=value"
+        handler.restore()
+        self.remove_file.assert_called_once()
+
+    def tearDown(self):
+        getstatusoutput_ok.reset_mock()
+        self.pickle_load.reset_mock()
+        self.pickle_dump.reset_mock()
+
+
+@mock.patch.object(utils_kernel_module.os.path, 'exists', return_value=False)
+class TestModuleNotLoaded(unittest.TestCase):
+
+    def test_instance_stores_not_loaded(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        self.assertFalse(handler._was_loaded)
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_not_forced(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        handler.load_module(force=False)
+        self.assertFalse(getstatusoutput_ok.assert_not_called())
+
+    @mock.patch.object(utils_kernel_module.process, 'getstatusoutput', getstatusoutput_ok)
+    def test_load_is_forced(self, *mocks):
+        handler = utils_kernel_module.KernelModuleHandler(some_module_name)
+        handler.load_module(params="key1=val1")
+        cmd = getstatusoutput_ok.call_args[0][0]
+        self.assertTrue("key1" in cmd)
+
+    def tearDown(self):
+        getstatusoutput_ok.reset_mock()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/virttest/utils_kernel_module.py
+++ b/virttest/utils_kernel_module.py
@@ -1,0 +1,151 @@
+import os
+import os.path
+import pickle
+import logging
+
+from avocado.utils import process
+from avocado.core import exceptions
+
+"""Handle Linux kernel modules"""
+
+
+class KernelModuleHandler(object):
+    """Class handling Linux kernel modules"""
+
+    def __init__(self, module_name, persistence_file=""):
+        """
+        Create kernel module handler. It backs up the current status
+        of the kernel module or get its current status from a backed up
+        file.
+
+        :param module_name:
+        :param persistence_file: absolute file path to store object in
+        """
+        self._module_name = module_name
+        self._was_loaded = None
+        self._loaded_config = ""
+        self._config_backup = ""
+        self._persistence_file = persistence_file
+        if os.path.isfile(self._persistence_file):
+            self._load()
+        else:
+            self._backup_config()
+
+    def load_module(self, force=True, params=""):
+        """
+        Load module with given parameters
+
+        :param force: Force load if currently not loaded. Default is True as
+        restore undoes loading.
+        :param params: Parameters to load with, 'key1=param1 key2=param2 ...'
+        """
+
+        if params == self._loaded_config:
+            logging.debug("Not reloading module, same parameters requested for"
+                          " module %s: %s" % (self._module_name, params))
+            return
+
+        if not force and not self._was_loaded:
+            logging.debug("Module %s isn't loaded. Set force=True to force"
+                          " loading." % self._module_name)
+        else:
+            cmd = ""
+            if self._was_loaded:
+                cmd += 'rmmod %s; ' % self._module_name
+            cmd += 'modprobe %s %s' % (self._module_name, params)
+            logging.debug("Loading module: %s" % cmd)
+            status, output = process.getstatusoutput(cmd, shell=True,
+                                                     ignore_status=True)
+            if status:
+                raise exceptions.TestError("Couldn't load module %s: %s" % (
+                    self._module_name, output
+                ))
+            else:
+                self._loaded_config = params
+
+        if self._persistence_file:
+            self.save()
+
+    def restore(self):
+        """Restore previous module state"""
+
+        if self._loaded_config:
+            if not self._was_loaded:
+                cmd = 'rmmod %s' % self._module_name
+            else:
+                cmd = 'rmmod %s; modprobe %s %s' % (self._module_name,
+                                                    self._module_name,
+                                                    self._config_backup)
+            logging.debug("Restoring module state: %s" % cmd)
+            status, output = process.getstatusoutput(cmd, shell=True,
+                                                     ignore_status=True)
+            if status:
+                raise exceptions.TestError("Couldn't restore module %s: %s" % (
+                    self._module_name, self._config_backup))
+
+        if self._persistence_file and \
+                os.path.isfile(self._persistence_file):
+            os.remove(self._persistence_file)
+
+    def _backup_config(self):
+        """
+        Check if self.module_name is loaded and read config
+
+        """
+        config = KernelModuleHandler._load_config(self._module_name)
+        if config:
+            self._config_backup = " ".join("%s=%s" % _ for _ in config.items())
+            self._was_loaded = True
+        else:
+            self._was_loaded = False
+        logging.debug("Backed up %s module state (was_loaded, params)"
+                      "=(%s, %s)" % (self._module_name, self._was_loaded,
+                                     self._config_backup))
+
+    def _load(self):
+        try:
+            with open(self._persistence_file, 'rb') as pickled:
+                self.__dict__.update(pickle.load(pickled))
+        except pickle.UnpicklingError as e:
+            logging.debug("Failed to unpickle kernel module helper for %s"
+                          " from %s:%s" % (self._module_name,
+                                           self._persistence_file,
+                                           e))
+
+    def save(self):
+        try:
+            with open(self._persistence_file, 'wb') as pickled:
+                pickle.dump(self.__dict__, pickled)
+        except pickle.PickleError as e:
+            logging.debug("Failed to pickle kernel module helper for %s to %s"
+                          ":%s" % (self._module_name, self._persistence_file, e))
+
+    def get_was_loaded(self):
+        """ Read-only property """
+
+        return self._was_loaded
+
+    def get_config_backup(self):
+        """ Read-only property """
+
+        return self._config_backup
+
+    @staticmethod
+    def _load_config(module_name):
+        """
+        Get current module parameters
+
+        :return: Dictionary holding module config {param:value, ...}, None if
+         module not loaded
+        """
+
+        mod_params_path = '/sys/module/%s/parameters/' % module_name
+        if not os.path.exists(mod_params_path):
+            return None
+
+        mod_params = {}
+        params = os.listdir(mod_params_path)
+        for param in params:
+            with open(os.path.join(mod_params_path, param), 'r') as v:
+                mod_params[param] = v.read().strip()
+        return mod_params


### PR DESCRIPTION
Handle cases where kvm module is loaded without hugepage support

1. Add class to help load and restore Linux kernel module configuration.

unittests:
```bash
python -m unittest /root/code/avocado-vt/virttest/unittests/test_utils_kernel_module.py -v
test_instance_backs_up (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_instance_persistence_existing (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_instance_persistence_not_existing (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_load_module (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_load_module_persists_itself_by_default (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_load_module_twice_different_params (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_load_module_twice_restore (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_load_module_twice_same_params (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_restore (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_restore_only_if_updated_config (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test_restore_removes_persistence_file_per_default (virttest.unittests.test_utils_kernel_module.TestKernelModuleLoaded) ... ok
test__load_config_module_loaded (virttest.unittests.test_utils_kernel_module.TestModuleInfo) ... ok
test__load_config_module_not_loaded (virttest.unittests.test_utils_kernel_module.TestModuleInfo) ... ok
test_instance_stores_not_loaded (virttest.unittests.test_utils_kernel_module.TestModuleNotLoaded) ... ok
test_load_is_forced (virttest.unittests.test_utils_kernel_module.TestModuleNotLoaded) ... ok
test_load_not_forced (virttest.unittests.test_utils_kernel_module.TestModuleNotLoaded) ... ok

----------------------------------------------------------------------
Ran 16 tests in 0.012s

OK
```

2. Hook activating hugepages with config into env_process
 a. Introduce variable `kvm_module_parameters` to define custom module parameters on load
 b. Introduce variable `kvm_module_force_load` to avoid loading module if not previously loaded
 c. Only load module parameters if not loaded before. Restore original config at start of first following
    test case that does not define `kvm_module_parameters`. `KernelModuleHandler` takes care of only
    loading module parameters if they differ from previous setting in order to reduce stress on test system.
    Use persistence file in avocado test directory to pass module handler instance from one test execution
    to the next during the same job. In order to further reduce clutter in log, only create module handler
    if parameters will be updated or need to be restored.
 d. Sample log output with `kvm_module_parameters = 'hpage=1'` and `kvm_module_force_load = yes`: 4 test
    cases were run, where only 2nd and 3rd test case required parameter update:
```bash
2020-02-19 05:42:51,248 utils_kernel_mod L0103 DEBUG| Backed up kvm module state (was_loaded, params)=(True, halt_poll_ns_shrink=0 hpage=0 halt_po
ll_ns=50000 halt_poll_ns_grow_start=10000 halt_poll_ns_grow=2 nested=0 halt_poll_max_steal=10)
2020-02-19 05:42:51,249 utils_kernel_mod L0056 DEBUG| Loading module: rmmod kvm; modprobe kvm hpage=1
2020-02-19 05:47:32,173 utils_kernel_mod L0045 DEBUG| Not reloading module, same parameters requested for module kvm: hpage=1
2020-02-19 05:48:12,169 utils_kernel_mod L0079 DEBUG| Restoring module state: rmmod kvm; modprobe kvm halt_poll_ns_shrink=0 hpage=0 halt_poll_ns=5
0000 halt_poll_ns_grow_start=10000 halt_poll_ns_grow=2 nested=0 halt_poll_max_steal=10
```

3. Make sure kvm module configuration is restored after last test modified it
   during `cleanup_env`. Catch all exceptions to have rest of cleanup run.
