### PR TITLE
Move vddk lib source settings to convert_srouce.cfg

### DIFF
--- a/backends/v2v/cfg/convert_source.cfg
+++ b/backends/v2v/cfg/convert_source.cfg
@@ -19,18 +19,22 @@ variants:
                 vpx_hostname = VPX_55_HOSTNAME_V2V_EXAMPLE
                 vpx_dc = VPX_55_DC_V2V_EXAMPLE
                 esx_hostname = ESX_55_HOSTNAME_V2V_EXAMPLE
+                vddk_libdir_src = MOUNT_SRC_VDDK65_LIB_DIR_V2V_EXAMPLE
             - esx_60:
                 datastore = VPX_60_DATASTORE_V2V_EXAMPLE
                 vpx_hostname = VPX_60_HOSTNAME_V2V_EXAMPLE
                 vpx_dc = VPX_60_DC_V2V_EXAMPLE
                 esx_hostname = ESX_60_HOSTNAME_V2V_EXAMPLE
+                vddk_libdir_src = MOUNT_SRC_VDDK65_LIB_DIR_V2V_EXAMPLE
             - esx_65:
                 datastore = VPX_65_DATASTORE_V2V_EXAMPLE
                 vpx_hostname = VPX_65_HOSTNAME_V2V_EXAMPLE
                 vpx_dc = VPX_65_DC_V2V_EXAMPLE
                 esx_hostname = ESX_65_HOSTNAME_V2V_EXAMPLE
+                vddk_libdir_src = MOUNT_SRC_VDDK67_LIB_DIR_V2V_EXAMPLE
             - esx_67:                                      
                 datastore = VPX_67_DATASTORE_V2V_EXAMPLE
                 vpx_hostname = VPX_67_HOSTNAME_V2V_EXAMPLE
                 vpx_dc = VPX_67_DC_V2V_EXAMPLE
                 esx_hostname = ESX_67_HOSTNAME_V2V_EXAMPLE
+                vddk_libdir_src = MOUNT_SRC_VDDK67_LIB_DIR_V2V_EXAMPLE


### PR DESCRIPTION
ESX6.7 and ESX6.5 use vddk-6.7, ESX6.0 and ESX5.5 use vddk-6.5.
So move setting vddk_libdir_src from tp-libvirt to avocado-vt
to avoide duplicate codes

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>