### PR TITLE
qemu_vm: Avoid resume vm in "inmigrate" status

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4512,7 +4512,10 @@ class VM(virt_vm.BaseVM):
         """
         self.monitor.cmd("cont")
         if timeout:
-            self.wait_for_status('running', timeout, 0.1)
+            if not self.wait_for_status('running', timeout, step=0.1):
+                raise virt_vm.VMStatusError("Failed to enter running status, "
+                                            "the actual status is %s" %
+                                            self.monitor.get_status())
         else:
             self.verify_status("running")
 


### PR DESCRIPTION
After migration, the dst guest might in "inmigration" state for certain
period, especially with "exec:gzip". But resume vm in "inmigrate" can't
work, so wait up to 120s to wait for the right status.

id: 1791785
Signed-off-by: Yanan Fu <yfu@redhat.com>