### PR TITLE
Cirrus CI: replace UBI8 for CentOS 8.1 based image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,9 +27,9 @@ fedora_30_task:
   dry_run_script: &dry_run_scr
     - $PYTHON -m avocado --show all run --dry-run -- boot
 
-rhel_8_task:
+centos_8_1_task:
   container:
-    image: quay.io/avocado-framework/avocado-vt-ci-rhel-8
+    image: quay.io/avocado-framework/avocado-vt-ci-centos-8.1
   env:
     PYTHON: python3
     matrix:

--- a/contrib/containers/ci/centos-8.1.docker
+++ b/contrib/containers/ci/centos-8.1.docker
@@ -1,0 +1,4 @@
+FROM centos:8.1.1911
+LABEL description "Centos 8 image used on integration checks, such as cirrus-ci"
+RUN dnf -y install git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
+RUN dnf -y clean all


### PR DESCRIPTION
The CentOS based image doesn't need the fake binaries, and the less
fake the testing the better.

Signed-off-by: Cleber Rosa <crosa@redhat.com>