### PR TITLE
Fixup: latest libvirt build issue

### DIFF
--- a/virttest/base_installer.py
+++ b/virttest/base_installer.py
@@ -693,10 +693,22 @@ class BaseLocalSourceInstaller(BaseInstaller):
         build_helper_name = self.params.get('%s_build_helper' %
                                             self.param_key_prefix,
                                             'gnu_autotools')
+        build_dir = None
+        if self.params.get("explicit_build_dir", None):
+            build_dir = os.path.join(self.test_workdir, self.params.get("explicit_build_dir"))
+            # Create a folder if not available
+            if os.path.exists(build_dir):
+                if not os.path.isdir(build_dir):
+                    raise exceptions.TestError('Existing file present with explicit'
+                                               ' build dir name %s, delete'
+                                               ' the same and re-trigger' % build_dir)
+            else:
+                os.makedirs(build_dir)
+
         if build_helper_name == 'gnu_autotools':
             self.build_helper = build_helper.GnuSourceBuildParamHelper(
                 self.params, self.param_key_prefix,
-                self.source_destination, self.install_prefix)
+                self.source_destination, self.install_prefix, build_dir)
         elif build_helper_name == 'linux_kernel':
             self.build_helper = build_helper.LinuxKernelBuildHelper(
                 self.params, self.param_key_prefix,

--- a/virttest/build_helper.py
+++ b/virttest/build_helper.py
@@ -823,7 +823,7 @@ class GnuSourceBuildParamHelper(GnuSourceBuildHelper):
     git_repo_foo_configure_options = --enable-feature
     """
 
-    def __init__(self, params, name, destination_dir, install_prefix):
+    def __init__(self, params, name, destination_dir, install_prefix, build_dir=None):
         """
         Instantiates a new GnuSourceBuildParamHelper
         """
@@ -831,6 +831,7 @@ class GnuSourceBuildParamHelper(GnuSourceBuildHelper):
         self.name = name
         self.destination_dir = destination_dir
         self.install_prefix = install_prefix
+        self.build_dir = build_dir
         self._parse_params()
 
     def _parse_params(self):
@@ -851,7 +852,8 @@ class GnuSourceBuildParamHelper(GnuSourceBuildHelper):
                                                         configure_options))
 
         self.source = self.destination_dir
-        self.build_dir = self.destination_dir
+        if not self.build_dir:
+            self.build_dir = self.destination_dir
         self.prefix = self.install_prefix
         self.configure_options = configure_options
         self.include_pkg_config_path()


### PR DESCRIPTION
Introduce a different build_dir to fix below error
(1/1) build:  ERROR: Command '/usr/share/avocado-plugins-vt/build/libvirt/configure --prefix=/usr/share/avocado-plugins-vt/bin' failed.
stdout: b''
stderr: b'configure: error: Build directory must be different from source directory\n'\nadditional_info: None (6.11 s)

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>