### PR TITLE
Fix ARM pcie-topology

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1238,6 +1238,28 @@ class DevContainer(object):
             devices.append(qdevices.QStringDevice('gpex-root',
                                                   {'addr': 0, 'driver': 'gpex-root'},
                                                   parent_bus={'aobject': 'pci.0'}))
+
+            # add default pcie root port plugging pcie device
+            port_name = '%s-0' % root_port_type
+            port_params = {
+                'type': root_port_type,
+                # reserve slot 0x0 for plugging in  pci bridge
+                'reserved_slots': '0x0'}
+            root_port = self.pcic_by_params(port_name, port_params)
+            if root_port_type == 'pcie-root-port':
+                root_port.set_param('multifunction', 'on')
+            devices.append(root_port)
+
+            # add pci bridge for plugging in legace pci device
+            bridge_name = '%s-0' % pci_bridge_type
+            bridge_parent_bus = {'aobject': root_port.get_qid()}
+            bridge_params = {'type': pci_bridge_type}
+            pci_bridge = self.pcic_by_params(bridge_name,
+                                             bridge_params,
+                                             bridge_parent_bus)
+            pci_bridge.set_param('addr', '0x0')
+            devices.append(pci_bridge)
+
             return devices
 
         def machine_s390_virtio(cmd=False):

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -2236,7 +2236,7 @@ class QPCIEBus(QPCIBus):
                         "vhost-vsock-pci", "virtio-net",
                         "virtio-scsi-pci", "virtio-balloon-pci",
                         "virtio-serial-pci", "virtio-rng-pci",
-                        "e1000e", "virtio-gpu-device", "qemu-xhci"]
+                        "e1000e", "virtio-gpu-pci", "qemu-xhci"]
         if device.get_param("driver") in pcie_devices and (
                 device.get_param("pcie_direct_plug", "no") == "no"):
             return False

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2373,31 +2373,30 @@ class VM(virt_vm.BaseVM):
                 if ats:
                     add_virtio_option("ats", ats, devices, device, dev_type)
 
-        if params.get('machine_type') == 'q35':
-            # Add extra root_port at the end of the command line only if there is
-            # free slot on pci.0, discarding them otherwise
-            func_0_addr = None
-            pcic_params = {'type': 'pcie-root-port'}
-            extra_port_num = int(params.get('pcie_extra_root_port', 0))
-            for num in range(extra_port_num):
-                try:
-                    # enable multifunction for root port
-                    port_name = "pcie_extra_root_port_%d" % num
-                    root_port = devices.pcic_by_params(port_name, pcic_params)
-                    func_num = num % 8
-                    if func_num == 0:
-                        root_port.set_param('multifunction', 'on')
-                        devices.insert(root_port)
-                        func_0_addr = root_port.get_param('addr')
-                    else:
-                        port_addr = '%s.%s' % (func_0_addr, hex(func_num))
-                        root_port.set_param('addr', port_addr)
-                        devices.insert(root_port)
-                except DeviceError:
-                    logging.warning("No sufficient free slot for extra"
-                                    " root port, discarding %d of them"
-                                    % (extra_port_num - num))
-                    break
+        # Add extra root_port at the end of the command line only if there is
+        # free slot on pci.0, discarding them otherwise
+        func_0_addr = None
+        pcic_params = {'type': 'pcie-root-port'}
+        extra_port_num = int(params.get('pcie_extra_root_port', 0))
+        for num in range(extra_port_num):
+            try:
+                # enable multifunction for root port
+                port_name = "pcie_extra_root_port_%d" % num
+                root_port = devices.pcic_by_params(port_name, pcic_params)
+                func_num = num % 8
+                if func_num == 0:
+                    root_port.set_param('multifunction', 'on')
+                    devices.insert(root_port)
+                    func_0_addr = root_port.get_param('addr')
+                else:
+                    port_addr = '%s.%s' % (func_0_addr, hex(func_num))
+                    root_port.set_param('addr', port_addr)
+                    devices.insert(root_port)
+            except DeviceError:
+                logging.warning("No sufficient free slot for extra"
+                                " root port, discarding %d of them"
+                                % (extra_port_num - num))
+                break
         return devices, spice_options
 
     def _del_port_from_bridge(self, nic):


### PR DESCRIPTION
The  #2387 broke arm64-pci because the multifunction rootport was not defined for it's machine type. This PR fixes the definition and also adds some fixes in related code. I tested this on arm as well as i440fx and q35.