### PR TITLE
Fix closing local virsh connection problems in V2V

### DIFF
--- a/backends/v2v/cfg/tests-shared.cfg
+++ b/backends/v2v/cfg/tests-shared.cfg
@@ -8,19 +8,19 @@ vm_type = v2v
 # The hypervisor uri (default, qemu://hostname/system, etc.)
 # where default or unset means derive from installed system
 connect_uri = default
-# Don't store vm info for v2v
-store_vm_info = no
 
 # Include the base config files.
 include base.cfg
-include subtests.cfg
 include machines.cfg
 include guest-os.cfg
 include guest-hw.cfg
 # Include configuration for v2v tests
 include convert_source.cfg
 include convert_destination.cfg
+include subtests.cfg
 
+# Don't store vm info for v2v
+store_vm_info = no
 # Modify/comment the following lines if you wish to modify the paths of the
 # image files, ISO files or qemu binaries.
 #

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -577,8 +577,11 @@ class LinuxVMCheck(VMCheck):
         """
         Get vm pci list.
         """
-        cmd = "lspci"
-        return self.run_cmd(cmd)[1]
+        cmd_list = ['lspci', 'lshw']
+        for cmd in cmd_list:
+            status, output = self.run_cmd(cmd)
+            if status == 0:
+                return output
 
     def get_vm_rc_local(self):
         """
@@ -696,11 +699,11 @@ class LinuxVMCheck(VMCheck):
         :param flags: A RegexFlag, Please refer RE moudule of python
         :return: True if search result meets expectation, otherwise False
         """
-        cmd = "journalctl"
+        cmd = "journalctl --no-pager"
         if options:
             cmd += " %s" % options
 
-        if self.vm_general_search(cmd, substr, flags, ignore_status=True):
+        if self.vm_general_search(cmd, substr, flags, ignore_status=True, debug=False):
             return True
         return False
 
@@ -1504,8 +1507,8 @@ def close_virsh_instance(virsh_instance=None):
     :param v2v_virsh_instance: a virsh instance
     """
 
-    if virsh_instance:
-        logging.debug('Close session_id %s in VT', virsh_instance.session_id)
+    logging.debug('Closing session (%s) in VT', virsh_instance)
+    if virsh_instance and hasattr(virsh_instance, 'close_session'):
         virsh_instance.close_session()
 
 


### PR DESCRIPTION
1) For local virsh connection, it may does' have session_id attribute,
   we need to check that.
2) Add '--no-pager' option for journal command, if not, the command may
   be timeout because of wating for user interaction.
3) Add 'lshw' for checking pci devices, because not every guest has 'lspci'
   command.
4) store_vm_info is defined in base.cfg, we need to reset its value after
   base.cfg.
5) Move subtests.cfg to the line after 'include convert_destination.cfg'
   in tests-shared.cfg.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>