### PR TITLE
Fix the env vms issue

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1014,7 +1014,7 @@ def preprocess(test, params, env):
     # Destroy and remove VMs that are no longer needed in the environment or
     # leave them untouched if they have to be disregarded only for this test
     requested_vms = params.objects("vms")
-    keep_unrequested_vms = params.get_boolean("keep_env_vms", "no")
+    keep_unrequested_vms = params.get_boolean("keep_env_vms", False)
     for key in list(env.keys()):
         vm = env[key]
         if not isinstance(vm, virt_vm.BaseVM):


### PR DESCRIPTION
There is a typo in `preprocess` and that would cause incorrect vm
registrations between tests, let's fix it.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1798405