### PR TITLE
qcontainer: Defaults the blockdev format node to RAW type

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1832,6 +1832,9 @@ class DevContainer(object):
                 format_cls = qdevices.QBlockdevFormatRaw
             elif imgfmt == 'luks':
                 format_cls = qdevices.QBlockdevFormatLuks
+            elif imgfmt is None:
+                # use RAW type as the default
+                format_cls = qdevices.QBlockdevFormatRaw
 
             format_node = format_cls(name)
             protocol_node = protocol_cls(name)


### PR DESCRIPTION
Defaults the blockdev format node to RAW type since will raise
UnboundLocalError while the imgfmt is None.

ID: 1797975
Signed-off-by: Yongxue Hong <yhong@redhat.com>