### PR TITLE
nodecpustat always send a blank line

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2585,7 +2585,11 @@ def nodecpustats(option='', **dargs):
     """
 
     cmd_nodecpustat = "nodecpustats %s" % option
-    return command(cmd_nodecpustat, **dargs)
+    result = command(cmd_nodecpustat, **dargs)
+    if result.splitline() == "":
+        return 1
+    else:
+        return result
 
 
 def nodememstats(option='', **dargs):


### PR DESCRIPTION
Even if command is invalid a blanc line is returned by the command.
Currently it is supposed as an error, so testing that case to prevent a
false error.

Signed-off-by: Thierry <tfauck@free.fr>