### PR TITLE
Add lvm support

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -282,6 +282,10 @@ variants image_backend:
         remove_emulated_image = no
         #lvm_reload_cmd = "systemctl reload lvm2-lvmetad.service;"
         #lvm_reload_cmd += "systemctl reload lvm2-monitor.service"
+    - logical_volume:
+        storage_type = logical_volume
+        enable_lvm = yes
+        image_raw_device = yes
     - ceph:
         storage_type = ceph
         # Some test case may need images from different backend. Please set up

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -716,3 +716,8 @@ class EmulatedLVM(LVM):
             cmd = "rm -f %s" % emulate_image_file
             process.system(cmd, ignore_status=True)
             logging.info("remove emulate image file %s", emulate_image_file)
+
+
+def get_image_filename(vg_name, lv_name):
+    """Return logical volume filesystem path."""
+    return "/dev/{vg_name}/{lv_name}".format(vg_name=vg_name, lv_name=lv_name)

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -106,7 +106,8 @@ def file_remove(params, filename_path):
         # TODO: Add implementation for gluster_brick
         return
 
-    if params.get('storage_type') in ('iscsi', 'lvm', 'iscsi-direct'):
+    if params.get('storage_type') in ('iscsi', 'lvm', 'iscsi-direct',
+                                      'logical_volume'):
         # TODO: Add implementation for iscsi/lvm
         return
 
@@ -151,6 +152,7 @@ def get_image_filename(params, root_dir, basename=False):
     enable_gluster = params.get("enable_gluster", "no") == "yes"
     enable_ceph = params.get("enable_ceph", "no") == "yes"
     enable_iscsi = params.get("enable_iscsi", "no") == "yes"
+    enable_lvm = params.get("enable_lvm", "no") == "yes"
     image_name = params.get("image_name")
     storage_type = params.get("storage_type")
     if image_name:
@@ -174,6 +176,10 @@ def get_image_filename(params, root_dir, basename=False):
             ceph_monitor = params.get('ceph_monitor')
             return ceph.get_image_filename(ceph_monitor, rbd_pool_name,
                                            rbd_image_name, ceph_conf)
+        if enable_lvm:
+            vg_name = params.get("vg_name")
+            lv_name = params.get("lv_name")
+            return lvm.get_image_filename(vg_name, lv_name)
         return get_image_filename_filesytem(params, root_dir, basename=basename)
     else:
         logging.warn("image_name parameter not set.")


### PR DESCRIPTION
add logical volume support for vm installation.

Usage:
```
storage_type = logical_volume
images = image1
image_name_image1 = images/rhel801-64-virtio-scsi
image_size_image1 = 20G
image_format_image1 = qcow2
vg_name_image1 = autotest
lv_name_image1 = lv0
```

Signed-off-by: lolyu <lolyu@redhat.com>