### PR TITLE
Remove usage of 52lts compatiblity layer by Avocado-VT itself

### DIFF
--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -28,7 +28,6 @@ except ImportError:
 from virttest import bootstrap
 from virttest import defaults
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class VTBootstrap(CLICmd):
@@ -117,14 +116,12 @@ class VTBootstrap(CLICmd):
             else:
                 logging.error('Bootstrap command failed')
                 logging.error('Command: %s', ce.command)
-                stderr = results_stderr_52lts(ce.result)
-                if stderr:
+                if ce.result.stderr_text:
                     logging.error('stderr output:')
-                    logging.error(stderr)
-                stdout = results_stdout_52lts(ce.result)
-                if stdout:
+                    logging.error(ce.result.stderr_text)
+                if ce.result.stdout_text:
                     logging.error('stdout output:')
-                    logging.error(stdout)
+                    logging.error(ce.result.stdout_text)
             sys.exit(1)
         except KeyboardInterrupt:
             logging.info('Bootstrap interrupted by user')

--- a/examples/tests/hostname.py
+++ b/examples/tests/hostname.py
@@ -9,7 +9,6 @@ Before this test please set your hostname to something meaningful.
 import logging
 
 from avocado.utils import process
-from virttest.compat_52lts import results_stdout_52lts
 
 
 def run(test, params, env):
@@ -22,4 +21,4 @@ def run(test, params, env):
     """
     result = process.run("hostname")
     logging.info("Output of 'hostname' cmd is '%s'",
-                 results_stdout_52lts(result))
+                 result.stdout_text)

--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -7,7 +7,6 @@ import os
 import unittest
 
 from avocado.utils import process
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
@@ -34,8 +33,8 @@ class DocBuildTest(unittest.TestCase):
         doc_dir = os.path.join(basedir, 'docs')
         process.run('make -C %s clean' % doc_dir)
         result = process.run('make -C %s html' % doc_dir)
-        stdout = results_stdout_52lts(result).splitlines()
-        stderr = results_stderr_52lts(result).splitlines()
+        stdout = result.stdout_text.splitlines()
+        stderr = result.stderr_text.splitlines()
         output_lines = stdout + stderr
         for line in output_lines:
             ignore_msg = False

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     import ConfigParser
 
+from avocado.utils import astring
 from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils import crypto
@@ -19,7 +20,6 @@ from six.moves import urllib
 from six import string_types
 
 from virttest import data_dir
-from virttest.compat_52lts import decode_to_text
 
 
 class ConfigLoader:
@@ -488,7 +488,7 @@ def download_file(asset_info, interactive=False, force=False):
         try:
             logging.info("Verifying expected SHA1 sum from %s", sha1_url)
             sha1_file = urllib.request.urlopen(sha1_url)
-            sha1_contents = decode_to_text(sha1_file.read())
+            sha1_contents = astring.to_text(sha1_file.read())
             sha1 = sha1_contents.split(" ")[0]
             logging.info("Expected SHA1 sum: %s", sha1)
         except Exception as e:

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -18,7 +18,6 @@ from . import cartesian_config
 from . import utils_selinux
 from . import defaults
 from . import arch
-from .compat_52lts import results_stdout_52lts
 
 
 LOG = logging.getLogger("avocado.app")
@@ -288,7 +287,7 @@ def sync_download_dir(interactive):
             if diff_result.exit_status != 0:
                 LOG.debug("%s result:\n %s",
                           diff_result.command,
-                          results_stdout_52lts(diff_result))
+                          diff_result.stdout_text)
                 answer = genio.ask('Download file "%s" differs from "%s". '
                                    'Overwrite?' % (dst_file, src_file),
                                    auto=not interactive)
@@ -604,7 +603,7 @@ def create_config_files(test_dir, shared_dir, interactive, t_type, step=None,
             if diff_result.exit_status != 0:
                 LOG.info("%s result:\n %s",
                          diff_result.command,
-                         results_stdout_52lts(diff_result))
+                         diff_result.stdout_text)
                 answer = genio.ask("Config file  %s differs from %s."
                                    "Overwrite?" % (dst_file, src_file),
                                    auto=force_update or not interactive)

--- a/virttest/build_helper.py
+++ b/virttest/build_helper.py
@@ -11,7 +11,6 @@ from avocado.utils import path
 from avocado.utils import process
 
 from virttest import data_dir
-from virttest.compat_52lts import decode_to_text
 
 
 def _force_copy(src, dest):
@@ -588,8 +587,8 @@ class GnuSourceBuildHelper(object):
 
         :return: list of options accepted by configure script
         """
-        help_raw = decode_to_text(process.system_output(
-            '%s --help' % self.get_configure_path(), ignore_status=True))
+        help_raw = process.run('%s --help' % self.get_configure_path(),
+                               ignore_status=True).stdout_text
         help_output = help_raw.split("\n")
         option_list = []
         for line in help_output:

--- a/virttest/ceph.py
+++ b/virttest/ceph.py
@@ -15,7 +15,6 @@ from avocado.utils import process
 
 from virttest import utils_numeric
 from virttest import error_context
-from virttest.compat_52lts import decode_to_text
 
 
 class CephError(Exception):
@@ -109,8 +108,8 @@ def rbd_image_exist(ceph_monitor, rbd_pool_name, rbd_image_name,
     opts = m_opt + ' ' + c_opt
     keyring = '--keyring %s' % keyfile if keyfile else ''
     cmd = cmd.format(opts=opts, pool=rbd_pool_name, keyring=keyring)
-    output = decode_to_text(process.system_output(cmd, ignore_status=True,
-                                                  verbose=True))
+    output = process.run(cmd, ignore_status=True,
+                         verbose=True).stdout_text
 
     logging.debug("Response from rbd ls command is: %s" % output)
 
@@ -167,7 +166,7 @@ def rbd_image_map(ceph_monitor, rbd_pool_name, rbd_image_name):
     """
     cmd = "rbd map %s --pool %s -m %s" % (rbd_image_name, rbd_pool_name,
                                           ceph_monitor)
-    output = decode_to_text(process.system_output(cmd, verbose=True))
+    output = process.system_output(cmd, verbose=True).stdout_text
     if os.path.exist(os.path.join("/dev/rbd", rbd_pool_name, rbd_image_name)):
         return os.path.join("/dev/rbd", rbd_pool_name, rbd_image_name)
     else:
@@ -183,7 +182,7 @@ def rbd_image_unmap(rbd_pool_name, rbd_image_name):
     :params rbd_image_name: The name of rbd image
     """
     cmd = "rbd unmap /dev/rbd/%s/%s" % (rbd_pool_name, rbd_image_name)
-    output = decode_to_text(process.system_output(cmd, verbose=True))
+    output = process.system_output(cmd, verbose=True).stdout_text
     if os.path.exist(os.path.join("/dev/rbd", rbd_pool_name, rbd_image_name)):
         logging.debug("Failed to unmap image from local: %s" % output)
 

--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -32,7 +32,6 @@ from virttest import virsh
 from virttest import utils_misc
 from virttest import libvirt_xml
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts, decode_to_text
 from virttest import libvirt_version
 
 
@@ -85,7 +84,7 @@ def hotplug_supported(vm_name, mtype):
         json_result = virsh.qemu_monitor_command(vm_name, cmd, "--pretty",
                                                  debug=False)
         try:
-            result = json.loads(results_stdout_52lts(json_result))
+            result = json.loads(json_result.stdout_text)
         except Exception:
             # Failure to parse json output and default support to False
             # TODO: Handle for failure cases
@@ -115,7 +114,7 @@ def affinity_from_vcpuinfo(vm):
 
     :return: affinity list of VM
     """
-    output = results_stdout_52lts(virsh.vcpuinfo(vm.name)).rstrip()
+    output = virsh.vcpuinfo(vm.name).stdout_text.rstrip()
     affinity = re.findall('CPU Affinity: +[-y]+', output)
     total_affinity = [list(vcpu_affinity.split()[-1].strip())
                       for vcpu_affinity in affinity]
@@ -160,7 +159,7 @@ def affinity_from_vcpupin(vm, vcpu=None, options=None):
     vcpupin_affinity = {}
     host_cpu_count = utils.total_cpus_count()
     result = virsh.vcpupin(vm.name, vcpu=vcpu, options=options, debug=True)
-    for vcpu in results_stdout_52lts(result).strip().split('\n')[2:]:
+    for vcpu in result.stdout_text.strip().split('\n')[2:]:
         # On newer version of libvirt, there is no ':' in
         # vcpupin output anymore
         vcpupin_output[int(vcpu.split()[0].rstrip(':'))] = vcpu.split()[1]
@@ -204,12 +203,12 @@ def get_vcpucount_details(vm, options):
 
     result = virsh.vcpucount(vm.name, options, ignore_status=True,
                              debug=True)
-    if results_stderr_52lts(result):
+    if result.stdout_text:
         logging.debug("vcpu count command failed")
         return (result, vcpucount_details)
 
     if options:
-        stdout = results_stdout_52lts(result).strip()
+        stdout = result.stdout_text.strip()
         if 'guest' in options:
             vcpucount_details['guest_live'] = int(stdout)
         elif 'config' in options:
@@ -223,7 +222,7 @@ def get_vcpucount_details(vm, options):
             else:
                 vcpucount_details['cur_live'] = int(stdout)
     else:
-        output = results_stdout_52lts(result).strip().split('\n')
+        output = result.stdout_text.strip().split('\n')
         for item in output:
             if ('maximum' in item) and ('config' in item):
                 vcpucount_details['max_config'] = int(item.split()[2].strip())
@@ -292,7 +291,7 @@ def check_vcpucount(vm, exp_vcpu, option="", guest_agent=False):
     if option == "--guest" and vm.is_alive() and guest_agent:
         vcpucount_option = "--guest"
     (vcresult, vcpucount_result) = get_vcpucount_details(vm, vcpucount_option)
-    if results_stderr_52lts(vcresult):
+    if vcresult.stderr_text:
         result = False
     if vcpucount_option == "--guest" and guest_agent:
         if vcpucount_result['guest_live'] != exp_vcpu['guest_live']:
@@ -401,9 +400,9 @@ def get_cpustats(vm, cpu=None):
         result = virsh.cpu_stats(vm.name, option)
         if result.exit_status != 0:
             logging.error("cpu stats command failed: %s",
-                          results_stderr_52lts(result))
+                          result.stderr_text)
             return None
-        output = results_stdout_52lts(result).strip().split()
+        output = result.stdout_text.strip().split()
         if re.match("CPU%s" % cpu, output[0]):
             cpustats[cpu] = [float(output[5]),  # vcputime
                              float(output[2]) - float(output[5]),  # emulator
@@ -416,9 +415,9 @@ def get_cpustats(vm, cpu=None):
             result = virsh.cpu_stats(vm.name, option)
             if result.exit_status != 0:
                 logging.error("cpu stats command failed: %s",
-                              results_stderr_52lts(result))
+                              result.stderr_text)
                 return None
-            output = results_stdout_52lts(result).strip().split()
+            output = result.stdout_text.strip().split()
             if re.match("CPU%s" % host_cpu_online[i], output[0]):
                 cpustats[host_cpu_online[i]] = [float(output[5]),
                                                 float(output[2]) - float(output[5]),
@@ -427,9 +426,9 @@ def get_cpustats(vm, cpu=None):
     cpustats["total"] = []
     if result.exit_status != 0:
         logging.error("cpu stats command failed: %s",
-                      results_stderr_52lts(result))
+                      results.stderr_text)
         return None
-    output = results_stdout_52lts(result).strip().split()
+    output = result.stdout_text.strip().split()
     cpustats["total"] = [float(output[2])]  # cputime
     return cpustats
 
@@ -442,7 +441,7 @@ def get_domstats(vm, key):
     :return: value string
     """
     domstats_output = virsh.domstats(vm.name)
-    for item in results_stdout_52lts(domstats_output).strip().split():
+    for item in domstats_output.stdout_text.strip().split():
         if key in item:
             return item.split("=")[1]
 
@@ -646,7 +645,7 @@ def get_thread_cpu(thread):
     :rtype: builtin.list
     """
     cmd = "ps -o cpuid,lwp -eL | grep -w %s$" % thread
-    cpu_thread = decode_to_text(process.system_output(cmd, shell=True))
+    cpu_thread = process.run(cmd, shell=True).stdout_text
     if not cpu_thread:
         return []
     return list(set([_.strip().split()[0] for _ in cpu_thread.splitlines()]))
@@ -662,7 +661,7 @@ def get_pid_cpu(pid):
     :rtype: builtin.list
     """
     cmd = "ps -o cpuid -L -p %s" % pid
-    cpu_pid = decode_to_text(process.system_output(cmd))
+    cpu_pid = process.run(cmd).stdout_text
     if not cpu_pid:
         return []
     return list(set([_.strip() for _ in cpu_pid.splitlines()]))
@@ -678,7 +677,7 @@ def get_cpu_info(session=None):
     cpu_info = {}
     cmd = "lscpu"
     if session is None:
-        output = decode_to_text(process.system_output(cmd, ignore_status=True)).splitlines()
+        output = process.run(cmd, ignore_status=True).stdout_text.splitlines()
     else:
         try:
             output = session.cmd_output(cmd).splitlines()
@@ -812,8 +811,7 @@ def get_recognized_cpuid_flags(qemu_binary="/usr/libexec/qemu-kvm"):
     :param qemu_binary: qemu-kvm binary file path
     :return: flags list
     """
-    out = decode_to_text(process.system_output("%s -cpu ?" % qemu_binary),
-                         errors='replace')
+    out = process.run("%s -cpu ?" % qemu_binary).stdout.decode(errors='replace')
     match = re.search("Recognized CPUID flags:(.*)", out, re.M | re.S)
     try:
         return list(filter(None, re.split('\s', match.group(1))))
@@ -1076,7 +1074,7 @@ def cpu_allowed_list_by_task(pid, tid):
     result = process.run(cmd, ignore_status=True, shell=True)
     if result.exit_status:
         return None
-    return results_stdout_52lts(result).strip()
+    return result.stdout_text.strip()
 
 
 def hotplug_domain_vcpu(vm, count, by_virsh=True, hotplug=True):
@@ -1147,10 +1145,10 @@ def hotplug_domain_vcpu(vm, count, by_virsh=True, hotplug=True):
             result = virsh.qemu_monitor_command(vm.name, cmd, cmd_type,
                                                 debug=True)
             if result.exit_status != 0:
-                raise exceptions.TestFail(results_stderr_52lts(result))
+                raise exceptions.TestFail(result.stderr_text)
             else:
                 logging.debug("Command output:\n%s",
-                              results_stdout_52lts(result).strip())
+                              result.stdout_text.strip())
     return result
 
 
@@ -1209,7 +1207,7 @@ def get_qemu_cpu_models(qemu_binary):
     """
     cmd = qemu_binary + " -cpu '?'"
     result = process.run(cmd, verbose=False)
-    return extract_qemu_cpu_models(results_stdout_52lts(result))
+    return extract_qemu_cpu_models(result.stdout_text)
 
 
 def get_qemu_best_cpu_model(params):

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -48,7 +48,6 @@ from virttest import utils_iptables
 from virttest import utils_package
 from virttest import utils_qemu
 from virttest.utils_version import VersionInterval
-from virttest.compat_52lts import decode_to_text
 from virttest.staging import service
 
 try:
@@ -93,8 +92,8 @@ def _get_qemu_version(qemu_cmd):
 
     :param qemu_cmd: Path to qemu binary
     """
-    version_output = decode_to_text(a_process.system_output(
-        "%s -version" % qemu_cmd, verbose=False))
+    version_output = a_process.run("%s -version" % qemu_cmd,
+                                   verbose=False).stdout_text
     version_line = version_output.split('\n')[0]
     matches = re.match(QEMU_VERSION_RE, version_line)
     if matches:
@@ -1078,8 +1077,8 @@ def preprocess(test, params, env):
 
     if kvm_userspace_ver_cmd:
         try:
-            kvm_userspace_version = decode_to_text(a_process.system_output(
-                kvm_userspace_ver_cmd, shell=True)).strip()
+            kvm_userspace_version = a_process.run(
+                kvm_userspace_ver_cmd, shell=True).stdout_text.strip()
         except a_process.CmdError:
             kvm_userspace_version = "Unknown"
     else:
@@ -1110,8 +1109,8 @@ def preprocess(test, params, env):
     if vm_type == "libvirt":
         libvirt_ver_cmd = params.get("libvirt_ver_cmd", "libvirtd -V|awk -F' ' '{print $3}'")
         try:
-            libvirt_version = decode_to_text(a_process.system_output(
-                libvirt_ver_cmd, shell=True)).strip()
+            libvirt_version = a_process.run(
+                libvirt_ver_cmd, shell=True).stdout_text.strip()
         except a_process.CmdError:
             libvirt_version = "Unknown"
         version_info["libvirt_version"] = str(libvirt_version)

--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -21,7 +21,6 @@ from virttest import remote
 from virttest import utils_misc
 from virttest import utils_net
 from virttest import error_context
-from virttest.compat_52lts import decode_to_text
 
 
 class GlusterError(Exception):
@@ -44,12 +43,12 @@ def glusterd_start():
     Check for glusterd status and start it
     """
     cmd = "service glusterd status"
-    output = decode_to_text(process.system_output(cmd, ignore_status=True))
+    output = process.run(cmd, ignore_status=True).stdout_text
     # The blank before 'active' makes a distinction with 'inactive'
     if ' active' not in output or 'running' not in output:
         cmd = "service glusterd start"
         error_context.context("Starting gluster dameon failed")
-        output = decode_to_text(process.system_output(cmd))
+        output = process.run(cmd).stdout_text
 
 
 @error_context.context_aware

--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -18,7 +18,6 @@ except ImportError:
 from avocado.utils import process
 
 from virttest import error_context
-from virttest.compat_52lts import decode_to_text
 from virttest.qemu_monitor import Monitor, MonitorError
 
 
@@ -543,7 +542,7 @@ class QemuAgent(Monitor):
 
         if crypted:
             openssl_cmd = "openssl passwd -crypt %s" % password
-            password = decode_to_text(process.system_output(openssl_cmd)).strip('\n')
+            password = process.run(openssl_cmd)).stdout_text.strip('\n')
 
         args = {"crypted": crypted, "username": username,
                 "password": base64.b64encode(password.encode()).decode()}

--- a/virttest/http_server.py
+++ b/virttest/http_server.py
@@ -12,7 +12,7 @@ except ImportError:
     from BaseHTTPServer import HTTPServer
     from SimpleHTTPServer import SimpleHTTPRequestHandler
 
-from virttest.compat_52lts import decode_to_text
+from avocado.utils.astring import to_text
 
 
 class HTTPRequestHandler(SimpleHTTPRequestHandler):
@@ -95,7 +95,7 @@ class HTTPRequestHandler(SimpleHTTPRequestHandler):
 
         """
         # abandon query parameters
-        path = urlparse(decode_to_text(path))[2]
+        path = urlparse(to_text(path))[2]
         path = posixpath.normpath(unquote(path))
         words = path.split('/')
         words = list(filter(None, words))

--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -10,7 +10,6 @@ import re
 from avocado.utils import process
 
 from virttest import virsh
-from virttest.compat_52lts import results_stdout_52lts
 from virttest.staging import utils_cgroup
 
 VIRSH_BLKIOTUNE_OUTPUT_MAPPING = {"weight": "weight",
@@ -273,7 +272,7 @@ class CgroupTest(object):
             logging.error("There is no virsh cmd '%s'", virsh_cmd)
             return None
         result = func(vm_name, ignore_status=True)
-        output = results_stdout_52lts(result).strip()
+        output = result.stdout_text.strip()
         output_list = output.splitlines()
         output_dict = {}
         for output_line in output_list:

--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -14,7 +14,6 @@ from avocado.utils import process
 
 from virttest import storage
 from virttest import virsh
-from virttest.compat_52lts import results_stdout_52lts, decode_to_text
 
 
 class QemuImg(storage.QemuImg):
@@ -132,7 +131,7 @@ class StoragePool(object):
         # Allow it raise exception if command has executed failed.
         result = self.virsh_instance.pool_list("--all", ignore_status=False)
         pools = {}
-        lines = results_stdout_52lts(result).strip().splitlines()
+        lines = result.stdout_text.strip().splitlines()
         if len(lines) > 2:
             head = lines[0]
             lines = lines[2:]
@@ -202,7 +201,7 @@ class StoragePool(object):
         except process.CmdError:
             return info
 
-        for line in results_stdout_52lts(result).splitlines():
+        for line in result.stdout_text.splitlines():
             params = line.split(':')
             if len(params) == 2:
                 name = params[0].strip()
@@ -439,7 +438,7 @@ class PoolVolume(object):
             logging.error('List volume failed: %s', detail)
             return volumes
 
-        lines = results_stdout_52lts(result).strip().splitlines()
+        lines = result.stdout_text.strip().splitlines()
         if len(lines) > 2:
             head = lines[0]
             lines = lines[2:]
@@ -473,7 +472,7 @@ class PoolVolume(object):
             logging.error("Get volume information failed: %s", detail)
             return info
 
-        for line in results_stdout_52lts(result).strip().splitlines():
+        for line in result.stdout_text.strip().splitlines():
             attr = line.split(':')[0]
             value = line.split("%s:" % attr)[-1].strip()
             info[attr] = value
@@ -558,10 +557,10 @@ def check_qemu_image_lock_support():
     """
     cmd = "qemu-img"
     try:
-        binary_path = decode_to_text(process.system_output("which %s" % cmd))
+        binary_path = process.run("which %s" % cmd).stdout_text
     except process.CmdError:
         raise process.CmdError(cmd, binary_path,
                                "qemu-img command is not found")
     cmd_result = process.run(binary_path + ' -h', ignore_status=True,
                              shell=True, verbose=False)
-    return '-U' in results_stdout_52lts(cmd_result)
+    return '-U' in cmd_result.stdout_text

--- a/virttest/libvirt_version.py
+++ b/virttest/libvirt_version.py
@@ -6,7 +6,7 @@ import re
 import logging
 
 from avocado.utils import process
-from virttest.compat_52lts import decode_to_text
+from avocado.utils.astring import to_text
 
 
 def version_compare(major, minor, update, session=None):
@@ -36,7 +36,7 @@ def version_compare(major, minor, update, session=None):
     try:
         regex = r'[Uu]sing\s*[Ll]ibrary:\s*[Ll]ibvirt\s*'
         regex += r'(\d+)\.(\d+)\.(\d+)'
-        lines = decode_to_text(func("virsh version")).splitlines()
+        lines = to_text(func("virsh version")).splitlines()
         for line in lines:
             mobj = re.search(regex, line)
             if bool(mobj):

--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -2,7 +2,6 @@ import logging
 import imp
 
 from avocado.utils import process
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 from .. import propcan, xml_utils, virsh
 from ..libvirt_xml import xcepts
@@ -225,8 +224,6 @@ class LibvirtXMLBase(propcan.PropCanBase):
         if schema_name:
             command += ' %s' % schema_name
         cmdresult = process.run(command, ignore_status=True)
-        cmdresult.stdout = results_stdout_52lts(cmdresult)
-        cmdresult.stderr = results_stderr_52lts(cmdresult)
         return cmdresult
 
 

--- a/virttest/libvirt_xml/domcapability_xml.py
+++ b/virttest/libvirt_xml/domcapability_xml.py
@@ -7,7 +7,6 @@ import six
 
 from virttest import xml_utils
 from virttest.libvirt_xml import base, accessors, xcepts
-from virttest.compat_52lts import results_stdout_52lts
 
 
 class DomCapabilityXML(base.LibvirtXMLBase):
@@ -34,7 +33,7 @@ class DomCapabilityXML(base.LibvirtXMLBase):
                                tag_name='vcpu', attribute='max')
         super(DomCapabilityXML, self).__init__(virsh_instance)
         result = self.__dict_get__('virsh').domcapabilities()
-        self['xml'] = results_stdout_52lts(result).strip()
+        self['xml'] = result.stdout_text.strip()
 
     def get_additional_feature_list(self, cpu_mode_name):
         """

--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -9,7 +9,6 @@ import six
 from virttest import xml_utils
 from virttest.libvirt_xml import base, xcepts, accessors
 from virttest.libvirt_xml.devices import librarian
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class RangeList(list):
@@ -720,7 +719,7 @@ class NetworkXML(NetworkXMLBase):
         for net_name in networks:
             new_copy = new_netxml.copy()
             dump_result = virsh_instance.net_dumpxml(net_name)
-            new_copy.xml = results_stdout_52lts(dump_result).strip()
+            new_copy.xml = dump_result.stdout_text.strip()
             result[net_name] = new_copy
         return result
 
@@ -735,7 +734,7 @@ class NetworkXML(NetworkXMLBase):
         """
         netxml = NetworkXML(virsh_instance=virsh_instance)
         dump_result = virsh_instance.net_dumpxml(network_name, extra)
-        netxml['xml'] = results_stdout_52lts(dump_result).strip()
+        netxml['xml'] = dump_result.stdout_text.strip()
         return netxml
 
     @staticmethod
@@ -808,7 +807,7 @@ class NetworkXML(NetworkXMLBase):
             raise xcepts.LibvirtXMLError("Failed to undefine network %s.\n"
                                          "Detail: %s" %
                                          (self.name,
-                                          results_stderr_52lts(cmd_result)))
+                                          cmd_result.stderr_text))
 
     def define(self):
         """
@@ -819,7 +818,7 @@ class NetworkXML(NetworkXMLBase):
             raise xcepts.LibvirtXMLError("Failed to define network %s.\n"
                                          "Detail: %s" %
                                          (self.name,
-                                          results_stderr_52lts(cmd_result)))
+                                          cmd_result.stderr_text))
 
     def start(self):
         """
@@ -830,7 +829,7 @@ class NetworkXML(NetworkXMLBase):
             raise xcepts.LibvirtXMLError("Failed to start network %s.\n"
                                          "Detail: %s" %
                                          (self.name,
-                                          results_stderr_52lts(cmd_result)))
+                                          cmd_result.stderr_text))
 
     def sync(self, state=None):
         """

--- a/virttest/libvirt_xml/nodedev_xml.py
+++ b/virttest/libvirt_xml/nodedev_xml.py
@@ -6,7 +6,6 @@ http://libvirt.org/formatnode.html
 import os
 
 from virttest.libvirt_xml import base, xcepts, accessors
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class CAPXML(base.LibvirtXMLBase):
@@ -489,10 +488,10 @@ class NodedevXML(NodedevXMLBase):
         nodedevxml = NodedevXML(virsh_instance=virsh_instance)
         dumpxml_result = virsh_instance.nodedev_dumpxml(dev_name)
         if dumpxml_result.exit_status:
-            stderr = results_stderr_52lts(dumpxml_result)
+            stderr = dumpxml_result.stderr_text
             raise xcepts.LibvirtXMLError("Nodedev_dumpxml %s failed.\n"
                                          "Error: %s." % (dev_name, stderr))
-        nodedevxml.xml = results_stdout_52lts(dumpxml_result)
+        nodedevxml.xml = dumpxml_result.stdout_text
 
         return nodedevxml
 

--- a/virttest/libvirt_xml/nwfilter_xml.py
+++ b/virttest/libvirt_xml/nwfilter_xml.py
@@ -5,7 +5,6 @@ http://libvirt.org/formatnwfilter.html
 
 from virttest.libvirt_xml import base, xcepts, accessors
 from virttest.libvirt_xml.nwfilter_protocols import librarian
-from virttest.compat_52lts import results_stdout_52lts
 
 
 class NwfilterRulesProtocol(list):
@@ -310,7 +309,7 @@ class NwfilterXML(NwfilterXMLBase):
         """
         filter_xml = NwfilterXML(virsh_instance=virsh_instance)
         result = virsh_instance.nwfilter_dumpxml(uuid, options=options)
-        filter_xml['xml'] = results_stdout_52lts(result).strip()
+        filter_xml['xml'] = result.stdout_text.strip()
 
         return filter_xml
 

--- a/virttest/libvirt_xml/pool_xml.py
+++ b/virttest/libvirt_xml/pool_xml.py
@@ -11,7 +11,6 @@ from avocado.utils import process
 from .. import data_dir
 from .. import libvirt_storage
 from ..libvirt_xml import base, xcepts, accessors
-from ..compat_52lts import results_stderr_52lts
 from virttest import element_tree as ET
 
 
@@ -323,7 +322,7 @@ class PoolXML(PoolXMLBase):
         if result.exit_status:
             logging.error("Define %s failed.\n"
                           "Detail: %s.", self.name,
-                          results_stderr_52lts(result))
+                          result.stderr_text)
             return False
         return True
 

--- a/virttest/libvirt_xml/secret_xml.py
+++ b/virttest/libvirt_xml/secret_xml.py
@@ -5,7 +5,6 @@ http://libvirt.org/formatsecret.html
 
 from virttest.libvirt_xml import base, accessors
 from virttest.libvirt_xml import xcepts
-from virttest.compat_52lts import results_stdout_52lts
 
 
 class SecretXMLBase(base.LibvirtXMLBase):
@@ -98,7 +97,7 @@ class SecretXML(SecretXMLBase):
         """
         secret_xml = SecretXML(virsh_instance=virsh_instance)
         result = virsh_instance.secret_dumpxml(uuid)
-        secret_xml['xml'] = results_stdout_52lts(result).strip()
+        secret_xml['xml'] = result.stdout_text.strip()
 
         return secret_xml
 

--- a/virttest/libvirt_xml/snapshot_xml.py
+++ b/virttest/libvirt_xml/snapshot_xml.py
@@ -7,7 +7,6 @@ from virttest import xml_utils
 from virttest.libvirt_xml import base, accessors
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml import xcepts
-from virttest.compat_52lts import results_stdout_52lts
 
 
 class SnapshotXMLBase(base.LibvirtXMLBase):
@@ -83,7 +82,7 @@ class SnapshotXML(SnapshotXMLBase):
         """
         snapshot_xml = SnapshotXML(virsh_instance=virsh_instance)
         result = virsh_instance.snapshot_dumpxml(name, snap_name)
-        snapshot_xml['xml'] = results_stdout_52lts(result).strip()
+        snapshot_xml['xml'] = result.stdout_text.strip()
 
         return snapshot_xml
 

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -9,7 +9,6 @@ from .. import xml_utils
 from .. import utils_misc
 from ..libvirt_xml import base, accessors, xcepts
 from ..libvirt_xml.devices import librarian
-from ..compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class VMXMLDevices(list):
@@ -623,7 +622,7 @@ class VMXML(VMXMLBase):
         # TODO: Look up hypervisor_type on incoming XML
         vmxml = VMXML(virsh_instance=virsh_instance)
         result = virsh_instance.dumpxml(vm_name, extra=options)
-        vmxml['xml'] = results_stdout_52lts(result).strip()
+        vmxml['xml'] = result.stdout_text.strip()
         return vmxml
 
     @staticmethod
@@ -668,7 +667,7 @@ class VMXML(VMXMLBase):
         if result.exit_status:
             logging.debug("Define %s failed.\n"
                           "Detail: %s.", self.vm_name,
-                          results_stderr_52lts(result))
+                          result.stderr_text)
             return False
         return True
 

--- a/virttest/libvirt_xml/vol_xml.py
+++ b/virttest/libvirt_xml/vol_xml.py
@@ -5,7 +5,6 @@ http://libvirt.org/formatstorage.html#StorageVol
 
 from virttest.libvirt_xml import base, accessors
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
-from virttest.compat_52lts import results_stdout_52lts
 
 
 class VolXMLBase(base.LibvirtXMLBase):
@@ -121,7 +120,7 @@ class VolXML(VolXMLBase):
         """
         volxml = VolXML(virsh_instance=virsh_instance)
         result = virsh_instance.vol_dumpxml(vol_name, pool_name)
-        volxml['xml'] = results_stdout_52lts(result).strip()
+        volxml['xml'] = result.stdout_text.strip()
         return volxml
 
     @staticmethod

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -34,7 +34,6 @@ from avocado.utils import process
 
 from virttest import utils_misc
 from virttest import data_dir
-from virttest.compat_52lts import results_stdout_52lts, decode_to_text
 
 UNIT = "B"
 COMMON_OPTS = "--noheading --nosuffix --unit=%s" % UNIT
@@ -52,7 +51,7 @@ def cmd_output(cmd, res="[\w/]+"):
     if result.exit_status != 0:
         logging.warn(result)
         return None
-    output = results_stdout_52lts(result)
+    output = result.stdout_text
     for line in output.splitlines():
         val = re.findall(res, line)
         if val:
@@ -436,7 +435,7 @@ class LVM(object):
         """
         lvs = []
         cmd = "lvm lvs -o lv_name,lv_size,vg_name %s" % COMMON_OPTS
-        output = decode_to_text(process.system_output(cmd))
+        output = process.run(cmd).stdout_text
         for line in output.splitlines():
             lv_name, lv_size, vg_name = line.split()
             vg = self.get_vol(vg_name, "vgs")
@@ -453,7 +452,7 @@ class LVM(object):
         """
         vgs = []
         cmd = "lvm vgs -opv_name,vg_name,vg_size %s" % COMMON_OPTS
-        output = decode_to_text(process.system_output(cmd))
+        output = process.run(cmd).stdout_text
         for line in output.splitlines():
             pv_name, vg_name, vg_size = line.split()
             pv = self.get_vol(pv_name, "pvs")
@@ -470,7 +469,7 @@ class LVM(object):
         """
         pvs = []
         cmd = "lvm pvs -opv_name,pv_size %s" % COMMON_OPTS
-        output = decode_to_text(process.system_output(cmd))
+        output = process.run(cmd).stdout_text
         for line in output.splitlines():
             pv_name, pv_size = line.split()
             pv = PhysicalVolume(pv_name, pv_size)
@@ -653,7 +652,7 @@ class EmulatedLVM(LVM):
         :return: loop back device name;
         """
         cmd = "losetup %s --show --find %s" % (extra_args, img_file)
-        pv_name = decode_to_text(process.system_output(cmd))
+        pv_name = process.run(cmd).stdout_text
         self.params["pv_name"] = pv_name.strip()
         return pv_name
 
@@ -664,7 +663,7 @@ class EmulatedLVM(LVM):
         pvs = []
         emulate_image_file = self.get_emulate_image_name()
         cmd = "losetup -j %s" % emulate_image_file
-        output = decode_to_text(process.system_output(cmd))
+        output = process.run(cmd).stdout_text
         try:
             pv_name = re.findall("(/dev/loop\d+)", output, re.M | re.I)[-1]
             pv = self.get_vol(pv_name, "pvs")
@@ -706,7 +705,7 @@ class EmulatedLVM(LVM):
         if self.params.get("remove_emulated_image", "no") == "yes":
             emulate_image_file = self.get_emulate_image_name()
             cmd = "losetup -j %s" % emulate_image_file
-            output = decode_to_text(process.system_output(cmd))
+            output = process.run(cmd).stdout_text
             devices = re.findall("(/dev/loop\d+)", output, re.M | re.I)
             for dev in devices:
                 cmd = "losetup -d %s" % dev

--- a/virttest/lvsbs.py
+++ b/virttest/lvsbs.py
@@ -7,7 +7,6 @@ from avocado.utils import service
 
 from . import lvsb_base
 from . import virsh
-from .compat_52lts import results_stdout_52lts
 
 
 class SandboxService(object):
@@ -95,7 +94,7 @@ class SandboxService(object):
         cmdresult = self.virsh.dom_list()  # uri is passed automatically
         result = []
         column_names = None  # scope outside loop
-        for lineno, line in results_stdout_52lts(cmdresult).strip():
+        for lineno, line in cmdresult.stdout_text.strip():
             if lineno == 0:
                 column_names = line.strip().split()
                 assert len(column_names) > 2
@@ -112,4 +111,4 @@ class SandboxService(object):
     @property  # behave like attribute for easy passing to XML handling methods
     def xmlstr(self):
         result = self.virsh.dumpxml(self.service_name)
-        return results_stdout_52lts(result).strip()
+        return result.stdout_text.strip()

--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -7,7 +7,6 @@ from avocado.utils import path
 from avocado.utils import process
 from avocado.utils import linux_modules
 
-from .compat_52lts import results_stdout_52lts
 from .versionable_class import VersionableClass, Manager, factory
 from . import utils_misc
 
@@ -173,7 +172,7 @@ class OpenVSwitchControl(object):
                                  path.find_command("ovs-vswitchd"))
             pattern = "ovs-vswitchd \(Open vSwitch\) (\d+\.\d+\.\d+).*"
             version = re.search(pattern,
-                                results_stdout_52lts(result)).group(1)
+                                result.stdout_text).group(1)
         except process.CmdError:
             logging.debug("OpenVSwitch is not available in system.")
         return version
@@ -266,7 +265,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
                            ignore_status=ignore_status, verbose=False)
 
     def status(self):
-        return results_stdout_52lts(self.ovs_vsctl(["show"]))
+        return self.ovs_vsctl(["show"]).stdout_text
 
     def add_br(self, br_name):
         self.ovs_vsctl(["add-br", br_name])
@@ -292,7 +291,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
         return True
 
     def list_br(self):
-        return results_stdout_52lts(self.ovs_vsctl(["list-br"])).splitlines()
+        return self.ovs_vsctl(["list-br"]).stdout.splitlines()
 
     def add_port(self, br_name, port_name):
         self.ovs_vsctl(["add-port", br_name, port_name])
@@ -316,7 +315,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
 
     def list_ports(self, br_name):
         result = self.ovs_vsctl(["list-ports", br_name])
-        return results_stdout_52lts(result).splitlines()
+        return result.stdout_text.splitlines()
 
     def port_to_br(self, port_name):
         """
@@ -328,7 +327,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
         bridge = None
         try:
             result = self.ovs_vsctl(["port-to-br", port_name])
-            bridge = results_stdout_52lts(result).strip()
+            bridge = result.stdout_text.strip()
         except process.CmdError as e:
             if e.result.exit_status == 1:
                 pass

--- a/virttest/qemu_installer.py
+++ b/virttest/qemu_installer.py
@@ -11,7 +11,6 @@ from avocado.core import exceptions
 from avocado.utils import process
 
 from virttest import base_installer
-from virttest.compat_52lts import decode_to_text
 
 __all__ = ['GitRepoInstaller', 'LocalSourceDirInstaller',
            'LocalSourceTarInstaller', 'RemoteSourceTarInstaller']
@@ -28,7 +27,7 @@ class QEMUBaseInstaller(base_installer.BaseInstaller):
     # We'll look for one of these binaries when linking the QEMU binary
     # to the test directory
     #
-    qemu_system = 'qemu-system-' + decode_to_text(process.system_output('uname -i'))
+    qemu_system = 'qemu-system-' + process.run('uname -i').stdout_text
     ACCEPTABLE_QEMU_BIN_NAMES = ['qemu-kvm', 'qemu-system-ppc64', qemu_system]
 
     #

--- a/virttest/qemu_io.py
+++ b/virttest/qemu_io.py
@@ -5,7 +5,6 @@ from avocado.utils import process
 
 from virttest import utils_misc
 from virttest import error_context
-from virttest.compat_52lts import decode_to_text
 
 
 class QemuIOParamError(Exception):
@@ -184,7 +183,7 @@ class QemuIOSystem(QemuIO):
 
         error_context.context(
             "Running command: %s" % qemu_io_cmd, self.log_func)
-        output = decode_to_text(process.system_output(qemu_io_cmd, timeout=timeout))
+        output = process.run(qemu_io_cmd, timeout=timeout).stdout_text
 
         # Record command line in log file
         if self.output_func:

--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -22,7 +22,6 @@ from avocado.utils import process
 from six.moves import xrange
 
 from virttest import data_dir
-from virttest.compat_52lts import decode_to_text
 
 SOCKET_SIZE = 2048
 
@@ -228,8 +227,8 @@ class GuestWorker(object):
         timeout = 10
         guest_script_src = os.path.join(data_dir.get_shared_dir(), 'scripts',
                                         'virtio_console_guest.py')
-        script_size = decode_to_text(process.system_output("du -b %s | cut -f1" %
-                                                           guest_script_src, shell=True)).strip()
+        script_size = process.run("du -b %s | cut -f1" % guest_script_src,
+                                  shell=True).stdout_text.strip()
         script_size_guest = self.session.cmd_output(cmd_guest_size).strip()
         if (script_size != script_size_guest or
                 self.session.cmd_status(cmd_already_compiled_chck)):

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -19,7 +19,6 @@ from virttest import utils_misc
 from virttest import rss_client
 from virttest.remote_commander import remote_master
 from virttest.remote_commander import messenger
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 class LoginError(Exception):
@@ -1347,8 +1346,6 @@ class RemoteRunner(object):
                                          (self.stderr_pipe, self.stderr_pipe))
         cmd_result = process.CmdResult(command=command, exit_status=status,
                                        stdout=output, stderr=errput)
-        cmd_result.stdout = results_stdout_52lts(cmd_result)
-        cmd_result.stderr = results_stderr_52lts(cmd_result)
         if status and (not ignore_status):
             raise process.CmdError(command, cmd_result)
         return cmd_result

--- a/virttest/ssh_key.py
+++ b/virttest/ssh_key.py
@@ -6,7 +6,6 @@ from avocado.utils import process
 from avocado.utils import path
 
 from virttest import remote
-from virttest.compat_52lts import decode_to_text
 
 
 def get_public_key():
@@ -231,7 +230,7 @@ def setup_remote_known_hosts_file(client_ip, server_ip,
         return None
 
     cmd = "%s %s" % (abs_path, client_ip)
-    host_key = decode_to_text(process.system_output(cmd, verbose=False))
+    host_key = process.run(cmd, verbose=False).stdout_text
     remote_known_hosts_file = remote.RemoteFile(
         address=server_ip,
         client='scp',

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -24,7 +24,6 @@ from virttest import gluster
 from virttest import lvm
 from virttest import ceph
 from virttest import data_dir
-from virttest.compat_52lts import decode_to_text
 
 
 def preprocess_images(bindir, params, env):
@@ -224,8 +223,8 @@ def get_image_filename_filesytem(params, root_dir, basename=False):
     if indirect_image_select:
         re_name = image_name
         indirect_image_select = int(indirect_image_select)
-        matching_images = decode_to_text(process.system_output("ls -1d %s" % re_name,
-                                                               shell=True))
+        matching_images = process.run("ls -1d %s" % re_name,
+                                      shell=True).stdout_text
         matching_images = sorted(matching_images.split('\n'),
                                  key=functools.cmp_to_key(sort_cmp))
         if matching_images[-1] == '':

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -34,7 +34,6 @@ from virttest import funcatexit
 from virttest import storage
 from virttest import error_context
 from virttest import qemu_storage
-from virttest.compat_52lts import decode_to_text
 
 
 # Whether to print all shell commands called
@@ -959,18 +958,18 @@ class UnattendedInstallConfig(object):
             kernel_basename = os.path.basename(self.kernel)
             initrd_basename = os.path.basename(self.initrd)
             sha1sum_kernel_cmd = 'sha1sum %s' % kernel_basename
-            sha1sum_kernel_output = decode_to_text(process.system_output(sha1sum_kernel_cmd,
-                                                                         ignore_status=True,
-                                                                         verbose=DEBUG))
+            sha1sum_kernel_output = process.run(sha1sum_kernel_cmd,
+                                                ignore_status=True,
+                                                verbose=DEBUG).stdout_text
             try:
                 sha1sum_kernel = sha1sum_kernel_output.split()[0]
             except IndexError:
                 sha1sum_kernel = ''
 
             sha1sum_initrd_cmd = 'sha1sum %s' % initrd_basename
-            sha1sum_initrd_output = decode_to_text(process.system_output(sha1sum_initrd_cmd,
-                                                                         ignore_status=True,
-                                                                         verbose=DEBUG))
+            sha1sum_initrd_output = process.run(sha1sum_initrd_cmd,
+                                                ignore_status=True,
+                                                verbose=DEBUG).stdout_text
             try:
                 sha1sum_initrd = sha1sum_initrd_output.split()[0]
             except IndexError:

--- a/virttest/utils_conn.py
+++ b/virttest/utils_conn.py
@@ -15,7 +15,6 @@ from virttest import propcan, remote, utils_libvirtd
 from virttest import data_dir
 from virttest import utils_package
 from virttest import libvirt_version
-from virttest.compat_52lts import results_stderr_52lts
 
 
 class ConnectionError(Exception):
@@ -1442,7 +1441,7 @@ def build_client_key(tmp_dir, client_cn="TLSClient", certtool="certtool",
     cmd = "%s --generate-privkey > %s" % (certtool, clientkey_path)
     CmdResult = process.run(cmd, ignore_status=True, shell=True)
     if CmdResult.exit_status:
-        raise ConnPrivKeyError(clientkey_path, results_stderr_52lts(CmdResult))
+        raise ConnPrivKeyError(clientkey_path, CmdResult.stderr_text)
 
     # prepare a info file to build clientcert.
     clientinfo_file = open(clientinfo_path, "w")
@@ -1461,7 +1460,7 @@ def build_client_key(tmp_dir, client_cn="TLSClient", certtool="certtool",
             cakey_path, clientinfo_path, clientcert_path))
     CmdResult = process.run(cmd, ignore_status=True)
     if CmdResult.exit_status:
-        raise ConnCertError(clientinfo_path, results_stderr_52lts(CmdResult))
+        raise ConnCertError(clientinfo_path, CmdResult.stderr_text)
 
 
 def build_server_key(tmp_dir, ca_cakey_path=None,
@@ -1505,7 +1504,7 @@ def build_server_key(tmp_dir, ca_cakey_path=None,
     cmd = "%s --generate-privkey > %s" % (certtool, serverkey_path)
     cmd_result = process.run(cmd, ignore_status=True, shell=True)
     if cmd_result.exit_status:
-        raise ConnPrivKeyError(serverkey_path, results_stderr_52lts(cmd_result))
+        raise ConnPrivKeyError(serverkey_path, cmd_result.stderr_text)
 
     # prepare a info file to build servercert and serverkey
     serverinfo_file = open(serverinfo_path, "w")
@@ -1524,7 +1523,7 @@ def build_server_key(tmp_dir, ca_cakey_path=None,
             cakey_path, serverinfo_path, servercert_path))
     CmdResult = process.run(cmd, ignore_status=True)
     if CmdResult.exit_status:
-        raise ConnCertError(serverinfo_path, results_stderr_52lts(CmdResult))
+        raise ConnCertError(serverinfo_path, CmdResult.stderr_text)
 
 
 def build_CA(tmp_dir, cn="AUTOTEST.VIRT", ca_cakey_path=None,
@@ -1558,7 +1557,7 @@ def build_CA(tmp_dir, cn="AUTOTEST.VIRT", ca_cakey_path=None,
         cmd = "%s --generate-privkey > %s " % (certtool, cakey_path)
         cmd_result = process.run(cmd, ignore_status=True, timeout=10, shell=True)
         if cmd_result.exit_status:
-            raise ConnPrivKeyError(cakey_path, results_stderr_52lts(cmd_result))
+            raise ConnPrivKeyError(cakey_path, cmd_result.stderr_text)
     # prepare a info file to build certificate file
     cainfo_file = open(cainfo_path, "w")
     cainfo_file.write("cn = %s\n" % cn)
@@ -1572,7 +1571,7 @@ def build_CA(tmp_dir, cn="AUTOTEST.VIRT", ca_cakey_path=None,
            (certtool, cakey_path, cainfo_path, cacert_path))
     CmdResult = process.run(cmd, ignore_status=True)
     if CmdResult.exit_status:
-        raise ConnCertError(cainfo_path, results_stderr_52lts(CmdResult))
+        raise ConnCertError(cainfo_path, CmdResult.stderr_text)
 
 
 class UNIXConnection(ConnectionBase):

--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -24,8 +24,6 @@ from avocado.utils.service import SpecificServiceManager
 
 from virttest import error_context
 from virttest import utils_numeric
-from virttest.compat_52lts import decode_to_text
-from virttest.compat_52lts import results_stdout_52lts
 
 PARTITION_TABLE_TYPE_MBR = "msdos"
 PARTITION_TABLE_TYPE_GPT = "gpt"
@@ -86,7 +84,7 @@ def is_mount(src, dst=None, fstype=None, options=None, verbose=False,
     if session:
         mount_result = session.cmd_output_safe(mount_list_cmd)
     else:
-        mount_result = decode_to_text(process.system_output(mount_list_cmd, shell=True))
+        mount_result = process.run(mount_list_cmd, shell=True).stdout_text
     if verbose:
         logging.debug("/proc/mounts contents:\n%s", mount_result)
 
@@ -1014,7 +1012,7 @@ def get_parts_list(session=None):
     if session:
         _, parts_out = session.cmd_status_output(parts_cmd)
     else:
-        parts_out = results_stdout_52lts(process.run(parts_cmd))
+        parts_out = process.run(parts_cmd).stdout_text
     parts = []
     if parts_out:
         for line in parts_out.rsplit("\n"):

--- a/virttest/utils_iptables.py
+++ b/virttest/utils_iptables.py
@@ -7,7 +7,6 @@ from avocado.utils import process
 from avocado.core import exceptions
 
 from virttest import remote
-from virttest.compat_52lts import decode_to_text
 
 
 class Iptables(object):
@@ -44,8 +43,8 @@ class Iptables(object):
                                            "remotely %s" % iptable_check_cmd)
         else:
             try:
-                cmd_output = decode_to_text(process.system_output(iptable_check_cmd,
-                                                                  shell=True))
+                cmd_output = process.run(iptable_check_cmd,
+                                         shell=True).stdout_text
                 exist_rules = cmd_output.strip().split('\n')
             except process.CmdError as info:
                 raise exceptions.TestError("iptables fails for command "
@@ -76,7 +75,7 @@ class Iptables(object):
                     logging.debug("iptable command success %s", command)
             else:
                 try:
-                    cmd_output = decode_to_text(process.system_output(command, shell=True))
+                    cmd_output = process.run(command, shell=True).stdout_text
                     logging.debug("iptable command success %s", command)
                 except process.CmdError as info:
                     raise exceptions.TestError("iptables fails for command "

--- a/virttest/utils_sasl.py
+++ b/virttest/utils_sasl.py
@@ -12,7 +12,6 @@ from avocado.utils import process
 from virttest import propcan
 from virttest import remote
 from virttest import virsh
-from virttest.compat_52lts import decode_to_text
 
 
 class SASL(propcan.PropCanBase):
@@ -113,7 +112,7 @@ class SASL(propcan.PropCanBase):
                 self.session = self.get_session()
                 return self.session.cmd_output(cmd)
             else:
-                return decode_to_text(process.system_output(cmd))
+                return process.run(cmd).stdout_text
         except process.CmdError:
             logging.error("Failed to set a user's sasl password %s", cmd)
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -58,7 +58,6 @@ from virttest import utils_package
 from virttest.utils_iptables import Iptables
 from virttest import data_dir
 from virttest.staging import utils_memory
-from virttest.compat_52lts import results_stdout_52lts, decode_to_text
 
 # Get back to importing submodules
 # This is essential for accessing these submodules directly from
@@ -370,8 +369,7 @@ def get_time(session, time_command, time_filter_re, time_format):
     elif re.findall("hwclock", time_command):
         loc = locale.getlocale(locale.LC_TIME)
         # Get and parse host time
-        host_time_out = results_stdout_52lts(
-            process.run(time_command, shell=True))
+        host_time_out = process.run(time_command, shell=True).stdout_text
         diff = host_time_out.split()[-2]
         host_time_out = " ".join(host_time_out.split()[:-2])
         try:
@@ -731,8 +729,8 @@ def run_virtio_serial_file_transfer(test, params, env, port_name=None,
                     return port.hostfile
 
     def run_host_cmd(host_cmd, timeout=720):
-        return decode_to_text(process.system_output(
-            host_cmd, shell=True, timeout=timeout))
+        return process.run(
+            host_cmd, shell=True, timeout=timeout).stdout_text
 
     def transfer_data(session, host_cmd, guest_cmd, n_time, timeout,
                       md5_check, action):
@@ -1351,8 +1349,7 @@ def run_autotest(vm, session, control_path, timeout,
         status_path = " ".join(status_paths)
 
         try:
-            output = decode_to_text(process.system_output("cat %s" % status_path
-                                                          ))
+            output = process.run("cat %s" % status_path).stdout_text
         except process.CmdError as e:
             logging.error("Error getting guest autotest status file: %s", e)
             return None
@@ -1996,7 +1993,7 @@ def get_date(session=None):
         if session:
             date_info = session.cmd_output(date_cmd).strip()
         else:
-            date_info = results_stdout_52lts(process.run(date_cmd)).strip()
+            date_info = process.run(date_cmd).stdout_text.strip()
         return date_info
     except (process.CmdError, aexpect.ShellError) as detail:
         raise exceptions.TestFail("Get date failed. %s " % detail)
@@ -2754,7 +2751,7 @@ class RemoteDiskManager(object):
             raise exceptions.TestError("Unsupported Disk Type %s" % disk_type)
 
         try:
-            output = results_stdout_52lts(self.runner.run(cmd))
+            output = self.runner.run(cmd).stdout_text
         except exceptions.CmdError as detail:
             logging.debug(output)
             raise exceptions.TestError("Get space failed: %s." % str(detail))
@@ -2795,18 +2792,18 @@ class RemoteDiskManager(object):
         """
         if is_login:
             discovery_cmd = "iscsiadm -m discovery -t sendtargets -p %s" % host
-            output = results_stdout_52lts(self.runner.run
-                                          (discovery_cmd, ignore_status=True))
+            output = self.runner.run(discovery_cmd,
+                                     ignore_status=True).stdout_text
             if target_name not in output:
                 raise exceptions.TestError("Discovery %s on %s failed."
                                            % (target_name, host))
             cmd = "iscsiadm --mode node --login --targetname %s" % target_name
-            output = results_stdout_52lts(self.runner.run(cmd))
+            output = self.runner.run(cmd).stdout_text
             if "successful" not in output:
                 raise exceptions.TestError("Login to %s failed." % target_name)
             else:
                 cmd = "iscsiadm -m session -P 3"
-                output = results_stdout_52lts(self.runner.run(cmd))
+                output = self.runner.run(cmd).stdout_text
                 pattern = r"Target:\s+%s.*?disk\s(\w+)\s+\S+\srunning" % target_name
                 device_name = re.findall(pattern, output, re.S)
                 try:
@@ -2819,8 +2816,8 @@ class RemoteDiskManager(object):
                 cmd = "iscsiadm --mode node --logout -T %s" % target_name
             else:
                 cmd = "iscsiadm --mode node --logout all"
-            output = results_stdout_52lts(self.runner.run
-                                          (cmd, ignore_status=True))
+            output = self.runner.run(cmd,
+                                     ignore_status=True).stdout_text
             if "successful" not in output:
                 logging.error("Logout to %s failed.", target_name)
 
@@ -2919,7 +2916,7 @@ def check_dest_vm_network(vm, vm_ip, remote_host, username, password,
         break
     if ping_failed:
         raise exceptions.TestFail("Failed to ping %s: %s"
-                                  % (vm.name, results_stdout_52lts(result)))
+                                  % (vm.name, result.stdout_text))
 
 
 class RemoteVMManager(object):
@@ -2998,12 +2995,12 @@ class RemoteVMManager(object):
                 continue
             else:
                 vm_net_connectivity = True
-                logging.info(results_stdout_52lts(result))
+                logging.info(result.stdout_text)
                 break
 
         if not vm_net_connectivity:
             raise exceptions.TestFail("Failed to ping %s: %s"
-                                      % (vm_ip, results_stdout_52lts(result)))
+                                      % (vm_ip, result.stdout_text))
 
     def run_command(self, vm_ip, command, vm_user="root", runner=None,
                     ignore_status=False):

--- a/virttest/utils_test/libguestfs.py
+++ b/virttest/utils_test/libguestfs.py
@@ -10,7 +10,6 @@ from .. import utils_net, xml_utils
 from .. import utils_libguestfs as lgf
 from .. import qemu_storage
 from ..libvirt_xml import vm_xml, xcepts
-from ..compat_52lts import results_stdout_52lts
 
 
 class VTError(Exception):
@@ -387,7 +386,7 @@ class VirtTools(object):
         if result.exit_status:
             raise exceptions.TestSkipError("Cannot get primary disk"
                                            " filesystem information!")
-        fs_info = results_stdout_52lts(result).strip().splitlines()
+        fs_info = results.stdout_text.strip().splitlines()
         if len(fs_info) <= 1:
             raise exceptions.TestSkipError("No disk filesystem information!")
         try:
@@ -473,7 +472,7 @@ class VirtTools(object):
             return sys_info
         # Analyse output to get information
         try:
-            xmltreefile = xml_utils.XMLTreeFile(results_stdout_52lts(result))
+            xmltreefile = xml_utils.XMLTreeFile(results.stdout_text)
             os_root = xmltreefile.find("operatingsystem")
             if os_root is None:
                 raise VTXMLParseError("operatingsystem", os_root)
@@ -536,7 +535,7 @@ class GuestfishTools(lgf.GuestfishPersistent):
         Get root filesystem w/ guestfish
         """
         getroot_result = self.inspect_os()
-        roots_list = results_stdout_52lts(getroot_result).splitlines()
+        roots_list = getroot_result.stdout_text.splitlines()
         if getroot_result.exit_status or not len(roots_list):
             logging.error("Get root failed:%s", getroot_result)
             return (False, getroot_result)
@@ -557,7 +556,7 @@ class GuestfishTools(lgf.GuestfishPersistent):
                         'fedora': "Fedora"}
         for key in release_type:
             if re.search(release_type[key],
-                         results_stdout_52lts(release_result)):
+                         release_result.stdout_text):
                 return (True, key)
 
     def write_file(self, path, content):
@@ -580,7 +579,7 @@ class GuestfishTools(lgf.GuestfishPersistent):
         if list_result.exit_status:
             logging.error("List partition info failed:%s", list_result)
             return (False, list_result)
-        list_lines = results_stdout_52lts(list_result.stdout).splitlines()
+        list_lines = list_result.stdout_text.splitlines()
         # This dict is a struct like this: {key:{a dict}, key:{a dict}}
         partitions = {}
         # This dict is a struct of normal dict, for temp value of a partition
@@ -767,14 +766,14 @@ class GuestfishTools(lgf.GuestfishPersistent):
             num = partition.get("num")
             mbr_id_result = self.part_get_mbr_id(device, num)
             if mbr_id_result.exit_status == 0:
-                return (True, results_stdout_52lts(mbr_id_result).strip())
+                return (True, mbr_id_result.stdout_text.strip())
         return (False, partitions)
 
     def get_part_type(self, device="/dev/sda"):
         part_type_result = self.part_get_parttype(device)
         if part_type_result.exit_status:
             return (False, part_type_result)
-        return (True, results_stdout_52lts(part_type_result).strip())
+        return (True, part_type_result.stdout_text.strip())
 
     def get_md5(self, path):
         """
@@ -785,7 +784,7 @@ class GuestfishTools(lgf.GuestfishPersistent):
         if md5_result.exit_status:
             logging.error("Check %s's md5 failed:%s", path, md5_result)
             return (False, md5_result)
-        return (True, results_stdout_52lts(md5_result).strip())
+        return (True, md5_result.stdout_text.strip())
 
     def reset_interface(self, iface_mac):
         """

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -33,7 +33,6 @@ from virttest import utils_misc
 from virttest import qemu_monitor
 from virttest.qemu_devices import qdevices
 from virttest.staging import utils_memory
-from virttest.compat_52lts import decode_to_text
 
 
 def guest_active(vm):
@@ -89,7 +88,7 @@ def get_nic_vendor(params, cmd):
     expected_nic_vendor = params.get("expected_nic_vendor",
                                      "IB InfiniBand")
     pattern = "(?<=Link layer: ).*"
-    output = decode_to_text(process.system_output(cmd))
+    output = process.run(cmd).stdout_text
     try:
         nic_vendor = re.findall(pattern, output)[0]
     except IndexError:

--- a/virttest/utils_test/qemu/migration.py
+++ b/virttest/utils_test/qemu/migration.py
@@ -32,7 +32,6 @@ from virttest import utils_test
 from virttest import utils_misc
 from virttest import env_process
 from virttest import error_context as error
-from virttest.compat_52lts import decode_to_text
 
 
 try:
@@ -63,7 +62,7 @@ def get_nic_vendor(params, cmd):
     expected_nic_vendor = params.get("expected_nic_vendor",
                                      "IB InfiniBand")
     pattern = "(?<=Link layer: ).*"
-    output = decode_to_text(process.system_output(cmd))
+    output = process.run(cmd).stdout_text
     try:
         nic_vendor = re.findall(pattern, output)[0]
     except IndexError:

--- a/virttest/utils_time.py
+++ b/virttest/utils_time.py
@@ -7,7 +7,6 @@ from avocado.core import exceptions
 
 from virttest import error_context
 from virttest import utils_test
-from virttest.compat_52lts import decode_to_text
 
 # command `grep --color` may have alias name `grep` in some systems,
 # so get explicit command 'grep' with path
@@ -22,8 +21,7 @@ def get_host_timezone():
     timezone_cmd = 'timedatectl | %s "Time zone"' % grep_binary
     timezone_pattern = '^(?:\s+Time zone:\s)(\w+\/\S+|UTC)(?:\s\(\S+,\s)([+|-]\d{4})\)$'
     error_context.context("Get host's timezone", logging.info)
-    host_timezone = decode_to_text(
-        process.system_output(timezone_cmd, timeout=240, shell=True))
+    host_timezone = process.run(timezone_cmd, timeout=240, shell=True).stdout_text
     try:
         host_timezone_set = re.match(timezone_pattern, host_timezone).groups()
         return {"timezone_city": host_timezone_set[0],

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -13,8 +13,8 @@ import random
 
 from avocado.utils import path
 from avocado.utils import process
+from avocado.utils.astring import to_text
 from avocado.core import exceptions
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts, decode_to_text
 
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
@@ -1160,9 +1160,6 @@ def v2v_cmd(params):
     # Post-process for v2v
     _v2v_post_cmd()
 
-    cmd_result.stdout = results_stdout_52lts(cmd_result)
-    cmd_result.stderr = results_stderr_52lts(cmd_result)
-
     return cmd_result
 
 
@@ -1273,15 +1270,11 @@ def check_exit_status(result, expect_error=False, error_flag='strict'):
     if not expect_error:
         if result.exit_status != 0:
             raise exceptions.TestFail(
-                decode_to_text(
-                    result.stderr,
-                    errors=error_flag))
+                to_text(result.stderr, errors=error_flag))
         else:
             logging.debug(
                 "Command output:\n%s",
-                decode_to_text(
-                    result.stdout,
-                    errors=error_flag).strip())
+                to_text(result.stdout, errors=error_flag).strip())
     elif expect_error and result.exit_status == 0:
         raise exceptions.TestFail("Run '%s' expect fail, but run "
                                   "successfully." % result.command)
@@ -1609,8 +1602,7 @@ def v2v_supported_option(opt_str):
     """
     cmd = 'virt-v2v --help'
     result = process.run(cmd, verbose=True, ignore_status=True)
-    result.stdout = results_stdout_52lts(result)
-    if re.search(r'%s' % opt_str, result.stdout):
+    if re.search(r'%s' % opt_str, result.stdout_text):
         return True
     return False
 

--- a/virttest/version.py
+++ b/virttest/version.py
@@ -17,7 +17,6 @@ import os
 from avocado.utils import process
 
 from virttest import data_dir
-from virttest.compat_52lts import results_stdout_52lts, decode_to_text
 
 _ROOT_PATH = data_dir.get_root_dir()
 RELEASE_VERSION_PATH = os.path.join(_ROOT_PATH, 'RELEASE-VERSION')
@@ -42,8 +41,8 @@ def _execute_git_command(command):
     os.chdir(_ROOT_PATH)
     try:
         try:
-            return decode_to_text(process.system_output(command,
-                                                        shell=True, verbose=False)).strip()
+            return process.run(command,
+                               shell=True, verbose=False).stdout_text.strip()
         finally:
             os.chdir(cwd)
     except process.CmdError:
@@ -119,7 +118,7 @@ def get_version(abbrev=4):
             cmd_result = process.run("rpm -q avocado-plugins-vt "
                                      "--queryformat '%{VERSION}'",
                                      shell=True, verbose=False)
-            return '%s (RPM install)' % results_stdout_52lts(cmd_result)
+            return '%s (RPM install)' % cmd_result.stdout_text
         except process.CmdError:
             return 'unknown'
 

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -39,7 +39,6 @@ from six.moves import urllib
 from virttest import propcan
 from virttest import remote
 from virttest import utils_misc
-from virttest.compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 # list of symbol names NOT to wrap as Virsh class methods
@@ -230,8 +229,6 @@ class VirshSession(aexpect.ShellSession):
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
 
-        result.stdout = results_stdout_52lts(result)
-        result.stderr = results_stderr_52lts(result)
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Virsh Command returned non-zero exit status")
@@ -698,14 +695,12 @@ def command(cmd, **dargs):
                           shell=True)
         # Mark return as not coming from persistent virsh session
         ret.from_session_id = None
-        ret.stdout = results_stdout_52lts(ret)
-        ret.stderr = results_stderr_52lts(ret)
 
     # Always log debug info, if persistent session or not
     if debug:
         logging.debug("status: %s", ret.exit_status)
-        logging.debug("stdout: %s", ret.stdout.strip())
-        logging.debug("stderr: %s", ret.stderr.strip())
+        logging.debug("stdout: %s", ret.stdout_text.strip())
+        logging.debug("stderr: %s", ret.stderr_text.strip())
 
     # Return CmdResult instance when ignore_status is True
     return ret
@@ -905,7 +900,7 @@ def canonical_uri(option='', **dargs):
     :return: standard output from command
     """
     result = command("uri %s" % option, **dargs)
-    return results_stdout_52lts(result).strip()
+    return result.stdout_text.strip()
 
 
 def hostname(option='', **dargs):
@@ -917,7 +912,7 @@ def hostname(option='', **dargs):
     :return: standard output from command
     """
     result = command("hostname %s" % option, **dargs)
-    return results_stdout_52lts(result).strip()
+    return result.stdout_text.strip()
 
 
 def version(option='', **dargs):
@@ -1154,7 +1149,7 @@ def dumpxml(name, extra="", to_file="", **dargs):
     result = command(cmd, **dargs)
     if to_file:
         result_file = open(to_file, 'w')
-        result_file.write(result.stdout.strip())
+        result_file.write(result.stdout_text.strip())
         result_file.close()
     return result
 
@@ -1286,7 +1281,7 @@ def is_dead(name, **dargs):
     """
     dargs['ignore_status'] = False
     try:
-        state = results_stdout_52lts(domstate(name, **dargs)).strip()
+        state = domstate(name, **dargs).stdout_text.strip()
     except process.CmdError:
         return True
     if state not in ('running', 'idle', 'paused', 'in shutdown', 'shut off',
@@ -1813,7 +1808,7 @@ def net_state_dict(only_names=False, virsh_instance=None, **dargs):
     else:
         net_list_result = net_list("--all", **dargs)
     # If command failed, exception would be raised here
-    netlist = results_stdout_52lts(net_list_result).strip().splitlines()
+    netlist = net_list_result.stdout_text.strip().splitlines()
     # First two lines contain table header followed by entries
     # for each network on the host, such as:
     #
@@ -2136,7 +2131,7 @@ def pool_state_dict(only_names=False, **dargs):
     dargs['ignore_status'] = False  # force problem detection
     pool_list_result = pool_list("--all", **dargs)
     # If command failed, exception would be raised here
-    poollist = results_stdout_52lts(pool_list_result).strip().splitlines()
+    poollist = pool_list_result.stdout_text.strip().splitlines()
     # First two lines contain table header followed by entries
     # for each pool on the host, such as:
     #
@@ -2317,7 +2312,7 @@ def pool_dumpxml(name, extra="", to_file="", **dargs):
     if result.exit_status:
         raise process.CmdError(cmd, result,
                                "Virsh dumpxml returned non-zero exit status")
-    return results_stdout_52lts(result).strip()
+    return result.stdout_text.strip()
 
 
 def pool_define(xml_path, **dargs):
@@ -2573,7 +2568,7 @@ def capabilities(option='', to_file=None, **dargs):
         result_file.write(cmd_result.stdout.strip())
         result_file.close()
 
-    return results_stdout_52lts(cmd_result).strip()
+    return cmd_result.stdout_text.strip()
 
 
 def nodecpustats(option='', **dargs):
@@ -2667,7 +2662,7 @@ def help_command_only(options='', cache=False, **dargs):
         VIRSH_COMMAND_CACHE = []
         regx_command_word = re.compile(r"\s+([a-z0-9-]+)\s+")
         result = help(options, **dargs)
-        for line in results_stdout_52lts(result).strip().splitlines():
+        for line in result.stdout_text.strip().splitlines():
             # Get rid of 'keyword' line
             if line.find("keyword") != -1:
                 continue
@@ -2695,7 +2690,7 @@ def help_command_group(options='', cache=False, **dargs):
         VIRSH_COMMAND_GROUP_CACHE = []
         regx_group_word = re.compile(r"[\']([a-zA-Z0-9]+)[\']")
         result = help(options, **dargs)
-        for line in results_stdout_52lts(result).strip().splitlines():
+        for line in result.stdout_text.strip().splitlines():
             # 'keyword' only exists in group line.
             if line.find("keyword") != -1:
                 mojb_group_word = regx_group_word.search(line)
@@ -2730,7 +2725,7 @@ def has_command_help_match(virsh_cmd, regex, **dargs):
     :return: re match object
     """
     result = help(virsh_cmd, **dargs)
-    command_help_output = results_stdout_52lts(result).strip()
+    command_help_output = result.stdout_text.strip()
     return re.search(regex, command_help_output)
 
 
@@ -2945,7 +2940,7 @@ def snapshot_list(name, options=None, **dargs):
             cmd, sc_output, "Failed to get list of snapshots")
 
     data = re.findall("\S* *\d*-\d*-\d* \d*:\d*:\d* [+-]\d* \w*",
-                      results_stdout_52lts(sc_output))
+                      sc_output.stdout_text)
     for rec in data:
         if not rec:
             continue
@@ -2999,7 +2994,7 @@ def snapshot_info(name, snapshot, **dargs):
 
     for val in values:
         data = re.search("(?<=%s:) *(\w.*|\w*)" % val,
-                         results_stdout_52lts(sc_output))
+                         sc_output.stdout_text)
         if data is None:
             continue
         ret[val] = data.group(0).strip()
@@ -3537,7 +3532,7 @@ def iface_dumpxml(iface, extra="", to_file="", **dargs):
     if result.exit_status:
         raise process.CmdError(cmd, result,
                                "Dumpxml returned non-zero exit status")
-    return results_stdout_52lts(result).strip()
+    return result.stdout_text.strip()
 
 
 def iface_name(mac, **dargs):

--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -35,7 +35,6 @@ from avocado.utils import process
 from . import propcan
 from . import remote
 from . import utils_misc
-from .compat_52lts import results_stdout_52lts, results_stderr_52lts
 
 
 # list of symbol names NOT to wrap as Virtadmin class methods
@@ -228,8 +227,6 @@ class VirtadminSession(aexpect.ShellSession):
         exit_status, stdout = self.cmd_status_output(cmd, timeout=timeout)
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
-        result.stdout = results_stdout_52lts(result)
-        result.stderr = results_stderr_52lts(result)
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Virtadmin Command returned non-zero exit status")
@@ -691,14 +688,12 @@ def command(cmd, **dargs):
                           shell=True)
         # Mark return as not coming from persistent virtadmin session
         ret.from_session_id = None
-        ret.stdout = results_stdout_52lts(ret)
-        ret.stderr = results_stderr_52lts(ret)
 
     # Always log debug info, if persistent session or not
     if debug:
         logging.debug("status: %s", ret.exit_status)
-        logging.debug("stdout: %s", ret.stdout.strip())
-        logging.debug("stderr: %s", ret.stderr.strip())
+        logging.debug("stdout: %s", ret.stdout_text.strip())
+        logging.debug("stderr: %s", ret.stderr_text.strip())
 
     # Return CmdResult instance when ignore_status is True
     return ret


### PR DESCRIPTION
Because Avocado 52lts has not been supported for a while, we should
drop the compatibility layer.  This is a first stage, which removes
the *usage* of that layer by Avocado itself.

The test providers also need to drop the usage of the 52lts
compatibility functions, and then we can remove it from Avocado-VT
itself.

There's one exception category, which was not touched on this commit,
which is the staging libraries.  My hope is that we can determine the
fate of those before we have to change them.  It seems that the course
of action is to move pending functionality, if any, to Avocado itself,
and them drop those from staging.

This deserves some serious testing, as I don't expect to have gotten
all the conversions right for the very first time.

Signed-off-by: Cleber Rosa <crosa@redhat.com>