### PR TITLE
Fix keep printing error logs when Client process terminated unexpectedly

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1216,6 +1216,8 @@ class BaseVM(object):
                 if serial:
                     break
                 raise
+            except remote.LoginProcessTerminatedError:
+                raise
             except Exception as err:
                 error = err
             not_tried = False


### PR DESCRIPTION
As you can see below, There are millions of error logs were printed in job.log. so the job.log
is very large which makes jenkins out-of-memory.

2020-02-23 23:28:41,427 virt_vm          L1188 DEBUG| Attempting to log into 'esx6.7-rhel8.1-x86_64WY0' (timeout 480s)
2020-02-23 23:29:21,840 ip_sniffing      L0053 DEBUG| Updated HWADDR (00:50:56:ac:06:41)<->(192.168.122.150) IP pair into address cache
2020-02-23 23:29:22,067 virt_vm          L0919 DEBUG| Found/Verified IP 192.168.122.150 for VM esx6.7-rhel8.1-x86_64WY0 NIC 0
2020-02-23 23:30:43,083 ip_sniffing      L0068 DEBUG| Dropped the address cache of HWADDR (00:50:56:ac:06:41)
2020-02-23 23:30:43,086 virt_vm          L1373 DEBUG| Attempting to log into 'esx6.7-rhel8.1-x86_64WY0' via serial console (timeout 10s)
2020-02-23 23:30:43,087 utils_net        L3648 WARNI| Error occur when update VM address cache: No console available.
2020-02-23 23:30:43,088 virt_vm          L1373 DEBUG| Attempting to log into 'esx6.7-rhel8.1-x86_64WY0' via serial console (timeout 10s)
2020-02-23 23:30:43,088 utils_net        L3648 WARNI| Error occur when update VM address cache: No console available.
2020-02-23 23:30:43,089 virt_vm          L1373 DEBUG| Attempting to log into 'esx6.7-rhel8.1-x86_64WY0' via serial console (timeout 10s)
2020-02-23 23:30:43,089 utils_net        L3648 WARNI| Error occur when update VM address cache: No console available.
2020-02-23 23:30:43,090 virt_vm          L1373 DEBUG| Attempting to log into 'esx6.7-rhel8.1-x86_64WY0' via serial console (timeout 10s)
2020-02-23 23:30:43,090 utils_net        L3648 WARNI| Error occur when update VM address cache: No console available.
2020-02-23 23:30:43,090 virt_vm          L1373 DEBUG| Attempting to log into 'esx6.7-rhel8.1-x86_64WY0' via serial console (timeout 10s)
2020-02-23 23:30:43,091 utils_net        L3648 WARNI| Error occur when update VM address cache: No console available.
2020-02-23 23:30:43,091 virt_vm          L1373 DEBUG| Attempting to log into 'esx6.7-rhel8.1-x86_64WY0' via serial console (timeout 10s)

Let's see how it happens by this simple chart.

wait_for_login ->
    while
        self.login ->
            remote_login ->
                handle_prompts

First wait_for_login was called, in the function, wait_for_get_address was called to get
the ip of the guest. By the log, we can see the ip (192.168.122.150) was acquired successfully.
Then the code goes into the while loop which calls function login. In the login function, it
calls remote_login, in remote_login it calls handle_promts. This process generates an ssh command
to connect to the guest. But for some unknow reason, the ssh command timeout, and handle_prompts
raise a timeout exception, and in the while loop of wait_for_login, the exception errors was only
saved silently and then try self.login again.

In the new self.login call, becase of the same unknow reason, the login timeout again.

After two times failure, the guest's state becomes to shutoff suddently, the shutoff reason is 'unknown'. It
might be casued by a crash, but this is another problem. so right now the Client process was terminated and
a exception 'remote.LoginProcessTerminatedError' was raised and be ignored in the while loop as same as the
timeout exception.

From now on, the new self.login will keep trying to connect to a dead guest, which cause the code to call
update_mac_ip_address to update the address by serial console, then reports 'No console available'. and
the failure log prints untill while loop timeout.

That's how the problem happens.

In fact, when the client process is terminated, it means something unrecoverable happens, the login process
should be stoped. so the fix is just capturing the LoginProcessTerminatedError exception and break the
while loop.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>