### PR TITLE
usb_device: move adding usb devices logic forward

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1840,6 +1840,11 @@ class VM(virt_vm.BaseVM):
             for dev in devices.usbc_by_params(usb_name, usb_params, parent_bus):
                 devices.insert(dev)
 
+        # Add usb devices
+        for usb_dev in params.objects("usb_devices"):
+            usb_dev_params = params.object_params(usb_dev)
+            devices.insert(devices.usb_by_params(usb_dev, usb_dev_params))
+
         # initialize iothread manager
         devices.initialize_iothread_manager(params, self.cpuinfo)
 
@@ -2092,11 +2097,6 @@ class VM(virt_vm.BaseVM):
                     devices.insert(_)
 
         add_floppy(devices, params)
-
-        # Add usb devices
-        for usb_dev in params.objects("usb_devices"):
-            usb_dev_params = params.object_params(usb_dev)
-            devices.insert(devices.usb_by_params(usb_dev, usb_dev_params))
 
         tftp = params.get("tftp")
         if tftp:


### PR DESCRIPTION
Move adding usb devices logic at the earlier stage in
make_create_command() before adding images to support
plugging usb-storage under usb-hub automatically.

ID: 1802010
Signed-off-by: ybduan <yduan@redhat.com>