### PR TITLE
Cirrus CI: also perform a libvirt based bootstrap/list

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,6 @@
 env:
   CIRRUS_CLONE_DEPTH: 1
+  VT_TYPE: qemu
 
 fedora_30_task:
   container:
@@ -16,16 +17,19 @@ fedora_30_task:
     matrix:
       - SETUP: setup.py develop --user
       - SETUP: -m pip install .
+    matrix:
+      - VT_TYPE: qemu
+      - VT_TYPE: libvirt
   setup_script: &setup_scr
     - $PYTHON --version
     - test -z $AVOCADO_SRC || $PYTHON -m pip install $AVOCADO_SRC
     - $PYTHON $SETUP
   bootstrap_script: &bootstrap_scr
-    - $PYTHON -m avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
+    - $PYTHON -m avocado vt-bootstrap --vt-type=$VT_TYPE --vt-skip-verify-download-assets --yes-to-all
   list_script: &list_scr
-    - $PYTHON -m avocado list
+    - $PYTHON -m avocado list --vt-type=$VT_TYPE
   dry_run_script: &dry_run_scr
-    - $PYTHON -m avocado --show all run --dry-run -- io-github-autotest-qemu.boot
+    - $PYTHON -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
 
 centos_8_1_task:
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ fedora_30_task:
   list_script: &list_scr
     - $PYTHON -m avocado list
   dry_run_script: &dry_run_scr
-    - $PYTHON -m avocado --show all run --dry-run -- boot
+    - $PYTHON -m avocado --show all run --dry-run -- io-github-autotest-qemu.boot
 
 centos_8_1_task:
   container:


### PR DESCRIPTION
Given that there's bootstrap specific code for different
virtualization types.  So far, this does it for only one OS (Fedora
30) which seems to be enough.

Signed-off-by: Cleber Rosa <crosa@redhat.com>