### PR TITLE
Add support for "-compat"

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -14,6 +14,9 @@ qemu_io_binary = qemu-io
 #disable_kvm = no
 # Explicitly pass -disable-shutdown to qemu (default no)
 #disable_shutdown = no
+# Set the "-compat" setting option (uncomment this to crash on the use of
+# a deprecated interface)
+# qemu_compat = deprecated-input=crash
 # Pass a custom bios path for debugging
 #bios_path = /path/to/coreboot.rom
 

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1352,10 +1352,15 @@ class VM(virt_vm.BaseVM):
 
         # Additional qemu commandline options to virt-install directly
         # helps to test new feature from qemu
-        virtinstall_qemu_cmdline = params.get("virtinstall_qemu_cmdline", "")
-        if virtinstall_qemu_cmdline:
-            if has_option(help_text, "qemu-commandline"):
+        if has_option(help_text, "qemu-commandline"):
+            virtinstall_qemu_cmdline = params.get("virtinstall_qemu_cmdline", "")
+            if virtinstall_qemu_cmdline:
                 virt_install_cmd += ' --qemu-commandline="%s"' % virtinstall_qemu_cmdline
+
+            compat = params.get("qemu_compat")
+            if compat:
+                # TODO: Add a check whether "-compat" is supported
+                virt_install_cmd += ' --qemu-commandline="-compat %s"' % compat
 
         virtinstall_extra_args = params.get("virtinstall_extra_args", "")
         if virtinstall_extra_args:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2286,6 +2286,10 @@ class VM(virt_vm.BaseVM):
             devices.insert(StrDev('kvm', cmdline=enable_kvm_option))
             logging.debug("qemu will run in KVM mode")
 
+        compat = params.get("qemu_compat")
+        if compat and devices.has_option("compat"):
+            devices.insert(StrDev('compat', cmdline="-compat %s" % compat))
+
         self.no_shutdown = (devices.has_option("no-shutdown") and
                             params.get("disable_shutdown", "no") == "yes")
         if self.no_shutdown:


### PR DESCRIPTION
The "-compat" option was introduced recently in qemu to let users
configure the behavior on the use of deprecated interfaces. See:

    Configurable policy for handling deprecated interfaces

email for more details. Let's add this interface to both qemu_vm and
libvirt_vm to allow developing tests or simply running tests with custom
policy (the example in base.cfg makes the qemu crash when deprecated
interface is used).

* Note in order to test this you need to apply the `Configurable policy for handling deprecated interfaces` patch to qemu (for example by `git fetch origin 'patchew/20200303163505.32041-1-armbru@redhat.com'` on the `https://github.com/patchew-project/qemu` git repo).
* I don't remember (and wasn't able to easily find) how to check whether given qemu command is available in libvirt_vm