### PR TITLE
Remove passfd files on python3 rpmbuild

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -106,7 +106,7 @@ Xunit output, among others.
 %if %{with_python3}
 %package -n python3-%{name}
 Summary: %{summary}
-Requires: python3, python3-devel, python3-avocado >= 51.0, python3-aexpect
+Requires: python3, python3-avocado >= 51.0, python3-aexpect
 Requires: python3-netaddr, python3-netifaces, python3-simplejson
 %{?python_provide:%python_provide python3-%{srcname}}
 %description -n python3-%{name}

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,8 @@ if __name__ == "__main__":
     requirements = ["netifaces", "aexpect", "netaddr", "simplejson", "six"]
     if sys.version_info[:2] >= (3, 0):
         requirements.append("avocado-framework>=68.0")
+        if sys.version_info[:2] >= (3, 3):
+            os.system("rm -rf virttest/passfd*")
     else:
         # Latest py2 supported stevedore is 1.10.0, need to limit it here
         # as older avocado versions were not limiting it.

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -22,6 +22,10 @@ from .compat_52lts import results_stdout_52lts
 
 
 LOG = logging.getLogger("avocado.app")
+if sys.version_info[:2] >= (3, 3):
+    qemu_headers = ['types.h', 'socket.h', 'unistd.h']
+else:
+    qemu_headers = ['Python.h', 'types.h', 'socket.h', 'unistd.h']
 
 basic_program_requirements = ['xz', 'tcpdump', 'nc', 'ip', 'arping']
 
@@ -45,7 +49,7 @@ mandatory_programs = {'qemu': basic_program_requirements + ['gcc'],
                       'v2v': basic_program_requirements,
                       'libguestfs': basic_program_requirements}
 
-mandatory_headers = {'qemu': ['Python.h', 'types.h', 'socket.h', 'unistd.h'],
+mandatory_headers = {'qemu': qemu_headers,
                      'spice': [],
                      'libvirt': [],
                      'openvswitch': [],


### PR DESCRIPTION
We should avoid to introduce c files on python project,
replace the function provided by passfd.c with socket.sendmsg
and socket.recvmsg on systems with python3.3 or later