### PR TITLE
Add config files for Fedora 31

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/31.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/31.cfg
@@ -1,0 +1,107 @@
+- 31:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64:
+            vm_arch_name = ppc64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - riscv64:
+            # Image provided by Rich Jones, for instructions read:
+            # https://avocado-vt.readthedocs.io/en/latest/Experimental.html#riscv64
+            no install, setup, unattended_install, svirt_install
+            vm_arch_name = riscv64
+            # The provided image uses "riscv" password
+            password = riscv
+            # Double the usual timeouts
+            timeout = 1200
+            login_timeout = 720
+            kill_timeout = 120
+            # Currently we have to boot via custom kernel
+            kernel = images/f31-${vm_arch_name}-kernel
+            kernel_params = "console=ttyS0 ro root=/dev/sda"
+            virtio_blk:
+                kernel_params = "console=ttyS0 ro root=/dev/vda"
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    image_name = images/f31-${vm_arch_name}
+    os_variant = fedora31
+    # default boot path is set in ../Fedora.cfg: boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel = images/f31-${vm_arch_name}/vmlinuz
+        initrd = images/f31-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/Fedora-31.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            url = http://dl.fedoraproject.org/pub/fedora/releases/31/Server/${vm_arch_name}/os/
+        # ARCH dependent things
+        aarch64:
+            arm64-mmio:
+                # Only latest updates contain virtio driver
+                inactivity_watcher = none
+                take_regular_screendumps = no
+            kernel_params = "console=ttyAMA0 console=ttyS0 serial"
+            unattended_install.cdrom:
+                md5sum_cd1 = 5629a2ae883f8afbc5f675f94798398c
+                md5sum_1m_cd1 = eebbca4eb53a276d79063fe30ddc6558
+            unattended_install.url:
+                url = http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Server/${vm_arch_name}/os
+                sha1sum_vmlinuz = f1bc444f795b5c3eb7f7cc229bfa5abb
+                sha1sum_initrd = 63c069ce4a4057abc23dcd54897fb03e
+        ppc64:
+            kernel_params = "console=hvc0 serial"
+            boot_path = ppc/ppc64
+            unattended_install.cdrom:
+                md5sum_cd1 = fdbc46e96cd1c210ab62f7a3ad51b938
+                md5sum_1m_cd1 = 2ef20babadfa30544fd9e94f9d3b573f
+            unattended_install.url:
+                sha1sum_vmlinuz = a682caf6ea9718cf48bda511f464a8a0
+                sha1sum_initrd = 824ae6ec75a39117b873ea85c48a5038
+        ppc64le:
+            kernel_params = "console=hvc0 serial"
+            boot_path = ppc/ppc64
+            unattended_install.cdrom:
+                md5sum_cd1 = c01d0d04b481c56380c88ea2c6e11ce5
+                md5sum_1m_cd1 = 0c78f0233155031b8f4183fb78631ffe
+            unattended_install.url:
+                sha1sum_vmlinuz = a816007723db93411b98cba454452b37
+                sha1sum_initrd = f0d51189f496e6ad8ed9336bd1128f8a
+        s390x:
+            kernel_params = "console=ttysclp0 serial"
+            boot_path = images
+            kernel = images/f31-s390x/kernel.img
+            # Anaconda hardcodes headless installation of F28 on s390x
+            vga = none
+            inactivity_watcher = none
+            take_regular_screendumps = no
+            unattended_install.cdrom:
+                md5sum_cd1 = 2694a40333d0f698fa9b4f7faea18ad7
+                md5sum_1m_cd1 = 4b6e4bbfa315283235ea014245b21d1d
+            unattended_install.url:
+                sha1sum_vmlinuz = 956a22a1134972dc08422b13595aac53
+                sha1sum_initrd = 735a5698f95463f4fbf7e1c90a75c1a2
+        x86_64:
+            kernel_params = "console=tty0 console=ttyS0"
+            unattended_install.cdrom:
+                md5sum_cd1 = 18740b445159c54d10bd887650e8d1d7
+                md5sum_1m_cd1 = cf06d7246d515d06ebb73e6e4a2f547f
+            unattended_install.url:
+                url = http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Server/${vm_arch_name}/os
+                sha1sum_vmlinuz = 93b2351535ed8cfe9e3440b4bba2402d
+                sha1sum_initrd = 0d7bb4b536872954e4c455c87599157b
+        # Shared specific setting
+        unattended_install.url:
+            kernel_params += " inst.repo=${url}"
+        unattended_install.cdrom:
+            cdrom_cd1 = isos/linux/Fedora-Server-dvd-${vm_arch_name}-31-1.9.iso
+        extra_cdrom_ks:
+            kernel_params += " ks=cdrom"
+            cdrom_unattended = images/f31-${vm_arch_name}/ks.iso
+        syslog_server_proto = tcp
+        kernel_params += " nicdelay=60 inst.sshd ip=dhcp"

--- a/shared/downloads/fedora-31-x86_64.ini
+++ b/shared/downloads/fedora-31-x86_64.ini
@@ -1,0 +1,4 @@
+[fedora-31-x86_64]
+title = Fedora 31 x86_64
+url = http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Server/x86_64/iso/Fedora-Server-dvd-x86_64-31-1.9.iso
+destination = isos/linux/Fedora-Server-dvd-x86_64-31-1.9.iso

--- a/shared/unattended/Fedora-31.ks
+++ b/shared/unattended/Fedora-31.ks
@@ -1,0 +1,47 @@
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+lang en_US
+keyboard us
+network --bootproto dhcp --hostname atest-guest
+rootpw 123456
+firewall --enabled --ssh
+selinux --permissive
+timezone --utc America/New_York
+firstboot --disable
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+poweroff
+KVM_TEST_LOGGING
+
+clearpart --all --initlabel
+autopart
+
+%packages --ignoremissing
+@c-development
+@development-tools
+net-tools
+sg3_utils
+# include avocado: allows using this machine with remote runner
+python3-avocado
+%end
+
+%post
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `cat /proc/consoles | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
+ECHO "OS install is completed"
+grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
+dhclient
+iptables -F
+systemctl mask tmp.mount
+# if package groups were missing from main installation repo
+# try again from installed system
+dnf -y groupinstall c-development development-tools
+dnf -y install net-tools sg3_utils python3-avocado
+systemctl enable sshd
+#From fedora31,root login is disabled by default,we need enable it for our test
+echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+
+ECHO 'Post set up finished'
+%end


### PR DESCRIPTION
This is needed by Fedora 31 and later test.
Fedora-25.ks won't work any more as  root login is disable by default from Fedora 31 on