### PR TITLE
Add config files for Fedora 31

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/28.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/28.cfg
@@ -53,8 +53,8 @@
                 md5sum_1m_cd1 = eebbca4eb53a276d79063fe30ddc6558
             unattended_install.url:
                 url = http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Server/${vm_arch_name}/os
-                sha1sum_vmlinuz = f1bc444f795b5c3eb7f7cc229bfa5abb
-                sha1sum_initrd = 63c069ce4a4057abc23dcd54897fb03e
+                sha1sum_vmlinuz = 3929512f5c10163471fbb2d8cde40aea823d30d3 
+                sha1sum_initrd = 31fbbf554035d7393503513925150d4fcee1f86d
         ppc64:
             kernel_params = "console=hvc0 serial"
             boot_path = ppc/ppc64
@@ -62,8 +62,8 @@
                 md5sum_cd1 = fdbc46e96cd1c210ab62f7a3ad51b938
                 md5sum_1m_cd1 = 2ef20babadfa30544fd9e94f9d3b573f
             unattended_install.url:
-                sha1sum_vmlinuz = a682caf6ea9718cf48bda511f464a8a0
-                sha1sum_initrd = 824ae6ec75a39117b873ea85c48a5038
+                sha1sum_vmlinuz = 44f1da4e23027ec8539ccb2f606dddba729041de 
+                sha1sum_initrd = c05f7292fbcfd18b971d05402cfd6c224b38db54
         ppc64le:
             kernel_params = "console=hvc0 serial"
             boot_path = ppc/ppc64
@@ -71,8 +71,8 @@
                 md5sum_cd1 = c01d0d04b481c56380c88ea2c6e11ce5
                 md5sum_1m_cd1 = 0c78f0233155031b8f4183fb78631ffe
             unattended_install.url:
-                sha1sum_vmlinuz = a816007723db93411b98cba454452b37
-                sha1sum_initrd = f0d51189f496e6ad8ed9336bd1128f8a
+                sha1sum_vmlinuz = b7298478589443e6e57623b3f30784003813b4f6
+                sha1sum_initrd = d6298af4f3baeec8d2e3de51d3d9337aa0aee5d9
         s390x:
             kernel_params = "console=ttysclp0 serial"
             boot_path = images
@@ -85,8 +85,8 @@
                 md5sum_cd1 = 2694a40333d0f698fa9b4f7faea18ad7
                 md5sum_1m_cd1 = 4b6e4bbfa315283235ea014245b21d1d
             unattended_install.url:
-                sha1sum_vmlinuz = 956a22a1134972dc08422b13595aac53
-                sha1sum_initrd = 735a5698f95463f4fbf7e1c90a75c1a2
+                sha1sum_vmlinuz = 7b4f42cda5118aeaf6bca09395b4172f120b22ed
+                sha1sum_initrd = 0ca3847db91945eb5480b099723f91a354a1dd66
         x86_64:
             kernel_params = "console=tty0 console=ttyS0"
             unattended_install.cdrom:
@@ -94,8 +94,8 @@
                 md5sum_1m_cd1 = cf06d7246d515d06ebb73e6e4a2f547f
             unattended_install.url:
                 url = http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Server/${vm_arch_name}/os
-                sha1sum_vmlinuz = 93b2351535ed8cfe9e3440b4bba2402d
-                sha1sum_initrd = 0d7bb4b536872954e4c455c87599157b
+                sha1sum_vmlinuz = 238e083e114c48200f80d889f7e32eeb2793e02a
+                sha1sum_initrd = 6bf9bc52f86191d8bbe39677595b9a2f0f2068b1
         # Shared specific setting
         unattended_install.url:
             # TODO: Remove the "inst.repo" in newer Fedora versions, requiring it was a bug/regression

--- a/shared/cfg/guest-os/Linux/Fedora/31.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/31.cfg
@@ -1,0 +1,97 @@
+- 31:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - riscv64:
+            # Image provided by Rich Jones, for instructions read:
+            # https://avocado-vt.readthedocs.io/en/latest/Experimental.html#riscv64
+            no install, setup, unattended_install, svirt_install
+            vm_arch_name = riscv64
+            # The provided image uses "riscv" password
+            password = riscv
+            # Double the usual timeouts
+            timeout = 1200
+            login_timeout = 720
+            kill_timeout = 120
+            # Currently we have to boot via custom kernel
+            kernel = images/f31-${vm_arch_name}-kernel
+            kernel_params = "console=ttyS0 ro root=/dev/sda"
+            virtio_blk:
+                kernel_params = "console=ttyS0 ro root=/dev/vda"
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    image_name = images/f31-${vm_arch_name}
+    os_variant = fedora31
+    # default boot path is set in ../Fedora.cfg: boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel = images/f31-${vm_arch_name}/vmlinuz
+        initrd = images/f31-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/Fedora-25.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/31/Server/${vm_arch_name}/os/
+        # ARCH dependent things
+        aarch64:
+            arm64-mmio:
+                # Only latest updates contain virtio driver
+                inactivity_watcher = none
+                take_regular_screendumps = no
+            kernel_params = "console=ttyAMA0 console=ttyS0 serial"
+            unattended_install.cdrom:
+                md5sum_cd1 = 041e59c5b4bc2f05c9d8bdc7b697fef8
+                md5sum_1m_cd1 = 89b0a217e0eef61f0c60360e560199ce
+            unattended_install.url:
+                url = http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Server/${vm_arch_name}/os
+                sha1sum_vmlinuz = 3505f2751e2833c681de78cee8dda1e49cabd2e8
+                sha1sum_initrd = df6acb53fa1ce6e15c2d65bda18a4ac8ea77701a
+        ppc64le:
+            kernel_params = "console=hvc0 serial"
+            boot_path = ppc/ppc64
+            unattended_install.cdrom:
+                md5sum_cd1 = e673856a2547121044ee372d184cd552
+                md5sum_1m_cd1 = 400455f87e58a976696ca25df331887b
+            unattended_install.url:
+                sha1sum_vmlinuz = 11ece09fe5a8ff5838027fe3f653adcfb6f26efe
+                sha1sum_initrd = 2de8c72f683ca875de3620f63c52e53709dbbb54
+        s390x:
+            kernel_params = "console=ttysclp0 serial"
+            boot_path = images
+            kernel = images/f31-s390x/kernel.img
+            # Anaconda hardcodes headless installation of F28 on s390x
+            vga = none
+            inactivity_watcher = none
+            take_regular_screendumps = no
+            unattended_install.cdrom:
+                md5sum_cd1 = ca302d6a5c21d1bfe41b871b75197767
+                md5sum_1m_cd1 = d459f5d89931a29d199e605be03c84a9
+            unattended_install.url:
+                sha1sum_vmlinuz = b93d1efcafcf29c1673a4ce371a1f8b43941cfeb
+                sha1sum_initrd = 3de45d411df5624b8d8ef21cd0b44419ab59b12f
+        x86_64:
+            kernel_params = "console=tty0 console=ttyS0"
+            unattended_install.cdrom:
+                md5sum_cd1 = af29363e2c8825948515aac36701fbfa
+                md5sum_1m_cd1 = 8c09623eee12715472242f844cf69e4e
+            unattended_install.url:
+                url = http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Server/${vm_arch_name}/os
+                sha1sum_vmlinuz = 5b6f6876e1b5bda314f93893271da0d5777b1f3c
+                sha1sum_initrd = 0d7b4bdccb3ca82e0a221104d9f20eda0cc53309
+        # Shared specific setting
+        unattended_install.url:
+            # TODO: Remove the "inst.repo" in newer Fedora versions, requiring it was a bug/regression
+            kernel_params += " inst.repo=${url}"
+        unattended_install.cdrom:
+            cdrom_cd1 = isos/linux/Fedora-Server-dvd-${vm_arch_name}-31-1.9.iso
+        extra_cdrom_ks:
+            kernel_params += " ks=cdrom"
+            cdrom_unattended = images/f31-${vm_arch_name}/ks.iso
+        syslog_server_proto = tcp
+        kernel_params += " nicdelay=60 inst.sshd ip=dhcp"

--- a/shared/downloads/fedora-31-x86_64.ini
+++ b/shared/downloads/fedora-31-x86_64.ini
@@ -1,0 +1,4 @@
+[fedora-31-x86_64]
+title = Fedora 31 x86_64
+url = http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Server/x86_64/iso/Fedora-Server-dvd-x86_64-31-1.9.iso
+destination = isos/linux/Fedora-Server-dvd-x86_64-31-1.9.iso


### PR DESCRIPTION
This is needed by Fedora 31 and later test.
Fedora-25.ks won't work any more as root login is disable by default from Fedora 31 on