### PR TITLE
classify installation cases for check_block_size

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -5,7 +5,7 @@
         modprobe_module = acpiphp
     block_hotplug:
         modprobe_module = acpiphp
-    unattended_install, check_block_size, svirt_install, with_installation:
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install, with_installation:
         kernel_params = "ks=cdrom inst.sshd ip=dhcp"
         # The below config breaks RHEL6 x86, so it's commented out until we figure out a decent
         # solution that works across the board.

--- a/shared/cfg/guest-os/Linux/RHEL/7.6.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.6.cfg
@@ -2,7 +2,7 @@
     no setup
     image_name = images/rhel76
     os_variant = rhel7
-    unattended_install, check_block_size, svirt_install, with_installation:
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install, with_installation:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
     unattended_install.url:

--- a/shared/cfg/guest-os/Linux/RHEL/7.6/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.6/x86_64.cfg
@@ -2,11 +2,11 @@
     grub_file = /boot/grub2/grub.cfg
     vm_arch_name = x86_64
     image_name += -64
-    unattended_install, check_block_size, svirt_install, with_installation:
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install, with_installation:
         cdrom_unattended = images/rhel76-64/ks.iso
         kernel = images/rhel76-64/vmlinuz
         initrd = images/rhel76-64/initrd.img
-    unattended_install.cdrom, check_block_size, svirt_install, with_installation:
+    unattended_install.cdrom, check_block_size..extra_cdrom_ks,svirt_install, with_installation:
         cdrom_cd1 = isos/linux/RHEL-7.6-x86_64-DVD.iso
         md5sum_cd1 = 7f0eb16e287e732af4046359184cf6f7
         md5sum_1m_cd1 = 940be7b67d3d78bcbb46904d1193882c

--- a/shared/cfg/guest-os/Linux/RHEL/7.7.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.7.cfg
@@ -2,7 +2,7 @@
     no setup
     image_name = images/rhel77
     os_variant = rhel7
-    unattended_install, check_block_size, svirt_install, with_installation:
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install, with_installation:
         unattended_file = unattended/RHEL-7-series.ks
         syslog_server_proto = udp
     unattended_install.url:

--- a/shared/cfg/guest-os/Linux/RHEL/7.7/x86_64.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/7.7/x86_64.cfg
@@ -2,11 +2,11 @@
     grub_file = /boot/grub2/grub.cfg
     vm_arch_name = x86_64
     image_name += -64
-    unattended_install, check_block_size, svirt_install, with_installation:
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install, with_installation:
         cdrom_unattended = images/rhel77-64/ks.iso
         kernel = images/rhel77-64/vmlinuz
         initrd = images/rhel77-64/initrd.img
-    unattended_install.cdrom, check_block_size, svirt_install, with_installation:
+    unattended_install.cdrom, check_block_size..extra_cdrom_ks,svirt_install, with_installation:
         cdrom_cd1 = isos/linux/RHEL-7.7-x86_64-DVD.iso
         md5sum_cd1 = faa7d8dd79085ecae05b94e6180d9cbd
         md5sum_1m_cd1 = ecab8bda0eaded401bb6bae29ec69623

--- a/shared/cfg/guest-os/Linux/RHEL/8.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL/8.cfg
@@ -17,7 +17,7 @@
     block_hotplug:
         modprobe_module =
     no unattended_install..floppy_ks
-    unattended_install, check_block_size, svirt_install:
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install:
         cdrom_unattended = images/${os_variant}-${vm_arch_name}/ks.iso
         syslog_server_proto = udp
     unattended_install, svirt_install:
@@ -38,7 +38,7 @@
             install_timeout = 7200
             kernel = images/${os_variant}-${vm_arch_name}/kernel.img
             kernel_params = "console=ttysclp0 serial"
-            unattended_install, check_block_size, svirt_install:
+            unattended_install, check_block_size..extra_cdrom_ks,svirt_install:
                 # Anaconda hardcodes headless installation of RHEL.7 on s390x
                 vga = none
                 inactivity_watcher = none

--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -45,7 +45,7 @@
     cdrom_check_cdrom_pattern = "\d\s+(\w).*CD-ROM"
     cdrom_test_cmd = "dir %s:\"
     cdrom_info_cmd = "wmic cdrom list full"
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         timeout = 7200
         finish_program = deps/finish/finish.bat
         # process need to check after post install

--- a/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -1,7 +1,7 @@
 - i386:
     vm_arch_name = i686
     image_name += -32
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         unattended_file = unattended/win10-32-autounattend.xml
         cdrom_cd1 = isos/windows/en_windows_10_enterprise_x86_dvd_6851156.iso
         md5sum_cd1 = 68162933e551e55779504dacdfb0c5ae

--- a/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win10/x86_64.cfg
@@ -3,7 +3,7 @@
     vm_arch_name = x86_64
     install:
         passwd = 1q2w3eP
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         cdrom_cd1 = isos/windows/en_windows_10_enterprise_x64_dvd_6851151.iso
         md5sum_cd1 = a67722adfaf209c72eacb3ab910ee65e
         md5sum_1m_cd1 = 0e246b56b7b63f0526c3367eb160ff7d

--- a/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
@@ -1,7 +1,7 @@
 - x86_64:
     vm_arch_name = x86_64
     image_name += -64
-    unattended_install.cdrom, svirt_install, check_block_size:
+    unattended_install.cdrom, svirt_install, check_block_size..extra_cdrom_ks:
         cdrom_cd1 = isos/windows/en_windows_server_2012_x64_dvd_915478.iso
         md5sum_cd1 = 8dcde01d0da526100869e2457aafb7ca
         md5sum_1m_cd1 = c6a4b1097449bb1f050492a6b57e7d21
@@ -32,7 +32,7 @@
         - @r1:
         - r2:
             image_name += r2
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
                 cdrom_cd1 = isos/windows/en_windows_server_2012_r2_x64_dvd_2707946.iso
                 md5sum_cd1 = 0e7c09aab20dec3cd7eab236dab90e78
                 md5sum_1m_cd1 = fab118cfa7f66d3606c38dc1330a769e

--- a/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2016/x86_64.cfg
@@ -3,7 +3,7 @@
     image_name += -64
     install:
         passwd = 1q2w3eP
-    unattended_install.cdrom, whql.support_vm_install, with_installation, check_block_size:
+    unattended_install.cdrom, whql.support_vm_install, with_installation, check_block_size..extra_cdrom_ks:
         cdrom_cd1 = isos/ISO/Win2016/en_windows_server_2016_x64_dvd_9327751.iso
         md5sum_cd1 = 91d7b2ebcff099b3557570af7a8a5cd6
         md5sum_1m_cd1 = 5f297f2178a618c166d1116475ed6368

--- a/shared/cfg/guest-os/Windows/Win2019/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win2019/x86_64.cfg
@@ -3,7 +3,7 @@
     image_name += -64
     install:
         passwd = 1q2w3eP
-    unattended_install.cdrom, whql.support_vm_install, with_installation, check_block_size:
+    unattended_install.cdrom, whql.support_vm_install, with_installation, check_block_size..extra_cdrom_ks:
         cdrom_cd1 = isos/ISO/Win2019/en_windows_server_2019_x64_dvd_4cb967d8.iso
         md5sum_cd1 = a876d230944abe3bf2b5c2b40da6c4a3
         md5sum_1m_cd1 = b6a3bfe488b969d85ba099cab62a4599

--- a/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -1,7 +1,7 @@
 - i386:
     vm_arch_name = i686
     image_name += -32
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         cdrom_cd1 = isos/windows/en_windows_8_enterprise_x86_dvd_917587.iso
         md5sum_cd1 = ad055cae50cef987586c51cc6cc3c62e
         md5sum_1m_cd1 = 92e5522e0ceff8c703d5fdca620c841f
@@ -41,7 +41,7 @@
         - @0:
         - 1:
             image_name += .1
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
                 cdrom_cd1 = isos/windows/en_windows_8_1_enterprise_x86_dvd_2972289.iso
                 md5sum_cd1 = bf620a67b5dda1e18e9ce17d25711201
                 md5sum_1m_cd1 = 0dddab9c979407e871c007424c7f75a3

--- a/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
+++ b/shared/cfg/guest-os/Windows/Win8/x86_64.cfg
@@ -9,7 +9,7 @@
         steps = steps/Win8-64.steps
     setup:
         steps = steps/Win8-64-rss.steps
-    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+    unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         cdrom_cd1 = isos/windows/en_windows_8_enterprise_x64_dvd_917522.iso
         md5sum_cd1 = 27aa354b8088527ffcd32007b51b25bf
         md5sum_1m_cd1 = 06f8883a669f55f27e98938e71e90d67
@@ -47,7 +47,7 @@
         - @0:
         - 1:
             image_name += .1
-            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size:
+            unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
                 cdrom_cd1 = isos/windows/en_windows_8_1_enterprise_x64_dvd_2971902.iso
                 md5sum_cd1 = 8e194185fcce4ea737f274ee9005ddf0
                 md5sum_1m_cd1 = ec868109e725742b83363908405d21f3


### PR DESCRIPTION
There are two scenarios in check_block_size:
one is related to the unattended installation,like as
512_512,4096_512,4096_4096 under ovmf. The other is
booting os directly. we need to specify the cases range
in configuratoin files to adapt different scenario.

ID:1810946,1766078,1804025

Signed-off-by: qingwangrh <qinwang@redhat.com>