### PR TITLE
Add debug info after installation of stress tool fails

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -2276,6 +2276,8 @@ class Stress(object):
         status, output = self.cmd_status_output(self.make_cmds,
                                                 timeout=self.stress_shell_timeout)
         if status != 0:
+            config_log = self.cmd_output_safe('cd %s;cat config.log' % install_path)
+            logging.debug(config_log)
             raise exceptions.TestError(
                 "Installation failed with output:\n %s" % output)
 


### PR DESCRIPTION
To debug what causes the failure of installation, we need to check
the content of config.log.

Signed-off-by: haizhao <haizhao@redhat.com>