### PR TITLE
Support gluster storage backend

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -249,6 +249,27 @@ variants image_backend:
         #Remote server address. Please set it if you want use remote gluster server.
         #Please also unset gluster_brick.
         gluster_server = <YOUR GLUSTER SERVER>
+    - gluster_direct:
+        # Access gluster storage directly by URI
+        storage_type = glusterfs-direct
+        enable_gluster = yes
+        # hostname or ip address of gluster server,
+        # unix domain socket to access gluster server,
+        # either gluster_server or gluster_unix_socket is required
+        #gluster_server =
+        #gluster_unix_socket =
+        # The name of gluster volume where VM image resides, required
+        #gluster_volume_name =
+        # A JSON doc string including array of SocketAddress, optional
+        #gluster_peers = '[{"type": "inet","host": "dell-per415-03.lab.eng.pek2.redhat.com","port":"12345"}, ...]'
+        # tcp, unix or rdma, optional
+        #gluster_transport =
+        # port number, optional
+        #gluster_port =
+        # libgfapi log level(1-9), optional
+        #gluster_debug =
+        # libgfapi log file, optional
+        #gluster_logfile =
     - lvm_partition:
         # use real logical volume partition as qemu block device drive
         only raw

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1724,10 +1724,30 @@ class DevContainer(object):
                 access_secret, secret_type = sec, sectype
 
         iscsi_initiator = None
+        gluster_debug = None
+        gluster_logfile = None
+        gluster_peers = {}
         access = image_access.image_auth if image_access else None
         if access is not None:
             if access.storage_type == 'iscsi-direct':
                 iscsi_initiator = access.iscsi_initiator
+            elif access.storage_type == 'glusterfs-direct':
+                gluster_debug = access.debug
+                gluster_logfile = access.logfile
+
+                peers = []
+                for peer in access.peers:
+                    if 'path' in peer:
+                        # access storage by unix domain socket
+                        peers.append({'type': 'unix', 'path': peer['path']})
+                    else:
+                        # access storage by hostname/ip + port
+                        peers.append({'host': peer['host'],
+                                      'type': peer.get('type', 'inet'),
+                                      'port': '%s' % peer.get('port', '0')})
+                gluster_peers.update({'server.{i}.{k}'.format(i=i+1, k=k): v
+                                     for i, server in enumerate(peers)
+                                     for k, v in six.iteritems(server)})
 
         use_device = self.has_option("device")
         if fmt == "scsi":   # fmt=scsi force the old version of devices
@@ -1868,6 +1888,8 @@ class DevContainer(object):
                 protocol_cls = qdevices.QBlockdevProtocolISCSI
             elif filename.startswith('rbd:'):
                 protocol_cls = qdevices.QBlockdevProtocolRBD
+            elif filename.startswith('gluster'):
+                protocol_cls = qdevices.QBlockdevProtocolGluster
             elif fmt in ('scsi-generic', 'scsi-block'):
                 protocol_cls = qdevices.QBlockdevProtocolHostDevice
             elif blkdebug is not None:
@@ -1968,6 +1990,12 @@ class DevContainer(object):
 
             if iscsi_initiator:
                 devices[-2].set_param('initiator-name', iscsi_initiator)
+            if gluster_debug:
+                devices[-2].set_param('debug', int(gluster_debug))
+            if gluster_logfile:
+                devices[-2].set_param('logfile', gluster_logfile)
+            for key, value in six.iteritems(gluster_peers):
+                devices[-2].set_param(key, value)
 
             for dev in (devices[-1], devices[-2]):
                 if not cache:
@@ -1997,6 +2025,10 @@ class DevContainer(object):
 
             if iscsi_initiator:
                 devices[-1].set_param('file.initiator-name', iscsi_initiator)
+            if gluster_debug:
+                devices[-1].set_param('file.debug', int(gluster_debug))
+            if gluster_logfile:
+                devices[-1].set_param('file.logfile', gluster_logfile)
 
         if drv_extra_params:
             drv_extra_params = (_.split('=', 1) for _ in

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -62,6 +62,39 @@ def filename_to_file_opts(filename):
                 if matches.group('conf') is not None:
                     # optional option
                     file_opts['conf'] = matches.group('conf')
+    elif filename.startswith('gluster'):
+        filename_pattern = re.compile(
+            r'gluster\+?(?P<type>.+)?://((?P<host>[^/]+?)(:(?P<port>\d+))?)?/'
+            r'(?P<volume>.+?)/(?P<path>[^,?]+)'
+            r'(\?socket=(?P<socket>[^,]+))?'
+        )
+        matches = filename_pattern.match(filename)
+        if matches:
+            servers = []
+            transport = 'inet' if not matches.group('type') or matches.group('type') == 'tcp' else matches.group('type')
+
+            if matches.group('host'):
+                # 'IPv4/hostname' or '[IPv6 address]'
+                host = matches.group('host').strip('[]')
+
+                # port should be set for both qemu-img and qemu-kvm
+                port = matches.group('port') if matches.group('port') else '0'
+
+                servers.append({'type': transport,
+                                'host': host,
+                                'port': port})
+            elif matches.group('socket'):
+                servers.append({'type': transport,
+                                'path': matches.group('socket')})
+
+            if matches.group('volume') and matches.group('path') and servers:
+                # required options for gluster
+                file_opts = {'driver': 'gluster',
+                             'volume': matches.group('volume'),
+                             'path': matches.group('path')}
+                file_opts.update({'server.{i}.{k}'.format(i=i, k=k): v
+                                 for i, server in enumerate(servers)
+                                 for k, v in six.iteritems(server)})
     # FIXME: Judge the host device by the string starts with "/dev/".
     elif filename.startswith('/dev/'):
         file_opts = {'driver': 'host_device', 'filename': filename}
@@ -106,6 +139,25 @@ def _get_image_meta(image, params, root_dir):
                 meta['file']['password'] = auth_info.data
             if auth_info.iscsi_initiator:
                 meta['file']['initiator-name'] = auth_info.iscsi_initiator
+        elif auth_info.storage_type == 'glusterfs-direct':
+            if auth_info.debug:
+                meta['file']['debug'] = int(auth_info.debug)
+            if auth_info.logfile:
+                meta['file']['logfile'] = auth_info.logfile
+
+            peers = []
+            for peer in auth_info.peers:
+                if 'path' in peer:
+                    # access storage with unix domain socket
+                    peers.append({'type': 'unix', 'path': peer['path']})
+                else:
+                    # access storage with hostname/ip + port
+                    peers.append({'host': peer['host'],
+                                  'type': peer.get('type', 'inet'),
+                                  'port': '%s' % peer.get('port', '0')})
+            meta['file'].update({'server.{i}.{k}'.format(i=i+1, k=k): v
+                                for i, server in enumerate(peers)
+                                for k, v in six.iteritems(server)})
 
     return meta
 
@@ -165,6 +217,10 @@ def get_image_repr(image, params, root_dir, representation=None):
                 # url with u/p is used to access iscsi image,
                 # besides u/p, iscsi access may need initiator
                 if auth_info.iscsi_initiator:
+                    access_needed = True
+            elif auth_info.storage_type == 'glusterfs-direct':
+                # debug, logfile and other servers represent in json
+                if auth_info.debug or auth_info.logfile or auth_info.peers:
                     access_needed = True
 
         func = mapping["json"] if image_secret or access_needed else mapping["filename"]


### PR DESCRIPTION
1. Access storage by 'qemu-kvm -drive'
        gluster[+tcp]://1.2.3.4[:24007]/testvol/dir/a.img
        gluster[+tcp]://[1:2:3:4:5:6:7:8][:24007]/testvol/dir/a.img
        gluster+unix:///testvol/dir/a.img?socket=/var/run/glusterd.sock
      2. Access storage by 'qemu-kvm -blockdev'
        driver=gluster,volume=..,path=..,server.0.type=inet,
        server.0.host=..,server.0.port=..,server.1.type=...

ID: 1789278