### PR TITLE
Revert "Fix keep printing error logs when Client process terminated u…

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1216,8 +1216,6 @@ class BaseVM(object):
                 if serial:
                     break
                 raise
-            except remote.LoginProcessTerminatedError:
-                raise
             except Exception as err:
                 error = err
             not_tried = False


### PR DESCRIPTION
…nexpectedly"

The failed client process might also be a not-yet-started VM in case the
IP address is still in the cache eg. from previous test execution.

Reproducer:

    avocado run boot boot boot

at least one test fails with:

/root: (monitor avocado-vt-vm1.qmpmonitor1) Sending command 'cont'
root: Send command: {'execute': 'cont', 'id': 'DfwhcJKw'}
-root: Context: Try to log into guest 'avocado-vt-vm1'.
root: Attempting to log into 'avocado-vt-vm1' (timeout 240s)
root: Found/Verified IP 192.168.122.12 for VM avocado-vt-vm1 NIC 0
|avocado.test:
avocado.test: Reproduced traceback from: /home/jenkins/avocado-vt/avocado_vt/test.py:436
avocado.test: Traceback (most recent call last):
avocado.test:   File "/home/jenkins/avocado-vt/virttest/remote.py", line 161, in handle_prompts
avocado.test:     timeout=timeout, internal_timeout=0.5)
avocado.test:   File "/usr/local/lib/python3.6/site-packages/aexpect/client.py", line 925, in read_until_last_line_matches
avocado.test:     print_func)
avocado.test:   File "/usr/local/lib/python3.6/site-packages/aexpect/client.py", line 861, in read_until_output_matches
avocado.test:     raise ExpectProcessTerminatedError(patterns, self.get_status(), o)
avocado.test: aexpect.exceptions.ExpectProcessTerminatedError: Process terminated while looking for patterns ['[Aa]re you sure', '[Pp]assword:\\s*', '\\(or (press|type) Control-D to continue\\):\\s*$', '[Gg]ive.*[Ll]ogin:\\s*$', '(?<![Ll]ast )[Ll]ogin:\\s*$', '[Cc]onnection.*closed', '[Cc]onnection.*refused', '[Pp]lease wait', '[Ww]arning', '[Ee]nter.*username', '[Ee]nter.*password', '[Cc]onnection timed out', '^\\[.*\\][\\#\\$]\\s*$', 'Escape character is.*', 'Command>']    (status: 255,    output: 'ssh: connect to host 192.168.122.12 port 22: No route to host\n')

although it should proceed with the next iteration and eventually ssh to
the machine.

This reverts commit b2ded91de9ab08fd76aa1544ddae6c3be8904ae5.

**Note this failed rapidly in my mini-CI, about 30-60% of tests failed just because it didn't get chance to ssh.**