### PR TITLE
Allow for sshd to come up on remote connections

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1216,8 +1216,11 @@ class BaseVM(object):
                 if serial:
                     break
                 raise
-            except remote.LoginProcessTerminatedError:
-                raise
+            except remote.LoginProcessTerminatedError as err:
+                if not re.match(r".*ssh:.*No route", err.output):
+                    raise
+                else:
+                    error = err
             except Exception as err:
                 error = err
             not_tried = False


### PR DESCRIPTION
When connecting through ssh the remote host sshd might not be up
yet. This happened often in test cases where the vms where
restarted before `env_process.py` called `vm.verify_dmesg` leading
to frequent error message in test logs
```bash
LoginProcessTerminatedError: Client process terminated    (status: 255,    output: 'ssh: connect to host 192.168.122.90 port 22: No route to host\n
```

If, however, `verify_dmesg` connects to a guest, it might take a while
for sshd to become responsive.

Before recent change https://github.com/avocado-framework/avocado-vt/pull/2451
the connection would just be retried.

Only raise exception now if we tried ssh connection and confirmed there's
no answer on target.