### PR TITLE
storage.file_remove: skip removal of raw device

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -111,6 +111,10 @@ def file_remove(params, filename_path):
         # TODO: Add implementation for iscsi/lvm
         return
 
+    # skip removing raw device
+    if params.get('image_raw_device') == 'yes':
+        return
+
     if os.path.exists(filename_path):
         os.unlink(filename_path)
         return


### PR DESCRIPTION
id: 1816048
for a raw device with `image_name = /dev/autotest/lv0`, current
implementation will remove the file path as releasing it. Let's simply
skip the removal and leave the decision to the user.

Signed-off-by: lolyu <lolyu@redhat.com>