### PR TITLE
qcontainer: Fix ValueError “Wrong filename None”

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1947,9 +1947,10 @@ class DevContainer(object):
         if not filename:
             cache = None
         if Flags.BLOCKDEV in self.caps:
-            file_opts = qemu_storage.filename_to_file_opts(filename)
-            for key, value in six.iteritems(file_opts):
-                devices[-2].set_param(key, value)
+            if filename:
+                file_opts = qemu_storage.filename_to_file_opts(filename)
+                for key, value in six.iteritems(file_opts):
+                    devices[-2].set_param(key, value)
 
             if access_secret is not None:
                 if secret_type == 'password':


### PR DESCRIPTION
For some scenarios that the driver file is empty, so
check whether the file is not None then get the options 
of file.

ID: 1787113, 1804030
Signed-off-by: Yongxue Hong <yhong@redhat.com>