### PR TITLE
Suppress non-error logging during wait_for_login

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -549,6 +549,10 @@ Ubuntu:
 login_timeout = 360
 test_timeout = 14400
 
+# Timeout logging behavior
+# Set 'yes' to reduce log output while waiting for login
+skip_non_error_waiting_for_login = no
+
 # libvirt (virt-install optional arguments)
 # TODO: Rename these with 'libvirt_' prefix
 use_autostart = no

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1207,6 +1207,11 @@ class BaseVM(object):
         # try to login if VM bootup really, at least once
         not_tried = True
         end_time = start_time + timeout
+        logger = None
+        if self.params.get("skip_non_error_waiting_for_login", "no") == "yes":
+            logger = logging.getLogger()
+            log_level = logger.level
+            logger.level = logging.ERROR
         while time.time() < end_time or not_tried:
             try:
                 return self.login(nic_index, internal_timeout,
@@ -1217,8 +1222,11 @@ class BaseVM(object):
                     break
                 raise
             except Exception as err:
+                time.sleep(0.5)
                 error = err
             not_tried = False
+        if logger:
+            logger.level = log_level
 
         print_guest_network_info()
         if serial:


### PR DESCRIPTION
Every failed login attempt in `BaseVM.wait_for_login` will log non-ERROR messages.
This clutters up the job.log and as a consequence Jenkins runs
out of memory, s. b2ded91de9ab08fd76aa1544ddae6c3be8904ae5

1. Add new configuration parameter to avoid logging non-ERROR message
logging while waiting for login. Per default, keep existing behavior.

2. Add a sleep in order to reduce number of attempts like in
`wait_for_serial_login` https://github.com/avocado-framework/avocado-vt/blob/a75febd923b8d6c8e6720bef12ecd9874ff7fe00/virttest/virt_vm.py#L1391

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
Signed-off-by: Lukas Doktor <ldoktor@redhat.com>