### PR TITLE
unattended_install: Two tweaks to attempt_to_log_useful_files

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1217,7 +1217,7 @@ def attempt_to_log_useful_files(test, vm):
                             fd_dst.write("Unknown exception while getting "
                                          "content: %s" % details)
                             failures = True
-            for cmd in ["journalctl --no-pager"]:
+            for cmd in ["journalctl --no-pager", "udevadm info --export-db"]:
                 dst = os.path.join(test.outputdir, vm.name, str(i),
                                    astring.string_to_safe_path(cmd))
                 with open(dst, 'w') as fd_dst:

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1231,7 +1231,6 @@ def attempt_to_log_useful_files(test, vm):
                                         "%s", details)
                         fd_dst.write("Unknown exception while getting "
                                      "cmd output: %s" % details)
-                        failures = True
             if not failures:
                 # All commands succeeded, no need to use next session
                 break


### PR DESCRIPTION
The commands might not be available on the systems or might fail for a different reason so let's just rely on errors from files logging. Also add "udevadm" dump on failure.