### PR TITLE
Update to support teaming for interface

### DIFF
--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -15,7 +15,7 @@ class Interface(base.TypedDeviceBase):
     __slots__ = ('source', 'hostdev_address', 'managed', 'mac_address',
                  'bandwidth', 'model', 'coalesce', 'link_state', 'target', 'driver',
                  'address', 'boot', 'rom', 'mtu', 'filterref', 'backend',
-                 'virtualport_type', 'alias', "ips")
+                 'virtualport_type', 'alias', "ips", "teaming")
 
     def __init__(self, type_name, virsh_instance=base.base.virsh):
         super(Interface, self).__init__(device_tag='interface',
@@ -117,6 +117,11 @@ class Interface(base.TypedDeviceBase):
                                  parent_xpath='/',
                                  marshal_from=self.marshal_from_ips,
                                  marshal_to=self.marshal_to_ips)
+        accessors.XMLElementDict(property_name="teaming",
+                                 libvirtxml=self,
+                                 forbidden=None,
+                                 parent_xpath='/',
+                                 tag_name='teaming')
 
     # For convenience
     Address = librarian.get('address')

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3667,6 +3667,7 @@ def modify_vm_iface(vm_name, oper, iface_dict, index=0):
     iface_type = iface_dict.get('type')
     iface_mtu = iface_dict.get('mtu')
     iface_alias = iface_dict.get('alias')
+    iface_teaming = iface_dict.get('teaming')
     iface_virtualport_type = iface_dict.get('virtualport_type')
     del_addr = iface_dict.get('del_addr')
     del_rom = iface_dict.get('del_rom')
@@ -3713,6 +3714,8 @@ def modify_vm_iface(vm_name, oper, iface_dict, index=0):
         iface.mtu = eval(iface_mtu)
     if iface_alias:
         iface.alias = eval(iface_alias)
+    if iface_teaming:
+        iface.teaming = eval(iface_teaming)
     if iface_virtualport_type:
         iface.virtualport_type = iface_virtualport_type
     if oper == "update_iface":


### PR DESCRIPTION
Add teaming element to Interface class.
And update libvirt.modify_vm_iface accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>