### PR TITLE
virttest.utils_test: Upgrade pip package

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -975,6 +975,11 @@ class AvocadoGuest(object):
             logging.error("Unable to find python.")
             return False
         self.pip_bin = find_bin(self.session, ['pip', 'pip2', 'pip3'])
+        if self.pip_bin:
+            cmd = "%s install --upgrade pip;" % (self.pip_bin)
+            if self.session.cmd_status(cmd, timeout=self.timeout) != 0:
+                logging.error("Unable to upgrade pip.")
+                return False
         if not utils_misc.make_dirs(self.test_path, session=self.session):
             logging.error("Failed to create test path in guest")
             return False


### PR DESCRIPTION
Adds error if not found any pip packages.
Apart from the list packages that should be upgraded, we should care if pip
was upgrading too. Because if it not, the exit code doesn't show errors during
upgrade or install packages.

Signed-off-by: Oksana Vohchana <ovoshcha@redhat.com>