### PR TITLE
guest-os: Add fedora 31 guest os for x86_64 and update kickstart

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/31.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/31.cfg
@@ -1,0 +1,39 @@
+- 31:
+    variants:
+        - x86_64:
+            vm_arch_name = x86_64
+    image_name = images/f31-${vm_arch_name}
+    os_variant = fedora31
+    # default boot path is set in ../Fedora.cfg: boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks
+    unattended_install, svirt_install:
+        kernel = images/f31-${vm_arch_name}/vmlinuz
+        initrd = images/f31-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/Fedora-25.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            # Unless overridden use secondary url, because it's the most common one
+            url = http://dl.fedoraproject.org/pub/fedora-secondary/releases/31/Server/${vm_arch_name}/os/
+        x86_64:
+            kernel_params = "console=tty0 console=ttyS0"
+            unattended_install.cdrom:
+                md5sum_cd1 = af29363e2c8825948515aac36701fbfa
+                md5sum_1m_cd1 = 8c09623eee12715472242f844cf69e4e
+            unattended_install.url:
+                url = http://dl.fedoraproject.org/pub/fedora/linux/releases/31/Server/${vm_arch_name}/os
+                sha1sum_vmlinuz = 0d9f05c54e44a11f7da2d9652b1df428
+                sha1sum_initrd = c505f11662b40745faad797e71883884
+        # Shared specific setting
+        unattended_install.url:
+            # TODO: Remove the "inst.repo" in newer Fedora versions, requiring it was a bug/regression
+            kernel_params += " inst.repo=${url}"
+        unattended_install.cdrom:
+            cdrom_cd1 = isos/linux/Fedora-Server-dvd-${vm_arch_name}-31-1.9.iso
+        extra_cdrom_ks:
+            kernel_params += " ks=cdrom"
+            cdrom_unattended = images/f31-${vm_arch_name}/ks.iso
+        syslog_server_proto = tcp
+        kernel_params += " nicdelay=60 inst.sshd ip=dhcp"

--- a/shared/unattended/Fedora-25.ks
+++ b/shared/unattended/Fedora-25.ks
@@ -36,6 +36,7 @@ ECHO "OS install is completed"
 grubby --remove-args="rhgb quiet" --update-kernel=$(grubby --default-kernel)
 dhclient
 chkconfig sshd on
+echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
 iptables -F
 systemctl mask tmp.mount
 echo 0 > /selinux/enforce


### PR DESCRIPTION
1. Add fedora 31 guest-os configuration for x86_64
2. Update kickstart file to allow 'root' user to login with ssh

id: 1821348

Signed-off-by: Yanan Fu <yfu@redhat.com>