### PR TITLE
Reduce login attempts on error

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1221,6 +1221,7 @@ class BaseVM(object):
                     break
                 raise
             except Exception as err:
+                time.sleep(0.5)
                 error = err
             not_tried = False
 


### PR DESCRIPTION
Every failed login attempt in will log non-ERROR messages.
This clutters up the job.log and as a consequence Jenkins runs
out of memory, s. https://github.com/avocado-framework/avocado-vt/commit/b2ded91de9ab08fd76aa1544ddae6c3be8904ae5

Add a sleep in order to reduce number of attempts like in
`wait_for_serial_login` https://github.com/avocado-framework/avocado-vt/blob/a75febd923b8d6c8e6720bef12ecd9874ff7fe00/virttest/virt_vm.py#L1391

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
Signed-off-by: Lukas Doktor <ldoktor@redhat.com>