### PR TITLE
Support qcow2 external data file

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -313,6 +313,11 @@ class QemuImg(storage.QemuImg):
                     options.append("%s=%s" % (opt_key.replace("_", "-"),
                                               str(opt_val)))
 
+        if self.data_file:
+            options.extend(
+                ("data_file=%s" % self.data_file.image_filename,
+                 "data_file_raw=%s" % params.get("data_file_raw", "off")))
+
         access_secret, secret_type = self._image_access_secret
         if access_secret is not None:
             if secret_type == 'password':


### PR DESCRIPTION
id: 1828649

Add support for qcow2 external data file.
New parameters:

`enable_data_file`: works when `image_format` is qcow2, will create
external data file(`root_dir/images/{image}.data_file` or specified by
`data_file_path`).

`data_file_path`: optional, used to specify the path to external
data file.

`data_file_raw`: if the data file is kept as a raw file.

Signed-off-by: lolyu <lolyu@redhat.com>