### PR TITLE
Fix variable reference issue

### DIFF
--- a/virttest/utils_conn.py
+++ b/virttest/utils_conn.py
@@ -1269,8 +1269,8 @@ class TLSConnection(ConnectionBase):
         # edit the /etc/libvirt/libvirtd.conf to add
         # listen_addr=$listen_addr
         if listen_addr:
-            pattern_to_repl[r".*listen_addr\s*=.*"] = \
-                "listen_addr='%s'" % (listen_addr)
+            pattern_to_repl = {r".*listen_addr\s*=.*":
+                               "listen_addr='%s'" % listen_addr}
             operate_libvirtdconf.sub_else_add(pattern_to_repl)
 
         # edit the /etc/libvirt/libvirtd.conf to add auth_tls=$auth_tls


### PR DESCRIPTION
Fix the error:
UnboundLocalError: local variable 'pattern_to_repl' referenced before assignment

Signed-off-by: Dan Zheng <dzheng@redhat.com>