### PR TITLE
Don't restrict mem zones on s390x

### DIFF
--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -503,7 +503,7 @@ class HugePageConfig(object):
             with open(self.kernel_hp_file, "r") as hugepage_allocated:
                 available_hugepages = int(hugepage_allocated.read().strip())
             chunk_bottom = int(math.log(self.hugepage_size / utils_memory.getpagesize(), 2))
-            if ARCH == 'ppc64le':
+            if ARCH in ['ppc64le', 's390x']:
                 chunk_info = utils_memory.get_buddy_info(">=%s" % chunk_bottom)
             else:
                 chunk_info = utils_memory.get_buddy_info(">=%s" % chunk_bottom,


### PR DESCRIPTION
On my z/VM only available zone is DMA. The current code
restricted info to DMA32 and Normal zones.

On s390x, follow ppc64le and don't restrict zones for chunk_info.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>