### PR TITLE
virttest.bootstrap: Add "diff" to list of required programs

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -24,7 +24,7 @@ from .compat import get_opt
 
 LOG = logging.getLogger("avocado.app")
 
-basic_program_requirements = ['xz', 'tcpdump', 'nc', 'ip', 'arping']
+basic_program_requirements = ['xz', 'tcpdump', 'nc', 'ip', 'arping', 'diff']
 
 recommended_programs = {'qemu': [('qemu-kvm', 'kvm'), ('qemu-img',),
                                  ('qemu-io',), ('virsh',)],


### PR DESCRIPTION
We use "diff" to visualize differences between config files.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>