### PR TITLE
Support NBD storage backend

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -249,6 +249,29 @@ variants image_backend:
         #Remote server address. Please set it if you want use remote gluster server.
         #Please also unset gluster_brick.
         gluster_server = <YOUR GLUSTER SERVER>
+    - nbd:
+        storage_type = nbd
+        enable_nbd = yes
+        force_create_image = no
+        # hostname or ip address, and unix domain socket to access NBD server,
+        # either nbd_server or nbd_unix_socket is required
+        #nbd_server =
+        #nbd_unix_socket =
+        # TCP port to connect to(default 10809), optional
+        #nbd_port =
+        # NBD volume export name, optional
+        #nbd_export_name =
+        # TLS credentials path for client, optional
+        #nbd_client_tls_creds =
+        # TLS credentials path for server, optional
+        #nbd_server_tls_creds =
+        # Force the use of the block driver for the format, used for qemu-nbd, optional
+        #nbd_export_format =
+        # NBD volume export description, used for qemu-nbd, optional
+        #nbd_export_description =
+        # On an unexpected disconnect, the nbd client tries to connect again
+        # until succeeding or encountering a serious error, optional
+        #nbd_reconnect_delay =
     - gluster_direct:
         # Access gluster storage directly by URI
         storage_type = glusterfs-direct

--- a/virttest/nbd.py
+++ b/virttest/nbd.py
@@ -1,0 +1,159 @@
+import os
+import string
+
+from virttest import error_context
+from virttest import utils_misc
+
+from avocado.utils import process
+
+
+@error_context.context_aware
+def get_image_filename(params):
+    """
+    Get the nbd image uri:
+      tcp: nbd://<server-ip>[:<port>]/[<export>]
+      unix domain socket: nbd+unix:///[<export>]?socket=<domain-socket>
+    :param params: image specified params
+    :return: nbd image uri string
+    """
+    server = params.get('nbd_server')
+    unix_socket = params.get('nbd_unix_socket')
+    export_name = '/%s' % params['nbd_export_name'] if params.get(
+        'nbd_export_name') else ''
+
+    if server:
+        port = ':%s' % params['nbd_port'] if params.get('nbd_port') else ''
+        return 'nbd://{server}{port}{export}'.format(server=server,
+                                                     port=port,
+                                                     export=export_name)
+    elif unix_socket:
+        return 'nbd+unix://{export}?socket={sock}'.format(export=export_name,
+                                                          sock=unix_socket)
+
+    raise ValueError('Either nbd_server or nbd_unix_socket is required.')
+
+
+@error_context.context_aware
+def export_image(qemu_nbd, filename, local_image, params):
+    """
+    Export a local file image with qemu-nbd command
+    :param qemu_nbd: path to the qemu-nbd binary
+    :param filename: image path for raw/qcow2 image or image json
+                     representation string for luks image
+    :param local_image: image tag defined in parameter images
+    :param params: local image specified params
+    :return: pid of qemu-nbd server or None
+    """
+    cmd_dict = {
+        "secret_object": "",
+        "tls_creds": "",
+        "export_format": "",
+        "persistent": "-t",
+        "desc": "",
+        "port": "",
+        "export_name": "",
+        "unix_socket": "",
+        "filename": "",
+        "fork": "--fork",
+        "pid_file": ""
+    }
+    export_cmd = ('{secret_object} {tls_creds} '
+                  '{export_format} {persistent} {desc} {port} '
+                  '{export_name} {fork} {pid_file} {unix_socket} {filename}')
+
+    pid_file = utils_misc.generate_tmp_file_name('%s_nbd_server' % local_image,
+                                                 'pid')
+    cmd_dict['pid_file'] = '--pid-file %s' % pid_file
+    cmd_dict['filename'] = filename
+
+    # auto-detect format if format(-f) is not specified
+    if params.get('nbd_export_format'):
+        cmd_dict['export_format'] = '-f %s' % params['nbd_export_format']
+
+        if params['nbd_export_format'] == 'luks':
+            # We can only export a local luks image in luks
+            if params.get("image_format") != 'luks':
+                raise ValueError("Only a luks image can be exported in luks")
+
+            secret_str = '--object secret,id={aid},data={data}'
+            cmd_dict.update({
+                'secret_object': secret_str.format(
+                    aid='%s_encrypt0' % local_image,
+                    data=params["image_secret"]),
+                'filename': "'%s'" % filename
+            })
+
+    if params.get('nbd_export_name'):
+        cmd_dict['export_name'] = '-x %s' % params['nbd_export_name']
+
+    if params.get('nbd_export_description'):
+        cmd_dict['desc'] = '-D "%s"' % params['nbd_export_description']
+
+    if params.get('nbd_unix_socket'):
+        cmd_dict['unix_socket'] = '-k %s' % params['nbd_unix_socket']
+    else:
+        # 10809 is used by defalut if port is not set
+        if params.get('nbd_port'):
+            cmd_dict['port'] = '-p %s' % params['nbd_port']
+
+        # tls creds is supported for ip only
+        if params.get('nbd_server_tls_creds'):
+            tls_str = ('--object tls-creds-x509,id={aid},endpoint=server,'
+                       'dir={tls_creds} --tls-creds {aid}')
+            cmd_dict['tls_creds'] = tls_str.format(
+                aid='%s_server_tls_creds' % local_image,
+                tls_creds=params['nbd_server_tls_creds']
+            )
+
+    qemu_nbd_pid = None
+    cmdline = qemu_nbd + ' ' + string.Formatter().format(export_cmd,
+                                                         **cmd_dict)
+    result = process.run(cmdline, ignore_status=True, shell=True,
+                         ignore_bg_processes=True)
+    if result.exit_status == 0:
+        with open(pid_file, "r") as pid_file_fd:
+            qemu_nbd_pid = int(pid_file_fd.read().strip())
+        os.unlink(pid_file)
+
+    return qemu_nbd_pid
+
+
+def list_exported_image(qemu_nbd, nbd_image, params):
+    """
+    List all details about the exports by qemu-nbd
+    :param qemu_nbd: path to the qemu-nbd binary
+    :param nbd_image: nbd image tag defined in parameter images
+    :param params: nbd image specified params
+    :return: CmdResult object of qemu-nbd output
+    """
+    cmd_dict = {
+        "tls_creds": "",
+        "port": "",
+        "server": ""
+    }
+    list_cmd = '-L {tls_creds} {port} {server}'
+
+    if params.get('nbd_unix_socket'):
+        cmd_dict['server'] = '-k %s' % params['nbd_unix_socket']
+    else:
+        # 0.0.0.0 is used by default if interface is not set
+        if params.get('nbd_server'):
+            cmd_dict['server'] = '-b %s' % params['nbd_server']
+
+        # 10809 is used by default if port is not set
+        if params.get('nbd_port'):
+            cmd_dict['port'] = '-p %s' % params['nbd_port']
+
+        # tls creds is supported for ip only
+        if params.get('nbd_client_tls_creds'):
+            tls_str = ('--object tls-creds-x509,id={aid},endpoint=client,'
+                       'dir={tls_creds} --tls-creds {aid}')
+            cmd_dict['tls_creds'] = tls_str.format(
+                aid='%s_client_tls_creds' % nbd_image,
+                tls_creds=params['nbd_client_tls_creds']
+            )
+
+    cmdline = qemu_nbd + ' ' + string.Formatter().format(list_cmd,
+                                                         **cmd_dict)
+    return process.run(cmdline, ignore_status=True, shell=True,
+                       ignore_bg_processes=True)

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1599,6 +1599,23 @@ class DevContainer(object):
         :param image_encryption: ImageEncryption object for image
         :param image_access: The logical image access information object
         """
+        def _get_access_tls_creds(image_access):
+            """Get all tls-creds objects of the image and its backing images"""
+            tls_creds = []
+            if image_access is not None:
+                creds_list = []
+                if image_access.image_backing_auth:
+                    creds_list.extend(image_access.image_backing_auth.values())
+                if image_access.image_auth:
+                    creds_list.append(image_access.image_auth)
+
+                for creds in creds_list:
+                    if creds.storage_type == 'nbd':
+                        if creds.tls_creds:
+                            tls_creds.append(creds)
+
+            return tls_creds
+
         def _get_access_secrets(image_access):
             """Get all secret objects of the image and its backing images"""
             secrets = []
@@ -1725,10 +1742,27 @@ class DevContainer(object):
                 access_secret_obj = devices[-1]
                 access_secret, secret_type = sec, sectype
 
+        tls_creds = None
+        tls_creds_obj = None
+        creds_list = _get_access_tls_creds(image_access)
+        for creds in creds_list:
+            # create and add all tls-creds objects
+            devices.append(qdevices.QObject('tls-creds-x509'))
+            devices[-1].set_param("id", creds.aid)
+            devices[-1].set_param("endpoint", 'client')
+            devices[-1].set_param("dir", creds.tls_creds)
+
+            if creds.image == name:
+                # only the top image should be associated
+                # with its tls-creds object
+                tls_creds_obj = devices[-1]
+                tls_creds = creds
+
         iscsi_initiator = None
         gluster_debug = None
         gluster_logfile = None
         gluster_peers = {}
+        reconnect_delay = None
         access = image_access.image_auth if image_access else None
         if access is not None:
             if access.storage_type == 'iscsi-direct':
@@ -1750,6 +1784,8 @@ class DevContainer(object):
                 gluster_peers.update({'server.{i}.{k}'.format(i=i+1, k=k): v
                                      for i, server in enumerate(peers)
                                      for k, v in six.iteritems(server)})
+            elif access.storage_type == 'nbd':
+                reconnect_delay = access.reconnect_delay
 
         use_device = self.has_option("device")
         if fmt == "scsi":   # fmt=scsi force the old version of devices
@@ -1892,6 +1928,8 @@ class DevContainer(object):
                 protocol_cls = qdevices.QBlockdevProtocolRBD
             elif filename.startswith('gluster'):
                 protocol_cls = qdevices.QBlockdevProtocolGluster
+            elif re.match(r'nbd(\+\w+)?://', filename):
+                protocol_cls = qdevices.QBlockdevProtocolNBD
             elif fmt in ('scsi-generic', 'scsi-block'):
                 protocol_cls = qdevices.QBlockdevProtocolHostDevice
             elif blkdebug is not None:
@@ -1990,6 +2028,10 @@ class DevContainer(object):
                     devices[-2].set_param('key-secret',
                                           access_secret_obj.get_qid())
 
+            if tls_creds is not None:
+                devices[-2].set_param('tls-creds', tls_creds_obj.get_qid())
+            if reconnect_delay is not None:
+                devices[-2].set_param('reconnect-delay', int(reconnect_delay))
             if iscsi_initiator:
                 devices[-2].set_param('initiator-name', iscsi_initiator)
             if gluster_debug:
@@ -2025,6 +2067,12 @@ class DevContainer(object):
                     devices[-1].set_param('file.key-secret',
                                           access_secret_obj.get_qid())
 
+            if tls_creds is not None:
+                devices[-1].set_param('file.tls-creds',
+                                      tls_creds_obj.get_qid())
+            if reconnect_delay is not None:
+                devices[-1].set_param('file.reconnect-delay',
+                                      int(reconnect_delay))
             if iscsi_initiator:
                 devices[-1].set_param('file.initiator-name', iscsi_initiator)
             if gluster_debug:

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -10,7 +10,6 @@ import logging
 import re
 import traceback
 from collections import OrderedDict
-from functools import reduce
 
 import aexpect
 
@@ -675,20 +674,21 @@ class QBlockdevNode(QCustomDevice):
         :return: Converted args.
         :rtype: dict
         """
-        new_args = {}
-        tmp = {}
-        for key, val in six.iteritems(args):
-            if val in ('on', 'yes'):
-                val = True
-            elif val in ('off', 'no'):
-                val = False
-            if '.' in key:
-                sub_key = key.split('.')
-                reduce(lambda d, k: d.setdefault(
-                    k, {}), sub_key[1:-1], tmp)[sub_key[-1]] = val
-                new_args[sub_key[0]] = tmp
-            else:
-                new_args[key] = val
+        new_args = dict()
+        for key, value in six.iteritems(args):
+            if value in ('on', 'yes'):
+                value = True
+            elif value in ('off', 'no'):
+                value = False
+
+            parts = key.split(".")
+            d = new_args
+            for part in parts[:-1]:
+                if part not in d:
+                    d[part] = dict()
+                d = d[part]
+            d[parts[-1]] = value
+
         return new_args
 
     def hotplug_qmp(self):
@@ -909,6 +909,11 @@ class QBlockdevProtocolGluster(QBlockdevProtocol):
         params['server'] = [servers[i] for i in sorted(servers)]
 
         return "blockdev-add", params
+
+
+class QBlockdevProtocolNBD(QBlockdevProtocol):
+    """ New a protocol nbd blockdev node. """
+    TYPE = 'nbd'
 
 
 class QDevice(QCustomDevice):

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -3309,3 +3309,79 @@ class QMPMonitor(Monitor):
             arguments["head"] = int(head)
         arguments["events"] = events
         return self.cmd(cmd, arguments)
+
+    def nbd_server_start(self, server, tls_creds=None, tls_authz=None):
+        """
+        Start an NBD server listening on the given host and port.
+        :param server: {'host': xx, 'port': 'type': 'inet'} or
+                       {'path': xx, 'type': 'unix'}
+        :param tls_creds: ID of the TLS credentials object (since 2.6).
+        :param tls_authz: ID of the QAuthZ authorization object used to
+                          validate the client's x509 distinguished name.
+                          (since 4.0)
+        """
+        cmd = "nbd-server-start"
+        self.verify_supported_cmd(cmd)
+        arguments = {
+            "addr": {
+                "type": server.pop("type"),
+                "data": server
+            }
+        }
+        if tls_creds:
+            arguments["tls-creds"] = tls_creds
+        if tls_authz:
+            arguments["tls-authz"] = tls_authz
+        return self.cmd(cmd, arguments)
+
+    def nbd_server_add(self, device, export_name=None,
+                       writable=None, bitmap=None):
+        """
+        Export a block node to QEMU's embedded NBD server.
+        :param device: The device name or node name to be exported
+        :param export_name: Export name. If unspecified, the device name
+                            is used as the export name.
+        :param writable: Whether clients should be able to write to the
+                         device via the NBD connection, 'yes' or 'no'
+        :param bitmap: Also export the dirty bitmap reachable from device,
+                       so the NBD client can use NBD_OPT_SET_META_CONTEXT
+                       with 'qemu:dirty-bitmap:NAME' to inspect the bitmap.
+                       (since 4.0)
+        """
+        cmd = "nbd-server-add"
+        self.verify_supported_cmd(cmd)
+        arguments = dict()
+        arguments["device"] = device
+        if export_name:
+            arguments["name"] = export_name
+        if writable:
+            arguments["writable"] = writable == "yes"
+        if bitmap:
+            arguments["bitmap"] = bitmap
+        return self.cmd(cmd, arguments)
+
+    def nbd_server_remove(self, export_name, remove_mode=None):
+        """
+        Remove NBD export by name.
+        :param export_name: Export name.
+        :param remove_mode: 'safe': Remove export if there are no existing
+                                    connections, fail otherwise.(default)
+                            'hard': Drop all connections immediately and
+                                    remove export.
+        """
+        cmd = "nbd-server-remove"
+        self.verify_supported_cmd(cmd)
+        arguments = dict()
+        arguments["name"] = export_name
+        if remove_mode:
+            arguments["mode"] = remove_mode
+        return self.cmd(cmd, arguments)
+
+    def nbd_server_stop(self):
+        """
+        Stop QEMU's embedded NBD server, and unregister all devices
+        previously added via nbd-server-add
+        """
+        cmd = "nbd-server-stop"
+        self.verify_supported_cmd(cmd)
+        return self.cmd(cmd)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2665,6 +2665,8 @@ class VM(virt_vm.BaseVM):
                 continue
             if cdrom_params.get("enable_iscsi") == "yes":
                 continue
+            if cdrom_params.get("enable_nbd") == "yes":
+                continue
             iso = cdrom_params.get("cdrom")
             if iso:
                 iso = utils_misc.get_path(data_dir.get_data_dir(), iso)

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -18,6 +18,7 @@ import json
 from avocado.core import exceptions
 from avocado.utils import process
 
+from virttest import nbd
 from virttest import iscsi
 from virttest import utils_misc
 from virttest import utils_numeric
@@ -152,13 +153,16 @@ def get_image_filename(params, root_dir, basename=False):
            image_format -- the format of the image (qcow2, raw etc)
     :raise VMDeviceError: When no matching disk found (in indirect method).
     """
-    enable_gluster = params.get("enable_gluster", "no") == "yes"
-    enable_ceph = params.get("enable_ceph", "no") == "yes"
-    enable_iscsi = params.get("enable_iscsi", "no") == "yes"
+    enable_nbd = params.get("enable_nbd") == "yes"
+    enable_gluster = params.get("enable_gluster") == "yes"
+    enable_ceph = params.get("enable_ceph") == "yes"
+    enable_iscsi = params.get("enable_iscsi") == "yes"
     image_name = params.get("image_name")
     storage_type = params.get("storage_type")
     if image_name:
         image_format = params.get("image_format", "qcow2")
+        if enable_nbd:
+            return nbd.get_image_filename(params)
         if enable_iscsi:
             if storage_type == 'iscsi-direct':
                 portal = params.get('portal_ip')
@@ -313,6 +317,7 @@ class StorageAuth(object):
     Image storage authentication class.
     iscsi auth: initiator + password
     ceph auth: ceph key
+    nbd auth: tls creds
     """
 
     def __init__(self, image, data, data_format, storage_type, **info):
@@ -324,9 +329,10 @@ class StorageAuth(object):
         :param info: other access information, such as:
                      iscsi-direct: initiator
                      gluster-direct: debug, logfile, peers
+                     nbd: tls creds path for client access
         """
         self.image = image
-        self.aid = '%s_access_secret' % self.image
+        self.aid = '%s_access' % self.image
         self.storage_type = storage_type
         self.filename = os.path.join(secret_dir, "%s.secret" % self.aid)
         self.data_format = data_format
@@ -343,6 +349,12 @@ class StorageAuth(object):
             # they'll be defined as common options for all backends
             self.debug = info['debug']
             self.logfile = info['logfile']
+        elif self.storage_type == 'nbd':
+            # TODO: now we only support tls-creds-x509, we can add a
+            # param 'nbd_tls_creds_object' to differentiate objects,
+            # e.g. tls-creds-psk
+            self.tls_creds = info['tls_creds']
+            self.reconnect_delay = info['reconnect_delay']
 
         if self.data is not None:
             self.save_to_file()
@@ -370,9 +382,10 @@ class StorageAuth(object):
         """
         auth = None
         storage_type = params.get("storage_type")
-        enable_ceph = params.get("enable_ceph", "no") == "yes"
-        enable_iscsi = params.get("enable_iscsi", "no") == "yes"
-        enable_gluster = params.get("enable_gluster", "no") == "yes"
+        enable_ceph = params.get("enable_ceph") == "yes"
+        enable_iscsi = params.get("enable_iscsi") == "yes"
+        enable_gluster = params.get("enable_gluster") == "yes"
+        enable_nbd = params.get("enable_nbd") == "yes"
 
         if enable_iscsi:
             if storage_type == 'iscsi-direct':
@@ -394,6 +407,16 @@ class StorageAuth(object):
                 auth = cls(image, None, None, storage_type,
                            debug=debug, logfile=logfile,
                            peers=peers) if debug or logfile or peers else None
+        elif enable_nbd:
+            # tls-creds is supported for ip only
+            tls_creds = params.get(
+                'nbd_client_tls_creds') if params.get('nbd_server') else None
+            reconnect_delay = params.get('nbd_reconnect_delay')
+            auth = cls(
+                image, None, None, storage_type,
+                tls_creds=tls_creds, reconnect_delay=reconnect_delay
+            ) if tls_creds or reconnect_delay else None
+
         return auth
 
 
@@ -605,7 +628,7 @@ class QemuImg(object):
         self.image_blkdebug_filename = get_image_blkdebug_filename(params,
                                                                    root_dir)
         self.remote_keywords = params.get("remote_image",
-                                          "gluster iscsi rbd").split()
+                                          "gluster iscsi rbd nbd").split()
         self.encryption_config = ImageEncryption.encryption_define_by_params(
             tag, params)
         image_chain = params.get("image_chain")

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2041,6 +2041,13 @@ def get_binary(binary_name, params):
     return binary_path
 
 
+def get_qemu_nbd_binary(params):
+    """
+    Get the path to the qemu-nbd binary currently in use.
+    """
+    return get_binary('qemu-nbd', params)
+
+
 def get_qemu_img_binary(params):
     """
     Get the path to the qemu-img binary currently in use.


### PR DESCRIPTION
Add nbd storage backend support

  1. Access nbd storage by uri:
    nbd://server
    nbd://server:port
    nbd://server/export
    nbd://server:port/export
    nbd://?socket=/path/sock
    nbd:///export?socket=/path/sock
  2. Access nbd storage by blockdev
    driver=nbd,server.type=inet,server.host=xxx,server.port=xxx
    driver=nbd,server.type=unix,server.path=xxx
    driver=nbd,server.type=inet,server.host=xxx,server.port=xxx,tls-creds=xxx

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 1825932