### PR TITLE
virttest.qemu_storage: drop unused decode_to_text() and default to process.run()

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -735,7 +735,7 @@ class QemuImg(storage.QemuImg):
                                        " parameters")
         cmd += " %s" % self.image_filename
 
-        decode_to_text(process.system_output(cmd))
+        process.system_output(cmd)
 
         return self.snapshot_tag
 
@@ -760,7 +760,7 @@ class QemuImg(storage.QemuImg):
         else:
             cmd += " %s" % self.image_filename
 
-        decode_to_text(process.system_output(cmd))
+        process.system_output(cmd)
 
     def snapshot_list(self):
         """
@@ -786,7 +786,7 @@ class QemuImg(storage.QemuImg):
             raise exceptions.TestError("Can not find the snapshot image"
                                        " parameters")
 
-        decode_to_text(process.system_output(cmd))
+        process.system_output(cmd)
 
     def remove(self):
         """

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -627,7 +627,7 @@ class QemuImg(storage.QemuImg):
 
         logging.info("Convert image %s from %s to %s", self.image_filename,
                      self.image_format, convert_image.image_format)
-        process.system(convert_cmd)
+        process.run(convert_cmd)
         if convert_image.encryption_config.key_secret:
             convert_image.encryption_config.key_secret.save_to_file()
 
@@ -680,7 +680,7 @@ class QemuImg(storage.QemuImg):
                                                       self.base_image_filename))
         rebase_cmd = self.image_cmd + " " + \
             self._cmd_formatter.format(self.rebase_cmd, **cmd_dict)
-        process.system(rebase_cmd)
+        process.run(rebase_cmd)
 
         return self.base_tag
 
@@ -715,7 +715,7 @@ class QemuImg(storage.QemuImg):
         commit_cmd = self.image_cmd + " " + \
             self._cmd_formatter.format(self.commit_cmd, **cmd_dict)
         logging.info("Commit image %s" % self.image_filename)
-        process.system(commit_cmd)
+        process.run(commit_cmd)
 
         return self.image_filename
 
@@ -735,7 +735,7 @@ class QemuImg(storage.QemuImg):
                                        " parameters")
         cmd += " %s" % self.image_filename
 
-        process.system_output(cmd)
+        process.run(cmd)
 
         return self.snapshot_tag
 
@@ -760,7 +760,7 @@ class QemuImg(storage.QemuImg):
         else:
             cmd += " %s" % self.image_filename
 
-        process.system_output(cmd)
+        process.run(cmd)
 
     def snapshot_list(self):
         """
@@ -786,7 +786,7 @@ class QemuImg(storage.QemuImg):
             raise exceptions.TestError("Can not find the snapshot image"
                                        " parameters")
 
-        process.system_output(cmd)
+        process.run(cmd)
 
     def remove(self):
         """


### PR DESCRIPTION
Just a few cleanups and optmizations on the `decode_to_text()` and `avocado.utils.process` usage on that module.