### PR TITLE
Enable "kernel syncronization delay fuzzing" flag in verifer for win8.1+ guests

### DIFF
--- a/shared/cfg/guest-os/Windows.cfg
+++ b/shared/cfg/guest-os/Windows.cfg
@@ -38,6 +38,13 @@
     #Try to catch windows bsod
     check_guest_bsod = yes
 
+    # Set verifier flags for windows guests
+    Win10, Win2016, Win2019:
+        windows_verifier_flags = "0x009209bb"
+
+    Win8..1, Win2012..r2:
+        windows_verifier_flags = "0x008209bb"
+
     # these config are used in virt_test_utils.get_readable_cdroms()
     cdrom_get_cdrom_cmd = "echo list volume > check_cdrom &&"
     cdrom_get_cdrom_cmd += " echo exit >> check_cdrom &&"


### PR DESCRIPTION
For win8.1+ guests, enable "kernel syncronization delay fuzzing";
For win8.1- guests, use standard setting since "kernel syncronization delay fuzzing" is not supported on them.

ID: 1827536

Signed-off-by: lijin <lijin@redhat.com>