### PR TITLE
Block execution if ovirtsdk4 is not found

### DIFF
--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -8,11 +8,8 @@ oVirt SDK wrapper module.
 import time
 import logging
 
-try:
-    import ovirtsdk4 as sdk
-    import ovirtsdk4.types as types
-except ImportError:
-    logging.warning("ovirtsdk4 module not present, please install it")
+import ovirtsdk4 as sdk
+import ovirtsdk4.types as types
 
 from virttest import virt_vm
 


### PR DESCRIPTION
The execution should be interrupted if ovirtsdk4 is not found.
If not, the guests cannot be cleaned up on rhv server.

Although it will not block convertion to other targets, but
the benefit is less than the disadvantage.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>