### PR TITLE
Support more properties for dimm devices

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -808,3 +808,13 @@ force_reset_go_down_check = "qmp"
 
 # Add -S  to qemu by default, if you don't need it, pls set it off.
 qemu_stop = on
+
+# Set uuid property of nvdimm device (Since QEMU-5.0), it supports the string
+# representation of a UUID as a URN. // RFC 4122
+# If you use a wrong format, will generate a random UUID base on uuid5 and
+# device name.
+# nvdimm_uuid = urn:uuid:ea0ec480-6066-40bc-9709-65d0467ad024
+nvdimm_uuid = ""
+
+# Add extra params for dimm devices
+#dimm_extra_params = "label-size=128k slot=1"

--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -38,6 +38,7 @@ variants:
         del rtc_drift
         del soundcards
         serial_type = 'spapr-vty'
+        nvdimm_uuid = <auto>
     - arm64-mmio:
         only aarch64
         auto_cpu_model = "no"


### PR DESCRIPTION
In addition to some common properties, nvdimm device has some unique
properties. pseries already supports this device since qemu-5.0, but it
needs to set the "uuid" property for this dimm device on the qemu
command line.

1. qcontainer: Set nvdimm's uuid if required
2. qcontainer: Supports add other properties with "dimm_extra_params"
3. Introduce of new params in the cfg

ID: 1829139
Signed-off-by: Yihuang Yu <yihyu@redhat.com>