### PR TITLE
Shared.RHEL:blockdev_snapshot_install installation options set

### DIFF
--- a/shared/cfg/guest-os/Linux/RHEL.cfg
+++ b/shared/cfg/guest-os/Linux/RHEL.cfg
@@ -5,7 +5,7 @@
         modprobe_module = acpiphp
     block_hotplug:
         modprobe_module = acpiphp
-    unattended_install, check_block_size..extra_cdrom_ks,svirt_install, with_installation, blockdev_commit_install:
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install, with_installation, blockdev_commit_install, blockdev_snapshot_install:
         kernel_params = "ks=cdrom inst.sshd ip=dhcp"
         # The below config breaks RHEL6 x86, so it's commented out until we figure out a decent
         # solution that works across the board.


### PR DESCRIPTION
Installation options set for case blockdev_snapshot_install

Signed-off-by: Aihua Liang <aliang@redhat.com>

id:1831968