### PR TITLE
Stabilize postcopy migration

### DIFF
--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -295,6 +295,7 @@ class MigrationTest(object):
                             except KeyError:
                                 func(args['func_params'])
                         elif func == virsh.migrate_postcopy:
+                            time.sleep(3)  # To avoid of starting postcopy before starting migration
                             func(vm.name, uri=srcuri, debug=True)
                         else:
                             func(args['func_params'])


### PR DESCRIPTION
Sometimes we execute migrate-postcopy command before migration really starts, so we get below error:
"error: internal error: unable to execute QEMU command 'migrate-start-postcopy': Enable postcopy
with migrate_set_capability before the start of migration".
So this is to stabilize the script.

Signed-off-by: Dan Zheng <dzheng@redhat.com>