### PR TITLE
Support qcow2 external data file

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -412,6 +412,11 @@ class QemuImg(storage.QemuImg):
                     options.append("%s=%s" % (opt_key.replace("_", "-"),
                                               str(opt_val)))
 
+        if self.data_file:
+            options.extend(
+                ("data_file=%s" % self.data_file.image_filename,
+                 "data_file_raw=%s" % params.get("image_data_file_raw", "off")))
+
         access_secret, secret_type = self._image_access_secret
         if access_secret is not None:
             if secret_type == 'password':
@@ -979,6 +984,12 @@ class QemuImg(storage.QemuImg):
         """
         logging.debug("Removing image file %s", self.image_filename)
         storage.file_remove(self.params, self.image_filename)
+
+        if self.data_file:
+            logging.debug("Removing external data file of image %s",
+                          self.data_file.image_filename)
+            storage.file_remove(self.data_file.params,
+                                self.data_file.image_filename)
 
         secret_files = []
         if self.encryption_config.key_secret:

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -22,6 +22,7 @@ from virttest import nbd
 from virttest import iscsi
 from virttest import utils_misc
 from virttest import utils_numeric
+from virttest import utils_params
 from virttest import virt_vm
 from virttest import gluster
 from virttest import lvm
@@ -667,6 +668,32 @@ class QemuImg(object):
         self.image_access = ImageAccessInfo.access_info_define_by_params(
                                                    self.tag, self.params)
 
+        self.data_file = self.external_data_file_defined_by_params(
+            params, root_dir, tag)
+
+    @classmethod
+    def external_data_file_defined_by_params(cls, params, root_dir, tag):
+        """Link image to an external data file."""
+        enable_data_file = params.get("enable_data_file", "no") == "yes"
+        image_format = params.get("image_format", "qcow2")
+        if not enable_data_file:
+            return
+        if image_format != "qcow2":
+            raise ValueError("The %s format does not support external "
+                             "data file" % image_format)
+        image_size = params["image_size"]
+        base_name = os.path.basename(params["image_name"])
+        data_file_path = params.get("image_data_file_path",
+                                    os.path.join(root_dir, "images",
+                                                 "%s.data_file"
+                                                 % base_name))
+        data_file_params = utils_params.Params(
+            {"image_name": data_file_path,
+             "image_format": "raw",
+             "image_size": image_size,
+             "image_raw_device": "yes"})
+        return cls(data_file_params, root_dir, "%s_data_file" % tag)
+
     def check_option(self, option):
         """
         Check if object has the option required.
@@ -777,6 +804,11 @@ class QemuImg(object):
             for src, dst in bk_set:
                 self.copy_data_file(src, dst)
 
+        # backup external data file
+        if self.data_file:
+            self.data_file.backup_image(self.data_file.params, root_dir,
+                                        action, good, skip_existing)
+
         for src, dst in backup_set:
             if action == 'backup' and skip_existing and os.path.exists(dst):
                 logging.debug("Image backup %s already exists, skipping...",
@@ -788,6 +820,10 @@ class QemuImg(object):
         """
         Remove backup image
         """
+        # remove external data file backup
+        if self.data_file:
+            self.data_file.rm_backup_image()
+
         backup_dir = utils_misc.get_path(self.root_dir,
                                          self.params.get("backup_dir", ""))
         image_name = os.path.join(backup_dir, "%s.backup" %


### PR DESCRIPTION
Add support for qcow2 external data file.
New parameters:

`enable_data_file`: works when `image_format` is qcow2, will create
external data file(`root_dir/images/{image}.data_file` or specified by
`image_data_file_path`).

`image_data_file_path`: optional, used to specify the path to external
data file.

`image_data_file_raw`: if the data file is kept as a raw file.

id: 1828649
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>
