### PR TITLE
env_process: Fix 'VM' object has no attribute 'devices'

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -620,7 +620,8 @@ def postprocess_vm(test, params, env, name):
             vm.undefine(options=params.get('kill_vm_libvirt_options'))
 
     if vm.is_dead():
-        vm.devices.cleanup_daemons()
+        if params.get('vm_type') == 'qemu':
+            vm.devices.cleanup_daemons()
 
     if params.get("enable_strace") == "yes":
         strace = test_setup.StraceQemu(test, params, env)


### PR DESCRIPTION
Fix 'VM' object has no attribute 'devices' for libvirt type
during cleaning up daemons.

Signed-off-by: Yongxue Hong <yhong@redhat.com>