### PR TITLE
Extract guest agent state

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2938,6 +2938,15 @@ class VM(virt_vm.BaseVM):
         self.install_package('pm-utils', ignore_status=True, timeout=15)
         self.install_package('qemu-guest-agent')
 
+        self.set_state_guest_agent(start)
+
+    def set_state_guest_agent(self, start):
+        """
+        Starts or stops the guest agent in guest.
+
+        :param start: Start (True) or stop (False) the agent
+        """
+
         session = self.wait_for_login()
 
         def _is_ga_running():


### PR DESCRIPTION
In order to allow for setting guest agent state without
re-installing package, extract method safely.

Legacy behavior is left unchanged.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>