### PR TITLE
Hotfix for the RuntimeError during Postprocess

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -621,7 +621,8 @@ def postprocess_vm(test, params, env, name):
 
     if vm.is_dead():
         if params.get('vm_type') == 'qemu':
-            vm.devices.cleanup_daemons()
+            if vm.devices is not None:
+                vm.devices.cleanup_daemons()
 
     if params.get("enable_strace") == "yes":
         strace = test_setup.StraceQemu(test, params, env)


### PR DESCRIPTION
The following failure could be emitted during `Postprocess`:

  RuntimeError: Failures occurred while postprocess:

  Postprocess: 'NoneType' object has no attribute 'cleanup_daemons'

it is introduced by commit 0148461, and because a qemu VM instance are
being `postprocess` without called `create` at its lifetime.

Signed-off-by: Xu Han <xuhan@redhat.com>