### PR TITLE
Fix the issue of duplicated adding panic device

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2078,7 +2078,7 @@ def add_panic_device(vm_name, model='isa', addr_type='isa', addr_iobase='0x505')
     """
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     panic_dev = vmxml.xmltreefile.find('devices/panic')
-    if panic_dev:
+    if panic_dev is not None:
         logging.info("Panic device already exists")
         return False
     else:


### PR DESCRIPTION
The original assertion is not correct, we must compare search result
with 'None' to confirm if there is already a panic device in vm xml.

Signed-off-by: haizhao <haizhao@redhat.com>