### PR TITLE
Add another command to check pci devices of linux guest

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -594,7 +594,7 @@ class LinuxVMCheck(VMCheck):
         """
         Get vm pci list.
         """
-        cmd_list = ['lspci', 'lshw']
+        cmd_list = ['lspci', 'lshw', 'hwinfo']
         return self.run_cmd(cmd_list)[1]
 
     def get_vm_rc_local(self):


### PR DESCRIPTION
SLES15SP1 guest which is installed minimal OS doesn't support
'lspci' and 'lshw' command, so add command 'hwinfo' to
check the pci devices of guest.

Signed-off-by: mxie91 <mxie@redhat.com>