### PR TITLE
Add correct parent bus for 'pci-serial' device

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2288,6 +2288,10 @@ class DevContainer(object):
                                  {"id": serial_id},
                                  parent_bus={'busid': bus}))
             devices[-1].set_param('name', serial_name)
+        elif serial_type == 'pci-serial':  # generate pci serial device with pci bus
+            devices.append(qdevices.QDevice(serial_type,
+                                            {"id": serial_id},
+                                            parent_bus=bus))
         else:  # none virtio type, generate serial device directly
             devices.append(qdevices.QDevice(serial_type, {"id": serial_id}))
             devices[-1].set_param("reg", reg)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1777,6 +1777,9 @@ class VM(virt_vm.BaseVM):
                 serial_name = prefix + str(len(self.virtio_ports))\
                     if prefix else serial
                 serial_params['serial_name'] = serial_name
+            if serial_params['serial_type'] == 'pci-serial':
+                serial_params['serial_bus'] = self._get_pci_bus(serial_params,
+                                                                'serial', False)
             serial_devices = devices.serials_define_by_params(
                 serial, serial_params, serial_filename)
 


### PR DESCRIPTION
With machine type pc, the parant bus is pci.
With machine type q35, the parent bus is pci-bridge.

id: 1818721
Signed-off-by: Yanan Fu <yfu@redhat.com>