### PR TITLE
Plug all pci-* serial devices into pci bus

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2288,7 +2288,8 @@ class DevContainer(object):
                                  {"id": serial_id},
                                  parent_bus={'busid': bus}))
             devices[-1].set_param('name', serial_name)
-        elif serial_type == 'pci-serial':  # generate pci serial device with pci bus
+        elif serial_type.startswith('pci'):
+            # plug pci* serial device into pci bus
             devices.append(qdevices.QDevice(serial_type,
                                             {"id": serial_id},
                                             parent_bus=bus))

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1777,7 +1777,7 @@ class VM(virt_vm.BaseVM):
                 serial_name = prefix + str(len(self.virtio_ports))\
                     if prefix else serial
                 serial_params['serial_name'] = serial_name
-            if serial_params['serial_type'] == 'pci-serial':
+            if serial_params['serial_type'].startswith('pci'):
                 serial_params['serial_bus'] = self._get_pci_bus(serial_params,
                                                                 'serial', False)
             serial_devices = devices.serials_define_by_params(


### PR DESCRIPTION
Small tweak to the merged https://github.com/avocado-framework/avocado-vt/pull/2566 to incorporate https://github.com/avocado-framework/avocado-vt/pull/2497

There are more than just pci-serial devices, but names of all of them
starts with "pci*". Let's treat them the same way by using startswith.