### PR TITLE
cpu: do not check cpu flag 'mpx' when determine cpu model

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -872,8 +872,8 @@ def get_host_cpu_models():
                                       "gfni,vaes,vpclmulqdq,avx512_vnni"),
                    "Cascadelake-Server": ("avx512f,avx512dq,avx512bw,avx512cd,"
                                           "avx512vl,clflushopt,avx512_vnni"),
-                   "Skylake-Server": "mpx,avx512f,clwb,xgetbv1,pcid",
-                   "Skylake-Client": "mpx,xgetbv1,pcid",
+                   "Skylake-Server": "avx512f,clwb,xgetbv1,pcid",
+                   "Skylake-Client": "xgetbv1,pcid",
                    "Broadwell": "adx,rdseed,3dnowprefetch,hle",
                    "Broadwell-noTSX": "adx,rdseed,3dnowprefetch",
                    "Haswell": "fma,avx2,movbe,hle",


### PR DESCRIPTION
According to bz 1661030, MPX support was removed from 8.0 machine
types. In order to get suitable cpu modle when run test with either
bare mental or VM, do not check this flag anymore

id: 1841486
Signed-off-by: Yanan Fu <yfu@redhat.com>