### PR TITLE
Fix wrong spell issue in cmd_run function of v2v

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1244,7 +1244,7 @@ def cmd_run(cmd, obj_be_cleaned=None, auto_clean=True, timeout=18000):
                 for obj in obj_be_cleaned:
                     obj.cleanup()
             else:
-                obj.cleanup()
+                obj_be_cleaned.cleanup()
 
     return cmd_result
 


### PR DESCRIPTION
A spell error caused undefine vaiant was used in cmd_run

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>