### PR TITLE
Add a helper function to parse testlist

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1188,6 +1188,28 @@ class AvocadoGuest(object):
             self.session.cmd("rm -rf %s" % self.test_path, timeout=self.timeout)
 
 
+def get_avocadotestlist(params):
+    """
+    Helper function to parse the params for avocado guest tests
+    and build a testlist to be used by run_avocado{_bg}()
+    :param params:  Test params
+    :return: list of tests used for run_avocado{_bg}()
+    """
+    testlist = []
+    avocadotest = params.get("avocadotest", "")
+    if not avocadotest:
+        return testlist
+    avocadomux = params.get("avocadomux", "")
+    for index, item in enumerate(avocadotest.split(',')):
+        try:
+            mux = ''
+            mux = avocadomux.split(',')[index]
+        except IndexError:
+            pass
+        testlist.append((item, mux))
+    return testlist
+
+
 def run_autotest(vm, session, control_path, timeout,
                  outputdir, params, copy_only=False, control_args=None,
                  ignore_session_terminated=False, boottool_update=False):


### PR DESCRIPTION
Add a helper function to parse testlist
for avocado guest tests, commit bb8c86acc
removed the parsing of testlist by run_avocado_bg()
method and expects user to pass by value,
due to which tests using it in mutiple places
silently skipping test run, lets have helper
function added to parse the testlist, still
the tests using run_avocado_bg() needs a change
and this API will help avoid code duplication
on muliple places.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>