### PR TITLE
Fixup: run_avocado method does not take arguments

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -2028,7 +2028,7 @@ def run_avocado_bg(vm, params, test, testlist=[], avocado_vt=False,
                                    avocado_vt=avocado_vt, reinstall=True,
                                    add_args=avocado_testargs,
                                    ignore_result=ignore_status)
-        bt = BackgroundTest(avocado_obj.run_avocado, params)
+        bt = BackgroundTest(avocado_obj.run_avocado, ())
         bt.start()
         return bt
     except Exception as info:


### PR DESCRIPTION
run_avocado method does not take arguments but
passed while calling from run_avocado_bg,
let's fix it.

Without this fix we will see below error
```
   File "/usr/local/lib/python3.6/site-packages/avocado_framework_plugin_vt-79.0-py3.6.egg/virttest/utils_test/__init__.py", line 1991, in join
     raise self.exception
   File "/usr/local/lib/python3.6/site-packages/avocado_framework_plugin_vt-79.0-py3.6.egg/virttest/utils_test/__init__.py", line 1974, in launch
     func(*params, **kwargs)
 TypeError: manage_session() takes 1 positional argument but 223 were given
```
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>