### PR TITLE
Add TPM device support to virt-install cmdline

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -820,5 +820,18 @@ qemu_stop = on
 # nvdimm_uuid = urn:uuid:ea0ec480-6066-40bc-9709-65d0467ad024
 nvdimm_uuid = ""
 
+
+# Set below params to attach TPM device to
+# guest xml
+# tpm_device_path takes the TPM device path in host
+# tpm_model takes model of TPM device to added
+# E:g models:- tpm-tis, tpm-crb, tpm-spapr etc
+# tpm_type takes type of device add either
+# passthrough or emulator
+#
+# tpm_device_path = "/dev/tpm0"
+# tpm_model = "tpm-spapr"
+# tpm_type = "passthrough"
+
 # Add extra params for dimm devices
 #dimm_extra_params = "label-size=128k slot=1"


### PR DESCRIPTION
this patchs adds support to add TPM device
to libvirt guest xml via virt-install using
user params.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>