### PR TITLE
Reuse the unified image directory upon vm image creation

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2183,7 +2183,8 @@ class DevContainer(object):
         image_access = storage.ImageAccessInfo.access_info_define_by_params(
                                                          name, image_params)
 
-        image_filename = storage.get_image_filename(image_params, data_root)
+        image_base_dir = image_params.get("images_base_dir", data_root)
+        image_filename = storage.get_image_filename(image_params, image_base_dir)
         imgfmt = image_params.get("image_format")
         if (Flags.BLOCKDEV in self.caps and
                 image_params.get("image_snapshot") == "yes"):

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2238,7 +2238,7 @@ class VM(virt_vm.BaseVM):
             if not os.path.exists(params['ovmf_path']):
                 raise exceptions.TestError("The OVMF path is not exist. Maybe you"
                                            " need to install related packages.")
-            current_data_dir = data_dir.get_data_dir()
+            current_data_dir = params.get("images_base_dir", data_dir.get_data_dir())
             ovmf_code_filename = params["ovmf_code_filename"]
             ovmf_code_path = os.path.join(params['ovmf_path'],
                                           ovmf_code_filename)


### PR DESCRIPTION
The base image directory parameter was ignored in some cases of image
creation where it should override the default path for this.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>