### PR TITLE
env_process: Handle the kvm_probe module together

### DIFF
--- a/virttest/arch.py
+++ b/virttest/arch.py
@@ -89,4 +89,9 @@ def get_kvm_module_list():
         host_cpu_type = cpu.get_cpu_vendor_name()
         return ["kvm", "kvm-%s" % host_cpu_type]
     elif ARCH in ('ppc64', 'ppc64le'):
+        # FIXME: Please correct it if anyone still want to use KVM-PR mode
+        return ["kvm", "kvm-hv"]
+    elif ARCH in ('s390', 's390x'):
         return ["kvm"]
+    elif ARCH == "aarch64":
+        return []


### PR DESCRIPTION
1. arch.get_kvm_module_list: Update kvm module list for powerpc and s390
2. Add support to handle the kvm_probe module.
3. Improve "reload_module" and "restore" methods which provided by
utils_kernel_module, now they will unload the module and those used by
this one.

ID: 1836116, 1836123
Signed-off-by: Yihuang Yu <yihyu@redhat.com>