### PR TITLE
qcontainer: Fix fail to allocate iothread for mulitple scsi hbas

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1672,12 +1672,12 @@ class DevContainer(object):
                                                child_bus=qbus(busid=bus_name))
                     if iothread:
                         try:
-                            iothread = self.allocate_iothread(iothread, dev)
+                            _iothread = self.allocate_iothread(iothread, dev)
                         except TypeError:
                             pass
                         else:
-                            if iothread and iothread not in self:
-                                devices.append(iothread)
+                            if _iothread and _iothread not in self:
+                                devices.append(_iothread)
                     devices.append(dev)
                 bus = _hba % bus
             if qbus == qdevices.QAHCIBus and unit is not None:


### PR DESCRIPTION
The alllocated iothread object will be passed in the self.allocate_iothread
again in the second iteration which will raise ValueError("Not support
request specific iothread") when applying multiple scsi hbas. Change the
variable to differentitate the params "image_iothread" and the allocated
iothread object.

ID: 1844337
Signed-off-by: Yongxue Hong <yhong@redhat.com>