### PR TITLE
qemu_monitor:  Reassign timeout default for _acquire_lock

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -366,7 +366,9 @@ class Monitor(object):
             pass
         self._socket.close()
 
-    def _acquire_lock(self, timeout=ACQUIRE_LOCK_TIMEOUT, lock=None):
+    def _acquire_lock(self, timeout=None, lock=None):
+        if timeout is None:
+            timeout = self.ACQUIRE_LOCK_TIMEOUT
         end_time = time.time() + timeout
         if not lock:
             lock = self._lock


### PR DESCRIPTION
The original timeout default maybe short in some scenarios where
send multiple commands with just one qmp monitor in parallel then
the timeout for acquiring lock need more time, so reassign timeout
default with instance attribute so that it could be modified in
the case level.

ID: 1844782
Signed-off-by: Yongxue Hong <yhong@redhat.com>