### PR TITLE
Fix VM cleanup issue when vm.start fails

### DIFF
--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -176,6 +176,8 @@ class VMManager(virt_vm.BaseVM):
         """
         Return MAC address of a VM.
         """
+        if not self.instance:
+            self.update_instance()
         vnet_list = self.instance.nics_service().list()
         if net_name != '*':
             vnet_list = [vnet for vnet in vnet_list if vnet.name == net_name]
@@ -377,7 +379,9 @@ class VMManager(virt_vm.BaseVM):
         :param export_name: Export domain name.
         :param storage_name: Storage domain name.
         :param cluster_name: Cluster name.
+        :param timeout: timeout value
         """
+        begin_time = time.time()
         end_time = time.time() + timeout
         vm = self.lookup_by_storagedomains(export_name)
         sds_service = self.connection.system_service().storage_domains_service()
@@ -403,7 +407,8 @@ class VMManager(virt_vm.BaseVM):
             time.sleep(1)
         if not vm_down:
             raise WaitVMStateTimeoutError("DOWN", self.state())
-        logging.info('Import %s successfully', self.name)
+        logging.info('Import %s successfully(time lapse %ds)',
+                     self.name, time.time() - begin_time)
 
     def export_from_export_domain(self, export_name, timeout=300):
         """

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1181,11 +1181,11 @@ def v2v_cmd(params, auto_clean=True, cmd_only=False):
         vpx_dc = None
     uri = uri_obj.get_uri(hostname, vpx_dc, esxi_host)
 
-    # Pre-process for v2v
-    _v2v_pre_cmd()
-
-    target_obj = Target(target, uri)
     try:
+        # Pre-process for v2v
+        _v2v_pre_cmd()
+
+        target_obj = Target(target, uri)
         # Return virt-v2v command line options based on 'target' and
         # 'hypervisor'
         options = target_obj.get_cmd_options(params)
@@ -1314,6 +1314,9 @@ def import_vm_to_ovirt(params, address_cache, timeout=600):
                 v2v_cmd)
     except Exception as e:
         logging.error("Start %s failed: %s", vm.name, e)
+        vm.delete()
+        if output_method != 'rhv_upload':
+            vm.delete_from_export_domain(export_name)
         return False
     return True
 


### PR DESCRIPTION
1) When vm.start fails, the vm should be deleted and image should
be removed from export domain.
2) When timeout is -1, wait forever until the VM is imported to
data domain successfully.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>