### PR TITLE
Requirements: update netaddr versions

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -6,7 +6,8 @@ inspektor==0.5.2
 autotest>=0.16.2; python_version < '3.0'
 aexpect==1.5.1
 simplejson==3.8.0
-netaddr>=0.7.18
+netaddr==0.7.19
+zipp==1.2.0; python_version < '3.0'
 netifaces>=0.10.5
 argparse==1.3.0; python_version < '2.7'
 logutils==0.3.3; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 autotest>=0.16.2; python_version < '3.0'
 aexpect>1.5.0
 simplejson>=3.5.3
-netaddr>=0.7.18
+netaddr<=0.7.19; python_version < '3.0'
+netaddr>=0.7.19
+zipp<=1.2.0; python_version < '3.0'
 netifaces>=0.10.5

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,10 @@ def pre_post_plugin_type():
 
 
 if __name__ == "__main__":
-    requirements = ["netifaces", "aexpect", "netaddr", "simplejson", "six"]
+    requirements = ["netifaces", "aexpect", "simplejson", "six"]
     if sys.version_info[:2] >= (3, 0):
         requirements.append("avocado-framework>=68.0")
+        requirements.append("netaddr")
     else:
         # Latest py2 supported stevedore is 1.10.0, need to limit it here
         # as older avocado versions were not limiting it.
@@ -91,6 +92,7 @@ if __name__ == "__main__":
         requirements.append("urllib3<=1.24.3")
         requirements.append("stevedore>=1.8.0,<=1.10.0")
         requirements.append("avocado-framework>=68.0,<70.0")
+        requirements.append("netaddr<=0.7.19")
 
     setup(name='avocado-framework-plugin-vt',
           version=VERSION,


### PR DESCRIPTION
Pinning 0.7.19 as the version for selftests (because 0.7.20 won't run
on Python 2 / EL 7), and updating to that minimum version for
installation purposes (just to keep more consistency between what's
used to test and what's used to run it).

Signed-off-by: Cleber Rosa <crosa@redhat.com>