### PR TITLE
Plugin: drop attempt to use pre 69.0 LTS interfaces

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -19,15 +19,9 @@ Avocado VT plugin
 import os
 
 from avocado.core.loader import loader
+from avocado.core.plugin_interfaces import CLI
 from avocado.core.settings import settings
 from avocado.utils import path as utils_path
-
-# Avocado's plugin interface module has changed location. Let's keep
-# compatibility with old for at, least, a new LTS release
-try:
-    from avocado.core.plugin_interfaces import CLI
-except ImportError:
-    from avocado.plugins.base import CLI    # pylint: disable=E0611,E0401
 
 from virttest import data_dir
 from virttest import defaults

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -17,13 +17,7 @@ import sys
 import logging
 
 from avocado.utils import process
-
-# Avocado's plugin interface module has changed location. Let's keep
-# compatibility with old for at, least, a new LTS release
-try:
-    from avocado.core.plugin_interfaces import CLICmd
-except ImportError:
-    from avocado.plugins.base import CLICmd
+from avocado.core.plugin_interfaces import CLICmd
 
 from virttest import bootstrap
 from virttest import defaults

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -11,20 +11,8 @@ from avocado.core.settings import settings
 from avocado.utils.process import pid_exists
 from avocado.utils.stacktrace import log_exc_info
 
-try:
-    try:
-        # JobPre has become JobPreTests on newer avocado versions
-        from avocado.core.plugin_interfaces import JobPreTests as Pre
-        # JobPost has become JobPostTests on newer avocado versions
-        from avocado.core.plugin_interfaces import JobPostTests as Post
-    # Avocado's plugin interface module has changed location. Let's keep
-    # compatibility with older for at least a new LTS release
-    except ImportError:
-        from avocado.core.plugin_interfaces import JobPre as Pre
-        from avocado.core.plugin_interfaces import JobPost as Post
-except ImportError:
-    from avocado.plugins.base import JobPre as Pre
-    from avocado.plugins.base import JobPost as Post
+from avocado.core.plugin_interfaces import JobPreTests as Pre
+from avocado.core.plugin_interfaces import JobPostTests as Post
 
 from ..test import VirtTest
 

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -21,13 +21,7 @@ import sys
 
 from avocado.core.loader import loader
 from avocado.core.settings import settings
-
-# Avocado's plugin interface module has changed location. Let's keep
-# compatibility with old for at, least, a new LTS release
-try:
-    from avocado.core.plugin_interfaces import CLI
-except ImportError:
-    from avocado.plugins.base import CLI    # pylint: disable=E0401,E0611
+from avocado.core.plugin_interfaces import CLI
 
 from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 from ..loader import VirtTestLoader


### PR DESCRIPTION
The current import logic looks for the plugin interfaces on a location
that was valid before the 69.0 LTS release.  Now, all current releases
have the interfaces at the same location, so this logic is not needed
anymore.

Signed-off-by: Cleber Rosa <crosa@redhat.com>