### PR TITLE
Add method to construct cpu xml from domcapabilities

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1899,6 +1899,24 @@ class VMCPUXML(base.LibvirtXMLBase):
             pass  # Element already doesn't exist
         self.xmltreefile.write()
 
+    @staticmethod
+    def from_domcapabilities(domcaps_xml):
+        """
+        Construct a cpu definition from domcapabilities host-model definition.
+
+        :param domcaps_xml: DomCapabilityXML with host-model definition
+        :return: None
+        """
+        cpu_xml = VMCPUXML()
+        cpu_xml['model'] = domcaps_xml.get_hostmodel_name()
+        features = domcaps_xml.get_additional_feature_list('host-model')
+        feature_names = [name for f_list in [list(d.keys()) for d in features]
+                         for name in f_list]
+        for feature_name in feature_names:
+            cpu_xml.add_feature(feature_name)
+
+        return cpu_xml
+
 
 class VMClockXML(VMXML):
 


### PR DESCRIPTION
Define a static constructor method to create a
VMCPUXML intance valid for cpu-compare.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>