### PR TITLE
Fix the error to decode the cmd result

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -2658,7 +2658,7 @@ def memtune_get(name, key):
     :param key: memory controller limit for which the value needed
     :return: the memory value of a key in Kbs
     """
-    memtune_output = memtune_list(name).stdout.strip()
+    memtune_output = memtune_list(name).stdout_text.strip()
     logging.info("memtune output is %s" % memtune_output)
     memtune_value = re.findall(r"%s\s*:\s+(\S+)" % key, str(memtune_output))
     if memtune_value:


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>
Before
```
# avocado run --vt-type libvirt virsh.memtune.positive_test.normal_1
JOB ID     : ffedfb827f8b266c79044a116c693a4fd13b76b4
JOB LOG    : /root/avocado/job-results/job-2020-06-30T22.42-ffedfb8/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_1: ERROR: invalid literal for int() with base 10: 'unlimited\\nsoft_limit' (28.08 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 29.42 s
```
After
```
# avocado run --vt-type libvirt virsh.memtune.positive_test.normal_1
JOB ID     : b1a52663c3045d473939321501b0e301164f1ac3
JOB LOG    : /root/avocado/job-results/job-2020-06-30T22.58-b1a5266/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_1: PASS (26.84 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 28.19 s
```