### PR TITLE
Fix the stdout error as compat_52lts removed

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -695,6 +695,8 @@ def command(cmd, **dargs):
                           shell=True)
         # Mark return as not coming from persistent virsh session
         ret.from_session_id = None
+        ret.stdout = ret.stdout_text
+        ret.stderr = ret.stderr_text
 
     # Always log debug info, if persistent session or not
     if debug:


### PR DESCRIPTION
Involved by commit d9acd3a3a19ff11e8a9987379379d3f332b3d1d0

Signed-off-by: Kyla Zhang <weizhan@redhat.com>