### PR TITLE
Fix some issues introduced by pr2611_lts_removal

### DIFF
--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -224,6 +224,8 @@ class LibvirtXMLBase(propcan.PropCanBase):
         if schema_name:
             command += ' %s' % schema_name
         cmdresult = process.run(command, ignore_status=True)
+        cmdresult.stdout = cmdresult.stdout_text
+        cmdresult.stderr = cmdresult.stderr_text
         return cmdresult
 
 

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -599,6 +599,8 @@ class QemuImg(storage.QemuImg):
                                        (self.image_filename, cmd_result))
         if self.encryption_config.key_secret:
             self.encryption_config.key_secret.save_to_file()
+        cmd_result.stdout = cmd_result.stdout_text
+        cmd_result.stderr = cmd_result.stderr_text
         return self.image_filename, cmd_result
 
     def convert(self, params, root_dir, cache_mode=None,

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -1346,6 +1346,8 @@ class RemoteRunner(object):
                                          (self.stderr_pipe, self.stderr_pipe))
         cmd_result = process.CmdResult(command=command, exit_status=status,
                                        stdout=output, stderr=errput)
+        cmd_result.stdout = cmd_result.stdout_text
+        cmd_result.stderr = cmd_result.stderr_text
         if status and (not ignore_status):
             raise process.CmdError(command, cmd_result)
         return cmd_result

--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -81,6 +81,8 @@ def lgf_command(cmd, ignore_status=True, debug=False, timeout=60):
         logging.debug("stderr: %s", ret.stderr_text.strip())
 
     # Return CmdResult instance when ignore_status is True
+    ret.stdout = ret.stdout_text
+    ret.stderr = ret.stderr_text
     return ret
 
 
@@ -353,6 +355,8 @@ class GuestfishRemote(object):
         exit_status, stdout = self.cmd_status_output(cmd)
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
+        result.stdout = result.stdout_text
+        result.stderr = result.stderr_text
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Guestfish Command returned non-zero exit status")
@@ -363,6 +367,8 @@ class GuestfishRemote(object):
         exit_status, stdout = self.cmd_status_output(cmd)
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
+        result.stdout = result.stdout_text
+        result.stderr = result.stderr_text
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Guestfish Command returned non-zero exit status")

--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -446,6 +446,8 @@ def del_defcon(context_type, pathregex, selinux_force=False):
 
     cmd = ("semanage fcontext --delete -t %s '%s'" % (context_type, pathregex))
     result = process.run(cmd, ignore_status=True)
+    result.stdout = result.stdout_text
+    result.stderr = result.stderr_text
     _no_semanage(result)
     if result.exit_status != 0:
         raise SeCmdError(cmd, result.stderr_text)

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1224,7 +1224,8 @@ def v2v_cmd(params, auto_clean=True, cmd_only=False):
 
     if cmd_only:
         return cmd
-
+    cmd_result.stdout = cmd_result.stdout_text
+    cmd_result.stderr = cmd_result.stderr_text
     return cmd_result
 
 

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -229,6 +229,8 @@ class VirshSession(aexpect.ShellSession):
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
 
+        result.stdout = result.stdout_text
+        result.stderr = result.stderr_text
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Virsh Command returned non-zero exit status")

--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -227,6 +227,8 @@ class VirtadminSession(aexpect.ShellSession):
         exit_status, stdout = self.cmd_status_output(cmd, timeout=timeout)
         stderr = ''  # no way to retrieve this separately
         result = process.CmdResult(cmd, stdout, stderr, exit_status)
+        result.stdout = result.stdout_text
+        result.stderr = result.stderr_text
         if not ignore_status and exit_status:
             raise process.CmdError(cmd, result,
                                    "Virtadmin Command returned non-zero exit status")


### PR DESCRIPTION
During lts removal,below command lines were removed in some python files:
        ret.stdout = results_stdout_52lts(ret)
        ret.stderr = results_stderr_52lts(ret)
During testing, finding that leads to some unanticipated results, for example virsh.cmd_result can not
return correct value.
As one solution, those similar command logic are added back.

Signed-off-by: chunfuwen <chwen@redhat.com>