### PR TITLE
Fix error of replacing exit_status with stdout

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -203,7 +203,7 @@ def get_vcpucount_details(vm, options):
 
     result = virsh.vcpucount(vm.name, options, ignore_status=True,
                              debug=True)
-    if result.stdout_text:
+    if result.exit_status:
         logging.debug("vcpu count command failed")
         return (result, vcpucount_details)
 


### PR DESCRIPTION
The replacements of removing 52lts bring in this error. According
to context, it should be exit_status, not stdout_text.

Signed-off-by: haizhao <haizhao@redhat.com>