### PR TITLE
Update ovirt vm instance before cleaning up

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -473,6 +473,10 @@ class VMCheck(object):
             self.session.close()
             self.session = None
 
+        # If VMChecker is instantiated before import_vm_to_ovirt and
+        # the VMChecker.run is skiped, self.vm.instance will be NULL.
+        # The update_instance should be ran before cleaning up.
+        self.vm.update_instance()
         if self.vm.instance and self.vm.is_alive():
             self.vm.destroy(gracefully=False)
             time.sleep(5)


### PR DESCRIPTION
Because VMCheck can be instantiated before import_vm_to_ovirt function,
the ovirt vm instance may still be NULL. It should be updated before
cleanup.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>