### PR TITLE
Fix update_instance and vm start timeout issue

### DIFF
--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -247,6 +247,7 @@ class VMManager(virt_vm.BaseVM):
                     else:
                         break
                 elif self.state() == types.VmStatus.UP:
+                    vm_up = True
                     break
                 time.sleep(1)
             if not vm_powering_up and not vm_up:

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -476,7 +476,8 @@ class VMCheck(object):
         # If VMChecker is instantiated before import_vm_to_ovirt and
         # the VMChecker.run is skiped, self.vm.instance will be NULL.
         # The update_instance should be ran before cleaning up.
-        self.vm.update_instance()
+        if hasattr(self.vm, 'update_instance'):
+            self.vm.update_instance()
         if self.vm.instance and self.vm.is_alive():
             self.vm.destroy(gracefully=False)
             time.sleep(5)


### PR DESCRIPTION
1) Fix not found update_instance issue
2) Fix incorrect waiting vm startup timeout issue
2020-07-03 06:20:44,055 ovirt            L0208 INFO | VM Auto-esx6.7-rhel7.5-sr04Nl status is <Down>
2020-07-03 06:20:44,056 ovirt            L0235 INFO | Starting VM Auto-esx6.7-rhel7.5-sr04Nl
2020-07-03 06:21:50,110 utils_v2v        L1320 ERROR| Start Auto-esx6.7-rhel7.5-sr04Nl failed: Timeout expired when waiting for VM to START, actual state is: up
2020-07-03 06:21:50,202 ovirt            L0335 INFO | Delete VM Auto-esx6.7-rhel7.5-sr04Nl

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>