### PR TITLE
Fix polkit configuration issue in split daemon job

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -37,6 +37,8 @@ from virttest import storage
 from virttest import utils_libguestfs
 from virttest import qemu_storage
 from virttest import utils_libvirtd
+from virttest import libvirtd_decorator
+from virttest import libvirt_version as libvirtd_ver
 from virttest import remote
 from virttest import data_dir
 from virttest import utils_net
@@ -1285,6 +1287,9 @@ def preprocess(test, params, env):
         # work on connect_uri as default behavior.
         os.environ['LIBVIRT_DEFAULT_URI'] = connect_uri
         if params.get("setup_libvirt_polkit") == "yes":
+            if (libvirtd_ver.version_compare(5, 6, 0) and
+               libvirtd_decorator.get_libvirtd_split_enable_bit()):
+                params.update({"conf_path": "/etc/libvirt/virtqemud.conf"})
             pol = test_setup.LibvirtPolkitConfig(params)
             try:
                 pol.setup()
@@ -1295,7 +1300,7 @@ def preprocess(test, params, env):
             except Exception as e:
                 logging.error("Unexpected error: '%s'" % str(e))
             if libvirtd_inst is None:
-                libvirtd_inst = utils_libvirtd.Libvirtd()
+                libvirtd_inst = utils_libvirtd.Libvirtd("virtqemud")
             libvirtd_inst.restart()
 
     # Execute any pre_commands

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -1876,8 +1876,8 @@ class LibvirtPolkitConfig(object):
         """
         :param params: Dict like object containing parameters for the test.
         """
-        self.libvirtd_path = "/etc/libvirt/libvirtd.conf"
-        self.libvirtd_backup_path = "/etc/libvirt/libvirtd.conf.virttest.backup"
+        self.conf_path = params.get("conf_path", "/etc/libvirt/libvirtd.conf")
+        self.conf_backup_path = self.conf_path + ".virttest.backup"
         self.polkit_rules_path = "/etc/polkit-1/rules.d/"
         self.polkit_rules_path += "500-libvirt-acl-virttest.rules"
         self.polkit_name = "polkit"
@@ -1946,22 +1946,22 @@ class LibvirtPolkitConfig(object):
         Config libvirtd
         """
         # Backup libvirtd.conf
-        shutil.copy(self.libvirtd_path, self.libvirtd_backup_path)
+        shutil.copy(self.conf_path, self.conf_backup_path)
 
         # Set the API access control scheme
         access_str = "access_drivers = [ \"polkit\" ]"
         access_pat = "^ *access_drivers"
-        self.file_replace_append(self.libvirtd_path, access_pat, access_str)
+        self.file_replace_append(self.conf_path, access_pat, access_str)
 
         # Set UNIX socket access controls
         sock_rw_str = "unix_sock_rw_perms = \"0777\""
         sock_rw_pat = "^ *unix_sock_rw_perms"
-        self.file_replace_append(self.libvirtd_path, sock_rw_pat, sock_rw_str)
+        self.file_replace_append(self.conf_path, sock_rw_pat, sock_rw_str)
 
         # Set authentication mechanism
         auth_unix_str = "auth_unix_rw = \"none\""
         auth_unix_pat = "^ *auth_unix_rw"
-        self.file_replace_append(self.libvirtd_path, auth_unix_pat,
+        self.file_replace_append(self.conf_path, auth_unix_pat,
                                  auth_unix_str)
 
     def _set_polkit_conf(self):
@@ -2079,8 +2079,8 @@ class LibvirtPolkitConfig(object):
         try:
             if os.path.exists(self.polkit_rules_path):
                 os.unlink(self.polkit_rules_path)
-            if os.path.exists(self.libvirtd_backup_path):
-                os.rename(self.libvirtd_backup_path, self.libvirtd_path)
+            if os.path.exists(self.conf_backup_path):
+                os.rename(self.conf_backup_path, self.conf_path)
             if self.user.count('EXAMPLE'):
                 self.user = 'testacl'
             if self.params.get('add_polkit_user'):


### PR DESCRIPTION
In split daemon environment, it needs to modify polkit related
settings in virtqemud.conf.

depends on https://github.com/avocado-framework/avocado-vt/pull/2646
Signed-off-by: Yingshun Cui <yicui@redhat.com>