### PR TITLE
libvirt check: delay the actual check until/if needed

### DIFF
--- a/virttest/libvirtd_decorator.py
+++ b/virttest/libvirtd_decorator.py
@@ -85,8 +85,17 @@ def get_libvirt_version_compare(major, minor, update, session=None):
     return False
 
 
-LIBVIRTD_SPLIT_ENABLE_BIT = get_libvirtd_split_enable_bit()
-IS_LIBVIRTD_SPLIT_VERSION = get_libvirt_version_compare(5, 6, 0)
+LIBVIRTD_SPLIT_ENABLE_BIT = None
+IS_LIBVIRTD_SPLIT_VERSION = None
+
+
+def check_libvirt_version():
+    global LIBVIRTD_SPLIT_ENABLE_BIT
+    global IS_LIBVIRTD_SPLIT_VERSION
+    if LIBVIRTD_SPLIT_ENABLE_BIT is None:
+        LIBVIRTD_SPLIT_ENABLE_BIT = get_libvirtd_split_enable_bit()
+    if IS_LIBVIRTD_SPLIT_VERSION is None:
+        IS_LIBVIRTD_SPLIT_VERSION = get_libvirt_version_compare(5, 6, 0)
 
 
 def libvirt_version_context_aware_libvirtd_legacy(fn):
@@ -102,6 +111,7 @@ def libvirt_version_context_aware_libvirtd_legacy(fn):
         :param args: function fixed args.
         :param kwargs: function varied args.
         """
+        check_libvirt_version()
         if not IS_LIBVIRTD_SPLIT_VERSION or not LIBVIRTD_SPLIT_ENABLE_BIT:
             logging.warn("legacy start libvirtd daemon NORMALLY with function name: %s" % fn.__name__)
             return fn(*args, **kwargs)
@@ -124,6 +134,7 @@ def libvirt_version_context_aware_libvirtd_split(fn):
         :param args: function fixed args.
         :param kwargs: function varied args.
         """
+        check_libvirt_version()
         if IS_LIBVIRTD_SPLIT_VERSION and LIBVIRTD_SPLIT_ENABLE_BIT:
             logging.warn("Split start libvirtd daemon NORMALLY with function name: %s" % fn.__name__)
             return fn(*args, **kwargs)


### PR DESCRIPTION
The way the current check for the libvirt version is done, at the
module level, means that the code will called even if Avocado-VT
is never used or the check is never needed.  For instance, running
an Avocado job with a simple "passtest.py" results in:

   $ ./examples/jobs/passjob_html.py
   WARNING:root:libvirtd -V
   WARNING:root:libvirt version value by libvirtd or virtqemud command: ['libvirtd (libvirt) 5.6.0']
   JOB ID     : 1d7dfcb1e047acee1abc8cf656cb91f9f7463bd1
   JOB LOG    : /home/cleber/avocado/job-results/job-2020-07-06T09.57-1d7dfcb/job.log
    (1/1) examples/tests/passtest.py:PassTest.test: PASS (0.00 s)
   RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : /home/cleber/avocado/job-results/job-2020-07-06T09.57-1d7dfcb/results.html

With this change, it will only be executed (once) if needed.

Signed-off-by: Cleber Rosa <crosa@redhat.com>