### PR TITLE
Make JobLock plugin compatible with latest Avocado's test suite

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -115,8 +115,12 @@ class VTJobLock(Pre, Post):
     def pre_tests(self, job):
         try:
             if job.test_suite is not None:
+                if hasattr(job.test_suite, 'tests'):
+                    tests = job.test_suite.tests
+                else:
+                    tests = job.test_suite
                 if any(test_factory[0] is VirtTest
-                       for test_factory in job.test_suite):
+                       for test_factory in tests):
                     self._lock(job)
         except Exception as detail:
             msg = "Failure trying to set Avocado-VT job lock: %s" % detail


### PR DESCRIPTION
Which got converted from a list into its own class, which contains
a property with the actual list of tests.

Reference: https://github.com/avocado-framework/avocado/pull/3980
Signed-off-by: Cleber Rosa <crosa@redhat.com>