### PR TITLE
Add a class for libvirtd/virtdproxy tls and tcp

### DIFF
--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -330,7 +330,7 @@ def systemd_command_generator(command):
         command = "status"
 
     def method(service_name):
-        return [command_name, command, "%s.service" % service_name]
+        return [command_name, command, service_name]
     return method
 
 


### PR DESCRIPTION
Since libvirt 5.6.0, there are 3 genres of running libvirtd
daemons - traditional, monolith, modular daemons. This PR updates
Libvirtd() to handle all of these 3 types and adds DaemonSocket()
to manage tls/tcp sockets.


Signed-off-by: Yingshun Cui <yicui@redhat.com>