### PR TITLE
Requirements: Fix netaddr version conflict on python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ autotest>=0.16.2; python_version < '3.0'
 aexpect>1.5.0
 simplejson>=3.5.3
 netaddr<=0.7.19; python_version < '3.0'
-netaddr>=0.7.19
+netaddr>=0.7.19; python_version >= '3.0'
 zipp<=1.2.0; python_version < '3.0'
 netifaces>=0.10.5


### PR DESCRIPTION
Limit the pthon version of "netaddr>=0.7.19" to 3, otherwise installing
requirements.txt via python2 will fail.

log:
```
$ pip2 install -r ./requirements.txt 
Double requirement given: netaddr>=0.7.19 (from -r ./requirements.txt (line 5)) (already in netaddr<=0.7.19 (from -r ./requirements.txt (line 4)), name='netaddr')
```

Signed-off-by: Yihuang Yu <yihyu@redhat.com>