### PR TITLE
Add a fucntion to save the xml from checkpoint-dumpxml

### DIFF
--- a/virttest/libvirt_xml/checkpoint_xml.py
+++ b/virttest/libvirt_xml/checkpoint_xml.py
@@ -57,3 +57,20 @@ class CheckpointXML(base.LibvirtXMLBase):
         if tag != 'disk':
             return None
         return dict(attr_dict)
+
+    @staticmethod
+    def new_from_checkpoint_dumpxml(name, checkpoint_name, options="",
+                                    virsh_instance=base.virsh):
+        """
+        Return new CheckpointXML instance from virsh checkpoint-dumpxml cmd
+
+        :param name: vm's name
+        :param checkpoint_name: checkpoint name
+        :param options: options passed to checkpoint-dumpxml
+        :param virsh_instance: virsh module or instance to use
+        :return: New initialized CheckpointXML instance
+        """
+        checkpoint_xml = CheckpointXML(virsh_instance=virsh_instance)
+        result = virsh_instance.checkpoint_dumpxml(name, checkpoint_name, options)
+        checkpoint_xml['xml'] = result.stdout_text.strip()
+        return checkpoint_xml


### PR DESCRIPTION
Uplayer product will frequently use 'checkpoint-dumpxml' and
'checkpoint-create --redefine' to redefine checkpoint, so we'll
need to test this. Add this function for convenience.

Signed-off-by: Yi Sun <yisun@redhat.com>