### PR TITLE
Support add extra params for pcie-root-port

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -169,6 +169,10 @@ serial_type = "isa-serial"
 # qemu-kvm -M ?
 # machine_type = pc
 
+# Add extra parameter for pcie-root-port. It's a global parameter for all
+# pcie-root-port except the one at slot 0. It works with 'pcie_extra_root_port'
+# too, multiple parameters connect with ','
+# pcie_root_port_params = "hotplug=off,vvv=vvv"
 
 
 ##### Low-level parameters for platform, networking, block, and usb devices.

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -995,6 +995,7 @@ class DevContainer(object):
             pci_bridge_type = 'pcie-pci-bridge'
         else:
             pci_bridge_type = 'pci-bridge'
+        pcie_root_port_params = params.get('pcie_root_port_params')
 
         def machine_q35(cmd=False):
             """
@@ -1005,7 +1006,8 @@ class DevContainer(object):
             logging.warn('Using Q35 machine which is not yet fully tested on '
                          'avocado-vt. False errors might occur.')
             devices = []
-            bus = (qdevices.QPCIEBus('pcie.0', 'PCIE', root_port_type, 'pci.0'),
+            bus = (qdevices.QPCIEBus('pcie.0', 'PCIE', root_port_type,
+                                     'pci.0', pcie_root_port_params),
                    qdevices.QStrictCustomBus(None, [['chassis'], [256]], '_PCI_CHASSIS',
                                              first_port=[1]),
                    qdevices.QStrictCustomBus(None, [['chassis_nr'], [256]],
@@ -1239,7 +1241,8 @@ class DevContainer(object):
             devices.append(qdevices.QStringDevice('AAVMF_VARS',
                                                   cmdline=aavmf_vars))
 
-            bus = (qdevices.QPCIEBus('pcie.0', 'PCIE', root_port_type, 'pci.0'),
+            bus = (qdevices.QPCIEBus('pcie.0', 'PCIE', root_port_type,
+                                     'pci.0', pcie_root_port_params),
                    qdevices.QStrictCustomBus(None, [['chassis'], [256]],
                                              '_PCI_CHASSIS', first_port=[1]),
                    qdevices.QStrictCustomBus(None, [['chassis_nr'], [256]],

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -2368,16 +2368,19 @@ class QPCIEBus(QPCIBus):
     device by default.)
     """
 
-    def __init__(self, busid, bus_type, root_port_type, aobject=None):
+    def __init__(self, busid, bus_type, root_port_type,
+                 aobject=None, root_port_params=None):
         """
         :param busid: id of the bus (pcie.0)
         :param bus_type: type of the bus (PCIE)
-        :param aobject: Related autotest object (pci.0)
         :param root_port_type: root port type
+        :param aobject: Related autotest object (pci.0)
+        :param root_port_params: root port params
         """
         super(QPCIEBus, self).__init__(busid, bus_type, aobject)
         self.__root_ports = {}
         self.__root_port_type = root_port_type
+        self.__root_port_params = root_port_params
         self.__last_port_index = [0]
 
     def is_direct_plug(self, device):
@@ -2410,32 +2413,34 @@ class QPCIEBus(QPCIBus):
             pass
         return None
 
-    def add_root_port(self, root_port_type, root_port=None):
+    def add_root_port(self, root_port_type, root_port=None,
+                      root_port_params=None):
         """
         Add pcie root port to the bus and __root_ports list, assign free slot,
         chassis, and addr for it according to current list.
 
         :param root_port_type: root port type
         :param root_port: pcie-root-port QDevice object
+        :param root_port_params: root port params
         :return: pcie-root-port QDevice object
         """
         if not root_port:
-            root_port = self._add_root_port(root_port_type)
+            root_port = self._add_root_port(root_port_type, root_port_params)
             root_port.set_param('multifunction', 'on')
             self.insert(root_port)
         else:
             addr = self._get_port_addr(root_port)
-            root_port = self._add_root_port(root_port_type)
+            root_port = self._add_root_port(root_port_type, root_port_params)
             root_port.set_param('addr', addr)
             self.insert(root_port)
         return root_port
 
-    def _add_root_port(self, root_port_type):
+    def _add_root_port(self, root_port_type, root_port_params=None):
         """
         Generate pcie-root-port QDevice object with certain addr and id
 
-        :param addr: addr to add the root port
         :param root_port_type: root port type
+        :param root_port_params: root port params
         :return: pcie-root-port QDevice object
         """
         index = self.__last_port_index[0] + 1
@@ -2444,6 +2449,10 @@ class QPCIEBus(QPCIBus):
         bus = QPCIBus(bus_id, 'PCIE', bus_id, length=1, first_port=0)
         parent_bus = {'busid': '_PCI_CHASSIS'}
         params = {'id': bus_id, 'port': hex(index)}
+        if root_port_params:
+            for extra_param in root_port_params.split(","):
+                key, value = extra_param.split('=')
+                params[key] = value
         root_port = QDevice(root_port_type,
                             params,
                             aobject=bus_id,
@@ -2517,8 +2526,10 @@ class QPCIEBus(QPCIBus):
         for root_port in root_ports:
             addr = self._get_port_addr(root_port)
             if addr is not None:
-                return self.add_root_port(self.__root_port_type, root_port)
-        return self.add_root_port(self.__root_port_type)
+                return self.add_root_port(self.__root_port_type, root_port,
+                                          self.__root_port_params)
+        return self.add_root_port(self.__root_port_type, None,
+                                  self.__root_port_params)
 
     def get_free_root_port(self):
         """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2398,6 +2398,11 @@ class VM(virt_vm.BaseVM):
                 # enable multifunction for root port
                 port_name = "pcie_extra_root_port_%d" % num
                 root_port = devices.pcic_by_params(port_name, pcic_params)
+                pcie_root_port_params = params.get('pcie_root_port_params')
+                if pcie_root_port_params:
+                    for extra_param in pcie_root_port_params.split(","):
+                        key, value = extra_param.split('=')
+                        root_port.set_param(key, value)
                 func_num = num % 8
                 if func_num == 0:
                     root_port.set_param('multifunction', 'on')


### PR DESCRIPTION
1. This is a global parameter for pcie-root-port except slot 0
2. This parameter work with 'pcie_extra_root_port' too

id: 1856690
Signed-off-by: Yanan Fu <yfu@redhat.com>