### PR TITLE
Fix check_qemu_image_lock_support problem

### DIFF
--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -557,7 +557,7 @@ def check_qemu_image_lock_support():
     """
     cmd = "qemu-img"
     try:
-        binary_path = process.run("which %s" % cmd).stdout_text
+        binary_path = process.run("which %s" % cmd).stdout_text.strip()
     except process.CmdError:
         raise process.CmdError(cmd, binary_path,
                                "qemu-img command is not found")


### PR DESCRIPTION
Strip the binary_path to avoid following error which return incorrect
result.

debug output:
ERROR: Command '/usr/bin/qemu-img\n -h' failed.\n

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>