### PR TITLE
qcontainer: Fix AttributeError: 'NoneType' object has no attribute

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2020,7 +2020,7 @@ class DevContainer(object):
         # More info from qemu commit 91a097e74.
         if not filename:
             cache = None
-        if filename.startswith('nvme://'):
+        elif filename.startswith('nvme://'):
             # NVMe controller doesn't support write cache configuration
             cache = 'writethrough'
         if Flags.BLOCKDEV in self.caps:


### PR DESCRIPTION
On commit 91fe444, there was a mistake that raised AttributeError:
'NoneType' object has no attribute 'startswith' in the scenario where
the filename was None.

ID: 1860277
Signed-off-by: Yongxue Hong <yhong@redhat.com>