### PR TITLE
Fix qemu-img usage checking failure

### DIFF
--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -557,7 +557,7 @@ def check_qemu_image_lock_support():
     """
     cmd = "qemu-img"
     try:
-        binary_path = process.run("which %s" % cmd).stdout_text
+        binary_path = process.run("which %s" % cmd).stdout_text.strip()
     except process.CmdError:
         raise process.CmdError(cmd, binary_path,
                                "qemu-img command is not found")


### PR DESCRIPTION
It failed to run 'qemu-img -h' because the previous command returned
qemu-img full path with '\n'.

Signed-off-by: Yingshun Cui <yicui@redhat.com>