### PR TITLE
Fixup Libvirtd.restart()

### DIFF
--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -115,7 +115,7 @@ class Libvirtd(object):
         for daem_item in self.daemons:
             if reset_failed:
                 daem_item.reset_failed()
-            if daem_item.restart():
+            if not daem_item.restart():
                 return False
             result.append(self._wait_for_start())
         return all(result)


### PR DESCRIPTION
It was introduced by 447804fc, 'not' was deleted by mistake.

Signed-off-by: Yingshun Cui <yicui@redhat.com>