### PR TITLE
correct the usage of parameter cache-size

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2110,6 +2110,8 @@ class DevContainer(object):
             drv_extra_params = (_.split('=', 1) for _ in
                                 drv_extra_params.split(',') if _)
             for key, value in drv_extra_params:
+                if key == 'cache-size' and imgfmt != 'qcow2':
+                    continue
                 if Flags.BLOCKDEV in self.caps:
                     if key == 'discard':
                         value = re.sub('on', 'unmap', re.sub('off', 'ignore', value))


### PR DESCRIPTION
cache-size is a qcow2 option, it cannot be given to any
imgfmt but qcow2.

ID: 1862315
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>