### PR TITLE
NumaInfo: Fix 'NoneType' object has no attribute 'groups' error

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1680,7 +1680,7 @@ class NumaInfo(object):
             node_meminfo = {}
             numa_sys = kernel_interface.SysFS(meminfo_file % node,
                                               session=self.session)
-            for info in str(numa_sys.sys_fs_value).split("\n"):
+            for info in str(numa_sys.sys_fs_value.strip()).split("\n"):
                 key, value = re.match(r'Node \d+ (\S+):\s+(\d+)', info).groups()
                 node_meminfo[key] = value
             meminfo[node] = node_meminfo


### PR DESCRIPTION
The content of /sys/devices/system/node/node*/meminfo may have space
after the last '\n', and will cause AttributeError.
e.g.
>>> file = '/sys/devices/system/node/node1/meminfo'
>>> data = os.popen('cat %s' %file).read()
>>> data.split('\n')[-1]
''
>>> data.strip().split('\n')[-1]
'Node 1 HugePages_Surp:      0'

id: 1862866

Signed-off-by: Yanan Fu <yfu@redhat.com>