### PR TITLE
Cirrus CI: drop editable requirements from GIT based installs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ fedora_30_task:
       # Latest LTS release is 69.x
       - AVOCADO_SRC: avocado-framework<70.0
       # Latest Avocado from git
-      - AVOCADO_SRC: -e git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+      - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado#egg=avocado_framework
     matrix:
       - SETUP: setup.py develop --user
       - SETUP: -m pip install .
@@ -39,11 +39,7 @@ centos_8_1_task:
     matrix:
       - AVOCADO_SRC:
       - AVOCADO_SRC: avocado-framework<70.0
-      # When installing from source, pip tries to install at
-      # /usr/local/lib/python3.6/site-packages/ and fails with:
-      # [Errno 2] No such file or directory: '/usr/local/lib/python3.6/site-packages/test-easy-install-78.write-test'
-      # workaround is to add "--prefix /"
-      - AVOCADO_SRC: --prefix / -e git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+      - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado#egg=avocado_framework
     matrix:
       - SETUP: setup.py develop --user
       - SETUP: -m pip install .


### PR DESCRIPTION
Turns out that the "-e" option is not a requirement for installations
from GIT.  The side effect of having that flag, is that a "python
setup.py develop" ended up being called, which did not create the
necessary directories and caused the failures in the comments:

```
   # When installing from source, pip tries to install at
   # /usr/local/lib/python3.6/site-packages/ and fails with:
   # [Errno 2] No such file or directory: '/usr/local/lib/python3.6/site-packages/test-easy-install-78.write-test'
```

Without '-e', a common installation occurs, and that failure is no
longer present.

Reference: https://github.com/avocado-framework/avocado/issues/3462
Signed-off-by: Cleber Rosa <crosa@redhat.com>