### PR TITLE
Add the second way to create object secret

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -115,6 +115,8 @@ variants:
     - luks:
         image_format = luks
         image_secret = redhat
+        # image_secret_expression = data
+        # value is data or file, the default value is data
     - qcow2v3:
         image_format = qcow2
         image_extra_params = "compat=1.1"


### PR DESCRIPTION
The following two ways should all work well:
1. --object secret,id={s.aid},data={s.data}
2. --object secret,id={s.aid},file={s.filename}

ID: 1867037
Signed-off-by: Xueqiang Wei <xuwei@redhat.com>