### PR TITLE
Fix get_conf_obj() to create config obj on non-modular daemon

### DIFF
--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -700,16 +700,16 @@ def get_conf_obj(config_type):
     :return: utils_config.LibvirtConfigCommon object
     """
     return {
-        'libvirt': LibvirtConfig(),
-        'libvirtd': LibvirtdConfig(),
-        'qemu': LibvirtQemuConfig(),
-        'sysconfig': LibvirtdSysConfig(),
-        'guestconfig': LibvirtGuestsConfig(),
-        'virtqemud': VirtQemudConfig(),
-        'virtproxyd': VirtProxydConfig(),
-        'virtnetworkd': VirtNetworkdConfig(),
-        'virtstoraged': VirtStoragedConfig(),
-        'virtinterfaced': VirtInterfacedConfig(),
-        'virtnodedevd': VirtNodedevdConfig(),
-        'virtnwfilterd': VirtNwfilterdConfig(),
-         }.get(config_type)
+        'libvirt': LibvirtConfig,
+        'libvirtd': LibvirtdConfig,
+        'qemu': LibvirtQemuConfig,
+        'sysconfig': LibvirtdSysConfig,
+        'guestconfig': LibvirtGuestsConfig,
+        'virtqemud': VirtQemudConfig,
+        'virtproxyd': VirtProxydConfig,
+        'virtnetworkd': VirtNetworkdConfig,
+        'virtstoraged': VirtStoragedConfig,
+        'virtinterfaced': VirtInterfacedConfig,
+        'virtnodedevd': VirtNodedevdConfig,
+        'virtnwfilterd': VirtNwfilterdConfig
+         }.get(config_type)()


### PR DESCRIPTION
Signed-off-by: Yingshun Cui <yicui@redhat.com>