### PR TITLE
Add port to network xml

### DIFF
--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -377,7 +377,7 @@ class NetworkXMLBase(base.LibvirtXMLBase):
                  'bandwidth_inbound', 'bandwidth_outbound', 'portgroup',
                  'dns', 'domain_name', 'nat_port', 'forward_interface',
                  'routes', 'virtualport_type', 'vf_list', 'driver', 'pf',
-                 'mtu', 'connection')
+                 'mtu', 'connection', 'port')
 
     __uncompareable__ = base.LibvirtXMLBase.__uncompareable__ + (
         'defined', 'active',
@@ -417,6 +417,8 @@ class NetworkXMLBase(base.LibvirtXMLBase):
         accessors.XMLElementDict('bandwidth_outbound', self,
                                  parent_xpath='/bandwidth',
                                  tag_name='outbound')
+        accessors.XMLElementDict('port', self, parent_xpath='/',
+                                 tag_name='port')
         accessors.XMLAttribute("mtu", self, parent_xpath='/',
                                tag_name='mtu',  attribute='size')
         accessors.XMLAttribute('domain_name', self, parent_xpath='/',

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1770,7 +1770,6 @@ def create_net_xml(net_name, params):
     """
     dns_dict = {}
     host_dict = {}
-    net_name = params.get("net_name", "default")
     net_bridge = params.get("net_bridge", '{}')
     net_forward = params.get("net_forward", '{}')
     net_forward_pf = params.get("net_forward_pf", '{}')
@@ -1803,6 +1802,7 @@ def create_net_xml(net_name, params):
     bootp_file = params.get("bootp_file")
     routes = params.get("routes", "").split()
     pg_name = params.get("portgroup_name", "").split()
+    net_port = params.get('net_port')
     try:
         if not virsh.net_info(net_name, ignore_status=True).exit_status:
             # Edit an existed network
@@ -1854,7 +1854,8 @@ def create_net_xml(net_name, params):
             netxml.bandwidth_outbound = net_outbound
         if net_virtualport:
             netxml.virtualport_type = net_virtualport
-
+        if net_port:
+            netxml.port = ast.literal_eval(net_port)
         if net_ip_family == "ipv6":
             ipxml = network_xml.IPXML()
             ipxml.family = net_ip_family


### PR DESCRIPTION
- Add dict-attr 'port' to network xml
- Update function create_net_xml() to support 'port'
- Fix error that net_name being overwritten by params['net_name'].
Before fix, if we provide a name by setting var 'net_name' but not
set on params['net_name'], the var will be overwritten to 'default'

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>