### PR TITLE
drive: New API to get disk drive value of porperties by serial number 

### DIFF
--- a/virttest/utils_windows/wmic.py
+++ b/virttest/utils_windows/wmic.py
@@ -61,6 +61,8 @@ def parse_list(data):
         for para in re.split("(?:\r?\n){2,}", data.strip()):
             keys, vals = [], []
             for line in para.splitlines():
+                if '=' not in line:
+                    continue
                 key, val = line.split('=', 1)
                 keys.append(key)
                 vals.append(val)


### PR DESCRIPTION
New API get_disk_props_by_serial_number to get disk drive value
of properties by serial number in windows guest.

ID: 1868329
Signed-off-by: Yongxue Hong <yhong@redhat.com>