### PR TITLE
Avocado compatibility: support for thew new settings [v2]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,9 @@ fedora_30_task:
       - AVOCADO_SRC: avocado-framework<70.0
       # Latest Avocado from git
       - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+      # Avocado with new settings module - this commit maps to the pull request at
+      # https://github.com/avocado-framework/avocado/pull/3944
+      - AVOCADO_SRC: git+https://github.com/beraldoleal/avocado@6b9fc350f32e877e5540353d0184366c876f9273#egg=avocado_framework
     matrix:
       - SETUP: setup.py develop --user
       - SETUP: -m pip install .

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -40,7 +40,7 @@ def guest_listing(config):
     """
     List available guest operating systems and info about image availability
     """
-    if get_opt(config, 'vt_type') == 'lvsb':
+    if get_opt(config, 'vt.type') == 'lvsb':
         raise ValueError("No guest types available for lvsb testing")
     LOG.debug("Using %s for guest images\n",
               os.path.join(data_dir.get_data_dir(), 'images'))
@@ -49,7 +49,7 @@ def guest_listing(config):
     for params in guest_name_parser.get_dicts():
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())
         image_name = storage.get_image_filename(params, base_dir)
-        machine_type = get_opt(config, 'vt_machine_type')
+        machine_type = get_opt(config, 'vt.common.machine_type')
         name = params['name'].replace('.%s' % machine_type, '')
         if os.path.isfile(image_name):
             out = name
@@ -64,14 +64,14 @@ def arch_listing(config):
     """
     List available machine/archs for given guest operating systems
     """
-    guest_os = get_opt(config, 'vt_guest_os')
+    guest_os = get_opt(config, 'vt.guest_os')
     if guest_os is not None:
         extra = " for guest os \"%s\"" % guest_os
     else:
         extra = ""
     LOG.info("Available arch profiles%s", extra)
     guest_name_parser = standalone_test.get_guest_name_parser(config)
-    machine_type = get_opt(config, 'vt_machine_type')
+    machine_type = get_opt(config, 'vt.common.machine_type')
     for params in guest_name_parser.get_dicts():
         LOG.debug(params['name'].replace('.%s' % machine_type, ''))
     LOG.debug("")
@@ -112,12 +112,12 @@ class VirtTestLoader(loader.TestLoader):
         if vt_extra_params:
             # We don't want to override the original config
             self.config = copy.deepcopy(self.config)
-            extra = get_opt(self.config, 'vt_extra_params')
+            extra = get_opt(self.config, 'vt.extra_params')
             if extra is not None:
                 extra += vt_extra_params
             else:
                 extra = vt_extra_params
-            set_opt(self.config, 'vt_extra_params', extra)
+            set_opt(self.config, 'vt.extra_params', extra)
 
     def _get_parser(self):
         options_processor = VirtTestOptionsProcess(self.config)
@@ -126,13 +126,13 @@ class VirtTestLoader(loader.TestLoader):
     def get_extra_listing(self):
         if get_opt(self.config, 'vt_list_guests'):
             config = copy.copy(self.config)
-            set_opt(config, 'vt_config', None)
-            set_opt(config, 'vt_guest_os', None)
+            set_opt(config, 'vt.config', None)
+            set_opt(config, 'vt.guest_os', None)
             guest_listing(config)
         if get_opt(self.config, 'vt_list_archs'):
             config = copy.copy(self.config)
-            set_opt(config, 'vt_machine_type', None)
-            set_opt(config, 'vt_arch', None)
+            set_opt(config, 'vt.common.machine_type', None)
+            set_opt(config, 'vt.common.arch', None)
             arch_listing(config)
 
     @staticmethod
@@ -180,17 +180,17 @@ class VirtTestLoader(loader.TestLoader):
             except cartesian_config.ParserError as details:
                 return self._report_bad_discovery(url, details, which_tests)
         elif (which_tests is loader.DiscoverMode.DEFAULT and
-              not get_opt(self.config, 'vt_config')):
-            # By default don't run anything unless vt_config provided
+              not get_opt(self.config, 'vt.config')):
+            # By default don't run anything unless vt.config provided
             return []
         # Create test_suite
         test_suite = []
         for params in (_ for _ in cartesian_parser.get_dicts()):
             # Evaluate the proper avocado-vt test name
             test_name = None
-            if get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt.config'):
                 test_name = params.get("shortname")
-            elif get_opt(self.config, 'vt_type') == "spice":
+            elif get_opt(self.config, 'vt.type') == "spice":
                 short_name_map_file = params.get("_short_name_map_file")
                 if "tests-variants.cfg" in short_name_map_file:
                     test_name = short_name_map_file["tests-variants.cfg"]

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -34,14 +34,6 @@ from .options import VirtTestOptionsProcess
 from .test import VirtTest
 
 
-if hasattr(loader, "DiscoverMode"):
-    LOADER_DEFAULT = loader.DiscoverMode.DEFAULT
-    LOADER_ALL = loader.DiscoverMode.ALL
-else:
-    LOADER_DEFAULT = loader.DEFAULT
-    LOADER_ALL = loader.ALL
-
-
 LOG = logging.getLogger("avocado.app")
 
 
@@ -205,12 +197,12 @@ class VirtTestLoader(loader.TestLoader):
 
     @staticmethod
     def _report_bad_discovery(name, reason, which_tests):
-        if which_tests is LOADER_ALL:
+        if which_tests is loader.DiscoverMode.ALL:
             return [(NotAvocadoVTTest, {"name": "%s: %s" % (name, reason)})]
         else:
             return []
 
-    def discover(self, url, which_tests=LOADER_DEFAULT):
+    def discover(self, url, which_tests=loader.DiscoverMode.DEFAULT):
         try:
             cartesian_parser = self._get_parser()
         except Exception as details:
@@ -225,7 +217,8 @@ class VirtTestLoader(loader.TestLoader):
             # the other test plugins to handle the URL.
             except cartesian_config.ParserError as details:
                 return self._report_bad_discovery(url, details, which_tests)
-        elif which_tests is LOADER_DEFAULT and not get_opt(self.args, 'vt_config'):
+        elif (which_tests is loader.DiscoverMode.DEFAULT and
+              not get_opt(self.args, 'vt_config')):
             # By default don't run anything unless vt_config provided
             return []
         # Create test_suite
@@ -249,7 +242,7 @@ class VirtTestLoader(loader.TestLoader):
             test_parameters = {'name': test_name,
                                'vt_params': params}
             test_suite.append((VirtTest, test_parameters))
-        if which_tests is LOADER_ALL and not test_suite:
+        if which_tests is loader.DiscoverMode.ALL and not test_suite:
             return self._report_bad_discovery(url, "No matching tests",
                                               which_tests)
         return test_suite

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -109,7 +109,6 @@ class VirtTestLoader(loader.TestLoader):
         # new and old releases
         if hasattr(self, 'config'):
             self.args = self.config
-        self._fill_optional_args()
         if vt_extra_params:
             # We don't want to override the original args
             self.args = copy.deepcopy(self.args)
@@ -119,43 +118,6 @@ class VirtTestLoader(loader.TestLoader):
             else:
                 extra = vt_extra_params
             set_opt(self.args, 'vt_extra_params', extra)
-
-    def _fill_optional_args(self):
-        def _add_if_not_exist(arg, value):
-            if not get_opt(self.args, arg):
-                set_opt(self.args, arg, value)
-        _add_if_not_exist('vt_config', None)
-        _add_if_not_exist('vt_verbose', True)
-        _add_if_not_exist('vt_log_level', 'debug')
-        _add_if_not_exist('vt_console_level', 'debug')
-        _add_if_not_exist('vt_datadir', data_dir.get_data_dir())
-        _add_if_not_exist('vt_tmp_dir', '')
-        _add_if_not_exist('vt_config', None)
-        _add_if_not_exist('vt_arch', None)
-        _add_if_not_exist('vt_machine_type', None)
-        _add_if_not_exist('vt_keep_guest_running', False)
-        _add_if_not_exist('vt_backup_image_before_test', True)
-        _add_if_not_exist('vt_restore_image_after_test', True)
-        _add_if_not_exist('vt_mem', 1024)
-        _add_if_not_exist('vt_no_filter', '')
-        _add_if_not_exist('vt_qemu_bin', None)
-        _add_if_not_exist('vt_dst_qemu_bin', None)
-        _add_if_not_exist('vt_nettype', 'user')
-        _add_if_not_exist('vt_only_type_specific', False)
-        _add_if_not_exist('vt_tests', '')
-        _add_if_not_exist('vt_connect_uri', 'qemu:///system')
-        _add_if_not_exist('vt_accel', 'kvm')
-        _add_if_not_exist('vt_monitor', 'human')
-        _add_if_not_exist('vt_smp', 1)
-        _add_if_not_exist('vt_image_type', 'qcow2')
-        _add_if_not_exist('vt_nic_model', 'virtio_net')
-        _add_if_not_exist('vt_disk_bus', 'virtio_blk')
-        _add_if_not_exist('vt_vhost', 'off')
-        _add_if_not_exist('vt_malloc_perturb', 'yes')
-        _add_if_not_exist('vt_qemu_sandbox', 'on')
-        _add_if_not_exist('vt_tests', '')
-        _add_if_not_exist('show_job_log', False)
-        _add_if_not_exist('test_lister', True)
 
     def _get_parser(self):
         options_processor = VirtTestOptionsProcess(self.args)

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -36,20 +36,20 @@ from .test import VirtTest
 LOG = logging.getLogger("avocado.app")
 
 
-def guest_listing(options):
+def guest_listing(config):
     """
     List available guest operating systems and info about image availability
     """
-    if get_opt(options, 'vt_type') == 'lvsb':
+    if get_opt(config, 'vt_type') == 'lvsb':
         raise ValueError("No guest types available for lvsb testing")
     LOG.debug("Using %s for guest images\n",
               os.path.join(data_dir.get_data_dir(), 'images'))
     LOG.info("Available guests in config:")
-    guest_name_parser = standalone_test.get_guest_name_parser(options)
+    guest_name_parser = standalone_test.get_guest_name_parser(config)
     for params in guest_name_parser.get_dicts():
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())
         image_name = storage.get_image_filename(params, base_dir)
-        machine_type = get_opt(options, 'vt_machine_type')
+        machine_type = get_opt(config, 'vt_machine_type')
         name = params['name'].replace('.%s' % machine_type, '')
         if os.path.isfile(image_name):
             out = name
@@ -60,18 +60,18 @@ def guest_listing(options):
     LOG.debug("")
 
 
-def arch_listing(options):
+def arch_listing(config):
     """
     List available machine/archs for given guest operating systems
     """
-    guest_os = get_opt(options, 'vt_guest_os')
+    guest_os = get_opt(config, 'vt_guest_os')
     if guest_os is not None:
         extra = " for guest os \"%s\"" % guest_os
     else:
         extra = ""
     LOG.info("Available arch profiles%s", extra)
-    guest_name_parser = standalone_test.get_guest_name_parser(options)
-    machine_type = get_opt(options, 'vt_machine_type')
+    guest_name_parser = standalone_test.get_guest_name_parser(config)
+    machine_type = get_opt(config, 'vt_machine_type')
     for params in guest_name_parser.get_dicts():
         LOG.debug(params['name'].replace('.%s' % machine_type, ''))
     LOG.debug("")
@@ -92,44 +92,48 @@ class VirtTestLoader(loader.TestLoader):
 
     name = 'vt'
 
-    def __init__(self, args, extra_params):
+    def __init__(self, config, extra_params):
         """
         Following extra_params are supported:
          * avocado_vt_extra_params: Will override the "vt_extra_params"
-           of this plugins "self.args" (extends the --vt-extra-params)
+           of this plugins "self.config" (extends the --vt-extra-params)
         """
         vt_extra_params = extra_params.pop("avocado_vt_extra_params", None)
-        super(VirtTestLoader, self).__init__(args, extra_params)
+        super(VirtTestLoader, self).__init__(config, extra_params)
         # Avocado has renamed "args" to "config" in 84ae9a5d61, lets
         # keep making the old name available for compatibility with
         # new and old releases
         if hasattr(self, 'config'):
-            self.args = self.config
+            self.args = self.config   # pylint: disable=E0203
+        # And in case an older Avocado is used, the Loader class will
+        # contain an "args" attribute instead
+        else:
+            self.config = self.args   # pylint: disable=E0203
         if vt_extra_params:
-            # We don't want to override the original args
-            self.args = copy.deepcopy(self.args)
-            extra = get_opt(self.args, 'vt_extra_params')
+            # We don't want to override the original config
+            self.config = copy.deepcopy(self.config)
+            extra = get_opt(self.config, 'vt_extra_params')
             if extra is not None:
                 extra += vt_extra_params
             else:
                 extra = vt_extra_params
-            set_opt(self.args, 'vt_extra_params', extra)
+            set_opt(self.config, 'vt_extra_params', extra)
 
     def _get_parser(self):
-        options_processor = VirtTestOptionsProcess(self.args)
+        options_processor = VirtTestOptionsProcess(self.config)
         return options_processor.get_parser()
 
     def get_extra_listing(self):
-        if get_opt(self.args, 'vt_list_guests'):
-            args = copy.copy(self.args)
-            set_opt(args, 'vt_config', None)
-            set_opt(args, 'vt_guest_os', None)
-            guest_listing(args)
-        if get_opt(self.args, 'vt_list_archs'):
-            args = copy.copy(self.args)
-            set_opt(args, 'vt_machine_type', None)
-            set_opt(args, 'vt_arch', None)
-            arch_listing(args)
+        if get_opt(self.config, 'vt_list_guests'):
+            config = copy.copy(self.config)
+            set_opt(config, 'vt_config', None)
+            set_opt(config, 'vt_guest_os', None)
+            guest_listing(config)
+        if get_opt(self.config, 'vt_list_archs'):
+            config = copy.copy(self.config)
+            set_opt(config, 'vt_machine_type', None)
+            set_opt(config, 'vt_arch', None)
+            arch_listing(config)
 
     @staticmethod
     def get_type_label_mapping():
@@ -176,7 +180,7 @@ class VirtTestLoader(loader.TestLoader):
             except cartesian_config.ParserError as details:
                 return self._report_bad_discovery(url, details, which_tests)
         elif (which_tests is loader.DiscoverMode.DEFAULT and
-              not get_opt(self.args, 'vt_config')):
+              not get_opt(self.config, 'vt_config')):
             # By default don't run anything unless vt_config provided
             return []
         # Create test_suite
@@ -184,9 +188,9 @@ class VirtTestLoader(loader.TestLoader):
         for params in (_ for _ in cartesian_parser.get_dicts()):
             # Evaluate the proper avocado-vt test name
             test_name = None
-            if get_opt(self.args, 'vt_config'):
+            if get_opt(self.config, 'vt_config'):
                 test_name = params.get("shortname")
-            elif get_opt(self.args, 'vt_type') == "spice":
+            elif get_opt(self.config, 'vt_type') == "spice":
                 short_name_map_file = params.get("_short_name_map_file")
                 if "tests-variants.cfg" in short_name_map_file:
                     test_name = short_name_map_file["tests-variants.cfg"]

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -16,7 +16,6 @@
 Avocado VT plugin
 """
 
-import argparse
 import copy
 import logging
 import os
@@ -100,9 +99,6 @@ class VirtTestLoader(loader.TestLoader):
            of this plugins "self.args" (extends the --vt-extra-params)
         """
         vt_extra_params = extra_params.pop("avocado_vt_extra_params", None)
-        # Compatibility with more recent Avocado configuration as dictionary
-        if isinstance(args, dict):
-            args = argparse.Namespace(**args)
         super(VirtTestLoader, self).__init__(args, extra_params)
         # Avocado has renamed "args" to "config" in 84ae9a5d61, lets
         # keep making the old name available for compatibility with

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -19,14 +19,13 @@ Avocado VT plugin
 import logging
 import os
 
-from avocado.core.settings import settings
 from avocado.utils import path as utils_path
 
 from virttest import cartesian_config
 from virttest import data_dir
 from virttest import defaults
 from virttest import standalone_test
-from virttest.compat import get_opt, set_opt
+from virttest.compat import get_opt, set_opt, set_opt_from_settings
 from virttest.standalone_test import SUPPORTED_DISK_BUSES
 from virttest.standalone_test import SUPPORTED_IMAGE_TYPES
 from virttest.standalone_test import SUPPORTED_LIBVIRT_DRIVERS
@@ -50,59 +49,70 @@ class VirtTestOptionsProcess(object):
         # Doing this makes things configurable yet the number of options
         # is not overwhelming.
         # setup section
-        set_opt(self.config, 'vt.setup.backup_image_before_test',
-                settings.get_value('vt.setup', 'backup_image_before_test',
-                                   key_type=bool, default=True))
-        set_opt(self.config, 'vt.setup.restore_image_after_test',
-                settings.get_value('vt.setup', 'restore_image_after_test',
-                                   key_type=bool, default=True))
-        set_opt(self.config, 'vt.setup.keep_guest_running',
-                settings.get_value('vt.setup', 'keep_guest_running',
-                                   key_type=bool, default=False))
+        set_opt_from_settings(self.config,
+                              'vt.setup', 'backup_image_before_test',
+                              key_type=bool, default=True)
+        set_opt_from_settings(self.config,
+                              'vt.setup', 'restore_image_after_test',
+                              key_type=bool, default=True)
+        set_opt_from_settings(self.config,
+                              'vt.setup', 'keep_guest_running',
+                              key_type=bool, default=False)
         # common section
-        set_opt(self.config, 'vt.common.data_dir',
-                settings.get_value('vt.common', 'data_dir', default=None))
-        set_opt(self.config, 'vt.common.tmp_dir',
-                settings.get_value('vt.common', 'tmp_dir', default=''))
-        set_opt(self.config, 'vt.common.type_specific',
-                settings.get_value('vt.common', 'type_specific_only',
-                                   key_type=bool, default=False))
-        set_opt(self.config, 'vt.common.mem',
-                settings.get_value('vt.common', 'mem', key_type=int,
-                                   default=None))
-        set_opt(self.config, 'vt.common.nettype',
-                settings.get_value('vt.common', 'nettype', default=None))
-        set_opt(self.config, 'vt.common_netdst',
-                settings.get_value('vt.common', 'netdst', default='virbr0'))
+        set_opt_from_settings(self.config,
+                              'vt.common', 'data_dir',
+                              default=None)
+        set_opt_from_settings(self.config,
+                              'vt.common', 'tmp_dir',
+                              default='')
+        set_opt_from_settings(self.config,
+                              'vt.common', 'type_specific',
+                              key_type=bool, default=False)
+        set_opt_from_settings(self.config,
+                              'vt.common', 'mem',
+                              default=None)
+        set_opt_from_settings(self.config,
+                              'vt.common', 'nettype',
+                              default=None)
+        set_opt_from_settings(self.config,
+                              'vt.common', 'netdst',
+                              default='virbr0')
         # qemu section
-        set_opt(self.config, 'vt.qemu.accel',
-                settings.get_value('vt.qemu', 'accel', default='kvm'))
-        set_opt(self.config, 'vt.qemu.vhost',
-                settings.get_value('vt.qemu', 'vhost', default='off'))
-        set_opt(self.config, 'vt.qemu.monitor',
-                settings.get_value('vt.qemu', 'monitor', default=None))
-        set_opt(self.config, 'vt.qemu.smp',
-                settings.get_value('vt.qemu', 'smp', default='2'))
-        set_opt(self.config, 'vt.qemu.image_type',
-                settings.get_value('vt.qemu', 'image_type',
-                                   default=SUPPORTED_IMAGE_TYPES[0]))
-        set_opt(self.config, 'vt.qemu.nic_model',
-                settings.get_value('vt.qemu', 'nic_model',
-                                   default=SUPPORTED_NIC_MODELS[0]))
-        set_opt(self.config, 'vt.qemu.disk_bus',
-                settings.get_value('vt.qemu', 'disk_bus',
-                                   default=SUPPORTED_DISK_BUSES[0]))
-        set_opt(self.config, 'vt.qemu.sandbox',
-                settings.get_value('vt.qemu', 'sandbox', default='on'))
-        set_opt(self.config, 'vt.qemu.defconfig',
-                settings.get_value('vt.qemu', 'defconfig', default='yes'))
-        set_opt(self.config, 'vt.qemu.malloc_perturb',
-                settings.get_value('vt.qemu', 'malloc_perturb', default='yes'))
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'accel',
+                              default='kvm')
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'vhost',
+                              default='off')
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'monitor',
+                              default=None)
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'smp',
+                              default='2')
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'image_type',
+                              default=SUPPORTED_IMAGE_TYPES[0])
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'nic_model',
+                              default=SUPPORTED_NIC_MODELS[0])
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'disk_bus',
+                              default=SUPPORTED_DISK_BUSES[0])
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'sandbox',
+                              default='on')
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'defconfig',
+                              default='yes')
+        set_opt_from_settings(self.config,
+                              'vt.qemu', 'malloc_perturb',
+                              default='yes')
 
         # debug section
-        set_opt(self.config, 'vt.debug.no_cleanup',
-                settings.get_value('vt.debug', 'no_cleanup',
-                                   key_type=bool, default=False))
+        set_opt_from_settings(self.config,
+                              'vt.debug', 'no_cleanup',
+                              key_type=bool, default=False)
 
         self.cartesian_parser = None
 

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -51,16 +51,6 @@ class VirtTestOptionsProcess(object):
             self.options = argparse.Namespace(**options)
         else:
             self.options = options
-        # There are a few options from the original virt-test runner
-        # that don't quite make sense for avocado (avocado implements a
-        # better version of the virt-test feature).
-        # So let's just inject some values into options.
-        set_opt(self.options, 'vt_verbose', False)
-        set_opt(self.options, 'vt_log_level', logging.DEBUG)
-        set_opt(self.options, 'vt_console_level', logging.DEBUG)
-        set_opt(self.options, 'vt_no_downloads', False)
-        set_opt(self.options, 'vt_selinux_setup', False)
-
         # Here we'll inject values from the config file.
         # Doing this makes things configurable yet the number of options
         # is not overwhelming.

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -89,13 +89,14 @@ class VirtTestOptionsProcess(object):
         set_opt(self.options, 'vt_smp',
                 settings.get_value('vt.qemu', 'smp', default='2'))
         set_opt(self.options, 'vt_image_type',
-                settings.get_value('vt.qemu', 'image_type', default='qcow2'))
+                settings.get_value('vt.qemu', 'image_type',
+                                   default=SUPPORTED_IMAGE_TYPES[0]))
         set_opt(self.options, 'vt_nic_model',
                 settings.get_value('vt.qemu', 'nic_model',
-                                   default='virtio_net'))
+                                   default=SUPPORTED_NIC_MODELS[0]))
         set_opt(self.options, 'vt_disk_bus',
                 settings.get_value('vt.qemu', 'disk_bus',
-                                   default='virtio_blk'))
+                                   default=SUPPORTED_DISK_BUSES[0]))
         set_opt(self.options, 'vt_qemu_sandbox',
                 settings.get_value('vt.qemu', 'sandbox', default='on'))
         set_opt(self.options, 'vt_qemu_defconfig',

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -50,57 +50,57 @@ class VirtTestOptionsProcess(object):
         # Doing this makes things configurable yet the number of options
         # is not overwhelming.
         # setup section
-        set_opt(self.config, 'vt_backup_image_before_test',
+        set_opt(self.config, 'vt.setup.backup_image_before_test',
                 settings.get_value('vt.setup', 'backup_image_before_test',
                                    key_type=bool, default=True))
-        set_opt(self.config, 'vt_restore_image_after_test',
+        set_opt(self.config, 'vt.setup.restore_image_after_test',
                 settings.get_value('vt.setup', 'restore_image_after_test',
                                    key_type=bool, default=True))
-        set_opt(self.config, 'vt_keep_guest_running',
+        set_opt(self.config, 'vt.setup.keep_guest_running',
                 settings.get_value('vt.setup', 'keep_guest_running',
                                    key_type=bool, default=False))
         # common section
-        set_opt(self.config, 'vt_data_dir',
+        set_opt(self.config, 'vt.common.data_dir',
                 settings.get_value('vt.common', 'data_dir', default=None))
-        set_opt(self.config, 'vt_tmp_dir',
+        set_opt(self.config, 'vt.common.tmp_dir',
                 settings.get_value('vt.common', 'tmp_dir', default=''))
-        set_opt(self.config, 'vt_type_specific',
+        set_opt(self.config, 'vt.common.type_specific',
                 settings.get_value('vt.common', 'type_specific_only',
                                    key_type=bool, default=False))
-        set_opt(self.config, 'vt_mem',
+        set_opt(self.config, 'vt.common.mem',
                 settings.get_value('vt.common', 'mem', key_type=int,
                                    default=None))
-        set_opt(self.config, 'vt_nettype',
+        set_opt(self.config, 'vt.common.nettype',
                 settings.get_value('vt.common', 'nettype', default=None))
-        set_opt(self.config, 'vt_netdst',
+        set_opt(self.config, 'vt.common_netdst',
                 settings.get_value('vt.common', 'netdst', default='virbr0'))
         # qemu section
-        set_opt(self.config, 'vt_accel',
+        set_opt(self.config, 'vt.qemu.accel',
                 settings.get_value('vt.qemu', 'accel', default='kvm'))
-        set_opt(self.config, 'vt_vhost',
+        set_opt(self.config, 'vt.qemu.vhost',
                 settings.get_value('vt.qemu', 'vhost', default='off'))
-        set_opt(self.config, 'vt_monitor',
+        set_opt(self.config, 'vt.qemu.monitor',
                 settings.get_value('vt.qemu', 'monitor', default=None))
-        set_opt(self.config, 'vt_smp',
+        set_opt(self.config, 'vt.qemu.smp',
                 settings.get_value('vt.qemu', 'smp', default='2'))
-        set_opt(self.config, 'vt_image_type',
+        set_opt(self.config, 'vt.qemu.image_type',
                 settings.get_value('vt.qemu', 'image_type',
                                    default=SUPPORTED_IMAGE_TYPES[0]))
-        set_opt(self.config, 'vt_nic_model',
+        set_opt(self.config, 'vt.qemu.nic_model',
                 settings.get_value('vt.qemu', 'nic_model',
                                    default=SUPPORTED_NIC_MODELS[0]))
-        set_opt(self.config, 'vt_disk_bus',
+        set_opt(self.config, 'vt.qemu.disk_bus',
                 settings.get_value('vt.qemu', 'disk_bus',
                                    default=SUPPORTED_DISK_BUSES[0]))
-        set_opt(self.config, 'vt_qemu_sandbox',
+        set_opt(self.config, 'vt.qemu.sandbox',
                 settings.get_value('vt.qemu', 'sandbox', default='on'))
-        set_opt(self.config, 'vt_qemu_defconfig',
+        set_opt(self.config, 'vt.qemu.defconfig',
                 settings.get_value('vt.qemu', 'defconfig', default='yes'))
-        set_opt(self.config, 'vt_malloc_perturb',
+        set_opt(self.config, 'vt.qemu.malloc_perturb',
                 settings.get_value('vt.qemu', 'malloc_perturb', default='yes'))
 
         # debug section
-        set_opt(self.config, 'vt_no_cleanup',
+        set_opt(self.config, 'vt.debug.no_cleanup',
                 settings.get_value('vt.debug', 'no_cleanup',
                                    key_type=bool, default=False))
 
@@ -112,15 +112,15 @@ class VirtTestOptionsProcess(object):
         """
         qemu_bin_setting = ('option --vt-qemu-bin or '
                             'config vt.qemu.qemu_bin')
-        if (get_opt(self.config, 'vt_config') and
-                get_opt(self.config, 'vt_qemu_bin') is None):
+        if (get_opt(self.config, 'vt.config') and
+                get_opt(self.config, 'vt.qemu.qemu_bin') is None):
             logging.info("Config provided and no %s set. Not trying "
                          "to automatically set qemu bin.", qemu_bin_setting)
         else:
             (qemu_bin_path, qemu_img_path, qemu_io_path,
              qemu_dst_bin_path) = standalone_test.find_default_qemu_paths(
-                 get_opt(self.config, 'vt_qemu_bin'),
-                 get_opt(self.config, 'vt_dst_qemu_bin'))
+                 get_opt(self.config, 'vt.qemu.qemu_bin'),
+                 get_opt(self.config, 'vt.qemu.qemu_dst_bin'))
             self.cartesian_parser.assign("qemu_binary", qemu_bin_path)
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
             self.cartesian_parser.assign("qemu_io_binary", qemu_io_path)
@@ -134,143 +134,144 @@ class VirtTestOptionsProcess(object):
         """
         qemu_img_setting = ('option --vt-qemu-img or '
                             'config vt.qemu.qemu_img')
-        if (get_opt(self.config, 'vt_config') and
-                get_opt(self.config, 'vt_qemu_bin') is None):
+        if (get_opt(self.config, 'vt.config') and
+                get_opt(self.config, 'vt.qemu.bin') is None):
             logging.info("Config provided and no %s set. Not trying "
                          "to automatically set qemu bin", qemu_img_setting)
         else:
             (_, qemu_img_path,
              _, _) = standalone_test.find_default_qemu_paths(
-                 get_opt(self.config, 'vt_qemu_bin'),
-                 get_opt(self.config, 'vt_dst_qemu_bin'))
+                 get_opt(self.config, 'vt.qemu.qemu_bin'),
+                 get_opt(self.config, 'vt.qemu.qemu_dst_bin'))
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
 
     def _process_qemu_accel(self):
         """
         Puts the value of the qemu bin option in the cartesian parser command.
         """
-        if get_opt(self.config, 'vt_accel') == 'tcg':
+        if get_opt(self.config, 'vt.qemu.accel') == 'tcg':
             self.cartesian_parser.assign("disable_kvm", "yes")
 
     def _process_bridge_mode(self):
         nettype_setting = 'config vt.qemu.nettype'
-        if not get_opt(self.config, 'vt_config'):
-            # Let's select reasonable defaults depending on vt_type
-            if not get_opt(self.config, 'vt_nettype'):
-                if get_opt(self.config, 'vt_type') == 'qemu':
-                    set_opt(self.config, 'vt_nettype',
+        if not get_opt(self.config, 'vt.config'):
+            # Let's select reasonable defaults depending on vt.type
+            if not get_opt(self.config, 'vt.common.nettype'):
+                if get_opt(self.config, 'vt.type') == 'qemu':
+                    set_opt(self.config, 'vt.common.nettype',
                             ("bridge" if os.getuid() == 0 else "user"))
-                elif get_opt(self.config, 'vt_type') == 'spice':
-                    set_opt(self.config, 'vt_nettype', "none")
+                elif get_opt(self.config, 'vt.type') == 'spice':
+                    set_opt(self.config, 'vt.common.nettype', "none")
                 else:
-                    set_opt(self.config, 'vt_nettype', "bridge")
+                    set_opt(self.config, 'vt.common.nettype', "bridge")
 
-            if get_opt(self.config, 'vt_nettype') not in SUPPORTED_NET_TYPES:
+            if get_opt(self.config, 'vt.common.nettype') not in SUPPORTED_NET_TYPES:
                 raise ValueError("Invalid %s '%s'. "
                                  "Valid values: (%s)" %
                                  (nettype_setting,
-                                  get_opt(self.config, 'vt_nettype'),
+                                  get_opt(self.config, 'vt.common.nettype'),
                                   ", ".join(SUPPORTED_NET_TYPES)))
-            if get_opt(self.config, 'vt_nettype') == 'bridge':
+            if get_opt(self.config, 'vt.common.nettype') == 'bridge':
                 if os.getuid() != 0:
                     raise ValueError("In order to use %s '%s' you "
                                      "need to be root" % (nettype_setting,
-                                                          get_opt(self.config, 'vt_nettype')))
+                                                          get_opt(self.config, 'vt.common.nettype')))
                 self.cartesian_parser.assign("nettype", "bridge")
-                self.cartesian_parser.assign("netdst", get_opt(self.config, 'vt_netdst'))
-            elif get_opt(self.config, 'vt_nettype') == 'user':
+                self.cartesian_parser.assign("netdst", get_opt(self.config, 'vt.common.netdst'))
+            elif get_opt(self.config, 'vt.common.nettype') == 'user':
                 self.cartesian_parser.assign("nettype", "user")
         else:
             logging.info("Config provided, ignoring %s", nettype_setting)
 
     def _process_monitor(self):
-        if not get_opt(self.config, 'vt_config'):
-            if not get_opt(self.config, 'vt_monitor'):
+        if not get_opt(self.config, 'vt.config'):
+            if not get_opt(self.config, 'vt.qemu.monitor'):
                 pass
-            elif get_opt(self.config, 'vt_monitor') == 'qmp':
+            elif get_opt(self.config, 'vt.qemu.monitor') == 'qmp':
                 self.cartesian_parser.assign("monitor_type", "qmp")
-            elif get_opt(self.config, 'vt_monitor') == 'human':
+            elif get_opt(self.config, 'vt.qemu.monitor') == 'human':
                 self.cartesian_parser.assign("monitor_type", "human")
         else:
             logging.info("Config provided, ignoring monitor setting")
 
     def _process_smp(self):
         smp_setting = 'config vt.qemu.smp'
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_smp') == '1':
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.qemu.smp') == '1':
                 self.cartesian_parser.only_filter("up")
-            elif get_opt(self.config, 'vt_smp') == '2':
+            elif get_opt(self.config, 'vt.qemu.smp') == '2':
                 self.cartesian_parser.only_filter("smp2")
             else:
                 try:
                     self.cartesian_parser.only_filter("up")
                     self.cartesian_parser.assign(
-                        "smp", int(get_opt(self.config, 'vt_smp')))
+                        "smp", int(get_opt(self.config, 'vt.qemu.smp')))
                 except ValueError:
                     raise ValueError("Invalid %s '%s'. Valid value: (1, 2, "
-                                     "or integer)" % get_opt(self.config, 'vt_smp'))
+                                     "or integer)" % get_opt(self.config, 'vt.qemu.smp'))
         else:
             logging.info("Config provided, ignoring %s", smp_setting)
 
     def _process_arch(self):
         arch_setting = "option --vt-arch or config vt.common.arch"
-        if get_opt(self.config, 'vt_arch') is None:
+        if get_opt(self.config, 'vt.common.arch') is None:
             pass
-        elif not get_opt(self.config, 'vt_config'):
-            self.cartesian_parser.only_filter(get_opt(self.config, 'vt_arch'))
+        elif not get_opt(self.config, 'vt.config'):
+            self.cartesian_parser.only_filter(get_opt(self.config, 'vt.common.arch'))
         else:
             logging.info("Config provided, ignoring %s", arch_setting)
 
     def _process_machine_type(self):
         machine_type_setting = ("option --vt-machine-type or config "
                                 "vt.common.machine_type")
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_machine_type') is None:
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.common.machine_type') is None:
                 # TODO: this is x86-specific, instead we can get the default
                 # arch from qemu binary and run on all supported machine types
-                if ((get_opt(self.config, 'vt_arch') is None) and
-                        (get_opt(self.config, 'vt_guest_os') is None)):
+                if ((get_opt(self.config, 'vt.common.arch') is None) and
+                        (get_opt(self.config, 'vt.guest_os') is None)):
                     self.cartesian_parser.only_filter(
                         defaults.DEFAULT_MACHINE_TYPE)
             else:
-                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_machine_type'))
+                self.cartesian_parser.only_filter(get_opt(self.config,
+                                                          'vt.common.machine_type'))
         else:
             logging.info("Config provided, ignoring %s", machine_type_setting)
 
     def _process_image_type(self):
         image_type_setting = 'config vt.qemu.image_type'
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_image_type') in SUPPORTED_IMAGE_TYPES:
-                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_image_type'))
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.qemu.image_type') in SUPPORTED_IMAGE_TYPES:
+                self.cartesian_parser.only_filter(get_opt(self.config, 'vt.qemu.image_type'))
             else:
                 self.cartesian_parser.only_filter("raw")
                 # The actual param name is image_format.
                 self.cartesian_parser.assign("image_format",
-                                             get_opt(self.config, 'vt_image_type'))
+                                             get_opt(self.config, 'vt.qemu.image_type'))
         else:
             logging.info("Config provided, ignoring %s", image_type_setting)
 
     def _process_nic_model(self):
         nic_model_setting = 'config vt.qemu.nic_model'
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_nic_model') in SUPPORTED_NIC_MODELS:
-                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_nic_model'))
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.qemu.nic_model') in SUPPORTED_NIC_MODELS:
+                self.cartesian_parser.only_filter(get_opt(self.config, 'vt.qemu.nic_model'))
             else:
                 self.cartesian_parser.only_filter("nic_custom")
                 self.cartesian_parser.assign(
-                    "nic_model", get_opt(self.config, 'vt_nic_model'))
+                    "nic_model", get_opt(self.config, 'vt.qemu.nic_model'))
         else:
             logging.info("Config provided, ignoring %s", nic_model_setting)
 
     def _process_disk_buses(self):
         disk_bus_setting = 'config vt.qemu.disk_bus'
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_disk_bus') in SUPPORTED_DISK_BUSES:
-                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_disk_bus'))
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.qemu.disk_bus') in SUPPORTED_DISK_BUSES:
+                self.cartesian_parser.only_filter(get_opt(self.config, 'vt.qemu.disk_bus'))
             else:
                 raise ValueError("Invalid %s '%s'. Valid values: %s" %
                                  (disk_bus_setting,
-                                  get_opt(self.config, 'vt_disk_bus'),
+                                  get_opt(self.config, 'vt.qemu.disk_bus'),
                                   SUPPORTED_DISK_BUSES))
         else:
             logging.info("Config provided, ignoring %s", disk_bus_setting)
@@ -278,43 +279,43 @@ class VirtTestOptionsProcess(object):
     def _process_vhost(self):
         nettype_setting = 'config vt.qemu.nettype'
         vhost_setting = 'config vt.qemu.vhost'
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_nettype') == "bridge":
-                if get_opt(self.config, 'vt_vhost') == "on":
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.common.nettype') == "bridge":
+                if get_opt(self.config, 'vt.qemu.vhost') == "on":
                     self.cartesian_parser.assign("vhost", "on")
-                elif get_opt(self.config, 'vt_vhost') == "force":
+                elif get_opt(self.config, 'vt.qemu.vhost') == "force":
                     self.cartesian_parser.assign("netdev_extra_params",
                                                  '",vhostforce=on"')
                     self.cartesian_parser.assign("vhost", "on")
             else:
-                if get_opt(self.config, 'vt_vhost') in ["on", "force"]:
+                if get_opt(self.config, 'vt.qemu.vhost') in ["on", "force"]:
                     raise ValueError("%s '%s' is incompatible with %s '%s'"
                                      % (nettype_setting,
-                                        get_opt(self.config, 'vt_nettype'),
+                                        get_opt(self.config, 'vt.common.nettype'),
                                         vhost_setting,
-                                        get_opt(self.config, 'vt_vhost')))
+                                        get_opt(self.config, 'vt.qemu.vhost')))
         else:
             logging.info("Config provided, ignoring %s", vhost_setting)
 
     def _process_qemu_sandbox(self):
         sandbox_setting = 'config vt.qemu.sandbox'
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_qemu_sandbox') == "off":
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.qemu.sandbox') == "off":
                 self.cartesian_parser.assign("qemu_sandbox", "off")
         else:
             logging.info("Config provided, ignoring %s", sandbox_setting)
 
     def _process_qemu_defconfig(self):
         defconfig_setting = 'config vt.qemu.sandbox'
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_qemu_defconfig') == "no":
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.qemu.defconfig') == "no":
                 self.cartesian_parser.assign("defconfig", "no")
         else:
             logging.info("Config provided, ignoring %s", defconfig_setting)
 
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
-                                     get_opt(self.config, 'vt_malloc_perturb'))
+                                     get_opt(self.config, 'vt.qemu.malloc_perturb'))
 
     def _process_qemu_specific_options(self):
         """
@@ -345,56 +346,58 @@ class VirtTestOptionsProcess(object):
         Calls for processing all options specific to libvirt test.
         """
         uri_setting = 'config vt.libvirt.connect_uri'
-        if get_opt(self.config, 'vt_connect_uri'):
+        if get_opt(self.config, 'vt.libvirt.connect_uri'):
             driver_found = False
             for driver in SUPPORTED_LIBVIRT_DRIVERS:
-                if get_opt(self.config, 'vt_connect_uri').count(driver):
+                if get_opt(self.config, 'vt.libvirt.connect_uri').count(driver):
                     driver_found = True
                     self.cartesian_parser.only_filter(driver)
             if not driver_found:
                 raise ValueError("Unsupported %s '%s'"
-                                 % (uri_setting, get_opt(self.config, 'vt_connect_uri')))
+                                 % (uri_setting,
+                                    get_opt(self.config,
+                                            'vt.libvbirt.connect_uri')))
         else:
             self.cartesian_parser.only_filter("qemu")
 
     def _process_guest_os(self):
         guest_os_setting = 'option --vt-guest-os'
 
-        if get_opt(self.config, 'vt_type') == 'spice':
+        if get_opt(self.config, 'vt.type') == 'spice':
             logging.info("Ignoring predefined OS: %s", guest_os_setting)
             return
 
-        if not get_opt(self.config, 'vt_config'):
+        if not get_opt(self.config, 'vt.config'):
             if len(standalone_test.get_guest_name_list(self.config)) == 0:
                 raise ValueError("%s '%s' is not on the known guest os for "
                                  "arch '%s' and machine type '%s'. (see "
                                  "--vt-list-guests)"
                                  % (guest_os_setting,
-                                    get_opt(self.config, 'vt_guest_os'),
-                                    get_opt(self.config, 'vt_arch'),
-                                    get_opt(self.config, 'vt_machine_type')))
+                                    get_opt(self.config, 'vt.guest_os'),
+                                    get_opt(self.config, 'vt.common.arch'),
+                                    get_opt(self.config, 'vt.common.machine_type')))
             self.cartesian_parser.only_filter(
-                get_opt(self.config, 'vt_guest_os') or defaults.DEFAULT_GUEST_OS)
+                get_opt(self.config, 'vt.guest_os') or defaults.DEFAULT_GUEST_OS)
         else:
             logging.info("Config provided, ignoring %s", guest_os_setting)
 
     def _process_restart_vm(self):
-        if not get_opt(self.config, 'vt_config'):
-            if not get_opt(self.config, 'vt_keep_guest_running'):
+        if not get_opt(self.config, 'vt.config'):
+            if not get_opt(self.config, 'vt.setup.keep_guest_running'):
                 self.cartesian_parser.assign("kill_vm", "yes")
 
     def _process_restore_image(self):
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_backup_image_before_test'):
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.setup.backup_image_before_test'):
                 self.cartesian_parser.assign("backup_image_before_testing",
                                              "yes")
-            if get_opt(self.config, 'vt_restore_image_after_test'):
+            if get_opt(self.config, 'vt.setup.restore_image_after_test'):
                 self.cartesian_parser.assign("restore_image_after_testing",
                                              "yes")
 
     def _process_mem(self):
-        if not get_opt(self.config, 'vt_config'):
-            mem = get_opt(self.config, 'vt_mem')
+        if not get_opt(self.config, 'vt.config'):
+            mem = get_opt(self.config, 'vt.common.mem')
             if mem is not None:
                 self.cartesian_parser.assign("mem", mem)
 
@@ -413,24 +416,24 @@ class VirtTestOptionsProcess(object):
             self.cartesian_parser.assign("run_tcpdump", "no")
 
     def _process_no_filter(self):
-        if get_opt(self.config, 'vt_no_filter'):
-            for item in get_opt(self.config, 'vt_no_filter').split(' '):
+        if get_opt(self.config, 'vt.no_filter'):
+            for item in get_opt(self.config, 'vt.no_filter').split(' '):
                 self.cartesian_parser.no_filter(item)
 
     def _process_only_filter(self):
-        if get_opt(self.config, 'vt_only_filter'):
-            for item in get_opt(self.config, 'vt_only_filter').split(' '):
+        if get_opt(self.config, 'vt.only_filter'):
+            for item in get_opt(self.config, 'vt.only_filter').split(' '):
                 self.cartesian_parser.only_filter(item)
 
     def _process_extra_params(self):
-        if get_opt(self.config, "vt_extra_params"):
-            for param in get_opt(self.config, "vt_extra_params"):
+        if get_opt(self.config, "vt.extra_params"):
+            for param in get_opt(self.config, "vt.extra_params"):
                 key, value = param.split('=', 1)
                 self.cartesian_parser.assign(key, value)
 
     def _process_only_type_specific(self):
-        if not get_opt(self.config, 'vt_config'):
-            if get_opt(self.config, 'vt_type_specific'):
+        if not get_opt(self.config, 'vt.config'):
+            if get_opt(self.config, 'vt.type_specific'):
                 self.cartesian_parser.only_filter("(subtest=type_specific)")
 
     def _process_general_options(self):
@@ -468,8 +471,8 @@ class VirtTestOptionsProcess(object):
         vt_type_setting = 'option --vt-type'
         vt_config_setting = 'option --vt-config'
 
-        vt_type = get_opt(self.config, 'vt_type')
-        vt_config = get_opt(self.config, 'vt_config')
+        vt_type = get_opt(self.config, 'vt.type')
+        vt_config = get_opt(self.config, 'vt.config')
 
         if (not vt_type) and (not vt_config):
             raise ValueError("No %s or %s specified" %
@@ -487,18 +490,18 @@ class VirtTestOptionsProcess(object):
         if vt_config:
             cfg = os.path.abspath(vt_config)
             self.cartesian_parser.parse_file(cfg)
-        elif get_opt(self.config, 'vt_filter_default_filters'):
+        elif get_opt(self.config, 'vt.filter.default_filters'):
             cfg = data_dir.get_backend_cfg_path(vt_type,
                                                 'tests-shared.cfg')
             self.cartesian_parser.parse_file(cfg)
             for arg in ('no_9p_export', 'no_virtio_rng', 'no_pci_assignable',
                         'smallpages', 'default_bios', 'bridge'):
-                if arg not in get_opt(self.config, 'vt_filter_default_filters'):
+                if arg not in get_opt(self.config, 'vt.filter.default_filters'):
                     self.cartesian_parser.only_filter(arg)
-            if 'image_backend' not in get_opt(self.config, 'vt_filter_default_filters'):
+            if 'image_backend' not in get_opt(self.config, 'vt.filter.default_filters'):
                 self.cartesian_parser.only_filter('(image_backend='
                                                   'filesystem)')
-            if 'multihost' not in get_opt(self.config, 'vt_filter_default_filters'):
+            if 'multihost' not in get_opt(self.config, 'vt.filter.default_filters'):
                 self.cartesian_parser.no_filter('multihost')
         else:
             cfg = data_dir.get_backend_cfg_path(vt_type, 'tests.cfg')

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -41,66 +41,66 @@ class VirtTestOptionsProcess(object):
     Pick virt test options and parse them to get to a cartesian parser.
     """
 
-    def __init__(self, options):
+    def __init__(self, config):
         """
         Parses options and initializes attributes.
         """
-        self.options = options
+        self.config = config
         # Here we'll inject values from the config file.
         # Doing this makes things configurable yet the number of options
         # is not overwhelming.
         # setup section
-        set_opt(self.options, 'vt_backup_image_before_test',
+        set_opt(self.config, 'vt_backup_image_before_test',
                 settings.get_value('vt.setup', 'backup_image_before_test',
                                    key_type=bool, default=True))
-        set_opt(self.options, 'vt_restore_image_after_test',
+        set_opt(self.config, 'vt_restore_image_after_test',
                 settings.get_value('vt.setup', 'restore_image_after_test',
                                    key_type=bool, default=True))
-        set_opt(self.options, 'vt_keep_guest_running',
+        set_opt(self.config, 'vt_keep_guest_running',
                 settings.get_value('vt.setup', 'keep_guest_running',
                                    key_type=bool, default=False))
         # common section
-        set_opt(self.options, 'vt_data_dir',
+        set_opt(self.config, 'vt_data_dir',
                 settings.get_value('vt.common', 'data_dir', default=None))
-        set_opt(self.options, 'vt_tmp_dir',
+        set_opt(self.config, 'vt_tmp_dir',
                 settings.get_value('vt.common', 'tmp_dir', default=''))
-        set_opt(self.options, 'vt_type_specific',
+        set_opt(self.config, 'vt_type_specific',
                 settings.get_value('vt.common', 'type_specific_only',
                                    key_type=bool, default=False))
-        set_opt(self.options, 'vt_mem',
+        set_opt(self.config, 'vt_mem',
                 settings.get_value('vt.common', 'mem', key_type=int,
                                    default=None))
-        set_opt(self.options, 'vt_nettype',
+        set_opt(self.config, 'vt_nettype',
                 settings.get_value('vt.common', 'nettype', default=None))
-        set_opt(self.options, 'vt_netdst',
+        set_opt(self.config, 'vt_netdst',
                 settings.get_value('vt.common', 'netdst', default='virbr0'))
         # qemu section
-        set_opt(self.options, 'vt_accel',
+        set_opt(self.config, 'vt_accel',
                 settings.get_value('vt.qemu', 'accel', default='kvm'))
-        set_opt(self.options, 'vt_vhost',
+        set_opt(self.config, 'vt_vhost',
                 settings.get_value('vt.qemu', 'vhost', default='off'))
-        set_opt(self.options, 'vt_monitor',
+        set_opt(self.config, 'vt_monitor',
                 settings.get_value('vt.qemu', 'monitor', default=None))
-        set_opt(self.options, 'vt_smp',
+        set_opt(self.config, 'vt_smp',
                 settings.get_value('vt.qemu', 'smp', default='2'))
-        set_opt(self.options, 'vt_image_type',
+        set_opt(self.config, 'vt_image_type',
                 settings.get_value('vt.qemu', 'image_type',
                                    default=SUPPORTED_IMAGE_TYPES[0]))
-        set_opt(self.options, 'vt_nic_model',
+        set_opt(self.config, 'vt_nic_model',
                 settings.get_value('vt.qemu', 'nic_model',
                                    default=SUPPORTED_NIC_MODELS[0]))
-        set_opt(self.options, 'vt_disk_bus',
+        set_opt(self.config, 'vt_disk_bus',
                 settings.get_value('vt.qemu', 'disk_bus',
                                    default=SUPPORTED_DISK_BUSES[0]))
-        set_opt(self.options, 'vt_qemu_sandbox',
+        set_opt(self.config, 'vt_qemu_sandbox',
                 settings.get_value('vt.qemu', 'sandbox', default='on'))
-        set_opt(self.options, 'vt_qemu_defconfig',
+        set_opt(self.config, 'vt_qemu_defconfig',
                 settings.get_value('vt.qemu', 'defconfig', default='yes'))
-        set_opt(self.options, 'vt_malloc_perturb',
+        set_opt(self.config, 'vt_malloc_perturb',
                 settings.get_value('vt.qemu', 'malloc_perturb', default='yes'))
 
         # debug section
-        set_opt(self.options, 'vt_no_cleanup',
+        set_opt(self.config, 'vt_no_cleanup',
                 settings.get_value('vt.debug', 'no_cleanup',
                                    key_type=bool, default=False))
 
@@ -112,15 +112,15 @@ class VirtTestOptionsProcess(object):
         """
         qemu_bin_setting = ('option --vt-qemu-bin or '
                             'config vt.qemu.qemu_bin')
-        if (get_opt(self.options, 'vt_config') and
-                get_opt(self.options, 'vt_qemu_bin') is None):
+        if (get_opt(self.config, 'vt_config') and
+                get_opt(self.config, 'vt_qemu_bin') is None):
             logging.info("Config provided and no %s set. Not trying "
                          "to automatically set qemu bin.", qemu_bin_setting)
         else:
             (qemu_bin_path, qemu_img_path, qemu_io_path,
              qemu_dst_bin_path) = standalone_test.find_default_qemu_paths(
-                 get_opt(self.options, 'vt_qemu_bin'),
-                 get_opt(self.options, 'vt_dst_qemu_bin'))
+                 get_opt(self.config, 'vt_qemu_bin'),
+                 get_opt(self.config, 'vt_dst_qemu_bin'))
             self.cartesian_parser.assign("qemu_binary", qemu_bin_path)
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
             self.cartesian_parser.assign("qemu_io_binary", qemu_io_path)
@@ -134,143 +134,143 @@ class VirtTestOptionsProcess(object):
         """
         qemu_img_setting = ('option --vt-qemu-img or '
                             'config vt.qemu.qemu_img')
-        if (get_opt(self.options, 'vt_config') and
-                get_opt(self.options, 'vt_qemu_bin') is None):
+        if (get_opt(self.config, 'vt_config') and
+                get_opt(self.config, 'vt_qemu_bin') is None):
             logging.info("Config provided and no %s set. Not trying "
                          "to automatically set qemu bin", qemu_img_setting)
         else:
             (_, qemu_img_path,
              _, _) = standalone_test.find_default_qemu_paths(
-                 get_opt(self.options, 'vt_qemu_bin'),
-                 get_opt(self.options, 'vt_dst_qemu_bin'))
+                 get_opt(self.config, 'vt_qemu_bin'),
+                 get_opt(self.config, 'vt_dst_qemu_bin'))
             self.cartesian_parser.assign("qemu_img_binary", qemu_img_path)
 
     def _process_qemu_accel(self):
         """
         Puts the value of the qemu bin option in the cartesian parser command.
         """
-        if get_opt(self.options, 'vt_accel') == 'tcg':
+        if get_opt(self.config, 'vt_accel') == 'tcg':
             self.cartesian_parser.assign("disable_kvm", "yes")
 
     def _process_bridge_mode(self):
         nettype_setting = 'config vt.qemu.nettype'
-        if not get_opt(self.options, 'vt_config'):
+        if not get_opt(self.config, 'vt_config'):
             # Let's select reasonable defaults depending on vt_type
-            if not get_opt(self.options, 'vt_nettype'):
-                if get_opt(self.options, 'vt_type') == 'qemu':
-                    set_opt(self.options, 'vt_nettype',
+            if not get_opt(self.config, 'vt_nettype'):
+                if get_opt(self.config, 'vt_type') == 'qemu':
+                    set_opt(self.config, 'vt_nettype',
                             ("bridge" if os.getuid() == 0 else "user"))
-                elif get_opt(self.options, 'vt_type') == 'spice':
-                    set_opt(self.options, 'vt_nettype', "none")
+                elif get_opt(self.config, 'vt_type') == 'spice':
+                    set_opt(self.config, 'vt_nettype', "none")
                 else:
-                    set_opt(self.options, 'vt_nettype', "bridge")
+                    set_opt(self.config, 'vt_nettype', "bridge")
 
-            if get_opt(self.options, 'vt_nettype') not in SUPPORTED_NET_TYPES:
+            if get_opt(self.config, 'vt_nettype') not in SUPPORTED_NET_TYPES:
                 raise ValueError("Invalid %s '%s'. "
                                  "Valid values: (%s)" %
                                  (nettype_setting,
-                                  get_opt(self.options, 'vt_nettype'),
+                                  get_opt(self.config, 'vt_nettype'),
                                   ", ".join(SUPPORTED_NET_TYPES)))
-            if get_opt(self.options, 'vt_nettype') == 'bridge':
+            if get_opt(self.config, 'vt_nettype') == 'bridge':
                 if os.getuid() != 0:
                     raise ValueError("In order to use %s '%s' you "
                                      "need to be root" % (nettype_setting,
-                                                          get_opt(self.options, 'vt_nettype')))
+                                                          get_opt(self.config, 'vt_nettype')))
                 self.cartesian_parser.assign("nettype", "bridge")
-                self.cartesian_parser.assign("netdst", get_opt(self.options, 'vt_netdst'))
-            elif get_opt(self.options, 'vt_nettype') == 'user':
+                self.cartesian_parser.assign("netdst", get_opt(self.config, 'vt_netdst'))
+            elif get_opt(self.config, 'vt_nettype') == 'user':
                 self.cartesian_parser.assign("nettype", "user")
         else:
             logging.info("Config provided, ignoring %s", nettype_setting)
 
     def _process_monitor(self):
-        if not get_opt(self.options, 'vt_config'):
-            if not get_opt(self.options, 'vt_monitor'):
+        if not get_opt(self.config, 'vt_config'):
+            if not get_opt(self.config, 'vt_monitor'):
                 pass
-            elif get_opt(self.options, 'vt_monitor') == 'qmp':
+            elif get_opt(self.config, 'vt_monitor') == 'qmp':
                 self.cartesian_parser.assign("monitor_type", "qmp")
-            elif get_opt(self.options, 'vt_monitor') == 'human':
+            elif get_opt(self.config, 'vt_monitor') == 'human':
                 self.cartesian_parser.assign("monitor_type", "human")
         else:
             logging.info("Config provided, ignoring monitor setting")
 
     def _process_smp(self):
         smp_setting = 'config vt.qemu.smp'
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_smp') == '1':
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_smp') == '1':
                 self.cartesian_parser.only_filter("up")
-            elif get_opt(self.options, 'vt_smp') == '2':
+            elif get_opt(self.config, 'vt_smp') == '2':
                 self.cartesian_parser.only_filter("smp2")
             else:
                 try:
                     self.cartesian_parser.only_filter("up")
                     self.cartesian_parser.assign(
-                        "smp", int(get_opt(self.options, 'vt_smp')))
+                        "smp", int(get_opt(self.config, 'vt_smp')))
                 except ValueError:
                     raise ValueError("Invalid %s '%s'. Valid value: (1, 2, "
-                                     "or integer)" % get_opt(self.options, 'vt_smp'))
+                                     "or integer)" % get_opt(self.config, 'vt_smp'))
         else:
             logging.info("Config provided, ignoring %s", smp_setting)
 
     def _process_arch(self):
         arch_setting = "option --vt-arch or config vt.common.arch"
-        if get_opt(self.options, 'vt_arch') is None:
+        if get_opt(self.config, 'vt_arch') is None:
             pass
-        elif not get_opt(self.options, 'vt_config'):
-            self.cartesian_parser.only_filter(get_opt(self.options, 'vt_arch'))
+        elif not get_opt(self.config, 'vt_config'):
+            self.cartesian_parser.only_filter(get_opt(self.config, 'vt_arch'))
         else:
             logging.info("Config provided, ignoring %s", arch_setting)
 
     def _process_machine_type(self):
         machine_type_setting = ("option --vt-machine-type or config "
                                 "vt.common.machine_type")
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_machine_type') is None:
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_machine_type') is None:
                 # TODO: this is x86-specific, instead we can get the default
                 # arch from qemu binary and run on all supported machine types
-                if ((get_opt(self.options, 'vt_arch') is None) and
-                        (get_opt(self.options, 'vt_guest_os') is None)):
+                if ((get_opt(self.config, 'vt_arch') is None) and
+                        (get_opt(self.config, 'vt_guest_os') is None)):
                     self.cartesian_parser.only_filter(
                         defaults.DEFAULT_MACHINE_TYPE)
             else:
-                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_machine_type'))
+                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_machine_type'))
         else:
             logging.info("Config provided, ignoring %s", machine_type_setting)
 
     def _process_image_type(self):
         image_type_setting = 'config vt.qemu.image_type'
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_image_type') in SUPPORTED_IMAGE_TYPES:
-                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_image_type'))
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_image_type') in SUPPORTED_IMAGE_TYPES:
+                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_image_type'))
             else:
                 self.cartesian_parser.only_filter("raw")
                 # The actual param name is image_format.
                 self.cartesian_parser.assign("image_format",
-                                             get_opt(self.options, 'vt_image_type'))
+                                             get_opt(self.config, 'vt_image_type'))
         else:
             logging.info("Config provided, ignoring %s", image_type_setting)
 
     def _process_nic_model(self):
         nic_model_setting = 'config vt.qemu.nic_model'
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_nic_model') in SUPPORTED_NIC_MODELS:
-                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_nic_model'))
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_nic_model') in SUPPORTED_NIC_MODELS:
+                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_nic_model'))
             else:
                 self.cartesian_parser.only_filter("nic_custom")
                 self.cartesian_parser.assign(
-                    "nic_model", get_opt(self.options, 'vt_nic_model'))
+                    "nic_model", get_opt(self.config, 'vt_nic_model'))
         else:
             logging.info("Config provided, ignoring %s", nic_model_setting)
 
     def _process_disk_buses(self):
         disk_bus_setting = 'config vt.qemu.disk_bus'
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_disk_bus') in SUPPORTED_DISK_BUSES:
-                self.cartesian_parser.only_filter(get_opt(self.options, 'vt_disk_bus'))
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_disk_bus') in SUPPORTED_DISK_BUSES:
+                self.cartesian_parser.only_filter(get_opt(self.config, 'vt_disk_bus'))
             else:
                 raise ValueError("Invalid %s '%s'. Valid values: %s" %
                                  (disk_bus_setting,
-                                  get_opt(self.options, 'vt_disk_bus'),
+                                  get_opt(self.config, 'vt_disk_bus'),
                                   SUPPORTED_DISK_BUSES))
         else:
             logging.info("Config provided, ignoring %s", disk_bus_setting)
@@ -278,43 +278,43 @@ class VirtTestOptionsProcess(object):
     def _process_vhost(self):
         nettype_setting = 'config vt.qemu.nettype'
         vhost_setting = 'config vt.qemu.vhost'
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_nettype') == "bridge":
-                if get_opt(self.options, 'vt_vhost') == "on":
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_nettype') == "bridge":
+                if get_opt(self.config, 'vt_vhost') == "on":
                     self.cartesian_parser.assign("vhost", "on")
-                elif get_opt(self.options, 'vt_vhost') == "force":
+                elif get_opt(self.config, 'vt_vhost') == "force":
                     self.cartesian_parser.assign("netdev_extra_params",
                                                  '",vhostforce=on"')
                     self.cartesian_parser.assign("vhost", "on")
             else:
-                if get_opt(self.options, 'vt_vhost') in ["on", "force"]:
+                if get_opt(self.config, 'vt_vhost') in ["on", "force"]:
                     raise ValueError("%s '%s' is incompatible with %s '%s'"
                                      % (nettype_setting,
-                                        get_opt(self.options, 'vt_nettype'),
+                                        get_opt(self.config, 'vt_nettype'),
                                         vhost_setting,
-                                        get_opt(self.options, 'vt_vhost')))
+                                        get_opt(self.config, 'vt_vhost')))
         else:
             logging.info("Config provided, ignoring %s", vhost_setting)
 
     def _process_qemu_sandbox(self):
         sandbox_setting = 'config vt.qemu.sandbox'
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_qemu_sandbox') == "off":
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_qemu_sandbox') == "off":
                 self.cartesian_parser.assign("qemu_sandbox", "off")
         else:
             logging.info("Config provided, ignoring %s", sandbox_setting)
 
     def _process_qemu_defconfig(self):
         defconfig_setting = 'config vt.qemu.sandbox'
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_qemu_defconfig') == "no":
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_qemu_defconfig') == "no":
                 self.cartesian_parser.assign("defconfig", "no")
         else:
             logging.info("Config provided, ignoring %s", defconfig_setting)
 
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
-                                     get_opt(self.options, 'vt_malloc_perturb'))
+                                     get_opt(self.config, 'vt_malloc_perturb'))
 
     def _process_qemu_specific_options(self):
         """
@@ -338,63 +338,63 @@ class VirtTestOptionsProcess(object):
         """
         Calls for processing all options specific to LVSB test
         """
-        set_opt(self.options, 'no_downloads', True)
+        set_opt(self.config, 'no_downloads', True)
 
     def _process_libvirt_specific_options(self):
         """
         Calls for processing all options specific to libvirt test.
         """
         uri_setting = 'config vt.libvirt.connect_uri'
-        if get_opt(self.options, 'vt_connect_uri'):
+        if get_opt(self.config, 'vt_connect_uri'):
             driver_found = False
             for driver in SUPPORTED_LIBVIRT_DRIVERS:
-                if get_opt(self.options, 'vt_connect_uri').count(driver):
+                if get_opt(self.config, 'vt_connect_uri').count(driver):
                     driver_found = True
                     self.cartesian_parser.only_filter(driver)
             if not driver_found:
                 raise ValueError("Unsupported %s '%s'"
-                                 % (uri_setting, get_opt(self.options, 'vt_connect_uri')))
+                                 % (uri_setting, get_opt(self.config, 'vt_connect_uri')))
         else:
             self.cartesian_parser.only_filter("qemu")
 
     def _process_guest_os(self):
         guest_os_setting = 'option --vt-guest-os'
 
-        if get_opt(self.options, 'vt_type') == 'spice':
+        if get_opt(self.config, 'vt_type') == 'spice':
             logging.info("Ignoring predefined OS: %s", guest_os_setting)
             return
 
-        if not get_opt(self.options, 'vt_config'):
-            if len(standalone_test.get_guest_name_list(self.options)) == 0:
+        if not get_opt(self.config, 'vt_config'):
+            if len(standalone_test.get_guest_name_list(self.config)) == 0:
                 raise ValueError("%s '%s' is not on the known guest os for "
                                  "arch '%s' and machine type '%s'. (see "
                                  "--vt-list-guests)"
                                  % (guest_os_setting,
-                                    get_opt(self.options, 'vt_guest_os'),
-                                    get_opt(self.options, 'vt_arch'),
-                                    get_opt(self.options, 'vt_machine_type')))
+                                    get_opt(self.config, 'vt_guest_os'),
+                                    get_opt(self.config, 'vt_arch'),
+                                    get_opt(self.config, 'vt_machine_type')))
             self.cartesian_parser.only_filter(
-                get_opt(self.options, 'vt_guest_os') or defaults.DEFAULT_GUEST_OS)
+                get_opt(self.config, 'vt_guest_os') or defaults.DEFAULT_GUEST_OS)
         else:
             logging.info("Config provided, ignoring %s", guest_os_setting)
 
     def _process_restart_vm(self):
-        if not get_opt(self.options, 'vt_config'):
-            if not get_opt(self.options, 'vt_keep_guest_running'):
+        if not get_opt(self.config, 'vt_config'):
+            if not get_opt(self.config, 'vt_keep_guest_running'):
                 self.cartesian_parser.assign("kill_vm", "yes")
 
     def _process_restore_image(self):
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_backup_image_before_test'):
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_backup_image_before_test'):
                 self.cartesian_parser.assign("backup_image_before_testing",
                                              "yes")
-            if get_opt(self.options, 'vt_restore_image_after_test'):
+            if get_opt(self.config, 'vt_restore_image_after_test'):
                 self.cartesian_parser.assign("restore_image_after_testing",
                                              "yes")
 
     def _process_mem(self):
-        if not get_opt(self.options, 'vt_config'):
-            mem = get_opt(self.options, 'vt_mem')
+        if not get_opt(self.config, 'vt_config'):
+            mem = get_opt(self.config, 'vt_mem')
             if mem is not None:
                 self.cartesian_parser.assign("mem", mem)
 
@@ -413,24 +413,24 @@ class VirtTestOptionsProcess(object):
             self.cartesian_parser.assign("run_tcpdump", "no")
 
     def _process_no_filter(self):
-        if get_opt(self.options, 'vt_no_filter'):
-            for item in get_opt(self.options, 'vt_no_filter').split(' '):
+        if get_opt(self.config, 'vt_no_filter'):
+            for item in get_opt(self.config, 'vt_no_filter').split(' '):
                 self.cartesian_parser.no_filter(item)
 
     def _process_only_filter(self):
-        if get_opt(self.options, 'vt_only_filter'):
-            for item in get_opt(self.options, 'vt_only_filter').split(' '):
+        if get_opt(self.config, 'vt_only_filter'):
+            for item in get_opt(self.config, 'vt_only_filter').split(' '):
                 self.cartesian_parser.only_filter(item)
 
     def _process_extra_params(self):
-        if get_opt(self.options, "vt_extra_params"):
-            for param in get_opt(self.options, "vt_extra_params"):
+        if get_opt(self.config, "vt_extra_params"):
+            for param in get_opt(self.config, "vt_extra_params"):
                 key, value = param.split('=', 1)
                 self.cartesian_parser.assign(key, value)
 
     def _process_only_type_specific(self):
-        if not get_opt(self.options, 'vt_config'):
-            if get_opt(self.options, 'vt_type_specific'):
+        if not get_opt(self.config, 'vt_config'):
+            if get_opt(self.config, 'vt_type_specific'):
                 self.cartesian_parser.only_filter("(subtest=type_specific)")
 
     def _process_general_options(self):
@@ -458,7 +458,7 @@ class VirtTestOptionsProcess(object):
         """
         # We can call here for self._process_qemu_specific_options()
         # to process some --options, but let SpiceQA tests will be independent
-        set_opt(self.options, 'no_downloads', True)
+        set_opt(self.config, 'no_downloads', True)
 
     def _process_options(self):
         """
@@ -468,8 +468,8 @@ class VirtTestOptionsProcess(object):
         vt_type_setting = 'option --vt-type'
         vt_config_setting = 'option --vt-config'
 
-        vt_type = get_opt(self.options, 'vt_type')
-        vt_config = get_opt(self.options, 'vt_config')
+        vt_type = get_opt(self.config, 'vt_type')
+        vt_config = get_opt(self.config, 'vt_config')
 
         if (not vt_type) and (not vt_config):
             raise ValueError("No %s or %s specified" %
@@ -487,18 +487,18 @@ class VirtTestOptionsProcess(object):
         if vt_config:
             cfg = os.path.abspath(vt_config)
             self.cartesian_parser.parse_file(cfg)
-        elif get_opt(self.options, 'vt_filter_default_filters'):
+        elif get_opt(self.config, 'vt_filter_default_filters'):
             cfg = data_dir.get_backend_cfg_path(vt_type,
                                                 'tests-shared.cfg')
             self.cartesian_parser.parse_file(cfg)
             for arg in ('no_9p_export', 'no_virtio_rng', 'no_pci_assignable',
                         'smallpages', 'default_bios', 'bridge'):
-                if arg not in get_opt(self.options, 'vt_filter_default_filters'):
+                if arg not in get_opt(self.config, 'vt_filter_default_filters'):
                     self.cartesian_parser.only_filter(arg)
-            if 'image_backend' not in get_opt(self.options, 'vt_filter_default_filters'):
+            if 'image_backend' not in get_opt(self.config, 'vt_filter_default_filters'):
                 self.cartesian_parser.only_filter('(image_backend='
                                                   'filesystem)')
-            if 'multihost' not in get_opt(self.options, 'vt_filter_default_filters'):
+            if 'multihost' not in get_opt(self.config, 'vt_filter_default_filters'):
                 self.cartesian_parser.no_filter('multihost')
         else:
             cfg = data_dir.get_backend_cfg_path(vt_type, 'tests.cfg')

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -223,13 +223,14 @@ class VirtTestOptionsProcess(object):
             logging.info("Config provided, ignoring %s", smp_setting)
 
     def _process_arch(self):
-        arch_setting = "option --vt-arch or config vt.common.arch"
-        if get_opt(self.config, 'vt.common.arch') is None:
-            pass
-        elif not get_opt(self.config, 'vt.config'):
-            self.cartesian_parser.only_filter(get_opt(self.config, 'vt.common.arch'))
-        else:
+        if get_opt(self.config, 'vt.config'):
+            arch_setting = "option --vt-arch or config vt.common.arch"
             logging.info("Config provided, ignoring %s", arch_setting)
+            return
+
+        arch = get_opt(self.config, 'vt.common.arch')
+        if arch:
+            self.cartesian_parser.only_filter(arch)
 
     def _process_machine_type(self):
         machine_type_setting = ("option --vt-machine-type or config "

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -16,7 +16,6 @@
 Avocado VT plugin
 """
 
-import argparse
 import logging
 import os
 
@@ -46,11 +45,7 @@ class VirtTestOptionsProcess(object):
         """
         Parses options and initializes attributes.
         """
-        # Compatibility with more recent Avocado configuration as dictionary
-        if isinstance(options, dict):
-            self.options = argparse.Namespace(**options)
-        else:
-            self.options = options
+        self.options = options
         # Here we'll inject values from the config file.
         # Doing this makes things configurable yet the number of options
         # is not overwhelming.

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -20,12 +20,12 @@ import os
 
 from avocado.core.loader import loader
 from avocado.core.plugin_interfaces import CLI
-from avocado.core.settings import settings
 from avocado.utils import path as utils_path
 
 from virttest import data_dir
 from virttest import defaults
 from virttest import standalone_test
+from virttest.compat import get_settings_value
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
 from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
 
@@ -54,11 +54,11 @@ def add_basic_vt_options(parser):
            ", ".join(SUPPORTED_TEST_TYPES))
     parser.add_argument("--vt-type", action="store", dest="vt.type",
                         help=msg, default=SUPPORTED_TEST_TYPES[0])
-    arch = settings.get_value('vt.common', 'arch', default=None)
+    arch = get_settings_value('vt.common', 'arch', default=None)
     parser.add_argument("--vt-arch", help="Choose the VM architecture. "
                         "Default: %(default)s", default=arch,
                         dest='vt.common.arch')
-    machine = settings.get_value('vt.common', 'machine_type',
+    machine = get_settings_value('vt.common', 'machine_type',
                                  default=defaults.DEFAULT_MACHINE_TYPE)
     parser.add_argument("--vt-machine-type", help="Choose the VM machine type."
                         " Default: %(default)s", default=machine,
@@ -102,7 +102,7 @@ def add_qemu_bin_vt_option(parser):
         qemu_bin_path = standalone_test.find_default_qemu_paths()[0]
     except (RuntimeError, utils_path.CmdNotFoundError):
         qemu_bin_path = None
-    qemu_bin = settings.get_value('vt.qemu', 'qemu_bin',
+    qemu_bin = get_settings_value('vt.qemu', 'qemu_bin',
                                   default=None)
     if qemu_bin is None:    # Allow default to be None when not set in setting
         default_qemu_bin = None
@@ -115,10 +115,10 @@ def add_qemu_bin_vt_option(parser):
                         " this flag is omitted, no attempt to set the qemu "
                         "binaries will be made. Current: %s"
                         % _str_or_none(qemu_bin))
-    qemu_dst = settings.get_value('vt.qemu', 'qemu_dst_bin',
+    qemu_dst = get_settings_value('vt.qemu', 'qemu_dst_bin',
                                   default=qemu_bin_path)
-    parser.add_argument("--vt-qemu-dst-bin", action="store", default=qemu_dst,
-                        dest="vt.qemu.qemu_dst_bin", help="Path "
+    parser.add_argument("--vt-qemu-dst-bin", action="store",
+                        dest="vt.qemu.qemu_dst_bin", default=qemu_dst, help="Path "
                         "to a custom qemu binary to be tested for the "
                         "destination of a migration, overrides --vt-qemu-bin. "
                         "If --vt-config is provided and this flag is omitted, "
@@ -161,7 +161,7 @@ class VTRun(CLI):
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)
         msg = ("Choose test connect uri for libvirt (E.g: %s). "
                "Current: %%(default)s" % supported_uris)
-        uri_current = settings.get_value('vt.libvirt', 'connect_uri',
+        uri_current = get_settings_value('vt.libvirt', 'connect_uri',
                                          default=None)
         vt_compat_group_libvirt.add_argument("--vt-connect-uri",
                                              action="store",

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -53,7 +53,7 @@ def add_basic_vt_options(parser):
     msg = ("Choose test type (%s). Default: %%(default)s" %
            ", ".join(SUPPORTED_TEST_TYPES))
     parser.add_argument("--vt-type", action="store", dest="vt_type",
-                        help=msg, default='qemu')
+                        help=msg, default=SUPPORTED_TEST_TYPES[0])
     arch = settings.get_value('vt.common', 'arch', default=None)
     parser.add_argument("--vt-arch", help="Choose the VM architecture. "
                         "Default: %(default)s", default=arch)

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -46,32 +46,34 @@ def add_basic_vt_options(parser):
     """
     Add basic vt options to parser
     """
-    parser.add_argument("--vt-config", action="store", dest="vt_config",
+    parser.add_argument("--vt-config", action="store", dest="vt.config",
                         help="Explicitly choose a cartesian config. When "
                         "choosing this, some options will be ignored (see "
                         "options below)")
     msg = ("Choose test type (%s). Default: %%(default)s" %
            ", ".join(SUPPORTED_TEST_TYPES))
-    parser.add_argument("--vt-type", action="store", dest="vt_type",
+    parser.add_argument("--vt-type", action="store", dest="vt.type",
                         help=msg, default=SUPPORTED_TEST_TYPES[0])
     arch = settings.get_value('vt.common', 'arch', default=None)
     parser.add_argument("--vt-arch", help="Choose the VM architecture. "
-                        "Default: %(default)s", default=arch)
+                        "Default: %(default)s", default=arch,
+                        dest='vt.common.arch')
     machine = settings.get_value('vt.common', 'machine_type',
                                  default=defaults.DEFAULT_MACHINE_TYPE)
     parser.add_argument("--vt-machine-type", help="Choose the VM machine type."
-                        " Default: %(default)s", default=machine)
+                        " Default: %(default)s", default=machine,
+                        dest='vt.common.machine_type')
     parser.add_argument("--vt-guest-os", action="store",
-                        dest="vt_guest_os", default=defaults.DEFAULT_GUEST_OS,
+                        dest="vt.guest_os", default=defaults.DEFAULT_GUEST_OS,
                         help="Select the guest OS to be used. If --vt-config "
                         "is provided, this will be ignored. Default: "
                         "%(default)s")
-    parser.add_argument("--vt-no-filter", action="store", dest="vt_no_filter",
+    parser.add_argument("--vt-no-filter", action="store", dest="vt.no_filter",
                         default="", help="List of space separated 'no' filters"
                         " to be passed to the config parser.  Default: "
                         "'%(default)s'")
     parser.add_argument("--vt-only-filter", action="store",
-                        dest="vt_only_filter", default="", help="List of space"
+                        dest="vt.only_filter", default="", help="List of space"
                         " separated 'only' filters to be passed to the config "
                         "parser.  Default: '%(default)s'")
     parser.add_argument("--vt-filter-default-filters", nargs='+',
@@ -83,7 +85,7 @@ def add_basic_vt_options(parser):
                         "no_pci_assignable,smallpages,default_bios,bridge,"
                         "image_backend,multihost. This can be used to eg. "
                         "run hugepages tests by filtering 'smallpages' via "
-                        "this option.")
+                        "this option.", dest='vt.filter.default_filters')
 
 
 def add_qemu_bin_vt_option(parser):
@@ -107,7 +109,7 @@ def add_qemu_bin_vt_option(parser):
         qemu_bin = qemu_bin_path
     else:
         default_qemu_bin = qemu_bin
-    parser.add_argument("--vt-qemu-bin", action="store", dest="vt_qemu_bin",
+    parser.add_argument("--vt-qemu-bin", action="store", dest="vt.qemu.qemu_bin",
                         default=default_qemu_bin, help="Path to a custom qemu"
                         " binary to be tested. If --vt-config is provided and"
                         " this flag is omitted, no attempt to set the qemu "
@@ -115,8 +117,8 @@ def add_qemu_bin_vt_option(parser):
                         % _str_or_none(qemu_bin))
     qemu_dst = settings.get_value('vt.qemu', 'qemu_dst_bin',
                                   default=qemu_bin_path)
-    parser.add_argument("--vt-qemu-dst-bin", action="store",
-                        dest="vt_dst_qemu_bin", default=qemu_dst, help="Path "
+    parser.add_argument("--vt-qemu-dst-bin", action="store", default=qemu_dst,
+                        dest="vt.qemu.qemu_dst_bin", help="Path "
                         "to a custom qemu binary to be tested for the "
                         "destination of a migration, overrides --vt-qemu-bin. "
                         "If --vt-config is provided and this flag is omitted, "
@@ -153,6 +155,7 @@ class VTRun(CLI):
         add_basic_vt_options(vt_compat_group_common)
         add_qemu_bin_vt_option(vt_compat_group_qemu)
         vt_compat_group_qemu.add_argument("--vt-extra-params", nargs='*',
+                                          dest="vt.extra_params",
                                           help="List of 'key=value' pairs "
                                           "passed to cartesian parser.")
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)
@@ -162,7 +165,7 @@ class VTRun(CLI):
                                          default=None)
         vt_compat_group_libvirt.add_argument("--vt-connect-uri",
                                              action="store",
-                                             dest="vt_connect_uri",
+                                             dest="vt.libvirt.connect_uri",
                                              default=uri_current,
                                              help=msg)
 

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -28,7 +28,6 @@ from virttest import defaults
 from virttest import standalone_test
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
 from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
-from virttest.standalone_test import SUPPORTED_NET_TYPES
 
 from ..loader import VirtTestLoader
 
@@ -143,10 +142,6 @@ class VTRun(CLI):
         run_subcommand_parser = parser.subcommands.choices.get('run', None)
         if run_subcommand_parser is None:
             return
-
-        qemu_nw_msg = "QEMU network option (%s). " % ", ".join(
-            SUPPORTED_NET_TYPES)
-        qemu_nw_msg += "Default: user"
 
         vt_compat_group_common = run_subcommand_parser.add_argument_group(
             'Virt-Test compat layer - Common options')

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -166,10 +166,10 @@ class VTRun(CLI):
                                              default=uri_current,
                                              help=msg)
 
-    def run(self, args):
+    def run(self, config):
         """
         Run test modules or simple tests.
 
-        :param args: Command line args received from the run subparser.
+        :param config: Command line args received from the run subparser.
         """
         loader.register_plugin(VirtTestLoader)

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -37,14 +37,15 @@ class VTBootstrap(CLICmd):
         parser.add_argument("--vt-type", action="store",
                             help=("Choose test type (%s)" %
                                   ", ".join(SUPPORTED_TEST_TYPES)),
-                            default='qemu')
+                            default='qemu', dest='vt.type')
         parser.add_argument("--vt-guest-os", action="store",
                             default="%s.%s" % (defaults.DEFAULT_GUEST_OS,
                                                defaults.ARCH),
                             help=("Select the guest OS to be used  "
                                   "optionally followed by guest arch. "
                                   "If -c is provided, this will be "
-                                  "ignored. Default: %(default)s"))
+                                  "ignored. Default: %(default)s"),
+                            dest='vt.guest_os')
         parser.add_argument("--vt-selinux-setup", action="store_true",
                             default=False,
                             help="Define default contexts of directory.")

--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -1,0 +1,184 @@
+from avocado.core import plugin_interfaces
+from avocado.core.settings import settings
+from avocado.utils import path as utils_path
+from virttest.compat import is_registering_settings_required
+from virttest.defaults import DEFAULT_MACHINE_TYPE
+from virttest.standalone_test import (SUPPORTED_DISK_BUSES,
+                                      SUPPORTED_IMAGE_TYPES,
+                                      SUPPORTED_NIC_MODELS,
+                                      find_default_qemu_paths)
+
+if hasattr(plugin_interfaces, 'Init'):
+    class VtInit(plugin_interfaces.Init):
+
+        name = 'vt-init'
+        description = "VT plugin initilization"
+
+        def initialize(self):
+            if not is_registering_settings_required():
+                return
+
+            # [vt.setup] section
+            section = 'vt.setup'
+            help_msg = 'Backup image before testing (if not already backed up)'
+            settings.register_option(section, 'backup_image_before_test',
+                                     help_msg=help_msg, key_type=bool,
+                                     default=True)
+
+            help_msg = 'Restore image after testing (if backup present)'
+            settings.register_option(section, 'restore_image_after_test',
+                                     help_msg=help_msg, key_type=bool,
+                                     default=True)
+
+            help_msg = 'Keep guest running between tests (faster, but unsafe)'
+            settings.register_option(section, 'keep_guest_running',
+                                     help_msg=help_msg, key_type=bool,
+                                     default=False)
+
+            # [vt.common] section
+            section = 'vt.common'
+
+            help_msg = ('Data dir path. If none specified, the default '
+                        'virt-test data dir will be used')
+            settings.register_option(section, 'data_dir',
+                                     help_msg=help_msg,
+                                     default='')
+
+            help_msg = ('Make the temporary dir path persistent across jobs if'
+                        ' needed. By default the data in the temporary '
+                        'directory will be wiped after each test in some cases'
+                        ' and after each job in others.')
+            settings.register_option(section, 'tmp_dir',
+                                     help_msg=help_msg,
+                                     default='')
+
+            help_msg = ('Enable only type specific tests. Shared tests will '
+                        'not be tested')
+            settings.register_option(section, 'type_specific_only',
+                                     help_msg=help_msg, key_type=bool,
+                                     default=False)
+
+            help_msg = ('RAM dedicated to the main VM. Usually defaults to '
+                        '1024, as set in "base.cfg", but can be a different '
+                        'value depending on the various other configuration '
+                        'files such as configuration files under "guest-os" '
+                        'and test provider specific files')
+            settings.register_option(section, 'mem',
+                                     help_msg=help_msg,
+                                     default='')
+
+            help_msg = 'Architecture under test'
+            settings.register_option(section, 'arch',
+                                     help_msg=help_msg,
+                                     default=None)
+
+            help_msg = 'Machine type under test'
+            settings.register_option(section, 'machine_type',
+                                     help_msg=help_msg,
+                                     default=DEFAULT_MACHINE_TYPE)
+
+            help_msg = 'Nettype (bridge, user, none)'
+            settings.register_option(section, 'nettype',
+                                     help_msg=help_msg,
+                                     default='')
+
+            help_msg = 'Bridge name to be used if you select bridge as a nettype'
+            settings.register_option(section, 'netdst',
+                                     help_msg=help_msg,
+                                     default='virbr0')
+
+            # [vt.qemu] section
+            section = 'vt.qemu'
+
+            try:
+                default_qemu_bin_path = find_default_qemu_paths()[0]
+            except (RuntimeError, utils_path.CmdNotFoundError):
+                default_qemu_bin_path = None
+            help_msg = 'Path to a custom qemu binary to be tested'
+            settings.register_option(section, 'qemu_bin',
+                                     help_msg=help_msg,
+                                     default=default_qemu_bin_path)
+
+            help_msg = ('Path to a custom qemu binary to be tested for the '
+                        'destination of a migration, overrides qemu_bin for '
+                        'that particular purpose')
+            settings.register_option(section, 'qemu_dst_bin',
+                                     help_msg=help_msg,
+                                     default=default_qemu_bin_path)
+
+            help_msg = 'Accelerator used to run qemu (kvm or tcg)'
+            settings.register_option(section, 'accel',
+                                     help_msg=help_msg,
+                                     default='kvm')
+
+            help_msg = ('Whether to enable vhost for qemu (on/off/force). '
+                        'Depends on nettype=bridge')
+            settings.register_option(section, 'vhost',
+                                     help_msg=help_msg,
+                                     default='off')
+
+            help_msg = 'Monitor type (human or qmp)'
+            settings.register_option(section, 'monitor',
+                                     help_msg=help_msg,
+                                     default='')
+
+            help_msg = 'Number of virtual cpus to use (1 or 2)'
+            settings.register_option(section, 'smp',
+                                     help_msg=help_msg,
+                                     default='2')
+
+            help_msg = 'Image format type to use (any valid qemu format)'
+            settings.register_option(section, 'image_type',
+                                     help_msg=help_msg,
+                                     default=SUPPORTED_IMAGE_TYPES[0])
+
+            help_msg = 'Guest network card model (any valid qemu card)'
+            settings.register_option(section, 'nic_model',
+                                     help_msg=help_msg,
+                                     default=SUPPORTED_NIC_MODELS[0])
+
+            help_msg = ('Guest disk bus for main image. One of ide, scsi, '
+                        'virtio_blk, virtio_scsi, lsi_scsi, ahci, usb2 '
+                        'or xenblk. Note: Older qemu versions and/or '
+                        'operating systems (such as WinXP) might not support '
+                        'virtio_scsi. Please use virtio_blk or ide instead.')
+            settings.register_option(section, 'disk_bus',
+                                     help_msg=help_msg,
+                                     default=SUPPORTED_DISK_BUSES[0])
+
+            help_msg = 'Enable qemu sandboxing (on/off)'
+            settings.register_option(section, 'sandbox',
+                                     help_msg=help_msg,
+                                     default='on')
+
+            help_msg = ('Prevent qemu from loading sysconfdir/qemu.conf '
+                        'and sysconfdir/target-ARCH.conf at startup (yes/no)')
+            settings.register_option(section, 'defconfig',
+                                     help_msg=help_msg,
+                                     default='yes')
+
+            help_msg = ('Use MALLOC_PERTURB_ env variable set to 1 to help '
+                        'catch memory allocation problems on qemu (yes/no)')
+            settings.register_option(section, 'malloc_perturb',
+                                     help_msg=help_msg,
+                                     default='yes')
+
+            # [vt.libvirt] section
+            help_msg = ('Test connect URI for libvirt (qemu:///system, '
+                        'lxc:///)')
+            settings.register_option('vt.libvirt', 'connect_uri',
+                                     help_msg=help_msg,
+                                     default='qemu:///session')
+
+            # [vt.debug] section
+            help_msg = ('Do not clean up tmp files or VM processes at the end '
+                        'of a virt-test execution')
+            settings.register_option('vt.debug', 'no_cleanup',
+                                     help_msg=help_msg, key_type=bool,
+                                     default=False)
+
+            # [plugins.vtjoblock] section
+            help_msg = 'Directory in which to write the lock file'
+            settings.register_option('plugins.vtjoblock', 'dir',
+                                     help_msg=help_msg,
+                                     default='/tmp')

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -7,7 +7,6 @@ import string
 import sys
 
 from avocado.core import exit_codes
-from avocado.core.settings import settings
 from avocado.utils.process import pid_exists
 from avocado.utils.stacktrace import log_exc_info
 
@@ -15,6 +14,8 @@ from avocado.core.plugin_interfaces import JobPreTests as Pre
 from avocado.core.plugin_interfaces import JobPostTests as Post
 
 from ..test import VirtTest
+
+from virttest.compat import get_settings_value
 
 from six.moves import xrange
 
@@ -41,11 +42,9 @@ class VTJobLock(Pre, Post):
 
     def __init__(self, **kwargs):
         self.log = logging.getLogger("avocado.app")
-        self.lock_dir = os.path.expanduser(settings.get_value(
-            section="plugins.vtjoblock",
-            key="dir",
-            key_type=str,
-            default='/tmp'))
+        lock_dir = get_settings_value("plugins.vtjoblock", "dir",
+                                      key_type=str, default='/tmp')
+        self.lock_dir = os.path.expanduser(lock_dir)
         self.lock_file = None
 
     def _create_self_lock_file(self, job):

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -20,9 +20,9 @@ import os
 import sys
 
 from avocado.core.loader import loader
-from avocado.core.settings import settings
 from avocado.core.plugin_interfaces import CLI
 
+from virttest.compat import get_settings_value
 from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 from ..loader import VirtTestLoader
 
@@ -55,7 +55,7 @@ VIRT_TEST_PATH = None
 if 'VIRT_TEST_PATH' in os.environ:
     VIRT_TEST_PATH = os.environ['VIRT_TEST_PATH']
 else:
-    VIRT_TEST_PATH = settings.get_value(section='virt_test',
+    VIRT_TEST_PATH = get_settings_value(section='virt_test',
                                         key='virt_test_path', default=None)
 
 if VIRT_TEST_PATH is not None:

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -113,5 +113,5 @@ class VTLister(CLI):
         add_basic_vt_options(vt_compat_group_lister)
         add_qemu_bin_vt_option(vt_compat_group_lister)
 
-    def run(self, args):
+    def run(self, config):
         loader.register_plugin(VirtTestLoader)

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,9 @@ if __name__ == "__main__":
               pre_post_plugin_type(): [
                   'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock',
                   ],
+              'avocado.plugins.init': [
+                  'vt-init = avocado_vt.plugins.vt_init:VtInit',
+                  ],
               },
           install_requires=requirements,
           )

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -341,7 +341,8 @@ def create_host_os_cfg(options):
             return forced
         else:
             return detected
-    host_os_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt_type'), 'host.cfg')
+    host_os_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt.type'),
+                                                     'host.cfg')
     with open(host_os_cfg_path, 'w') as cfg:
         detected = distro.detect()
         name = host_os_get_distro_name(options, detected)
@@ -860,14 +861,14 @@ def bootstrap(options, interactive=False):
     if get_opt(options, 'yes_to_all'):
         interactive = False
 
-    vt_type = get_opt(options, 'vt_type')
+    vt_type = get_opt(options, 'vt.type')
     LOG.info("Running bootstrap for %s", vt_type)
     step = 0
 
     LOG.info("")
     step += 1
     LOG.info("%d - Checking the mandatory programs and headers", step)
-    guest_os = get_opt(options, 'vt_guest_os') or defaults.DEFAULT_GUEST_OS
+    guest_os = get_opt(options, 'vt.guest_os') or defaults.DEFAULT_GUEST_OS
     try:
         verify_mandatory_programs(vt_type, guest_os)
     except Exception as details:

--- a/virttest/compat.py
+++ b/virttest/compat.py
@@ -43,6 +43,10 @@ if is_registering_settings_required():
     def set_opt_from_settings(opt, section, key, **kwargs):
         """No-op, default values are set at settings.register_option()."""
         pass
+
+    def get_settings_value(section, key, **kwargs):
+        namespace = '%s.%s' % (section, key)
+        return settings.as_dict().get(namespace)
 else:
     def get_opt(opt, name):
         """
@@ -74,3 +78,6 @@ else:
         value = settings.get_value(section, key, **kwargs)
         namespace = '%s.%s' % (section, key)
         set_opt(opt, namespace, value)
+
+    def get_settings_value(section, key, **kwargs):
+        return settings.get_value(section, key, **kwargs)

--- a/virttest/compat.py
+++ b/virttest/compat.py
@@ -1,28 +1,66 @@
 import argparse
 
+from avocado.core.settings import settings
 
-def get_opt(opt, name):
-    """
-    Compatibility handler for options in either argparse.Namespace or dict
 
-    :param opt: either an argpase.Namespace instance or a dict
-    :param name: the name of the attribute or key
+def is_registering_settings_required():
+    """Checks the characteristics of the Avocado settings API.
+
+    And signals if the explicit registration of options is required, along
+    with other API details that should be followed.
+
+    The heuristic used here is to check for methods that are only present
+    in the new API, and should be "safe enough".
+
+    TODO: remove this once support for Avocado releases before 81.0,
+    including 69.x LTS is dropped.
     """
-    if isinstance(opt, argparse.Namespace):
-        return getattr(opt, name, None)
-    else:
+    return all((hasattr(settings, 'add_argparser_to_option'),
+                hasattr(settings, 'register_option'),
+                hasattr(settings, 'as_json')))
+
+
+if is_registering_settings_required():
+    def get_opt(opt, name):
+        """
+        Compatibility handler to Avocado with configuration as dict
+
+        :param opt: a configuration dict, usually from settings.as_dict()
+        :param name: the name of the configuration key, AKA namespace
+        """
         return opt.get(name)
 
+    def set_opt(opt, name, value):
+        """
+        Compatibility handler to Avocado with configuration as dict
 
-def set_opt(opt, name, value):
-    """
-    Compatibility handler for options in either argparse.Namespace or dict
-
-    :param opt: either an argpase.Namespace instance or a dict
-    :param name: the name of the attribute or key
-    :param value: the value to be set
-    """
-    if isinstance(opt, argparse.Namespace):
-        setattr(opt, name, value)
-    else:
+        :param opt: a configuration dict, usually from settings.as_dict()
+        :param name: the name of the configuration key, AKA namespace
+        :param value: the value to be set
+        """
         opt[name] = value
+else:
+    def get_opt(opt, name):
+        """
+        Compatibility handler for options in either argparse.Namespace or dict
+
+        :param opt: either an argpase.Namespace instance or a dict
+        :param name: the name of the attribute or key
+        """
+        if isinstance(opt, argparse.Namespace):
+            return getattr(opt, name, None)
+        else:
+            return opt.get(name)
+
+    def set_opt(opt, name, value):
+        """
+        Compatibility handler for options in either argparse.Namespace or dict
+
+        :param opt: either an argpase.Namespace instance or a dict
+        :param name: the name of the attribute or key
+        :param value: the value to be set
+        """
+        if isinstance(opt, argparse.Namespace):
+            setattr(opt, name, value)
+        else:
+            opt[name] = value

--- a/virttest/compat.py
+++ b/virttest/compat.py
@@ -39,6 +39,10 @@ if is_registering_settings_required():
         :param value: the value to be set
         """
         opt[name] = value
+
+    def set_opt_from_settings(opt, section, key, **kwargs):
+        """No-op, default values are set at settings.register_option()."""
+        pass
 else:
     def get_opt(opt, name):
         """
@@ -64,3 +68,9 @@ else:
             setattr(opt, name, value)
         else:
             opt[name] = value
+
+    def set_opt_from_settings(opt, section, key, **kwargs):
+        """Sets option default value from the configuration file."""
+        value = settings.get_value(section, key, **kwargs)
+        namespace = '%s.%s' % (section, key)
+        set_opt(opt, namespace, value)

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -11,9 +11,10 @@ import shutil
 import stat
 
 from avocado.core import data_dir
-from avocado.core.settings import settings
 from avocado.utils import distro
 from avocado.utils import path as utils_path
+
+from virttest.compat import get_settings_value
 
 from six.moves import xrange
 
@@ -209,7 +210,7 @@ def get_tmp_dir(public=True):
 
     :param public: If public for all users' access
     """
-    persistent_dir = settings.get_value('vt.common', 'tmp_dir',
+    persistent_dir = get_settings_value('vt.common', 'tmp_dir',
                                         default="")
     if persistent_dir != "":
         return persistent_dir

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -110,18 +110,18 @@ def get_cartesian_parser_details(cartesian_parser):
 
 def get_guest_name_parser(options):
     cartesian_parser = cartesian_config.Parser()
-    machines_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt_type'),
+    machines_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt.type'),
                                                       'machines.cfg')
-    guest_os_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt_type'),
+    guest_os_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt.type'),
                                                       'guest-os.cfg')
     cartesian_parser.parse_file(machines_cfg_path)
     cartesian_parser.parse_file(guest_os_cfg_path)
-    if get_opt(options, 'vt_arch'):
-        cartesian_parser.only_filter(get_opt(options, 'vt_arch'))
-    if get_opt(options, 'vt_machine_type'):
-        cartesian_parser.only_filter(get_opt(options, 'vt_machine_type'))
-    if get_opt(options, 'vt_guest_os'):
-        cartesian_parser.only_filter(get_opt(options, 'vt_guest_os'))
+    if get_opt(options, 'vt.common.arch'):
+        cartesian_parser.only_filter(get_opt(options, 'vt.common.arch'))
+    if get_opt(options, 'vt.common.machine_type'):
+        cartesian_parser.only_filter(get_opt(options, 'vt.common.machine_type'))
+    if get_opt(options, 'vt.guest_os'):
+        cartesian_parser.only_filter(get_opt(options, 'vt.guest_os'))
     return cartesian_parser
 
 

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -21,14 +21,18 @@ def _variant_only_file(filename):
                       if not _.lstrip().startswith('#')])
 
 
+#: The first entry of these lists will be used as a default value.
+#: Only change the first entry if you intend to change the default
+#: value.  See :func:`avocado_vt.plugins.vt.add_basic_vt_options` and
+#: class:`avocado_vt.options.VirtTestOptionsProcess` for usage examples.
 SUPPORTED_TEST_TYPES = [
     'qemu', 'libvirt', 'libguestfs', 'openvswitch', 'v2v', 'lvsb', 'spice']
 
 SUPPORTED_LIBVIRT_URIS = ['qemu:///system', 'lxc:///']
 SUPPORTED_LIBVIRT_DRIVERS = ['qemu', 'lxc', 'xen']
 
-SUPPORTED_IMAGE_TYPES = ['raw', 'qcow2', 'qed', 'vmdk']
-SUPPORTED_DISK_BUSES = ['ide', 'scsi', 'virtio_blk',
+SUPPORTED_IMAGE_TYPES = ['qcow2', 'raw', 'qed', 'vmdk']
+SUPPORTED_DISK_BUSES = ['virtio_blk', 'ide', 'scsi',
                         'virtio_scsi', 'lsi_scsi', 'ahci', 'usb2', 'xenblk']
 SUPPORTED_NIC_MODELS = ["virtio_net", "e1000", "rtl8139", "spapr-vlan"]
 SUPPORTED_NET_TYPES = ["bridge", "user", "none"]


### PR DESCRIPTION
The primary goal of this PR is to support the new Avocado settings implementation, which is in itself, very different from the current one.  All of Avocado itself has been ported to the new API, but the `avocado.core.settings` module has not yet been removed and replaced by the new because Avocado-VT is missing compatibility.  See:

https://github.com/avocado-framework/avocado/pull/3944

This PR brings the best support I could come up with for the different Avocado versions, including the one with Avocado PR 3944 merged.  This is why there's a commit called `[REMOVE ME]: Test with avocado new settings implementation`, which adds a Cirrus CI task that checks Avocado-VT compatibility with the proposed changes in Avocado.

This needs to be thoroughly tested, just as some of the previous mass changes to drop old compatibility required. 

---

Changes from v1 (#2623):

* On the (temporary) Cirrus CI check, the Avocado GIT reference was updated to the rebased version of the settings

* Removed unnecessary block that was setting `qemu_dst` from `qemu_bin_path`, in commit "avocado_vt/plugins/vt.py: add more dynamic settings of qemu_dst_bin" (@pevogam)

* Renamed `vt_extra_params` namespace to `vt.extra_params`

* Added docstring/comment on the importance of the order of items on lists of supported configurations such `SUPPORTED_TEST_TYPES`, `SUPPORTED_IMAGE_TYPES`, etc (first item is used as the default option). (@pevogam)

* Used the first item from lists such as `SUPPORTED_TEST_TYPES`, `SUPPORTED_IMAGE_TYPES` also on the `avocado_vt.options.VirtTestOptionsProcess` class.

* Renamed `options` parameter to `config` on `guest_listing` and `arch_listing` methods and in the `vt_list` module (@YongxueHong)

* Style change on `is_registering_settings_required()` using `all()` (@YongxueHong)

* Fixed missing `monitor` key name on `vt.qemu` section (@luckyh)

* Fixed missing `no_cleanup` key name on `vt.debug` section (@luckyh, @pevogam)

* Added a probe for the system qemu binaries and register the first one as default.

Not changed:

* Introduction of a list of supported accellerators.  Discussion to happen here:  https://github.com/avocado-framework/avocado-vt/issues/2707

