### PR TITLE
Configuration files: provide them as example only

### DIFF
--- a/avocado_vt/conf.d/vt.conf
+++ b/avocado_vt/conf.d/vt.conf
@@ -1,71 +1,71 @@
 [vt.setup]
 # Backup image before testing (if not already backed up)
-backup_image_before_test = True
+#backup_image_before_test = True
 # Restore image after testing (if backup present)
-restore_image_after_test = True
+#restore_image_after_test = True
 # Keep guest running between tests (faster, but unsafe)
-keep_guest_running = False
+#keep_guest_running = False
 
 [vt.common]
 # Data dir path. If none specified, the default virt-test data dir will be used
-data_dir =
+#data_dir =
 # Make the temporary dir path persistent across jobs if needed.
 # By default the data in the temporary directory will be wiped after each test
 # in some cases and after each job in others.
-tmp_dir =
+#tmp_dir =
 # Enable only type specific tests. Shared tests will not be tested
-type_specific_only = False
+#type_specific_only = False
 # RAM dedicated to the main VM
 # Usually defaults to 1024, as set in "base.cfg", but can be a different
 # value depending on the various other configuration files such as
 # configuration files under "guest-os" and test provider specific files
-mem =
+#mem =
 # Architecture under test
-arch =
+#arch =
 # Machine type under test
-machine_type =
+#machine_type =
 # Nettype (bridge, user, none)
-nettype =
+#nettype =
 # Bridge name to be used if you select bridge as a nettype
-netdst = virbr0
+#netdst = virbr0
 
 [vt.qemu]
 # Path to a custom qemu binary to be tested
-qemu_bin =
+#qemu_bin =
 # Path to a custom qemu binary to be tested for the
 # destination of a migration, overrides qemu_bin for
 # that particular purpose
-qemu_dst_bin =
+#qemu_dst_bin =
 # Accelerator used to run qemu (kvm or tcg)
-accel = kvm
+#accel = kvm
 # Whether to enable vhost for qemu (on/off/force). Depends on nettype=bridge
-vhost = off
+#vhost = off
 # Monitor type (human or qmp)
-monitor =
+#monitor =
 # Number of virtual cpus to use (1 or 2)
-smp = 2
+#smp = 2
 # Image format type to use (any valid qemu format)
-image_type = qcow2
+#image_type = qcow2
 # Guest network card model (any valid qemu card)
-nic_model = virtio_net
+#nic_model = virtio_net
 # Guest disk bus for main image. One of
 # ('ide', 'scsi', 'virtio_blk', 'virtio_scsi', 'lsi_scsi', 'ahci', 'usb2', 'xenblk')
 # Note: Older qemu versions and/or operating systems might not support
 #       "virtio_scsi" (WinXP) Please use virtio_blk" or "ide" instead.
-disk_bus = virtio_scsi
+#disk_bus = virtio_scsi
 # Enable qemu sandboxing (on/off)
-sandbox = on
+#sandbox = on
 # Prevent qemu from loading sysconfdir/qemu.conf and sysconfdir/target-ARCH.conf at startup
 # (yes/no)
-defconfig = yes
+#defconfig = yes
 # Use MALLOC_PERTURB_ env variable set to 1 to help catch memory allocation problems on qemu
 # (yes/no)
-malloc_perturb = yes
+#malloc_perturb = yes
 
 [vt.libvirt]
 # Test connect URI for libvirt (qemu:///system', 'lxc:///')
-connect_uri = qemu:///session
+#connect_uri = qemu:///session
 
 [vt.debug]
 # Don't clean up tmp files or VM processes at the end of a virt-test execution
-no_cleanup = False
+#no_cleanup = False

--- a/avocado_vt/conf.d/vt_joblock.conf
+++ b/avocado_vt/conf.d/vt_joblock.conf
@@ -1,4 +1,4 @@
 [plugins.vtjoblock]
 # Directory where the lock file will be located. Avocado should have permission
 # to write to this directory.
-dir=/tmp
+# dir=/tmp


### PR DESCRIPTION
With the new Avocado settings module, configuration file content takes
precedence over builtin defaults.  With this new model, the current
configuration files are breaking Avocado-VT when used with the latest
Avocado.

By commenting them out, we leave them as examples only, and users can
uncomment and enable only their specific configurations.  Fortunately,
Avocado-VT doesn't *need* the settings on the configuration files even
when running with Avocado 69.x LTS.

This should fix the Cirrus CI checks with the latest Avocado.

Signed-off-by: Cleber Rosa <crosa@redhat.com>