### PR TITLE
Fix windows guest installation issue with ovmf in case block_with_iommu

### DIFF
--- a/shared/cfg/guest-hw.cfg
+++ b/shared/cfg/guest-hw.cfg
@@ -456,7 +456,7 @@ variants:
         ovmf_path = /usr/share/OVMF
         ovmf_code_filename = OVMF_CODE.secboot.fd
         ovmf_vars_filename = OVMF_VARS.fd
-        unattended_install:
+        unattended_install, block_with_iommu:
             restore_ovmf_vars = yes
             Windows:
                 send_key_at_install = ret


### PR DESCRIPTION
Default not send key when run case block_with_iommu with ovmf that
cause the guest can not boot from CD.

ID: 1838944
Signed-off-by: Menghuan Li menli@redhat.com