### PR TITLE
openvswitch: fix "list_br" returns byte-like issue

### DIFF
--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -291,7 +291,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControl):
         return True
 
     def list_br(self):
-        return self.ovs_vsctl(["list-br"]).stdout.splitlines()
+        return self.ovs_vsctl(["list-br"]).stdout_text.splitlines()
 
     def list_interface(self):
         return self.ovs_vsctl(["list", "interface"]).stdout_text.strip()


### PR DESCRIPTION
This issue is from #2611, CmdResult.stdout is a raw stdout (bytes), and
"list_br" needs to return a string list.

ID: 1871741
Signed-off-by: Yihuang Yu <yihyu@redhat.com>