### PR TITLE
Add new function for autostart handling

### DIFF
--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -449,3 +449,12 @@ def service_libvirtd_control(action, session=None):
     libvirtd_instance = Libvirtd(session=session)
     deprecation_warning()
     getattr(libvirtd_instance, action)()
+
+
+def unmark_storage_autostarted():
+    """
+    By removing this file libvirt start behavior at boot
+    is simulated.
+    """
+    cmd = "rm -rf /var/run/libvirt/storage/autostarted"
+    process.run(cmd, ignore_status=True, shell=True)


### PR DESCRIPTION
Extract logic from tp-libvirt commit 7a213bd18c49ccd6f135a7aac131036543337a78 (https://github.com/autotest/tp-libvirt/pull/2513)
into new function in avocado-vt for reuse.

By removing the autostarted file behavior of daemon at reboot can be simulated
regarding storage autostart behavior.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>