### PR TITLE
Support boot vm with '--preconfig'

### DIFF
--- a/shared/cfg/base.cfg
+++ b/shared/cfg/base.cfg
@@ -827,6 +827,9 @@ force_reset_go_down_check = "qmp"
 # Add -S  to qemu by default, if you don't need it, pls set it off.
 qemu_stop = on
 
+# Do not add --preconfig to qemu by default, set it on if needed.
+qemu_preconfig = off
+
 # Set uuid property of nvdimm device (Since QEMU-5.0), it supports the string
 # representation of a UUID as a URN. // RFC 4122
 # If you use a wrong format, will generate a random UUID base on uuid5 and

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -792,16 +792,6 @@ class HumanMonitor(Monitor):
 
             self._get_supported_cmds()
 
-            # set_link in RHEL5 host use "up|down" instead of "on|off" which is
-            # used in RHEL6 host and Fedora host. So here find out the string
-            # this monitor accept.
-            o = self.cmd("help set_link")
-            try:
-                self.on_str, self.off_str = re.findall("(\w+)\|(\w+)", o)[0]
-            except IndexError:
-                # take a default value if can't get on/off string from monitor.
-                self.on_str, self.off_str = "on", "off"
-
         except MonitorError as e:
             self._close_sock()
             if suppress_exceptions:
@@ -1053,9 +1043,7 @@ class HumanMonitor(Monitor):
         :param up: Bool value, True=set up this link, False=Set down this link
         :return: The response to the command
         """
-        status = self.off_str
-        if up:
-            status = self.on_str
+        status = "on" if up else "off"
         return self.cmd("set_link %s %s" % (name, status))
 
     def live_snapshot(self, device, snapshot_file, **kwargs):

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1738,7 +1738,6 @@ class QMPMonitor(Monitor):
             self.cmd("qmp_capabilities")
 
             self._get_supported_cmds()
-            self._get_supported_hmp_cmds()
 
         except MonitorError as e:
             self._close_sock()
@@ -1858,6 +1857,8 @@ class QMPMonitor(Monitor):
 
         :return: True if cmd is supported, False if not supported.
         """
+        if not self._supported_hmp_cmds:
+            self._get_supported_hmp_cmds()
         if cmd and cmd in self._supported_hmp_cmds:
             return True
         return False

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1014,6 +1014,12 @@ class HumanMonitor(Monitor):
         """
         return self.cmd("info %s" % what, debug=debug)
 
+    def exit_preconfig(self):
+        """
+        Send "exit_preconfig" and return the response
+        """
+        return self.cmd(cmd="exit_preconfig")
+
     def query(self, what):
         """
         Alias for info.
@@ -2068,6 +2074,16 @@ class QMPMonitor(Monitor):
         if o['status'] == status:
             return True
         return False
+
+    def exit_preconfig(self):
+        """
+        Send "(x-)exit-preconfig" and return the response
+        """
+        feature = pick_supported_x_feature("exit-preconfig",
+                                           self._supported_cmds,
+                                           disable_auto_x_evaluation=False,
+                                           error_on_missing=True)
+        return self.cmd(cmd=feature)
 
     def get_events(self):
         """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -166,7 +166,6 @@ class VM(virt_vm.BaseVM):
             self.virtio_ports = []      # virtio_console / virtio_serialport
             self.pci_assignable = None
             self.uuid = None
-            self.vcpu_threads = []
             self.vhost_threads = []
             self.devices = None
             self.logs = {}
@@ -203,6 +202,10 @@ class VM(virt_vm.BaseVM):
         self.start_monotonic_time = 0.0
         self.last_boot_index = 0
         self.last_driver_index = 0
+
+    @property
+    def vcpu_threads(self):
+        return self.get_vcpu_pids(debug=False)
 
     def check_capability(self, capability):
         """
@@ -257,6 +260,18 @@ class VM(virt_vm.BaseVM):
             return False
         try:
             self.verify_status("paused")
+            return True
+        except virt_vm.VMStatusError:
+            return False
+
+    def is_preconfig(self):
+        """
+        Return True if the qemu process is in preconfig status
+        """
+        if self.is_dead():
+            return False
+        try:
+            self.verify_status("preconfig")
             return True
         except virt_vm.VMStatusError:
             return False
@@ -1452,6 +1467,9 @@ class VM(virt_vm.BaseVM):
         qemu_stop = params.get("qemu_stop", "on")
         if qemu_stop == "on":
             devices.insert(StrDev('-S', cmdline="-S"))
+        qemu_preconfig = params.get_boolean("qemu_preconfig")
+        if qemu_preconfig:
+            devices.insert(StrDev('preconfig', cmdline="--preconfig"))
         # Add the VM's name
         devices.insert(StrDev('vmname', cmdline=add_name(name)))
 
@@ -3077,8 +3095,9 @@ class VM(virt_vm.BaseVM):
                 raise e
 
             logging.debug("VM appears to be alive with PID %s", self.get_pid())
-            self.vcpu_threads = self.get_vcpu_pids(debug=True)
-
+            # Record vcpu infos in debug log
+            if not self.is_preconfig():
+                self.get_vcpu_pids(debug=True)
             vhost_thread_pattern = params.get("vhost_thread_pattern",
                                               r"\w+\s+(\d+)\s.*\[vhost-%s\]")
             self.vhost_threads = self.get_vhost_threads(vhost_thread_pattern)
@@ -3097,6 +3116,9 @@ class VM(virt_vm.BaseVM):
             # Wait for IO channels setting up completely,
             # such as serial console.
             time.sleep(1)
+
+            if self.is_preconfig():
+                return
 
             if params.get("paused_after_start_vm") != "yes":
                 # start guest
@@ -3601,7 +3623,6 @@ class VM(virt_vm.BaseVM):
         except qemu_monitor.QMPCmdError as e:
             return (False, str(e))
 
-        self.vcpu_threads = self.get_vcpu_pids()
         # Will hotplug/unplug more than one vcpu.
         add_remove_count = int(self.params.get("vcpu_threads", 1))
         if unplug == "yes":
@@ -4154,6 +4175,10 @@ class VM(virt_vm.BaseVM):
                 'qemu_binary'] = utils_misc.get_qemu_dst_binary(self.params)
         if env:
             env.register_vm("%s_clone" % clone.name, clone)
+
+        # "preconfig" is meaningless for dest, remove it whatever the value is
+        if "qemu_preconfig" in clone.params:
+            del clone.params["qemu_preconfig"]
 
         try:
             if (local and not (migration_exec_cmd_src and


### PR DESCRIPTION
1. qemu_monitor: get supported hmp cmds from qmp monitor when it is needed
2. qemu_monitor: Make 'set_link' only accept on/off from now on
3. qemu_vm: Support boot vm with '--preconfig'
    1. Use 'qemu_preconfig' to determin if boot vm with "--preconfig"
    2. In migration scenario, '--preconfig' with dest is meanningless,
        remove it.
    3. Skip some steps that are meanningless under 'preconfig' status
    4. "query-cpu-fast" that be used to generate "vm.vcpu_threads" is
        not permitted under preconfig status, so generate this property
        only when it was called.
4. qemu_monitor: Add exit_preconfig method

id: 1871156
Signed-off-by: Yanan Fu <yfu@redhat.com>