### PR TITLE
migration: Support for setting migration parameters

### DIFF
--- a/virttest/qemu_capabilities.py
+++ b/virttest/qemu_capabilities.py
@@ -21,6 +21,14 @@ class Flags(object):
     BLOCKDEV = _auto_value()
     SMP_DIES = _auto_value()
     INCOMING_DEFER = _auto_value()
+    MIGRATION_PARAMS = _auto_value()
+
+
+class MigrationParams(object):
+    """Enumerate migration parameters."""
+    DOWNTIME_LIMIT = _auto_value()
+    MAX_BANDWIDTH = _auto_value()
+    XBZRLE_CACHE_SIZE = _auto_value()
 
 
 class Capabilities(object):

--- a/virttest/qemu_migration.py
+++ b/virttest/qemu_migration.py
@@ -1,0 +1,51 @@
+"""
+Interface for QEMU migration.
+"""
+
+from virttest.qemu_capabilities import MigrationParams
+from virttest.qemu_capabilities import Flags
+
+from virttest.utils_numeric import normalize_data_size
+
+
+def set_downtime(vm, value):
+    """
+    Set maximum tolerated downtime for migration.
+
+    :param vm: VM object.
+    :param value: Maximum downtime in seconds.
+    :return: Output of command.
+    """
+    if (vm.check_capability(Flags.MIGRATION_PARAMS) and
+            vm.check_migration_parameter(MigrationParams.DOWNTIME_LIMIT)):
+        return vm.monitor.set_migrate_parameter('downtime-limit', value * 1000)
+    return vm.monitor.migrate_set_downtime(value)
+
+
+def set_speed(vm, value):
+    """
+    Set maximum speed for migration.
+
+    :param vm: VM object.
+    :param value: Speed in bytes/sec.
+    :return: Output of command.
+    """
+    if (vm.check_capability(Flags.MIGRATION_PARAMS) and
+            vm.check_migration_parameter(MigrationParams.MAX_BANDWIDTH)):
+        value = int(normalize_data_size(value, 'B'))
+        return vm.monitor.set_migrate_parameter('max-bandwidth', value)
+    return vm.monitor.migrate_set_speed(value)
+
+
+def set_cache_size(vm, value):
+    """
+    Set cache size for migration.
+
+    :param vm: VM object.
+    :param value: Cache size to set.
+    :return: Output of command.
+    """
+    if (vm.check_capability(Flags.MIGRATION_PARAMS) and
+            vm.check_migration_parameter(MigrationParams.XBZRLE_CACHE_SIZE)):
+        return vm.monitor.set_migrate_parameter('xbzrle-cache-size', value)
+    return vm.monitor.set_migrate_cache_size(value)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -35,6 +35,7 @@ from virttest import utils_misc
 from virttest import cpu
 from virttest import virt_vm
 from virttest import test_setup
+from virttest import qemu_migration
 from virttest import qemu_monitor
 from virttest import qemu_virtio_port
 from virttest import data_dir
@@ -214,12 +215,25 @@ class VM(virt_vm.BaseVM):
         Check whether the given capability is set in the vm capabilities.
 
         :param capability: the given capability
-        :rtype capability: qemu_capabilities.Flags
+        :type capability: qemu_capabilities.Flags
         """
         if self.devices is None:
             raise virt_vm.VMStatusError('Using capabilities before '
                                         'VM being defined')
         return capability in self.devices.caps
+
+    def check_migration_parameter(self, parameter):
+        """
+        Check whether the given migration parameter is set in the vm migration
+        parameters.
+
+        :param parameter: the given migration parameter
+        :type parameter: qemu_capabilities.MigrationParams
+        """
+        if self.devices is None:
+            raise virt_vm.VMStatusError('Using migration parameters before '
+                                        'VM being defined')
+        return parameter in self.devices.mig_params
 
     def verify_alive(self):
         """
@@ -1470,6 +1484,9 @@ class VM(virt_vm.BaseVM):
         if (params.get("qemu_force_use_static_incoming_expression", "no") == "yes" and
                 Flags.INCOMING_DEFER in devices.caps):
             devices.caps.clear_flag(Flags.INCOMING_DEFER)
+        if (params.get("qemu_force_disable_migration_parameter", "no") == "yes" and
+                Flags.MIGRATION_PARAMS in devices.caps):
+            devices.caps.clear_flag(Flags.MIGRATION_PARAMS)
 
         devices.insert(StrDev('PREFIX', cmdline=cmd))
         # Add the qemu binary
@@ -4566,8 +4583,8 @@ class VM(virt_vm.BaseVM):
         """
         self.verify_status('paused')  # Throws exception if not
         # Set high speed 1TB/S
-        self.monitor.migrate_set_speed(str(2 << 39))
-        self.monitor.migrate_set_downtime(self.MIGRATE_TIMEOUT)
+        qemu_migration.set_speed(self, str(2 << 39))
+        qemu_migration.set_downtime(self, self.MIGRATE_TIMEOUT)
         logging.debug("Saving VM %s to %s" % (self.name, path))
         # Can only check status if background migration
         self.monitor.migrate("exec:cat>%s" % path, wait=False)
@@ -4579,8 +4596,8 @@ class VM(virt_vm.BaseVM):
             self.MIGRATE_TIMEOUT, 2, 2,
             "Waiting for save to %s to complete" % path)
         # Restore the speed and downtime to default values
-        self.monitor.migrate_set_speed(str(32 << 20))
-        self.monitor.migrate_set_downtime(0.03)
+        qemu_migration.set_speed(self, str(32 << 20))
+        qemu_migration.monitor.set_downtime(self, 0.03)
         # Base class defines VM must be off after a save
         self.monitor.cmd("system_reset")
         self.verify_status('paused')  # Throws exception if not

--- a/virttest/utils_test/qemu/migration.py
+++ b/virttest/utils_test/qemu/migration.py
@@ -33,7 +33,7 @@ from virttest import utils_test
 from virttest import utils_misc
 from virttest import env_process
 from virttest import error_context as error
-
+from virttest import qemu_migration
 
 try:
     import aexpect
@@ -1491,7 +1491,7 @@ class MigrationBase(object):
         if self.is_src:
             error.context("Set cache size to %s." % value, logging.info)
             vm = self.env.get_vm(self.params["main_vm"])
-            vm.monitor.set_migrate_cache_size(value)
+            qemu_migration.set_cache_size(vm, value)
 
     @error.context_aware
     def get_migration_parameter(self, index=0):
@@ -1547,7 +1547,7 @@ class MigrationBase(object):
         if self.is_src:
             error.context("Set migration speed to %s." % value, logging.info)
             vm = self.env.get_vm(self.params["main_vm"])
-            vm.monitor.migrate_set_speed("%sB" % value)
+            qemu_migration.set_speed(vm, "%sB" % value)
 
     @error.context_aware
     def set_migration_downtime(self, value):
@@ -1561,7 +1561,7 @@ class MigrationBase(object):
         if self.is_src:
             error.context("Set downtime to %s." % value, logging.info)
             vm = self.env.get_vm(self.params["main_vm"])
-            vm.monitor.migrate_set_downtime(value)
+            qemu_migration.set_downtime(vm, value)
 
     @error.context_aware
     def set_migration_cancel(self):


### PR DESCRIPTION
Some migration parameters are deprecated and replaced by other parameters after qemu-5.1.

1."migrate_set_downtime" is deprecated and replaced by "migrate_set_parameter":
2."migrate_set_speed" is deprecated and replaced by "migrate_set_parameter": 
3."migrate_set_cache_size" is deprecated and replaced by "migrate_set_parameter";

ID: 1845429
Signed-off-by: Yongxue Hong yhong@redhat.com