### PR TITLE
Fix image resizing before video encoding

### DIFF
--- a/virttest/video_maker.py
+++ b/virttest/video_maker.py
@@ -125,9 +125,9 @@ class GiEncoder(object):
             image_size = (800, 600)
         else:
             if image_size[0] < 640:
-                image_size = 640
+                image_size[0] = 640
             if image_size[1] < 480:     # is list pylint: disable=E1136
-                image_size = 480
+                image_size[1] = 480
 
         if self.verbose:
             logging.debug('Normalizing image files to size: %s' % (image_size,))


### PR DESCRIPTION
`image_size` is correctly initialized as a tuple, which is the type
expected by `PIL.Image.resize()`, but when the size is smaller than
640x480 the tuple is inadvertently replaced by an integer.

Signed-off-by: Samir Aguiar <samir.aguiar@intra2net.com>