### PR TITLE
Add support to install and use Fedora rawhide guest

### DIFF
--- a/shared/cfg/guest-os/Linux/Fedora/devel.cfg
+++ b/shared/cfg/guest-os/Linux/Fedora/devel.cfg
@@ -1,0 +1,71 @@
+- devel:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - riscv64:
+            # Image provided by Rich Jones, for instructions read:
+            # https://avocado-vt.readthedocs.io/en/latest/Experimental.html#riscv64
+            no install, setup, unattended_install, svirt_install
+            vm_arch_name = riscv64
+            # The provided image uses "riscv" password
+            password = riscv
+            # Double the usual timeouts
+            timeout = 1200
+            login_timeout = 720
+            kill_timeout = 120
+            # Currently we have to boot via custom kernel
+            kernel = images/fdevel-${vm_arch_name}-kernel
+            kernel_params = "console=ttyS0 ro root=/dev/sda"
+            virtio_blk:
+                kernel_params = "console=ttyS0 ro root=/dev/vda"
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    image_name = images/fdevel-${vm_arch_name}
+    os_variant = fedora-rawhide
+    # default boot path is set in ../Fedora.cfg: boot_path = "images/pxeboot"
+    no unattended_install..floppy_ks,unattended_install.cdrom
+    unattended_install, svirt_install:
+        unattended_file_kernel_param_name = inst.ks
+        kernel = images/fdevel-${vm_arch_name}/vmlinuz
+        initrd = images/fdevel-${vm_arch_name}/initrd.img
+        # Unattended-file does not require any changes
+        unattended_file = unattended/Fedora-25.ks
+        unattended_install.url:
+            # Installation works fine with mem=1024 on methods such as cdrom
+            # but fails ("No space left on device") with methods such as url.
+            mem = 2048
+            url = https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Server/${vm_arch_name}/os
+        # ARCH dependent things
+        aarch64:
+            arm64-mmio:
+                # Only latest updates contain virtio driver
+                inactivity_watcher = none
+                take_regular_screendumps = no
+            kernel_params = "console=ttyAMA0 console=ttyS0 serial"
+            unattended_install.url:
+                url = https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/${vm_arch_name}/os
+        ppc64le:
+            kernel_params = "console=hvc0 serial"
+            boot_path = ppc/ppc64
+        s390x:
+            kernel_params = "console=ttysclp0 serial"
+            boot_path = images
+            kernel = images/fdevel-s390x/kernel.img
+            # Anaconda hardcodes headless installation of F28 on s390x
+            vga = none
+            inactivity_watcher = none
+            take_regular_screendumps = no
+        x86_64:
+            kernel_params = "console=tty0 console=ttyS0"
+            unattended_install.url:
+                url = https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/${vm_arch_name}/os
+        # Shared specific setting
+        unattended_install.url:
+            # TODO: Remove the "inst.repo" in newer Fedora versions, requiring it was a bug/regression
+            kernel_params += " inst.repo=${url}"
+        syslog_server_proto = tcp
+        kernel_params += " nicdelay=60 inst.sshd ip=dhcp"


### PR DESCRIPTION
Add support to install and use Fedora rawhide guest
image.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>