### PR TITLE
VT Joblock plugin: be lenient with test suites containing Tasks

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -111,6 +111,13 @@ class VTJobLock(Pre, Post):
                     except OSError:
                         self.log.warn("Unable to remove stale lock: %s", path)
 
+    @staticmethod
+    def _get_klass_or_none(test_factory):
+        try:
+            return test_factory[0]
+        except TypeError:
+            return None
+
     def pre_tests(self, job):
         try:
             if job.test_suite is not None:
@@ -118,7 +125,7 @@ class VTJobLock(Pre, Post):
                     tests = job.test_suite.tests
                 else:
                     tests = job.test_suite
-                if any(test_factory[0] is VirtTest
+                if any(self._get_klass_or_none(test_factory) is VirtTest
                        for test_factory in tests):
                     self._lock(job)
         except Exception as detail:


### PR DESCRIPTION
With the resolver/nrunner implementation, there won't be the
traditional "test factories" in the test suites, but Tasks.

This attempts to fetch the class from the test factory, and ignores if
it fails, which would happen if a Task is there instead.

This leniency isn't a problem because the joblock plugin should only
enforce a lock if a VT (VirtTest) test in within the test suite, which
won't happen at this point as there's no resolver for VT tests.

Fixes: https://github.com/avocado-framework/avocado/issues/4102
Signed-off-by: Cleber Rosa <crosa@redhat.com>