### PR TITLE
Revert "XMLElementList:support list of xml elements with child elements"

### DIFF
--- a/virttest/libvirt_xml/accessors.py
+++ b/virttest/libvirt_xml/accessors.py
@@ -5,7 +5,6 @@ Specializations of base.AccessorBase for particular XML manipulation types
 import logging
 
 from virttest import xml_utils
-from virttest import element_tree
 from virttest.propcan import PropCanBase
 from virttest.libvirt_xml import xcepts, base
 
@@ -697,8 +696,7 @@ class XMLElementList(AccessorGeneratorBase):
     required_dargs = ('parent_xpath', 'tag_name', 'marshal_from', 'marshal_to')
 
     def __init__(self, property_name, libvirtxml, forbidden=None,
-                 parent_xpath=None, marshal_from=None, marshal_to=None,
-                 has_subclass=None):
+                 parent_xpath=None, marshal_from=None, marshal_to=None):
         """
         Create undefined accessors on libvirt instance
 
@@ -721,8 +719,7 @@ class XMLElementList(AccessorGeneratorBase):
                                              forbidden,
                                              parent_xpath=parent_xpath,
                                              marshal_from=marshal_from,
-                                             marshal_to=marshal_to,
-                                             has_subclass=has_subclass)
+                                             marshal_to=marshal_to)
 
     class Getter(AccessorBase):
 
@@ -730,7 +727,7 @@ class XMLElementList(AccessorGeneratorBase):
         Retrieve list of values as returned by the marshal_to callable
         """
 
-        __slots__ = add_to_slots('parent_xpath', 'marshal_to', 'has_subclass')
+        __slots__ = add_to_slots('parent_xpath', 'marshal_to')
 
         def __call__(self):
             # Parent structure cannot be pre-determined as in other classes
@@ -750,23 +747,14 @@ class XMLElementList(AccessorGeneratorBase):
             for child in parent.getchildren():
                 # Call user-defined helper to translate Element
                 # into simple pre-defined format.
-
-                # To support converting xml elements directly to a list of
-                # xml objects, first create xmltreefile for new object
-                if self.has_subclass:
-                    new_xmltreefile = xml_utils.XMLTreeFile(
-                        element_tree.tostring(child))
-                    item = self.marshal_to(child.tag, new_xmltreefile,
+                try:
+                    # To support an optional text parameter, compatible
+                    # with no text parameter.
+                    item = self.marshal_to(child.tag, dict(list(child.items())),
+                                           index, self.libvirtxml, child.text)
+                except TypeError:
+                    item = self.marshal_to(child.tag, dict(list(child.items())),
                                            index, self.libvirtxml)
-                else:
-                    try:
-                        # To support an optional text parameter, compatible
-                        # with no text parameter.
-                        item = self.marshal_to(child.tag, dict(list(child.items())),
-                                               index, self.libvirtxml, child.text)
-                    except TypeError:
-                        item = self.marshal_to(child.tag, dict(list(child.items())),
-                                               index, self.libvirtxml)
                 if item is not None:
                     result.append(item)
                 # Always use absolute index (even if item was None)
@@ -779,7 +767,7 @@ class XMLElementList(AccessorGeneratorBase):
         Set child elements as returned by the marshal_to callable
         """
 
-        __slots__ = add_to_slots('parent_xpath', 'marshal_from', 'has_subclass')
+        __slots__ = add_to_slots('parent_xpath', 'marshal_from')
 
         def __call__(self, value):
             type_check('value', value, list)
@@ -812,12 +800,6 @@ class XMLElementList(AccessorGeneratorBase):
                                                 index,
                                                 str(item)))
                     raise xcepts.LibvirtXMLAccessorError(msg)
-
-                # Handle xml sub-element items
-                if self.has_subclass:
-                    parent.append(element_tuple[1].xmltreefile.getroot())
-                    self.xmltreefile().write()
-                    continue
 
                 # Handle element text values in element_tuple[1].
                 text = None
@@ -856,7 +838,7 @@ class XMLElementList(AccessorGeneratorBase):
         Remove ALL child elements for which marshal_to does NOT return None
         """
 
-        __slots__ = add_to_slots('parent_xpath', 'marshal_to', 'has_subclass')
+        __slots__ = add_to_slots('parent_xpath', 'marshal_to')
 
         def __call__(self):
             parent = self.xmltreefile().find(self.parent_xpath)
@@ -867,22 +849,14 @@ class XMLElementList(AccessorGeneratorBase):
             todel = []
             index = 0
             for child in parent.getchildren():
-                # To support directly deleting xml elements xml objects,
-                # first create xmltreefile for new object
-                if self.has_subclass:
-                    new_xmltreefile = xml_utils.XMLTreeFile(
-                        element_tree.tostring(child))
-                    item = self.marshal_to(child.tag, new_xmltreefile,
+                try:
+                    # To support an optional text parameter, compatible
+                    # with no text parameter.
+                    item = self.marshal_to(child.tag, dict(list(child.items())),
+                                           index, self.libvirtxml, child.text)
+                except TypeError:
+                    item = self.marshal_to(child.tag, dict(list(child.items())),
                                            index, self.libvirtxml)
-                else:
-                    try:
-                        # To support an optional text parameter, compatible
-                        # with no text parameter.
-                        item = self.marshal_to(child.tag, dict(list(child.items())),
-                                               index, self.libvirtxml, child.text)
-                    except TypeError:
-                        item = self.marshal_to(child.tag, dict(list(child.items())),
-                                               index, self.libvirtxml)
                 # Always use absolute index (even if item was None)
                 index += 1
                 # Account for case where child elements are mixed in

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1770,9 +1770,8 @@ class VMCPUXML(base.LibvirtXMLBase):
         accessors.XMLElementList(property_name="numa_cell",
                                  libvirtxml=self,
                                  parent_xpath='numa',
-                                 marshal_from=self.marshal_from_cells,
-                                 marshal_to=self.marshal_to_cells,
-                                 has_subclass=True)
+                                 marshal_from=self.marshal_from_cell,
+                                 marshal_to=self.marshal_to_cell)
         accessors.XMLElementDict(property_name="cache",
                                  libvirtxml=self,
                                  forbidden=[],
@@ -1785,26 +1784,28 @@ class VMCPUXML(base.LibvirtXMLBase):
         self.xml = '<cpu/>'
 
     @staticmethod
-    def marshal_from_cells(item, index, libvirtxml):
+    def marshal_from_cell(item, index, libvirtxml):
         """
-        Convert an xml object to cache tag and xml element.
+        Convert a dict to cell tag and attributes.
         """
-        if isinstance(item, NumaCellXML):
-            return 'cell', item
-        else:
-            raise xcepts.LibvirtXMLError("Expected a list of numa cell "
-                                         "instances, not a %s" % str(item))
+        del index
+        del libvirtxml
+        if not isinstance(item, dict):
+            raise xcepts.LibvirtXMLError("Expected a dictionary of cell "
+                                         "attributes, not a %s"
+                                         % str(item))
+        return ('cell', dict(item))
 
     @staticmethod
-    def marshal_to_cells(tag, new_treefile, index, libvirtxml):
+    def marshal_to_cell(tag, attr_dict, index, libvirtxml):
         """
-        Convert a cache tag xml element to an object of CellCacheXML.
+        Convert a cell tag and attributes to a dict.
         """
+        del index
+        del libvirtxml
         if tag != 'cell':
-            return None     # Don't convert this item
-        newone = NumaCellXML(virsh_instance=libvirtxml.virsh)
-        newone.xmltreefile = new_treefile
-        return newone
+            return None
+        return dict(attr_dict)
 
     def get_feature_list(self):
         """
@@ -1905,30 +1906,6 @@ class VMCPUXML(base.LibvirtXMLBase):
             feature_node.update({'policy': policy})
         xml_utils.ElementTree.SubElement(node, 'feature', feature_node)
 
-    @staticmethod
-    def dicts_to_cells(cell_list):
-        """
-        Convert a list of dict-type numa cell attrs to a list of numa cells
-        Only support str of int type of attr value, not support xml sub elements
-
-        :param cell_list: a list of attrs of numa cells
-        :return: a list of numa cells
-        """
-        # Attributes of numa cells should be dict-type.
-        if not all([isinstance(attr, dict) for attr in cell_list]):
-            raise TypeError('Attributes of numa cells should be dict-type.')
-
-        # Attributes values should be str-type of int-type.
-        attr_values = [val for cell_val in cell_list for val in cell_val.values()]
-        if not all([isinstance(val, str) or isinstance(val, int) for val in attr_values]):
-            raise TypeError('Attributes values should be str-type of int-type.')
-
-        # Convert list of attrs to list of NumaCellXML objects
-        cells = [(NumaCellXML(), attrs) for attrs in cell_list]
-        [x[0].update(x[1]) for x in cells]
-        numa_cells = [x[0] for x in cells]
-        return numa_cells
-
     def remove_numa_cells(self):
         """
         Remove numa cells from xml
@@ -1956,110 +1933,6 @@ class VMCPUXML(base.LibvirtXMLBase):
             cpu_xml.add_feature(feature_name)
 
         return cpu_xml
-
-
-# Sub-element of cpu/numa
-class NumaCellXML(base.LibvirtXMLBase):
-
-    """cell element of numa"""
-
-    __slots__ = ('id', 'cpus', 'memory', 'unit', 'discard', 'memAccess',
-                 'caches')
-
-    def __init__(self, virsh_instance=base.virsh):
-        """
-        Create new Numa_CellXML instance
-        """
-        accessors.XMLAttribute(property_name="id",
-                               libvirtxml=self,
-                               forbidden=[],
-                               parent_xpath='/',
-                               tag_name='cell',
-                               attribute='id')
-        accessors.XMLAttribute(property_name="cpus",
-                               libvirtxml=self,
-                               forbidden=[],
-                               parent_xpath='/',
-                               tag_name='cell',
-                               attribute='cpus')
-        accessors.XMLAttribute(property_name="memory",
-                               libvirtxml=self,
-                               forbidden=[],
-                               parent_xpath='/',
-                               tag_name='cell',
-                               attribute='memory')
-        accessors.XMLAttribute(property_name="unit",
-                               libvirtxml=self,
-                               forbidden=[],
-                               parent_xpath='/',
-                               tag_name='cell',
-                               attribute='unit')
-        accessors.XMLAttribute(property_name="discard",
-                               libvirtxml=self,
-                               forbidden=[],
-                               parent_xpath='/',
-                               tag_name='cell',
-                               attribute='discard')
-        accessors.XMLAttribute(property_name="memAccess",
-                               libvirtxml=self,
-                               forbidden=[],
-                               parent_xpath='/',
-                               tag_name='cell',
-                               attribute='memAccess')
-        accessors.XMLElementList(property_name="caches",
-                                 libvirtxml=self,
-                                 parent_xpath='/',
-                                 marshal_from=self.marshal_from_caches,
-                                 marshal_to=self.marshal_to_caches,
-                                 has_subclass=True)
-        super(NumaCellXML, self).__init__(virsh_instance=virsh_instance)
-        self.xml = '<cell/>'
-
-    @staticmethod
-    def marshal_from_caches(item, index, libvirtxml):
-        """
-        Convert an xml object to cache tag and xml element.
-        """
-        if isinstance(item, CellCacheXML):
-            return 'cache', item
-        else:
-            raise xcepts.LibvirtXMLError("Expected a list of cell cache "
-                                         "instances, not a %s" % str(item))
-
-    @staticmethod
-    def marshal_to_caches(tag, new_treefile, index, libvirtxml):
-        """
-        Convert a cache tag xml element to an object of CellCacheXML.
-        """
-        if tag != 'cache':
-            return None     # Don't convert this item
-        newone = CellCacheXML(virsh_instance=libvirtxml.virsh)
-        newone.xmltreefile = new_treefile
-        return newone
-
-
-class CellCacheXML(base.LibvirtXMLBase):
-
-    """Cell element of cache"""
-
-    __slots__ = ('attrs', 'size_attrs', 'line_attrs')
-
-    def __init__(self, virsh_instance=base.virsh):
-        """
-        Create new CellCacheXML instance
-        """
-        accessors.XMLElementDict('attrs', self,
-                                 parent_xpath='/',
-                                 tag_name='cache')
-        accessors.XMLElementDict('size_attrs', self,
-                                 parent_xpath='/',
-                                 tag_name='size')
-        accessors.XMLElementDict('line_attrs', self,
-                                 parent_xpath='/',
-                                 tag_name='line')
-        super(CellCacheXML, self).__init__(
-            virsh_instance=virsh_instance)
-        self.xml = '<cache/>'
 
 
 class VMClockXML(VMXML):


### PR DESCRIPTION
Reverts avocado-framework/avocado-vt#2749
This need tp-libvirt cases changes at the same time,otherwise leads to many cases failures
revert it firstly to avoid cases failures
