### PR TITLE
Revert "Adopt Avocado cpu library changes"

### DIFF
--- a/virttest/arch.py
+++ b/virttest/arch.py
@@ -86,8 +86,8 @@ else:
 
 def get_kvm_module_list():
     if ARCH == 'x86_64':
-        vendor = cpu.get_vendor() if hasattr(cpu, 'get_vendor') else cpu.get_cpu_vendor_name()
-        return ["kvm", "kvm-%s" % vendor]
+        host_cpu_type = cpu.get_cpu_vendor_name()
+        return ["kvm", "kvm-%s" % host_cpu_type]
     elif ARCH in ('ppc64', 'ppc64le'):
         # FIXME: Please correct it if anyone still want to use KVM-PR mode
         return ["kvm", "kvm-hv"]

--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -181,7 +181,7 @@ def affinity_from_xml(vm):
 
     :return: dict of affinity of VM
     """
-    host_cpu_count = utils.total_count()
+    host_cpu_count = utils.total_cpus_count()
     xml_affinity_list = []
     xml_affinity = {}
     try:
@@ -208,7 +208,7 @@ def affinity_from_vcpupin(vm, vcpu=None, options=None):
     """
     vcpupin_output = {}
     vcpupin_affinity = {}
-    host_cpu_count = utils.total_count()
+    host_cpu_count = utils.total_cpus_count()
     result = virsh.vcpupin(vm.name, vcpu=vcpu, options=options, debug=True)
     for vcpu in result.stdout_text.strip().split('\n')[2:]:
         # On newer version of libvirt, there is no ':' in
@@ -230,7 +230,7 @@ def affinity_from_proc(vm):
     pid = vm.get_pid()
     proc_affinity = {}
     vcpu_pids = []
-    host_cpu_count = utils.total_count()
+    host_cpu_count = utils.total_cpus_count()
     vcpu_pids = vm.get_vcpus_pid()
     for vcpu in range(len(vcpu_pids)):
         output = cpu_allowed_list_by_task(pid, vcpu_pids[vcpu])
@@ -298,7 +298,7 @@ def check_affinity(vm, expect_vcpupin):
     :return: True if affinity matches from different virsh API outputs,
              False if not
     """
-    host_cpu_count = utils.total_count()
+    host_cpu_count = utils.total_cpus_count()
     affinity_xml = affinity_from_xml(vm)
     affinity_vcpupin = affinity_from_vcpupin(vm)
     affinity_vcpuinfo = affinity_from_vcpuinfo(vm)
@@ -443,7 +443,7 @@ def get_cpustats(vm, cpu=None):
     ..
     'total':[cputime]}
      """
-    host_cpu_online = utils.online_list()
+    host_cpu_online = utils.cpu_online_list()
     cpustats = {}
     if cpu:
         cpustats[cpu] = []

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -316,7 +316,7 @@ def preprocess_vm(test, params, env, name):
             else:
                 kernel_extra_params_remove += " pci=nomsi"
         if (params.get("enable_guest_iommu") and
-                cpu_utils.get_vendor() == 'intel'):
+                cpu_utils.get_cpu_vendor_name() == 'intel'):
             enable_guest_iommu = params.get("enable_guest_iommu")
             if enable_guest_iommu == "yes":
                 kernel_extra_params_add += " intel_iommu=on"
@@ -928,16 +928,16 @@ def preprocess(test, params, env):
     # done as root, here we do a check whether
     # we satisfy that condition, if not try to make it off
     # otherwise throw TestError with respective error message
-    cpu_family = cpu_utils.get_family()
+    cpu_arch = cpu_utils.get_cpu_arch()
     migration_setup = params.get("migration_setup", "no") == "yes"
-    if "power" in cpu_family:
+    if "power" in cpu_arch:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())
         power9_compat = "yes" == params.get("power9_compat", "no")
 
-        if "power8" in cpu_family:
+        if "power8" in cpu_arch:
             test_setup.switch_smt(state="off")
-        elif "power9" in cpu_family and power9_compat and pvr < 2.2:
+        elif "power9" in cpu_arch and power9_compat and pvr < 2.2:
             test_setup.switch_indep_threads_mode(state="N")
             test_setup.switch_smt(state="off")
 
@@ -1511,7 +1511,7 @@ def postprocess(test, params, env):
             os.makedirs(gcov_qemu_dir)
             os.chdir(qemu_builddir)
             collect_cmd_opts = params.get("gcov_qemu_collect_cmd_opts", "--html")
-            collect_cmd = "gcovr -j %s -o %s -s %s ." % (cpu_utils.online_count(),
+            collect_cmd = "gcovr -j %s -o %s -s %s ." % (cpu_utils.online_cpus_count(),
                                                          os.path.join(gcov_qemu_dir, "gcov.html"),
                                                          collect_cmd_opts)
             a_process.system(collect_cmd, shell=True)
@@ -1679,14 +1679,14 @@ def postprocess(test, params, env):
     libvirtd_inst = None
     vm_type = params.get("vm_type")
 
-    cpu_family = cpu_utils.get_family()
-    if "power" in cpu_family:
+    cpu_arch = cpu_utils.get_cpu_arch()
+    if "power" in cpu_arch:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())
         # Restore SMT changes in the powerpc host is set
         if params.get("restore_smt", "no") == "yes":
             power9_compat = "yes" == params.get("power9_compat", "no")
-            if "power9" in cpu_family and power9_compat and pvr < 2.2:
+            if "power9" in cpu_arch and power9_compat and pvr < 2.2:
                 test_setup.switch_indep_threads_mode(state="Y")
                 test_setup.switch_smt(state="on")
 

--- a/virttest/utils_stress.py
+++ b/virttest/utils_stress.py
@@ -19,7 +19,7 @@ class VMStressEvents():
         """
         :param params: test param
         """
-        self.host_cpu_list = cpu.online_list()
+        self.host_cpu_list = cpu.cpu_online_list()
         self.iterations = int(params.get("stress_itrs", 1))
         self.host_iterations = int(params.get("host_event_itrs", 10))
         self.event_sleep_time = int(params.get("event_sleep_time", 10))
@@ -179,17 +179,17 @@ class VMStressEvents():
         """
         for itr in range(self.host_iterations):
             if "cpu_freq_governor" in event:
-                cpu.set_freq_governor()
-                logging.debug("Current governor: %s", cpu.get_freq_governor())
+                cpu.set_cpufreq_governor()
+                logging.debug("Current governor: %s", cpu.get_cpufreq_governor())
                 time.sleep(self.event_sleep_time)
             elif "cpu_idle" in event:
-                idlestate = cpu.get_idle_state()
-                cpu.set_idle_state()
+                idlestate = cpu.get_cpuidle_state()
+                cpu.set_cpuidle_state()
                 time.sleep(self.event_sleep_time)
-                cpu.set_idle_state(setstate=idlestate)
+                cpu.set_cpuidle_state(setstate=idlestate)
                 time.sleep(self.event_sleep_time)
             elif "cpuoffline" in event:
-                processor = self.host_cpu_list[random.randint(0, cpu.online_count()-1)]
+                processor = self.host_cpu_list[random.randint(0, cpu.online_cpus_count()-1)]
                 cpu.offline(processor)
                 time.sleep(self.event_sleep_time)
                 cpu.online(processor)


### PR DESCRIPTION
Reverts avocado-framework/avocado-vt#2455
@sathnaga,
In our CI environment, we use avocado 69lts,but use latest avocao-vt version, so this merged PR will totally crash current testing.
so suggest revert it first. And we can discuss more how to handle this gracefully.