### PR TITLE
Fixup: Handle cpu utils failure on AMD and ARM cpu archs

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -928,7 +928,10 @@ def preprocess(test, params, env):
     # done as root, here we do a check whether
     # we satisfy that condition, if not try to make it off
     # otherwise throw TestError with respective error message
-    cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
+    try:
+        cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
+    except NotImplementedError:
+        cpu_family = "unknown"
     migration_setup = params.get("migration_setup", "no") == "yes"
     if "power" in cpu_family:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
@@ -1679,8 +1682,10 @@ def postprocess(test, params, env):
 
     libvirtd_inst = None
     vm_type = params.get("vm_type")
-
-    cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
+    try:
+        cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
+    except NotImplementedError:
+        cpu_family = "unknown"
     if "power" in cpu_family:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())


### PR DESCRIPTION
get_family() method is not yet implemented for certain cpu archs like
amd, arm in avocado cpu utils so while using in the generic code path
like in below libraries hit unwanted error, So let's handle it.

```
Reproduced traceback from: /usr/lib/python3.8/site-packages/avocado_vt/test.py:442
Traceback (most recent call last):
File "/usr/lib/python3.8/site-packages/virttest/error_context.py", line 135, in new_fn
return fn(*args, **kwargs)
File "/usr/lib/python3.8/site-packages/virttest/env_process.py", line 932, in preprocess
cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
File "/usr/lib/python3.8/site-packages/avocado/utils/cpu.py", line 188, in get_family
raise NotImplementedError
NotImplementedError
```

Reported-by: Plamen Dimitrov pdimitrov@pevogam.com
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>