### PR TITLE
Change default value of 'mem' from empty string to 'None'

### DIFF
--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -65,7 +65,7 @@ if hasattr(plugin_interfaces, 'Init'):
                         'and test provider specific files')
             settings.register_option(section, 'mem',
                                      help_msg=help_msg,
-                                     default='')
+                                     default=None)
 
             help_msg = 'Architecture under test'
             settings.register_option(section, 'arch',


### PR DESCRIPTION
When running with Avocado 82.0, is_registering_settings_required()
returns True, settings will be registered, default value of mem is ''.
Setting of mem in 'base.cfg' or other config files from test provider
will not take effect if 'mem' is registered as empty string, changing
to 'None' could fix it.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>