### PR TITLE
Fixup: Root dir resolution for copying backend files

### DIFF
--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -28,11 +28,11 @@ else:
 
 if (os.path.isdir(_DEFAULT_SHARED_PATH) and
         len(os.listdir(_DEFAULT_SHARED_PATH)) > 0):
-    _ROOT_PATH = os.path.dirname(_DEFAULT_SHARED_PATH)
+    ROOT_DIR = os.path.abspath(os.path.dirname(_DEFAULT_SHARED_PATH))
 else:
-    _ROOT_PATH = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
+    ROOT_DIR = os.path.join(os.path.realpath(os.path.dirname(os.path.dirname(__file__))),
+                            "usr", "share", "avocado-plugins-vt")
 
-ROOT_DIR = os.path.abspath(_ROOT_PATH)
 BASE_BACKEND_DIR = os.path.join(ROOT_DIR, 'backends')
 DATA_DIR = os.path.join(data_dir.get_data_dir(), 'avocado-vt')
 SHARED_DIR = os.path.join(ROOT_DIR, 'shared')


### PR DESCRIPTION
avocado vt-bootstrap fails to copy backend avocado files
as it resolves to wrong root directory and hits below error

```
  File "/usr/local/lib/python3.9/site-packages/avocado_vt/plugins/vt_bootstrap.py", line 100, in run
    bootstrap.bootstrap(options=config, interactive=True)
  File "/usr/local/lib/python3.9/site-packages/virttest/bootstrap.py", line 890, in bootstrap
    dir_util.copy_tree(tp_base_dir, tp_local_dir)
  File "/usr/lib64/python3.9/distutils/dir_util.py", line 123, in copy_tree
    raise DistutilsFileError(
distutils.errors.DistutilsFileError: cannot copy tree '/usr/local/lib/python3.9/site-packages/test-
```

Let's handle it.

Fixes: https://github.com/avocado-framework/avocado/issues/4235

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>