### PR TITLE
Handle the failures when getting host cpu family

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -357,7 +357,7 @@ def create_host_os_cfg(options):
         if hasattr(cpu, 'get_family'):
             try:
                 family = cpu.get_family()
-            except NotImplementedError:
+            except Exception:
                 pass
         cpu_version = cpu.get_version() if hasattr(cpu, 'get_version') else None
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -928,10 +928,11 @@ def preprocess(test, params, env):
     # done as root, here we do a check whether
     # we satisfy that condition, if not try to make it off
     # otherwise throw TestError with respective error message
+    cpu_family = "unknown"
     try:
         cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
-    except NotImplementedError:
-        cpu_family = "unknown"
+    except Exception:
+        logging.warning("Could not get host cpu family")
     migration_setup = params.get("migration_setup", "no") == "yes"
     if "power" in cpu_family:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
@@ -1682,10 +1683,11 @@ def postprocess(test, params, env):
 
     libvirtd_inst = None
     vm_type = params.get("vm_type")
+    cpu_family = "unknown"
     try:
         cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
-    except NotImplementedError:
-        cpu_family = "unknown"
+    except Exception:
+        logging.warning("Could not get host cpu family")
     if "power" in cpu_family:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())


### PR DESCRIPTION
Some routines would request the information of host cpu family for
branch selection, so we need to suppress all the exceptions to ensure
that the whole procedure won't be interrupted.

Reported-by: Qinghua Cheng <qcheng@redhat.com>
Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1878675