### PR TITLE
Enhance EFI boot process at q35 chip and aarch64 platform

### DIFF
--- a/shared/cfg/machines.cfg
+++ b/shared/cfg/machines.cfg
@@ -55,6 +55,11 @@ variants:
         vir_domain_undefine_nvram = yes
         inactivity_watcher = none
         take_regular_screendumps = no
+        aavmf_path = /usr/share/edk2/aarch64/
+        aavmf_code_filename = QEMU_EFI-silent-pflash.raw
+        aavmf_vars_filename = vars-template-pflash.raw
+        unattended_install:
+            restore_aavmf_vars = yes
     - arm64-pci:
         only aarch64
         auto_cpu_model = "no"
@@ -66,6 +71,11 @@ variants:
         vga = virtio
         vir_domain_undefine_nvram = yes
         pcie_extra_root_port = 2
+        aavmf_path = /usr/share/edk2/aarch64/
+        aavmf_code_filename = QEMU_EFI-silent-pflash.raw
+        aavmf_vars_filename = vars-template-pflash.raw
+        unattended_install:
+            restore_aavmf_vars = yes
     - riscv64-mmio:
         only riscv64
         # USB subsystem not available


### PR DESCRIPTION
machines.cfg:
1. Introduce aavmf params to configure aarch64's pflashs from cfg

qemu_vm.py
1. Migrate pflash handler from qemu_vm.py to qcontainer.py

qcontainer.py:
1. Add a method to handle pflash firmware
2. Handle pflash only on supported machine types
3. Split pflash command from 1 to 2 if using `-blockdev`

ID: 1883407
Signed-off-by: Yihuang Yu <yihyu@redhat.com>