### PR TITLE
env_process:check value of cpu_family in case it's None

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -934,7 +934,7 @@ def preprocess(test, params, env):
     except Exception:
         logging.warning("Could not get host cpu family")
     migration_setup = params.get("migration_setup", "no") == "yes"
-    if "power" in cpu_family:
+    if cpu_family is not None and "power" in cpu_family:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())
         power9_compat = "yes" == params.get("power9_compat", "no")
@@ -1688,7 +1688,7 @@ def postprocess(test, params, env):
         cpu_family = cpu_utils.get_family() if hasattr(cpu_utils, 'get_family') else cpu_utils.get_cpu_arch()
     except Exception:
         logging.warning("Could not get host cpu family")
-    if "power" in cpu_family:
+    if cpu_family is not None and "power" in cpu_family:
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())
         # Restore SMT changes in the powerpc host is set


### PR DESCRIPTION
cpu_family could be 'None' according to function get_family(), and
'NoneType' is not iterable. Therefore check whether it's None or not
before string comparing.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>