### PR TITLE
utils_net: Strip the output of cmd "which arping"

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3351,7 +3351,7 @@ def verify_ip_address_ownership(ip, macs, timeout=60.0, devs=None,
         regex = re.compile(r"\b%s\b.*\b(%s)\b" % (ip, mac_regex), re.I)
         arping_bin = utils_path.find_command("arping")
         if session:
-            arping_bin = func("which arping", timeout=timeout, **dargs)
+            arping_bin = func("which arping", timeout=timeout, **dargs).strip()
         cmd = "%s --help" % arping_bin
         if "-C count" in func(cmd, timeout=timeout, **dargs):
             regex = re.compile(r"\b%s\b.*\b(%s)" % (mac_regex, ip), re.I)
@@ -3390,7 +3390,7 @@ def verify_ip_address_ownership(ip, macs, timeout=60.0, devs=None,
         # Get the name of the bridge device for ip route cache
         ip_cmd = utils_path.find_command("ip")
         if session:
-            ip_cmd = func("which ip", timeout=timeout, **dargs)
+            ip_cmd = func("which ip", timeout=timeout, **dargs).strip()
         ip_cmd = "%s route get %s; %s -%d route | grep default" % (
             ip_cmd, ip, ip_cmd, ip_ver)
         output = func(ip_cmd, timeout=timeout, **dargs)


### PR DESCRIPTION
The output of cmd "which <cmd>" includes a trailing "\n", which
leads to the failure of cmd "arping/ip".


Signed-off-by: Fangge Jin <fjin@redhat.com>