### PR TITLE
Add multiple python version with python 3.6 afterwards in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
-
-matrix:
-  allow_failures:
-    - python: "3.4"
+    - "3.6"
+    - "3.7"
+    - "3.8"
 
 sudo: false
 


### PR DESCRIPTION
Remove allow_failures for python 3+, and add more disable lint items to allow travis test pass

Signed-off-by: chunfuwen <chwen@redhat.com>