### PR TITLE
Upgrade aexpect version request to 1.6.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2; python_version < '3.0'
-aexpect>1.5.0
+aexpect>=1.6.0
 simplejson>=3.5.3
 netaddr<=0.7.19; python_version < '3.0'
 netaddr>=0.7.19; python_version >= '3.0'


### PR DESCRIPTION
Somehow,current aexpect version leads to bootstrap error,
and upgrade to 1.6.0 afterwards, the issue can be fixed

Signed-off-by: chunfuwen <chwen@redhat.com>