### PR TITLE
utils_cgroup: hotfix for missing one list of elements

### DIFF
--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -624,7 +624,7 @@ def get_load_per_cpu(_stats=None):
     if _stats:
         for line in range(len(_stats)):
             l_stat = []
-            for i in range(1, len(_stats[line])):
+            for i in range(len(_stats[line])):
                 l_stat.append(int(f_stat[line].split()[i+1]) - _stats[line][i])
             stats.append(l_stat)
     else:


### PR DESCRIPTION
This is a issue introduced by commit:
0099798c8be9b073e59475a21ac05c31ec15ccec

id: 1875683
Signed-off-by: Yanan Fu <yfu@redhat.com>