### PR TITLE
Support to dump data from NBD export with TLS in backup function

### DIFF
--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -481,6 +481,9 @@ class LibvirtQemuConfig(LibvirtConfigCommon):
         'swtpm_group': 'string',
         'capability_filters': 'list',
         'nbd_tls_x509_secret_uuid': 'string',
+        'backup_tls_x509_cert_dir': 'string',
+        'backup_tls_x509_verify': 'boolean',
+        'backup_tls_x509_secret_uuid': 'string',
     }
 
 


### PR DESCRIPTION
Libvirt-6.6.0-1.el8 starts to support TLS authentication for pull mode
incremntal backup, we need to support dumping the data from TLS
enabled NBD export to local image.

Signed-off-by: Yi Sun <yisun@redhat.com>