### PR TITLE
setup.py: use older and compatible aexpect on Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,15 +80,17 @@ def pre_post_plugin_type():
 
 
 if __name__ == "__main__":
-    requirements = ["netifaces", "aexpect", "simplejson", "six"]
+    requirements = ["netifaces", "simplejson", "six"]
     if sys.version_info[:2] >= (3, 0):
         requirements.append("avocado-framework>=68.0")
         requirements.append("netaddr")
+        requirements.append("aexpect")
     else:
         # Latest py2 supported stevedore is 1.10.0, need to limit it here
         # as older avocado versions were not limiting it.
         # Note: Avocado 70+ doesn't require stevedore and older Avocado
         # can use whatever version of stevedore on py3
+        requirements.append("aexpect<=1.6.0")
         requirements.append("urllib3<=1.24.3")
         requirements.append("stevedore>=1.8.0,<=1.10.0")
         requirements.append("avocado-framework>=68.0,<70.0")


### PR DESCRIPTION
The latest release, aexpect 1.6.1, contains Python 2
incompatibilities.  Let's pin it to 1.6.0 or earlier on those
circumstances.

Signed-off-by: Cleber Rosa <crosa@redhat.com>