### PR TITLE
Fix up:Update default value of 'nat_attrs' of create_net_xml()

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1801,7 +1801,7 @@ def create_net_xml(net_name, params):
     net_ip_netmask = params.get("net_ip_netmask", "255.255.255.0")
     net_ipv6_address = params.get("net_ipv6_address")
     net_ipv6_prefix = params.get("net_ipv6_prefix", "64")
-    nat_attrs = params.get('nat_attrs')
+    nat_attrs = params.get('nat_attrs', '{}')
     nat_port = params.get("nat_port")
     guest_name = params.get("guest_name")
     guest_ipv4 = params.get("guest_ipv4")


### PR DESCRIPTION
Assign '{}' to  'nat_attrs' as default value to avoid eval()
taking 'None' as input param.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>