### PR TITLE
adapt inittab pattern for more OSes

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1826,8 +1826,8 @@ class VM(virt_vm.BaseVM):
             try:
                 # Only configurate RHEL5 and below
                 regex = "gettys are handled by"
-                # As of RHEL7 systemd message is displayed
-                regex += "|inittab is no longer used when using systemd"
+                # As of RHEL7/8 systemd message is displayed
+                regex += "|inittab is no longer used"
                 output = session.cmd_output("cat /etc/inittab")
                 if re.search(regex, output):
                     logging.debug("Skip setting inittab for %s", device)


### PR DESCRIPTION
set_console_getty() will update /etc/inittab to allow user login from a specific
device(ttyS0 for example) if /etc/inittab takes effect.

We check the specific pattern in /etc/inittab to decide if /etc/inittab is still
used. However for modern OSes, the patterns are a bit difference, so we should
need to update the pattern to adapt more OSes.

RHEL7: inittab is no longer used when using systemd
RHEL8/Fedora27: inittab is no longer used

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>