### PR TITLE
Fix error #2808 brought in: testprovider download dir path changed

### DIFF
--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -226,7 +226,9 @@ def get_download_dir():
     return DOWNLOAD_DIR
 
 
-TEST_PROVIDERS_DOWNLOAD_DIR = os.path.join(get_data_dir(), 'test-providers.d',
+TEST_PROVIDERS_DOWNLOAD_DIR = os.path.join(get_data_dir(),
+                                           'virttest',
+                                           'test-providers.d',
                                            'downloads')
 
 


### PR DESCRIPTION
Testprovider download dir should be under 'virttest'

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>