### PR TITLE
Fix centos 7.1 cirrus failure issue due to aexpect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 autotest>=0.16.2; python_version < '3.0'
-aexpect>=1.6.0
+aexpect>=1.6.0;python_version >= '3.0'
+aexpect>1.5.0; python_version < '3.0'
 simplejson>=3.5.3
 netaddr<=0.7.19; python_version < '3.0'
 netaddr>=0.7.19; python_version >= '3.0'


### PR DESCRIPTION
On centos 7.1, it use python 2.7 and need relatively lower aexpect version
Signed-off-by: chunfuwen <chwen@redhat.com>