### PR TITLE
env_process: Introduce a new param to configure the kernel command line

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -303,6 +303,7 @@ def preprocess_vm(test, params, env, name):
                           migration_exec_cmd=params.get("migration_exec_cmd_dst"))
 
         # Update kernel param
+        serial_login = params.get_boolean("kernel_extra_params_serial_login")
         kernel_extra_params_add = params.get("kernel_extra_params_add", "")
         kernel_extra_params_remove = params.get("kernel_extra_params_remove", "")
         if params.get("disable_pci_msi"):
@@ -329,7 +330,8 @@ def preprocess_vm(test, params, env, name):
         if kernel_extra_params_add or kernel_extra_params_remove:
             utils_test.update_boot_option(vm,
                                           args_added=kernel_extra_params_add,
-                                          args_removed=kernel_extra_params_remove)
+                                          args_removed=kernel_extra_params_remove,
+                                          serial_login=serial_login)
 
     elif not vm.is_alive():    # VM is dead and won't be started, update params
         vm.devices = None
@@ -574,6 +576,7 @@ def postprocess_vm(test, params, env, name):
 
     if params.get("start_vm") == "yes":
         # recover the changes done to kernel params in postprocess
+        serial_login = params.get_boolean("kernel_extra_params_serial_login")
         kernel_extra_params_add = params.get("kernel_extra_params_add", "")
         kernel_extra_params_remove = params.get("kernel_extra_params_remove", "")
 
@@ -592,7 +595,8 @@ def postprocess_vm(test, params, env, name):
                     vm.create(params=params)
                 utils_test.update_boot_option(vm,
                                               args_added=kernel_extra_params_remove,
-                                              args_removed=kernel_extra_params_add)
+                                              args_removed=kernel_extra_params_add,
+                                              serial_login=serial_login)
 
     # Close all SSH sessions that might be active to this VM
     for s in vm.remote_sessions[:]:

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -901,3 +901,6 @@ nvdimm_uuid = ""
 # image_throttle_group_stg1 = "group1"
 # Declare image stg2 belong to throttle group2
 # image_throttle_group_stg2 = "group2"
+
+# Update guest default kernel option via serial session
+# kernel_extra_params_serial_login = no

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -166,7 +166,8 @@ def __run_cmd_and_handle_error(msg, cmd, session, test_fail_msg):
 
 
 def update_boot_option(vm, args_removed="", args_added="",
-                       need_reboot=True, guest_arch_name='x86_64'):
+                       need_reboot=True, guest_arch_name='x86_64',
+                       serial_login=False):
     """
     Update guest default kernel option.
 
@@ -175,6 +176,7 @@ def update_boot_option(vm, args_removed="", args_added="",
     :param args_added: Kernel options want to add.
     :param need_reboot: Whether need reboot VM or not.
     :param guest_arch_name: Guest architecture, e.g. x86_64, s390x
+    :param serial_login: Login guest via serial session
     :raise exceptions.TestError: Raised if fail to update guest kernel cmdline.
 
     """
@@ -189,8 +191,8 @@ def update_boot_option(vm, args_removed="", args_added="",
         logging.warning(msg)
         return
     login_timeout = int(vm.params.get("login_timeout"))
-    session = vm.wait_for_serial_login(timeout=login_timeout,
-                                       restart_network=True)
+    session = vm.wait_for_login(timeout=login_timeout, serial=serial_login,
+                                restart_network=True)
     try:
         # check for args that are really required to be added/removed
         req_args, req_remove_args = check_kernel_cmdline(session,
@@ -226,7 +228,8 @@ def update_boot_option(vm, args_removed="", args_added="",
         # reboot is required only if we really add/remove any args
         if need_reboot and (req_args or req_remove_args):
             logging.info("Rebooting guest ...")
-            session = vm.reboot(session=session, timeout=login_timeout, serial=True)
+            session = vm.reboot(session=session, timeout=login_timeout,
+                                serial=serial_login)
             # check nothing is required to be added/removed by now
             req_args, req_remove_args = check_kernel_cmdline(session,
                                                              remove_args=args_removed,


### PR DESCRIPTION
Introduce a new param to configure the kernel command line

Introduce kernel_extra_params_serial_login to configure the kernel command line in env_process, sometimes the guest does not have a serial session available. The issue is from #2564


ID: 1899377
Signed-off-by: Yihuang Yu <yihyu@redhat.com>