### PR TITLE
Add virttest/passfd.c back to packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.rst
 include VERSION
+include virttest/passfd.c
 recursive-include avocado_vt/conf.d *
 recursive-include virttest/test-providers.d *
 recursive-include virttest/backends *


### PR DESCRIPTION
With commit ba63274, virttest/passfd.c is not being packaged.  Let's
add it to the manifest file.

Signed-off-by: Cleber Rosa <crosa@redhat.com>