### PR TITLE
libvirt_vm: Correct the cdrom type in make_create_command

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1285,7 +1285,7 @@ class VM(virt_vm.BaseVM):
                             "Using --cdrom instead of --disk for install")
                         logging.debug("Skipping CDROM:%s:%s", cdrom, iso)
                         continue
-                if params.get("medium") == 'cdrom_no_kernel_initrd':
+                if params.get("medium") == 'cdrom':
                     if iso == params.get("cdrom_cd1"):
                         logging.debug("Using cdrom or url for install")
                         logging.debug("Skipping CDROM: %s", iso)


### PR DESCRIPTION
unattended_install will not use "cdrom_no_kernel_initrd" anywhere, it
should be "cdrom". Otherwise, the virt-install will add the cdrom_cd1 in
"--location" and "--disk".

Signed-off-by: Yihuang Yu <yihyu@redhat.com>