### PR TITLE
v2v: update vddklib path

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -258,7 +258,7 @@ class Target(object):
 
                     vddk_lib_prefix = 'vddklib_'
                     # General vddk directory
-                    vddk_lib_rootdir = '/var/tmp/vddk_libdir'
+                    vddk_lib_rootdir = os.path.expanduser('~/vddk_libdir')
                     vddk_libdir = '%s/latest' % vddk_lib_rootdir
                     check_list = ['FILES',
                                   'lib64/libgvmomi.so',


### PR DESCRIPTION
Don't use '/var/tmp' to store vddklib to avoid accidentally file corruption.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>