### PR TITLE
Initialization with Job API

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -134,12 +134,12 @@ class VirtTestLoader(loader.TestLoader):
                 cartesian_config.write("%s\n" % statement)
 
     def get_extra_listing(self):
-        if get_opt(self.config, 'vt_list_guests'):
+        if get_opt(self.config, 'vt.list_guests'):
             config = copy.copy(self.config)
             set_opt(config, 'vt.config', None)
             set_opt(config, 'vt.guest_os', None)
             guest_listing(config)
-        if get_opt(self.config, 'vt_list_archs'):
+        if get_opt(self.config, 'vt.list_archs'):
             config = copy.copy(self.config)
             set_opt(config, 'vt.common.machine_type', None)
             set_opt(config, 'vt.common.arch', None)

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -18,19 +18,18 @@ Avocado VT plugin
 
 import os
 
+from avocado.core import plugin_interfaces
 from avocado.core.loader import loader
 from avocado.core.plugin_interfaces import CLI
+from avocado.core.settings import settings, Settings
 from avocado.utils import path as utils_path
 
-from virttest import data_dir
-from virttest import defaults
-from virttest import standalone_test
+from virttest import data_dir, defaults, standalone_test
 from virttest.compat import get_settings_value
-from virttest.standalone_test import SUPPORTED_TEST_TYPES
-from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
+from virttest.standalone_test import (SUPPORTED_LIBVIRT_URIS,
+                                      SUPPORTED_TEST_TYPES)
 
 from ..loader import VirtTestLoader
-
 
 _PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_test_providers_dir(),
                                        'downloads')
@@ -42,59 +41,109 @@ except (OSError, AssertionError):
                       "plugin to get rid of this message")
 
 
+def add_option(parser, namespace, arg, default=None, action='store',
+               help_msg='', nargs=None):
+    if hasattr(Settings, 'add_argparser_to_option'):
+        settings.add_argparser_to_option(
+            namespace=namespace,
+            action=action,
+            parser=parser,
+            allow_multiple=True,
+            long_arg=arg)
+    else:
+        if default is None:
+            parser.add_argument(arg, action=action, dest=namespace,
+                                nargs=nargs, help=help_msg)
+        else:
+            parser.add_argument(arg, action=action, dest=namespace,
+                                nargs=nargs, default=default, help=help_msg)
+
+
 def add_basic_vt_options(parser):
     """
     Add basic vt options to parser
     """
-    parser.add_argument("--vt-config", action="store", dest="vt.config",
-                        help="Explicitly choose a cartesian config. When "
-                        "choosing this, some options will be ignored (see "
-                        "options below)")
-    parser.add_argument("--vt-save-config", action="store",
-                        dest="vt.save_config",
-                        help="Save the resulting cartesian config to a file")
-    msg = ("Choose test type (%s). Default: %%(default)s" %
-           ", ".join(SUPPORTED_TEST_TYPES))
-    parser.add_argument("--vt-type", action="store", dest="vt.type",
-                        help=msg, default=SUPPORTED_TEST_TYPES[0])
+
+    help_msg = ("Explicitly choose a cartesian config. When choosing this, "
+                "some options will be ignored (see options below)")
+    add_option(parser,
+               namespace='vt.config',
+               arg='--vt-config',
+               help_msg=help_msg)
+
+    help_msg = "Save the resulting cartesian config to a file"
+    add_option(parser,
+               namespace='vt.save_config',
+               arg='--vt-save-config',
+               help_msg=help_msg)
+    help_msg = ("Choose test type (%s). Default: %%(default)s" %
+                ", ".join(SUPPORTED_TEST_TYPES))
+    add_option(parser,
+               namespace='vt.type',
+               arg='--vt-type',
+               help_msg=help_msg)
+
     arch = get_settings_value('vt.common', 'arch', default=None)
-    parser.add_argument("--vt-arch", help="Choose the VM architecture. "
-                        "Default: %(default)s", default=arch,
-                        dest='vt.common.arch')
+    help_msg = "Choose the VM architecture. Default: %(default)s"
+    add_option(parser,
+               namespace='vt.common.arch',
+               arg='--vt-arch',
+               default=arch,
+               help_msg=help_msg)
+
     machine = get_settings_value('vt.common', 'machine_type',
                                  default=defaults.DEFAULT_MACHINE_TYPE)
-    parser.add_argument("--vt-machine-type", help="Choose the VM machine type."
-                        " Default: %(default)s", default=machine,
-                        dest='vt.common.machine_type')
-    parser.add_argument("--vt-guest-os", action="store",
-                        dest="vt.guest_os", default=defaults.DEFAULT_GUEST_OS,
-                        help="Select the guest OS to be used. If --vt-config "
-                        "is provided, this will be ignored. Default: "
-                        "%(default)s")
-    parser.add_argument("--vt-no-filter", action="store", dest="vt.no_filter",
-                        default="", help="List of space separated 'no' filters"
-                        " to be passed to the config parser.  Default: "
-                        "'%(default)s'")
-    parser.add_argument("--vt-only-filter", action="store",
-                        dest="vt.only_filter", default="", help="List of space"
-                        " separated 'only' filters to be passed to the config "
-                        "parser.  Default: '%(default)s'")
-    parser.add_argument("--vt-filter-default-filters", nargs='+',
-                        help="Allows to selectively skip certain default "
-                        "filters. This uses directly 'tests-shared.cfg' and "
-                        "instead of '$provider/tests.cfg' and applies "
-                        "following lists of default filters, unless they are "
-                        "specified as arguments: no_9p_export,no_virtio_rng,"
-                        "no_pci_assignable,smallpages,default_bios,bridge,"
-                        "image_backend,multihost. This can be used to eg. "
-                        "run hugepages tests by filtering 'smallpages' via "
-                        "this option.", dest='vt.filter.default_filters')
+    help_msg = "Choose the VM machine type. Default: %(default)s"
+    add_option(parser,
+               namespace='vt.common.machine_type',
+               arg='--vt-machine-type',
+               default=machine,
+               help_msg=help_msg)
+
+    help_msg = ("Select the guest OS to be used. If --vt-config is provided, "
+                "this will be ignored. Default: %(default)s")
+    add_option(parser,
+               namespace='vt.guest_os',
+               arg='--vt-guest-os',
+               default=defaults.DEFAULT_GUEST_OS,
+               help_msg=help_msg)
+
+    help_msg = ("List of space separated 'no' filters to be passed to the "
+                "config parser.  Default: '%(default)s'")
+    add_option(parser,
+               namespace='vt.no_filter',
+               arg='--vt-no-filter',
+               default="",
+               help_msg=help_msg)
+
+    help_msg = ("List of space separated 'only' filters to be passed to the "
+                "config parser.  Default: '%(default)s'")
+    add_option(parser,
+               namespace='vt.only_filter',
+               arg='--vt-only-filter',
+               default="",
+               help_msg=help_msg)
+
+    help_msg = ("Allows to selectively skip certain default filters. This uses "
+                "directly 'tests-shared.cfg' and instead of "
+                "'$provider/tests.cfg' and applies following lists of default "
+                "filters, unless they are specified as arguments: "
+                "no_9p_export,no_virtio_rng,no_pci_assignable,smallpages,"
+                "default_bios,bridge,image_backend,multihost. This can be used"
+                " to eg. run hugepages tests by filtering 'smallpages' via "
+                "this option.")
+    add_option(parser,
+               namespace='vt.filter.default_filters',
+               arg='--vt-filter-default-filters',
+               nargs='+',
+               help_msg=help_msg)
 
 
 def add_qemu_bin_vt_option(parser):
     """
     Add qemu-bin vt option to parser
     """
+
     def _str_or_none(arg):
         if arg is None:
             return "Could not find one"
@@ -107,26 +156,33 @@ def add_qemu_bin_vt_option(parser):
         qemu_bin_path = None
     qemu_bin = get_settings_value('vt.qemu', 'qemu_bin',
                                   default=None)
-    if qemu_bin is None:    # Allow default to be None when not set in setting
+    if qemu_bin is None:  # Allow default to be None when not set in setting
         default_qemu_bin = None
         qemu_bin = qemu_bin_path
     else:
         default_qemu_bin = qemu_bin
-    parser.add_argument("--vt-qemu-bin", action="store", dest="vt.qemu.qemu_bin",
-                        default=default_qemu_bin, help="Path to a custom qemu"
-                        " binary to be tested. If --vt-config is provided and"
-                        " this flag is omitted, no attempt to set the qemu "
-                        "binaries will be made. Current: %s"
-                        % _str_or_none(qemu_bin))
+
+    help_msg = ("Path to a custom qemu binary to be tested. If --vt-config is "
+                "provided and this flag is omitted, no attempt to set the "
+                "qemu binaries will be made. Current: %s" %
+                _str_or_none(qemu_bin))
+    add_option(parser,
+               namespace='vt.qemu.qemu_bin',
+               arg='--vt-qemu-bin',
+               default=default_qemu_bin,
+               help_msg=help_msg)
+
     qemu_dst = get_settings_value('vt.qemu', 'qemu_dst_bin',
                                   default=qemu_bin_path)
-    parser.add_argument("--vt-qemu-dst-bin", action="store",
-                        dest="vt.qemu.qemu_dst_bin", default=qemu_dst, help="Path "
-                        "to a custom qemu binary to be tested for the "
-                        "destination of a migration, overrides --vt-qemu-bin. "
-                        "If --vt-config is provided and this flag is omitted, "
-                        "no attempt to set the qemu binaries will be made. "
-                        "Current: %s" % _str_or_none(qemu_dst))
+    help_msg = ("Path to a custom qemu binary to be tested for the destination"
+                " of a migration, overrides --vt-qemu-bin. If --vt-config is "
+                "provided and this flag is omitted, no attempt to set the qemu"
+                " binaries will be made. Current: %s" % _str_or_none(qemu_dst))
+    add_option(parser,
+               namespace='vt.qemu.qemu_dst_bin',
+               arg='--vt-qemu-dst-bin',
+               default=qemu_dst,
+               help_msg=help_msg)
 
 
 class VTRun(CLI):
@@ -157,25 +213,29 @@ class VTRun(CLI):
 
         add_basic_vt_options(vt_compat_group_common)
         add_qemu_bin_vt_option(vt_compat_group_qemu)
-        vt_compat_group_qemu.add_argument("--vt-extra-params", nargs='*',
-                                          dest="vt.extra_params",
-                                          help="List of 'key=value' pairs "
-                                          "passed to cartesian parser.")
+
+        help_msg = "List of 'key=value' pairs passed to cartesian parser."
+        add_option(parser=vt_compat_group_qemu,
+                   namespace='vt.extra_params',
+                   arg='--vt-extra-params',
+                   nargs='*',
+                   help_msg=help_msg)
+
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)
-        msg = ("Choose test connect uri for libvirt (E.g: %s). "
-               "Current: %%(default)s" % supported_uris)
+        help_msg = ("Choose test connect uri for libvirt (E.g: %s). Current: "
+                    "%%(default)s" % supported_uris)
         uri_current = get_settings_value('vt.libvirt', 'connect_uri',
                                          default=None)
-        vt_compat_group_libvirt.add_argument("--vt-connect-uri",
-                                             action="store",
-                                             dest="vt.libvirt.connect_uri",
-                                             default=uri_current,
-                                             help=msg)
+        add_option(parser=vt_compat_group_libvirt,
+                   namespace='vt.libvirt.connect_uri',
+                   arg='--vt-connect-uri',
+                   default=uri_current,
+                   help_msg=help_msg)
 
     def run(self, config):
         """
         Run test modules or simple tests.
-
         :param config: Command line args received from the run subparser.
         """
-        loader.register_plugin(VirtTestLoader)
+        if not hasattr(plugin_interfaces, 'Init'):
+            loader.register_plugin(VirtTestLoader)


### PR DESCRIPTION
Right now when we want to run tests through avocado Job API the avocado-vt is
not loaded, because a lot of avocado-vt settings is initialized through CLI
plugin.  This commit moves the initialization to the Init plugin and leaves CLI
plugin just for necessary command line setup

Signed-off-by: Jan Richter <jarichte@redhat.com>