### PR TITLE
Support kata style vm template

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1884,7 +1884,8 @@ class VM(virt_vm.BaseVM):
             add_virtio_rng(devices, rng_params, parent_bus)
 
         # Add logging
-        devices.insert(StrDev('isa-log', cmdline=add_log_seabios(devices)))
+        if params.get("enable_debugcon") == "yes":
+            devices.insert(StrDev('isa-log', cmdline=add_log_seabios(devices)))
         if params.get("anaconda_log", "no") == "yes":
             parent_bus = self._get_pci_bus(params, None, True)
             add_log_anaconda(devices, parent_bus)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1174,14 +1174,14 @@ class VM(virt_vm.BaseVM):
             # Pay attention that rtc-td-hack is for early version
             # if "rtc " in help:
             if devices.has_option("rtc"):
-                cmd = " -rtc base=%s" % params.get("rtc_base", "utc")
-                cmd += _add_option("clock", params.get("rtc_clock", "host"))
-                cmd += _add_option("driftfix", params.get("rtc_drift", None))
-                return cmd
+                cmd = _add_option("base", params.get("rtc_base"))
+                cmd += _add_option("clock", params.get("rtc_clock"))
+                cmd += _add_option("driftfix", params.get("rtc_drift"))
+                if cmd:
+                    return " -rtc %s" % cmd.lstrip(",")
             elif devices.has_option("rtc-td-hack"):
                 return " -rtc-td-hack"
-            else:
-                return ""
+            return ""
 
         def add_kernel_cmdline(cmdline):
             return " -append '%s'" % cmdline

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2334,12 +2334,13 @@ class VM(virt_vm.BaseVM):
         if (params.get("disable_kvm", "no") == "yes"):
             params["enable_kvm"] = "no"
 
-        if (params.get("enable_kvm", "yes") == "no"):
-            devices.insert(StrDev('nokvm', cmdline=disable_kvm_option))
-            logging.debug("qemu will run in TCG mode")
-        else:
-            devices.insert(StrDev('kvm', cmdline=enable_kvm_option))
-            logging.debug("qemu will run in KVM mode")
+        if not params.get("vm_accelerator"):
+            if (params.get("enable_kvm", "yes") == "no"):
+                devices.insert(StrDev('nokvm', cmdline=disable_kvm_option))
+                logging.debug("qemu will run in TCG mode")
+            else:
+                devices.insert(StrDev('kvm', cmdline=enable_kvm_option))
+                logging.debug("qemu will run in KVM mode")
 
         compat = params.get("qemu_compat")
         if compat and devices.has_option("compat"):

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -12,6 +12,9 @@ qemu_io_binary = qemu-io
 #enable_kvm = yes
 # Explicitly pass -no-kvm to qemu (default no)
 #disable_kvm = no
+# For enabling an accelerator explicitly (default ''). This option has
+# higher priority than `enable_kvm` or `disable_kvm`.
+#vm_accelerator =
 # Explicitly pass -disable-shutdown to qemu (default no)
 #disable_shutdown = no
 # Set the "-compat" setting option (uncomment this to crash on the use of

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -359,6 +359,9 @@ catch_monitor = catch_monitor
 chardev_backend_catch_monitor = unix_socket
 #monitor_type_catch_monitor = qmp
 
+# Add a debugging console to guest.
+enable_debugcon = yes
+
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc
 

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -409,6 +409,12 @@ boot_menu = off
 # Enable/Disable strict boot
 boot_strict = off
 
+# Guest RTC base (utc, localtime, <datetime>)
+rtc_base = utc
+# Guest RTC clock (host, rt, vm)
+rtc_clock = host
+# Guest RTC drift (none, slew)
+#rtc_drift =
 
 #### SPICE related options valid if display == spice,
 #### you should set vga = qxl to get SPICE in use


### PR DESCRIPTION
Let some of the qemu opitons to be configurable, in order to support kata style vm template.

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1902565