### PR TITLE
Initialization with Job API [v2]

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -134,12 +134,12 @@ class VirtTestLoader(loader.TestLoader):
                 cartesian_config.write("%s\n" % statement)
 
     def get_extra_listing(self):
-        if get_opt(self.config, 'vt_list_guests'):
+        if get_opt(self.config, 'vt.list_guests'):
             config = copy.copy(self.config)
             set_opt(config, 'vt.config', None)
             set_opt(config, 'vt.guest_os', None)
             guest_listing(config)
-        if get_opt(self.config, 'vt_list_archs'):
+        if get_opt(self.config, 'vt.list_archs'):
             config = copy.copy(self.config)
             set_opt(config, 'vt.common.machine_type', None)
             set_opt(config, 'vt.common.arch', None)

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -25,7 +25,7 @@ from avocado.utils import path as utils_path
 from virttest import data_dir
 from virttest import defaults
 from virttest import standalone_test
-from virttest.compat import get_settings_value
+from virttest.compat import get_settings_value, add_option
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
 from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
 
@@ -46,55 +46,87 @@ def add_basic_vt_options(parser):
     """
     Add basic vt options to parser
     """
-    parser.add_argument("--vt-config", action="store", dest="vt.config",
-                        help="Explicitly choose a cartesian config. When "
-                        "choosing this, some options will be ignored (see "
-                        "options below)")
-    parser.add_argument("--vt-save-config", action="store",
-                        dest="vt.save_config",
-                        help="Save the resulting cartesian config to a file")
-    msg = ("Choose test type (%s). Default: %%(default)s" %
-           ", ".join(SUPPORTED_TEST_TYPES))
-    parser.add_argument("--vt-type", action="store", dest="vt.type",
-                        help=msg, default=SUPPORTED_TEST_TYPES[0])
+
+    help_msg = ("Explicitly choose a cartesian config. When choosing this, "
+                "some options will be ignored (see options below)")
+    add_option(parser,
+               dest='vt.config',
+               arg='--vt-config',
+               help=help_msg)
+
+    help_msg = "Save the resulting cartesian config to a file"
+    add_option(parser,
+               dest='vt.save_config',
+               arg='--vt-save-config',
+               help=help_msg)
+    help_msg = ("Choose test type (%s). Default: %%(default)s" %
+                ", ".join(SUPPORTED_TEST_TYPES))
+    add_option(parser,
+               dest='vt.type',
+               arg='--vt-type',
+               help=help_msg)
+
     arch = get_settings_value('vt.common', 'arch', default=None)
-    parser.add_argument("--vt-arch", help="Choose the VM architecture. "
-                        "Default: %(default)s", default=arch,
-                        dest='vt.common.arch')
+    help_msg = "Choose the VM architecture. Default: %(default)s"
+    add_option(parser,
+               dest='vt.common.arch',
+               arg='--vt-arch',
+               default=arch,
+               help=help_msg)
+
     machine = get_settings_value('vt.common', 'machine_type',
                                  default=defaults.DEFAULT_MACHINE_TYPE)
-    parser.add_argument("--vt-machine-type", help="Choose the VM machine type."
-                        " Default: %(default)s", default=machine,
-                        dest='vt.common.machine_type')
-    parser.add_argument("--vt-guest-os", action="store",
-                        dest="vt.guest_os", default=defaults.DEFAULT_GUEST_OS,
-                        help="Select the guest OS to be used. If --vt-config "
-                        "is provided, this will be ignored. Default: "
-                        "%(default)s")
-    parser.add_argument("--vt-no-filter", action="store", dest="vt.no_filter",
-                        default="", help="List of space separated 'no' filters"
-                        " to be passed to the config parser.  Default: "
-                        "'%(default)s'")
-    parser.add_argument("--vt-only-filter", action="store",
-                        dest="vt.only_filter", default="", help="List of space"
-                        " separated 'only' filters to be passed to the config "
-                        "parser.  Default: '%(default)s'")
-    parser.add_argument("--vt-filter-default-filters", nargs='+',
-                        help="Allows to selectively skip certain default "
-                        "filters. This uses directly 'tests-shared.cfg' and "
-                        "instead of '$provider/tests.cfg' and applies "
-                        "following lists of default filters, unless they are "
-                        "specified as arguments: no_9p_export,no_virtio_rng,"
-                        "no_pci_assignable,smallpages,default_bios,bridge,"
-                        "image_backend,multihost. This can be used to eg. "
-                        "run hugepages tests by filtering 'smallpages' via "
-                        "this option.", dest='vt.filter.default_filters')
+    help_msg = "Choose the VM machine type. Default: %(default)s"
+    add_option(parser,
+               dest='vt.common.machine_type',
+               arg='--vt-machine-type',
+               default=machine,
+               help=help_msg)
+
+    help_msg = ("Select the guest OS to be used. If --vt-config is provided, "
+                "this will be ignored. Default: %(default)s")
+    add_option(parser,
+               dest='vt.guest_os',
+               arg='--vt-guest-os',
+               default=defaults.DEFAULT_GUEST_OS,
+               help=help_msg)
+
+    help_msg = ("List of space separated 'no' filters to be passed to the "
+                "config parser.  Default: '%(default)s'")
+    add_option(parser,
+               dest='vt.no_filter',
+               arg='--vt-no-filter',
+               default="",
+               help=help_msg)
+
+    help_msg = ("List of space separated 'only' filters to be passed to the "
+                "config parser.  Default: '%(default)s'")
+    add_option(parser,
+               dest='vt.only_filter',
+               arg='--vt-only-filter',
+               default="",
+               help=help_msg)
+
+    help_msg = ("Allows to selectively skip certain default filters. This uses "
+                "directly 'tests-shared.cfg' and instead of "
+                "'$provider/tests.cfg' and applies following lists of default "
+                "filters, unless they are specified as arguments: "
+                "no_9p_export,no_virtio_rng,no_pci_assignable,smallpages,"
+                "default_bios,bridge,image_backend,multihost. This can be used"
+                " to eg. run hugepages tests by filtering 'smallpages' via "
+                "this option.")
+    add_option(parser,
+               dest='vt.filter.default_filters',
+               arg='--vt-filter-default-filters',
+               nargs='+',
+               help=help_msg)
 
 
 def add_qemu_bin_vt_option(parser):
     """
     Add qemu-bin vt option to parser
     """
+
     def _str_or_none(arg):
         if arg is None:
             return "Could not find one"
@@ -107,26 +139,33 @@ def add_qemu_bin_vt_option(parser):
         qemu_bin_path = None
     qemu_bin = get_settings_value('vt.qemu', 'qemu_bin',
                                   default=None)
-    if qemu_bin is None:    # Allow default to be None when not set in setting
+    if qemu_bin is None:  # Allow default to be None when not set in setting
         default_qemu_bin = None
         qemu_bin = qemu_bin_path
     else:
         default_qemu_bin = qemu_bin
-    parser.add_argument("--vt-qemu-bin", action="store", dest="vt.qemu.qemu_bin",
-                        default=default_qemu_bin, help="Path to a custom qemu"
-                        " binary to be tested. If --vt-config is provided and"
-                        " this flag is omitted, no attempt to set the qemu "
-                        "binaries will be made. Current: %s"
-                        % _str_or_none(qemu_bin))
+
+    help_msg = ("Path to a custom qemu binary to be tested. If --vt-config is "
+                "provided and this flag is omitted, no attempt to set the "
+                "qemu binaries will be made. Current: %s" %
+                _str_or_none(qemu_bin))
+    add_option(parser,
+               dest='vt.qemu.qemu_bin',
+               arg='--vt-qemu-bin',
+               default=default_qemu_bin,
+               help=help_msg)
+
     qemu_dst = get_settings_value('vt.qemu', 'qemu_dst_bin',
                                   default=qemu_bin_path)
-    parser.add_argument("--vt-qemu-dst-bin", action="store",
-                        dest="vt.qemu.qemu_dst_bin", default=qemu_dst, help="Path "
-                        "to a custom qemu binary to be tested for the "
-                        "destination of a migration, overrides --vt-qemu-bin. "
-                        "If --vt-config is provided and this flag is omitted, "
-                        "no attempt to set the qemu binaries will be made. "
-                        "Current: %s" % _str_or_none(qemu_dst))
+    help_msg = ("Path to a custom qemu binary to be tested for the destination"
+                " of a migration, overrides --vt-qemu-bin. If --vt-config is "
+                "provided and this flag is omitted, no attempt to set the qemu"
+                " binaries will be made. Current: %s" % _str_or_none(qemu_dst))
+    add_option(parser,
+               dest='vt.qemu.qemu_dst_bin',
+               arg='--vt-qemu-dst-bin',
+               default=qemu_dst,
+               help=help_msg)
 
 
 class VTRun(CLI):
@@ -157,25 +196,28 @@ class VTRun(CLI):
 
         add_basic_vt_options(vt_compat_group_common)
         add_qemu_bin_vt_option(vt_compat_group_qemu)
-        vt_compat_group_qemu.add_argument("--vt-extra-params", nargs='*',
-                                          dest="vt.extra_params",
-                                          help="List of 'key=value' pairs "
-                                          "passed to cartesian parser.")
+
+        help_msg = "List of 'key=value' pairs passed to cartesian parser."
+        add_option(parser=vt_compat_group_qemu,
+                   dest='vt.extra_params',
+                   arg='--vt-extra-params',
+                   nargs='*',
+                   help=help_msg)
+
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)
-        msg = ("Choose test connect uri for libvirt (E.g: %s). "
-               "Current: %%(default)s" % supported_uris)
+        help_msg = ("Choose test connect uri for libvirt (E.g: %s). Current: "
+                    "%%(default)s" % supported_uris)
         uri_current = get_settings_value('vt.libvirt', 'connect_uri',
                                          default=None)
-        vt_compat_group_libvirt.add_argument("--vt-connect-uri",
-                                             action="store",
-                                             dest="vt.libvirt.connect_uri",
-                                             default=uri_current,
-                                             help=msg)
+        add_option(parser=vt_compat_group_libvirt,
+                   dest='vt.libvirt.connect_uri',
+                   arg='--vt-connect-uri',
+                   default=uri_current,
+                   help=help_msg)
 
     def run(self, config):
         """
         Run test modules or simple tests.
-
         :param config: Command line args received from the run subparser.
         """
         loader.register_plugin(VirtTestLoader)

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -22,12 +22,10 @@ from avocado.core.loader import loader
 from avocado.core.plugin_interfaces import CLI
 from avocado.utils import path as utils_path
 
-from virttest import data_dir
-from virttest import defaults
-from virttest import standalone_test
+from virttest import data_dir, defaults, standalone_test
 from virttest.compat import get_settings_value, add_option
-from virttest.standalone_test import SUPPORTED_TEST_TYPES
-from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS
+from virttest.standalone_test import (SUPPORTED_LIBVIRT_URIS,
+                                      SUPPORTED_TEST_TYPES)
 
 from ..loader import VirtTestLoader
 

--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -1,11 +1,18 @@
+import importlib
+
 from avocado.core import plugin_interfaces
+from avocado.core.loader import loader
 from avocado.core.settings import settings
 from avocado.utils import path as utils_path
-from virttest.compat import is_registering_settings_required
-from virttest.defaults import DEFAULT_MACHINE_TYPE
+
+from virttest.compat import (get_settings_value,
+                             is_registering_settings_required)
+from virttest.defaults import (DEFAULT_GUEST_OS,
+                               DEFAULT_MACHINE_TYPE)
 from virttest.standalone_test import (SUPPORTED_DISK_BUSES,
                                       SUPPORTED_IMAGE_TYPES,
                                       SUPPORTED_NIC_MODELS,
+                                      SUPPORTED_TEST_TYPES,
                                       find_default_qemu_paths)
 
 if hasattr(plugin_interfaces, 'Init'):
@@ -18,8 +25,60 @@ if hasattr(plugin_interfaces, 'Init'):
             if not is_registering_settings_required():
                 return
 
+            # [vt] section
+            section = 'vt'
+
+            help_msg = ('Explicitly choose a cartesian config. When choosing '
+                        'this, some options will be ignored (see options '
+                        'below)')
+            settings.register_option(section, key='config', default=None,
+                                     help_msg=help_msg)
+
+            help_msg = 'Save the resulting cartesian config to a file'
+            settings.register_option(section, key='save_config', default=None,
+                                     help_msg=help_msg)
+
+            help_msg = ("Choose test type (%s). Default: %%(default)s" %
+                        ", ".join(SUPPORTED_TEST_TYPES))
+            settings.register_option(section, key='type',
+                                     default=SUPPORTED_TEST_TYPES[0],
+                                     help_msg=help_msg)
+
+            help_msg = ("Select the guest OS to be used. If --vt-config is "
+                        "provided, this will be ignored. Default: %s" %
+                        DEFAULT_GUEST_OS)
+            settings.register_option(section, key='guest_os',
+                                     default=DEFAULT_GUEST_OS,
+                                     help_msg=help_msg)
+
+            help_msg = ("List of space separated 'no' filters to be passed to "
+                        "the config parser.")
+            settings.register_option(section, key='no_filter', default='',
+                                     help_msg=help_msg)
+
+            help_msg = ("List of space separated 'only' filters to be passed "
+                        "to the config  parser.")
+            settings.register_option(section, key='only_filter', default='',
+                                     help_msg=help_msg)
+
+            help_msg = "List of 'key=value' pairs passed to cartesian parser."
+            settings.register_option(section, key='extra_params', nargs='*',
+                                     default=None, help_msg=help_msg)
+
+            help_msg = ("Also list the available guests (this option ignores "
+                        "the --vt-config and --vt-guest-os)")
+            settings.register_option(section, key='list_guests', key_type=bool,
+                                     default=False, help_msg=help_msg)
+            help_msg = ("Also list the available arch/machines for the given "
+                        "guest OS. (Use \"--vt-guest-os ''\" to see all "
+                        "combinations; --vt-config --vt-machine-type and "
+                        "--vt-arch args are ignored)")
+            settings.register_option(section, key='list_archs', key_type=bool,
+                                     default=False, help_msg=help_msg)
+
             # [vt.setup] section
             section = 'vt.setup'
+
             help_msg = 'Backup image before testing (if not already backed up)'
             settings.register_option(section, 'backup_image_before_test',
                                      help_msg=help_msg, key_type=bool,
@@ -94,10 +153,15 @@ if hasattr(plugin_interfaces, 'Init'):
                 default_qemu_bin_path = find_default_qemu_paths()[0]
             except (RuntimeError, utils_path.CmdNotFoundError):
                 default_qemu_bin_path = None
+            qemu_bin = get_settings_value(section, 'qemu_bin', default=None)
+            if qemu_bin is None:  # Allow default to be None when not set in setting
+                default_qemu_bin = None
+            else:
+                default_qemu_bin = qemu_bin
             help_msg = 'Path to a custom qemu binary to be tested'
             settings.register_option(section, 'qemu_bin',
                                      help_msg=help_msg,
-                                     default=default_qemu_bin_path)
+                                     default=default_qemu_bin)
 
             help_msg = ('Path to a custom qemu binary to be tested for the '
                         'destination of a migration, overrides qemu_bin for '
@@ -164,11 +228,14 @@ if hasattr(plugin_interfaces, 'Init'):
                                      default='yes')
 
             # [vt.libvirt] section
+            section = 'vt.libvirt'
+
+            uri_current = get_settings_value(section, 'connect_uri',
+                                             default=None)
             help_msg = ('Test connect URI for libvirt (qemu:///system, '
                         'lxc:///)')
-            settings.register_option('vt.libvirt', 'connect_uri',
-                                     help_msg=help_msg,
-                                     default='qemu:///session')
+            settings.register_option(section, 'connect_uri',
+                                     help_msg=help_msg, default=uri_current)
 
             # [vt.debug] section
             help_msg = ('Do not clean up tmp files or VM processes at the end '
@@ -177,8 +244,26 @@ if hasattr(plugin_interfaces, 'Init'):
                                      help_msg=help_msg, key_type=bool,
                                      default=False)
 
+            # [vt.filter] section
+            help_msg = ("Allows to selectively skip certain default filters. "
+                        "This uses directly 'tests-shared.cfg' and instead of "
+                        "'$provider/tests.cfg' and applies following lists of "
+                        "default filters, unless they are specified as "
+                        "arguments: no_9p_export,no_virtio_rng,"
+                        "no_pci_assignable,smallpages,default_bios,ridge,"
+                        "image_backend,multihost. This can be used to eg. run "
+                        "hugepages tests by filtering 'smallpages' via this "
+                        "option.")
+            settings.register_option('vt.filter', key='default_filters',
+                                     nargs='+', default=None,
+                                     help_msg=help_msg)
+
             # [plugins.vtjoblock] section
             help_msg = 'Directory in which to write the lock file'
             settings.register_option('plugins.vtjoblock', 'dir',
                                      help_msg=help_msg,
                                      default='/tmp')
+
+            virt_loader = getattr(importlib.import_module('avocado_vt.loader'),
+                                  'VirtTestLoader')
+            loader.register_plugin(virt_loader)

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -22,7 +22,7 @@ import sys
 from avocado.core.loader import loader
 from avocado.core.plugin_interfaces import CLI
 
-from virttest.compat import get_settings_value
+from virttest.compat import get_settings_value, add_option
 from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 from ..loader import VirtTestLoader
 
@@ -96,20 +96,27 @@ class VTLister(CLI):
 
         vt_compat_group_lister = list_subcommand_parser.add_argument_group(
             'Virt-Test compat layer - Lister options')
-        vt_compat_group_lister.add_argument("--vt-list-guests",
-                                            action="store_true",
-                                            default=False,
-                                            help="Also list the available "
-                                            "guests (this option ignores the "
-                                            "--vt-config and --vt-guest-os)")
-        vt_compat_group_lister.add_argument("--vt-list-archs", default=False,
-                                            action="store_true",
-                                            help="Also list the available "
-                                            "arch/machines for the given "
-                                            "guest OS. (Use \"--vt-guest-os "
-                                            "''\" to see all combinations; "
-                                            "--vt-config --vt-machine-type "
-                                            "and --vt-arch args are ignored)")
+
+        help_msg = ("Also list the available guests (this option ignores the "
+                    "--vt-config and --vt-guest-os)")
+        add_option(parser=vt_compat_group_lister,
+                   dest='vt.list_guests',
+                   arg='--vt-list-guests',
+                   action='store_true',
+                   default=False,
+                   help=help_msg)
+
+        help_msg = ("Also list the available arch/machines for the given guest"
+                    " OS. (Use \"--vt-guest-os ''\" to see all combinations; "
+                    "--vt-config --vt-machine-type and --vt-arch args are "
+                    "ignored)")
+        add_option(parser=vt_compat_group_lister,
+                   dest='vt.list_archs',
+                   arg='--vt-list-archs',
+                   action='store_true',
+                   default=False,
+                   help=help_msg)
+
         add_basic_vt_options(vt_compat_group_lister)
         add_qemu_bin_vt_option(vt_compat_group_lister)
 

--- a/virttest/compat.py
+++ b/virttest/compat.py
@@ -47,6 +47,16 @@ if is_registering_settings_required():
     def get_settings_value(section, key, **kwargs):
         namespace = '%s.%s' % (section, key)
         return settings.as_dict().get(namespace)
+
+    def add_option(parser, arg, **kwargs):
+        """Add a command-line argument parser to an existing option."""
+        settings.add_argparser_to_option(
+            namespace=kwargs.get('dest'),
+            action=kwargs.get('action', 'store'),
+            parser=parser,
+            allow_multiple=True,
+            long_arg=arg)
+
 else:
     def get_opt(opt, name):
         """
@@ -81,3 +91,7 @@ else:
 
     def get_settings_value(section, key, **kwargs):
         return settings.get_value(section, key, **kwargs)
+
+    def add_option(parser, arg, **kwargs):
+        """Adds new command-line argument option to the parser"""
+        parser.add_argument(arg, **kwargs)


### PR DESCRIPTION
Right now when we want to run tests through avocado Job API the avocado-vt is
not loaded, because a lot of avocado-vt settings is initialized through CLI
plugin. This commit moves the initialization to the Init plugin and leaves CLI
plugin just for necessary command line setup

Signed-off-by: Jan Richter jarichte@redhat.com

---
Changes form v1:

- put style fixes to the separated commits
- usage of `virttest.compat`