### PR TITLE
update kernel console cmdline through network first

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1506,10 +1506,10 @@ class VM(virt_vm.BaseVM):
             kernel_params += ",%s" % speed
         if remove:
             utils_test.update_boot_option(self, args_removed=kernel_params,
-                                          guest_arch_name=guest_arch_name)
+                                          guest_arch_name=guest_arch_name, serial=False)
         else:
             utils_test.update_boot_option(self, args_added=kernel_params,
-                                          guest_arch_name=guest_arch_name)
+                                          guest_arch_name=guest_arch_name, serial=False)
         logging.debug("Set kernel params for %s is successful", device)
         return True
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -166,7 +166,7 @@ def __run_cmd_and_handle_error(msg, cmd, session, test_fail_msg):
 
 
 def update_boot_option(vm, args_removed="", args_added="",
-                       need_reboot=True, guest_arch_name='x86_64'):
+                       need_reboot=True, guest_arch_name='x86_64', serial=True):
     """
     Update guest default kernel option.
 
@@ -175,6 +175,7 @@ def update_boot_option(vm, args_removed="", args_added="",
     :param args_added: Kernel options want to add.
     :param need_reboot: Whether need reboot VM or not.
     :param guest_arch_name: Guest architecture, e.g. x86_64, s390x
+    :param login guest through serial
     :raise exceptions.TestError: Raised if fail to update guest kernel cmdline.
 
     """
@@ -189,8 +190,11 @@ def update_boot_option(vm, args_removed="", args_added="",
         logging.warning(msg)
         return
     login_timeout = int(vm.params.get("login_timeout"))
-    session = vm.wait_for_serial_login(timeout=login_timeout,
-                                       restart_network=True)
+    if serial:
+        session = vm.wait_for_serial_login(timeout=login_timeout,
+                                           restart_network=True)
+    else:
+        session = vm.wait_for_login(timeout=login_timeout, restart_network=True)
     try:
         # check for args that are really required to be added/removed
         req_args, req_remove_args = check_kernel_cmdline(session,
@@ -226,7 +230,7 @@ def update_boot_option(vm, args_removed="", args_added="",
         # reboot is required only if we really add/remove any args
         if need_reboot and (req_args or req_remove_args):
             logging.info("Rebooting guest ...")
-            session = vm.reboot(session=session, timeout=login_timeout, serial=True)
+            session = vm.reboot(session=session, timeout=login_timeout, serial=serial)
             # check nothing is required to be added/removed by now
             req_args, req_remove_args = check_kernel_cmdline(session,
                                                              remove_args=args_removed,


### PR DESCRIPTION
JOB ID     : 41a4fd9b8d3448bfd74f4f5ef6cdf1d64dae8c8f
JOB LOG    : /root/avocado/job-results/job-2020-12-03T10.26-41a4fd9/job.log
 (01/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.non_acl.valid_domname: PASS (179.14 s)
 (02/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.non_acl.valid_domid: PASS (180.32 s)
 (03/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.non_acl.valid_domuuid: PASS (393.12 s)
 (04/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domname: \^[[PASS (184.93 s)
 (05/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domid: PASS (183.38 s)
 (06/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domuuid: PASS (184.78 s)                                                                                                    
 (07/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.invalid_domname: PASS (145.72 s)
 (08/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.invalid_domid: PASS (145.78 s)
 (09/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.hex_domid: PASS (145.49 s)
 (10/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.invalid_domuuid: PASS (145.45 s)
 (11/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.none_domname: PASS (145.78 s)
 (12/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.special_operation.vm_paused: PASS (176.21 s)
 (13/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.special_operation.vm_shut_off: PASS (145.96 s)
 (14/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.acl_test: PASS (150.87 s)
RESULTS    : PASS 14 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
