### PR TITLE
Introduce "--vt-short-names-when-config" to switch test names display

### DIFF
--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -199,7 +199,9 @@ class VirtTestLoader(loader.TestLoader):
         for params in (_ for _ in cartesian_parser.get_dicts()):
             # Evaluate the proper avocado-vt test name
             test_name = None
-            if get_opt(self.config, 'vt.type') == "spice":
+            if get_opt(self.config, 'vt.config'):
+                test_name = params.get("shortname")
+            elif get_opt(self.config, 'vt.type') == "spice":
                 short_name_map_file = params.get("_short_name_map_file")
                 if "tests-variants.cfg" in short_name_map_file:
                     test_name = short_name_map_file["tests-variants.cfg"]

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -199,7 +199,8 @@ class VirtTestLoader(loader.TestLoader):
         for params in (_ for _ in cartesian_parser.get_dicts()):
             # Evaluate the proper avocado-vt test name
             test_name = None
-            if get_opt(self.config, 'vt.config'):
+            if (get_opt(self.config, 'vt.config')
+                    and get_opt(self.config, 'vt.short_names_when_config')):
                 test_name = params.get("shortname")
             elif get_opt(self.config, 'vt.type') == "spice":
                 short_name_map_file = params.get("_short_name_map_file")

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -57,6 +57,13 @@ def add_basic_vt_options(parser):
                dest='vt.save_config',
                arg='--vt-save-config',
                help=help_msg)
+
+    help_msg = "Enable short names as test names when using a config file"
+    add_option(parser,
+               dest='vt.short_names_when_config',
+               arg='--vt-short-names-when-config',
+               help=help_msg)
+
     help_msg = ("Choose test type (%s). Default: %%(default)s" %
                 ", ".join(SUPPORTED_TEST_TYPES))
     add_option(parser,

--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -38,6 +38,12 @@ if hasattr(plugin_interfaces, 'Init'):
             settings.register_option(section, key='save_config', default=None,
                                      help_msg=help_msg)
 
+            help_msg = ("Enable short names as test names when using a config "
+                        "file")
+            settings.register_option(section, key='short_names_when_config',
+                                     key_type=bool, default=False,
+                                     help_msg=help_msg)
+
             help_msg = ("Choose test type (%s). Default: %%(default)s" %
                         ", ".join(SUPPORTED_TEST_TYPES))
             settings.register_option(section, key='type',


### PR DESCRIPTION
Sometimes, when we use the config file to run avocado, we want to use
short names as test names, so "--vt-short-names-when-config" is
introduced to allow users to switch it.

ID: 1905350 
Signed-off-by: Yihuang Yu <yihyu@redhat.com>
