### PR TITLE
Introduce standalone commands to list guests and archs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,6 +36,7 @@ fedora_33_task:
     - $PYTHON -m avocado list --vt-config=/tmp/config --vt-type=$VT_TYPE -- boot | tee /tmp/list_from_config
     - diff /tmp/list /tmp/list_from_config
     - $PYTHON -m avocado vt-list-guests --vt-type=$VT_TYPE
+    - $PYTHON -m avocado vt-list-archs --vt-type=$VT_TYPE
   dry_run_script: &dry_run_scr
     - $PYTHON -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,7 @@ fedora_33_task:
     - test $VT_TYPE == "libvirt" || test $(wc -l < /tmp/list) -eq 1
     - $PYTHON -m avocado list --vt-config=/tmp/config --vt-type=$VT_TYPE -- boot | tee /tmp/list_from_config
     - diff /tmp/list /tmp/list_from_config
+    - $PYTHON -m avocado vt-list-guests --vt-type=$VT_TYPE
   dry_run_script: &dry_run_scr
     - $PYTHON -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
 

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -36,7 +36,7 @@ from .test import VirtTest
 LOG = logging.getLogger("avocado.app")
 
 
-def guest_listing(config):
+def guest_listing(config, guest_name_parser=None):
     """
     List available guest operating systems and info about image availability
     """
@@ -45,7 +45,8 @@ def guest_listing(config):
     LOG.debug("Using %s for guest images\n",
               os.path.join(data_dir.get_data_dir(), 'images'))
     LOG.info("Available guests in config:")
-    guest_name_parser = standalone_test.get_guest_name_parser(config)
+    if guest_name_parser is None:
+        guest_name_parser = standalone_test.get_guest_name_parser(config)
     for params in guest_name_parser.get_dicts():
         base_dir = params.get("images_base_dir", data_dir.get_data_dir())
         image_name = storage.get_image_filename(params, base_dir)

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -61,7 +61,7 @@ def guest_listing(config, guest_name_parser=None):
     LOG.debug("")
 
 
-def arch_listing(config):
+def arch_listing(config, guest_name_parser=None):
     """
     List available machine/archs for given guest operating systems
     """
@@ -71,7 +71,8 @@ def arch_listing(config):
     else:
         extra = ""
     LOG.info("Available arch profiles%s", extra)
-    guest_name_parser = standalone_test.get_guest_name_parser(config)
+    if guest_name_parser is None:
+        guest_name_parser = standalone_test.get_guest_name_parser(config)
     machine_type = get_opt(config, 'vt.common.machine_type')
     for params in guest_name_parser.get_dicts():
         LOG.debug(params['name'].replace('.%s' % machine_type, ''))

--- a/avocado_vt/plugins/vt_list_archs.py
+++ b/avocado_vt/plugins/vt_list_archs.py
@@ -1,0 +1,26 @@
+from avocado.core.plugin_interfaces import CLICmd
+from virttest.compat import add_option
+from virttest.standalone_test import get_guest_name_parser
+
+from ..loader import arch_listing
+
+
+class VTListArchs(CLICmd):
+
+    """
+    Avocado VT - implements vt-list-archs command
+    """
+
+    name = 'vt-list-archs'
+    description = "Avocado-VT 'vt-list-archs' command"
+
+    def configure(self, parser):
+        parser = super(VTListArchs, self).configure(parser)
+        # Expose the --vt-type option, as the archs definitions depend on it
+        add_option(parser=parser, dest='vt.type', arg='--vt-type')
+
+    def run(self, config):
+        guest_name_parser = get_guest_name_parser(config,
+                                                  arch=None,
+                                                  machine=None)
+        arch_listing(config, guest_name_parser)

--- a/avocado_vt/plugins/vt_list_guests.py
+++ b/avocado_vt/plugins/vt_list_guests.py
@@ -1,0 +1,39 @@
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.settings import settings
+from virttest.compat import add_option, is_registering_settings_required
+from virttest.standalone_test import get_guest_name_parser
+
+from ..loader import guest_listing
+
+
+class VTListGuests(CLICmd):
+
+    """
+    Avocado VT - implements vt-list-guests command
+    """
+
+    name = 'vt-list-guests'
+    description = "Avocado-VT 'vt-list-guests' command"
+
+    def configure(self, parser):
+        parser = super(VTListGuests, self).configure(parser)
+
+        # [vt.list_guests] section
+        section = 'vt.list_guests'
+
+        key = 'guest_os'
+        if is_registering_settings_required():
+            settings.register_option(section, key=key, default=None,
+                                     help_msg='List only specific guests')
+
+        namespace = "%s.%s" % (section, key)
+        add_option(parser=parser, dest=namespace, arg='--guest-os')
+
+        # Also expose the --vt-type option, as the guests depend on it
+        add_option(parser=parser, dest='vt.type', arg='--vt-type')
+
+    def run(self, config):
+        guest_name_parser = get_guest_name_parser(
+            config,
+            guest_os='vt.list_guests.guest_os')
+        guest_listing(config, guest_name_parser)

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ if __name__ == "__main__":
                   ],
               'avocado.plugins.cli.cmd': [
                   'vt-bootstrap = avocado_vt.plugins.vt_bootstrap:VTBootstrap',
+                  'vt-list-guests = avocado_vt.plugins.vt_list_guests:VTListGuests',
                   ],
               pre_post_plugin_type(): [
                   'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock',

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
               'avocado.plugins.cli.cmd': [
                   'vt-bootstrap = avocado_vt.plugins.vt_bootstrap:VTBootstrap',
                   'vt-list-guests = avocado_vt.plugins.vt_list_guests:VTListGuests',
+                  'vt-list-archs = avocado_vt.plugins.vt_list_archs:VTListArchs',
                   ],
               pre_post_plugin_type(): [
                   'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock',

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -108,7 +108,10 @@ def get_cartesian_parser_details(cartesian_parser):
     return details
 
 
-def get_guest_name_parser(options):
+def get_guest_name_parser(options,
+                          arch='vt.common.arch',
+                          machine='vt.common.machine_type',
+                          guest_os='vt.guest_os'):
     cartesian_parser = cartesian_config.Parser()
     machines_cfg_path = data_dir.get_backend_cfg_path(get_opt(options, 'vt.type'),
                                                       'machines.cfg')
@@ -116,12 +119,13 @@ def get_guest_name_parser(options):
                                                       'guest-os.cfg')
     cartesian_parser.parse_file(machines_cfg_path)
     cartesian_parser.parse_file(guest_os_cfg_path)
-    if get_opt(options, 'vt.common.arch'):
-        cartesian_parser.only_filter(get_opt(options, 'vt.common.arch'))
-    if get_opt(options, 'vt.common.machine_type'):
-        cartesian_parser.only_filter(get_opt(options, 'vt.common.machine_type'))
-    if get_opt(options, 'vt.guest_os'):
-        cartesian_parser.only_filter(get_opt(options, 'vt.guest_os'))
+
+    filter_options = (arch, machine, guest_os)
+    for filter_option in filter_options:
+        if filter_option:
+            opt = get_opt(options, filter_option)
+            if opt:
+                cartesian_parser.only_filter(opt)
     return cartesian_parser
 
 


### PR DESCRIPTION
The current `--vt-list-guests` and `--vt-list-archs` options to `avocado list` depend on the `avocado.core.loader`'s "extra listing" feature, which is not a great thing.

Also, users tend to want to have access to that specific information, and not that and the test list.

This is also a preparation to when the `avocado.core.loader` is removed for good (in place of the resolver).