### PR TITLE
VirtTest refactors

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -340,18 +340,8 @@ class VirtTest(test.Test):
         provider = params.get("provider", None)
 
         if provider is None:
-            # Verify if we have the correspondent source file for
-            # it
-            generic_subdirs = asset.get_test_provider_subdirs(
-                'generic')
-            for generic_subdir in generic_subdirs:
-                subtest_dirs += data_dir.SubdirList(generic_subdir,
-                                                    test_filter)
-            specific_subdirs = asset.get_test_provider_subdirs(
-                params.get("vm_type"))
-            for specific_subdir in specific_subdirs:
-                subtest_dirs += data_dir.SubdirList(
-                    specific_subdir, bootstrap.test_filter)
+            subtest_dirs += utils.find_generic_specific_subtest_dirs(
+                params.get("vm_type"), test_filter)
         else:
             provider_info = asset.get_test_provider_info(provider)
             for key in provider_info['backends']:

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -333,21 +333,10 @@ class VirtTest(test.Test):
                             "as root may produce unexpected results!!!")
             logging.warning("")
 
-        # Find the test
-        subtest_dirs = []
         test_filter = bootstrap.test_filter
-
-        other_subtests_dirs = params.get("other_tests_dirs", "")
-        for d in other_subtests_dirs.split():
-            # If d starts with a "/" an absolute path will be assumed
-            # else the relative path will be searched in the bin_dir
-            subtestdir = os.path.join(self.bindir, d, "tests")
-            if not os.path.isdir(subtestdir):
-                raise exceptions.TestError("Directory %s does not "
-                                           "exist" % subtestdir)
-            subtest_dirs += data_dir.SubdirList(subtestdir,
-                                                test_filter)
-
+        subtest_dirs = utils.find_subtest_dirs(params.get("other_tests_dirs", ""),
+                                               self.bindir,
+                                               test_filter)
         provider = params.get("provider", None)
 
         if provider is None:

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -358,23 +358,7 @@ class VirtTest(test.Test):
 
         utils.insert_dirs_to_path(subtest_dirs)
 
-        test_modules = {}
-        for t_type in t_types:
-            for d in subtest_dirs:
-                module_path = os.path.join(d, "%s.py" % t_type)
-                if os.path.isfile(module_path):
-                    logging.debug("Found subtest module %s",
-                                  module_path)
-                    subtest_dir = d
-                    break
-            if subtest_dir is None:
-                msg = ("Could not find test file %s.py on test"
-                       "dirs %s" % (t_type, subtest_dirs))
-                raise exceptions.TestError(msg)
-            # Load the test module
-            f, p, d = imp.find_module(t_type, [subtest_dir])
-            test_modules[t_type] = imp.load_module(t_type, f, p, d)
-            f.close()
+        test_modules = utils.find_test_modules(t_types, subtest_dirs)
 
         # Open the environment file
         env_filename = os.path.join(data_dir.get_tmp_dir(),

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -30,7 +30,6 @@ from avocado.utils import stacktrace
 from avocado.utils import process
 from avocado.utils import genio
 
-from virttest import asset
 from virttest import error_event
 from virttest import bootstrap
 from virttest import data_dir
@@ -343,12 +342,8 @@ class VirtTest(test.Test):
             subtest_dirs += utils.find_generic_specific_subtest_dirs(
                 params.get("vm_type"), test_filter)
         else:
-            provider_info = asset.get_test_provider_info(provider)
-            for key in provider_info['backends']:
-                subtest_dirs += data_dir.SubdirList(
-                    provider_info['backends'][key]['path'],
-                    bootstrap.test_filter)
-
+            subtest_dirs += utils.find_provider_subtest_dirs(provider,
+                                                             test_filter)
         subtest_dir = None
 
         # Get the test routine corresponding to the specified

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -41,6 +41,9 @@ from virttest import utils_params
 from virttest import utils_misc
 from virttest import version
 
+from avocado_vt import utils
+
+
 # avocado-vt no longer needs autotest for the majority of its functionality,
 # except by:
 # 1) Run autotest on VMs
@@ -378,10 +381,8 @@ class VirtTest(test.Test):
                       params.get("provider", None))
 
         t_types = params.get("type").split()
-        # Make sure we can load provider_lib in tests
-        for s in subtest_dirs:
-            if os.path.dirname(s) not in sys.path:
-                sys.path.insert(0, os.path.dirname(s))
+
+        utils.insert_dirs_to_path(subtest_dirs)
 
         test_modules = {}
         for t_type in t_types:

--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -54,3 +54,25 @@ def find_subtest_dirs(other_subtests_dirs, bindir, ignore_files=None):
         subtest_dirs += data_dir.SubdirList(subtestdir,
                                             ignore_files)
     return subtest_dirs
+
+
+def find_generic_specific_subtest_dirs(vm_type, ignore_files=None):
+    """Find generic and specific directories containing subtests.
+
+    This verifies if we have the correspondent source file.
+
+    :param vm_type: type of test provider and thus VM (qemu, libvirt, etc)
+    :type vm_type: string
+    :param ignore_files: files/dirs to ignore as possible candidates
+    :type ignore_files: list or None
+    """
+    subtest_dirs = []
+    generic_subdirs = asset.get_test_provider_subdirs('generic')
+    for generic_subdir in generic_subdirs:
+        subtest_dirs += data_dir.SubdirList(generic_subdir,
+                                            ignore_files)
+    specific_subdirs = asset.get_test_provider_subdirs(vm_type)
+    for specific_subdir in specific_subdirs:
+        subtest_dirs += data_dir.SubdirList(specific_subdir,
+                                            ignore_files)
+    return subtest_dirs

--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -15,6 +15,10 @@
 import os
 import sys
 
+from avocado.core import exceptions
+
+from virttest import data_dir
+
 
 def insert_dirs_to_path(dirs):
     """Insert directories into the Python path.
@@ -27,3 +31,26 @@ def insert_dirs_to_path(dirs):
     for directory in dirs:
         if os.path.dirname(directory) not in sys.path:
             sys.path.insert(0, os.path.dirname(directory))
+
+
+def find_subtest_dirs(other_subtests_dirs, bindir, ignore_files=None):
+    """Find directories containining subtests.
+
+    :param other_subtests_dirs: space separate list of directories
+    :type other_subtests_dirs: string
+    :param bindir: the test's "binary directory"
+    :type bindir: str
+    :param ignore_files: files/dirs to ignore as possible candidates
+    :type ignore_files: list or None
+    """
+    subtest_dirs = []
+    for d in other_subtests_dirs.split():
+        # If d starts with a "/" an absolute path will be assumed
+        # else the relative path will be searched in the bin_dir
+        subtestdir = os.path.join(bindir, d, "tests")
+        if not os.path.isdir(subtestdir):
+            raise exceptions.TestError("Directory %s does not "
+                                       "exist" % subtestdir)
+        subtest_dirs += data_dir.SubdirList(subtestdir,
+                                            ignore_files)
+    return subtest_dirs

--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -17,6 +17,7 @@ import sys
 
 from avocado.core import exceptions
 
+from virttest import asset
 from virttest import data_dir
 
 
@@ -76,3 +77,20 @@ def find_generic_specific_subtest_dirs(vm_type, ignore_files=None):
         subtest_dirs += data_dir.SubdirList(specific_subdir,
                                             ignore_files)
     return subtest_dirs
+
+
+def find_provider_subtest_dirs(provider, ignore_files=None):
+    """Find directories containing subtests for specific providers.
+
+    :param provider: provider name
+    :type vm_type: string
+    :param ignore_files: files/dirs to ignore as possible candidates
+    :type ignore_files: list or None
+    """
+    subtests_dirs = []
+    provider_info = asset.get_test_provider_info(provider)
+    for key in provider_info['backends']:
+        subtests_dirs += data_dir.SubdirList(
+            provider_info['backends'][key]['path'],
+            ignore_files)
+    return subtests_dirs

--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -1,0 +1,29 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Cleber Rosa <crosa@redhat.com>
+
+import os
+import sys
+
+
+def insert_dirs_to_path(dirs):
+    """Insert directories into the Python path.
+
+    This is used so that tests from other providers can be loaded.
+
+    :param dirs: directories to be added to the Python path
+    :type dirs: list
+    """
+    for directory in dirs:
+        if os.path.dirname(directory) not in sys.path:
+            sys.path.insert(0, os.path.dirname(directory))

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2981,27 +2981,9 @@ def get_test_entrypoint_func(name, module):
     :returns: the test entry point function
     :rtype: func
     '''
-    has_run = hasattr(module, "run")
-    legacy_run = "run_%s" % name
-    has_legacy_run = hasattr(module, legacy_run)
-
-    if has_run:
-        if has_legacy_run:
-            msg = ('Both legacy and new test entry point function names '
-                   'present. Please update your test and use "run()" '
-                   'instead of "%s()". Also, please avoid using "%s()" '
-                   'as a regular function name in your test as it causes '
-                   'confusion with the legacy naming standard. Function '
-                   '"run()" will be used in favor of "%s()"')
-            logging.warn(msg, legacy_run, legacy_run, legacy_run)
-        return getattr(module, "run")
-
-    elif has_legacy_run:
-        logging.warn('Legacy test entry point function name found. Please '
-                     'update your test and use "run()" as the new function '
-                     'name')
-        return getattr(module, legacy_run)
-
+    run = getattr(module, "run", None)
+    if run is not None:
+        return run
     else:
         raise ValueError("Missing test entry point")
 


### PR DESCRIPTION
This simplifies the `VirtTest._runTest` method by moving blocks of code into their own utility functions.  The reasons are:
 * Maintainability
 * I'm working on a runner based on the nrunner architecture, and those blocks of code are also needed in this other implementation too