### PR TITLE
`--vt-type` default

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -62,6 +62,7 @@ def add_basic_vt_options(parser):
     add_option(parser,
                dest='vt.type',
                arg='--vt-type',
+               default=SUPPORTED_TEST_TYPES[0],
                help=help_msg)
 
     arch = get_settings_value('vt.common', 'arch', default=None)


### PR DESCRIPTION
In the commit f54b602 was introduced a configuration of command line options
compatible with avocado Job API. Unfortunately there missing default value for
`--vt-type` option on avocado versions 80 and lower. This commit fixing this
problem.

Signed-off-by: Jan Richter <jarichte@redhat.com>