### PR TITLE
[libvirt.attach_disks] set correct disk_type for lvm

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2927,7 +2927,7 @@ def attach_disks(vm, path, vgname, params):
             set_controller_multifunction(vm.name, disk_target)
 
         disk_params = {}
-        disk_params['type_name'] = disk_type
+        disk_params['type_name'] = disk_type if not disk_type == 'lvm' else 'block'
         disk_params['target_dev'] = target_dev
         disk_params['target_bus'] = disk_target
         disk_params['device_type'] = params.get("device_type", "disk")


### PR DESCRIPTION
disk_type is used both for disk definition xml and for create_local_disk function
call. Since commit avocado-vt 18fd732 create_local_disk won't
default to lvm for value `block` anymore. Therefore, any call to attach_disks with disk_type
block is currently failing. Those calls should be fixed to pass `lvm` now to be more specific
as later changes to create_local_disk might add other block disk types besides lvm.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>