### PR TITLE
bootstrap:Replace special chars in cpu_version

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -359,6 +359,8 @@ def create_host_os_cfg(options):
             except Exception:
                 pass
         cpu_version = cpu.get_version() if hasattr(cpu, 'get_version') else None
+        # Replace special chars with _ to avoid bootstrap failure
+        cpu_version = re.sub(r'[^\w-]', '_', cpu_version) if cpu_version else cpu_version
 
         cfg.write("variants:\n")
         cfg.write("    - @Host:\n")


### PR DESCRIPTION
Special chars like '()' cannot be parsed successfully in cfg file.
Replacing special chars with _ could avoid bootstrap failure

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>