### PR TITLE
virt_vm: avoid of vm's unstable status

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1380,6 +1380,7 @@ class BaseVM(object):
             eg. during reboot or pause)
         :return: ConsoleSession instance.
         """
+        time.sleep(60) # Guest needs more time to start sometimes.
         logging.debug("Attempting to log into '%s' via serial console "
                       "(timeout %ds)", self.name, timeout)
         end_time = time.time() + timeout


### PR DESCRIPTION
This function usually is invoked after vm starts. But sometimes on specific host, like
in openstack, the vm starts a little slow, so serial console login may get unexpected
result when recogizing the console output message. This is to make sure the vm is in
proper state before console message is prompted and recoginized correctly.

Signed-off-by: Dan Zheng <dzheng@redhat.com>