### PR TITLE
Fix disk xml is used before all contents are completly written in

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1749,6 +1749,12 @@ def create_disk_xml(params):
             return True
     utils_misc.wait_for(file_exists, 5)
 
+    # Wait for file write over with '</disk>' keyword at the file end
+    def file_write_over():
+        if not process.run("grep '</disk>' %s" % diskxml.xml,
+                           ignore_status=True).exit_status:
+            return True
+    utils_misc.wait_for(file_write_over, 10)
     return diskxml.xml
 
 


### PR DESCRIPTION
In some cases, observe that disk xml is used before all contents are completely written in
By allowing additional wait until </disk> keyword is at end of xml file

Signed-off-by: chunfuwen <chwen@redhat.com>