### PR TITLE
XMLElementList: create parent xpath if not exists

### DIFF
--- a/virttest/libvirt_xml/accessors.py
+++ b/virttest/libvirt_xml/accessors.py
@@ -786,7 +786,12 @@ class XMLElementList(AccessorGeneratorBase):
             # Allow other classes to generate parent structure
             parent = self.xmltreefile().find(self.parent_xpath)
             if parent is None:
-                raise xcepts.LibvirtXMLNotFoundError
+                # Create parent xpath if not exists
+                self.xmltreefile().create_by_xpath(self.parent_xpath)
+                parent = self.xmltreefile().find(self.parent_xpath)
+                if parent is None:
+                    raise xcepts.LibvirtXMLNotFoundError(
+                        'Parent xpath %s not found.' % self.parent_xpath)
             # Remove existing by calling accessor method, allowing
             # any "untouchable" or "filtered" elements (by marshal)
             # to be ignored and left as-is.


### PR DESCRIPTION
It fails if trying to assign an XMLElementList if its parent xpath
not exists. This commit will try to create the missing parent xpath.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>