### PR TITLE
Replace 'isAlive' with 'is_alive' for threading.Thread

### DIFF
--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -310,7 +310,7 @@ class MigrationTest(object):
                 logging.debug("start_time:%d, eclipse_time:%d", stime, eclipse_time)
                 if eclipse_time < thread_timeout:
                     migration_thread.join(thread_timeout - eclipse_time)
-                if migration_thread.isAlive():
+                if migration_thread.is_alive():
                     logging.error("Migrate %s timeout.", migration_thread)
                     self.RET_LOCK.acquire()
                     self.RET_MIGRATION = False
@@ -330,7 +330,7 @@ class MigrationTest(object):
                 thread1.join(thread_timeout)
                 thread2.join(thread_timeout)
                 vm_remote = vm
-                if thread1.isAlive() or thread1.isAlive():
+                if thread1.is_alive() or thread1.is_alive():
                     logging.error("Cross migrate timeout.")
                     self.RET_LOCK.acquire()
                     self.RET_MIGRATION = False
@@ -350,7 +350,7 @@ class MigrationTest(object):
             # listen threads until they end
             for thread in migration_threads:
                 thread.join(thread_timeout)
-                if thread.isAlive():
+                if thread.is_alive():
                     logging.error("Migrate %s timeout.", thread)
                     self.RET_LOCK.acquire()
                     self.RET_MIGRATION = False

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -4060,8 +4060,8 @@ class AsyncJob(BgJob):
         # Make sure we've got stdout and stderr
         self.stdout_thread.join(1)
         self.stderr_thread.join(1)
-        assert not self.stdout_thread.isAlive()
-        assert not self.stderr_thread.isAlive()
+        assert not self.stdout_thread.is_alive()
+        assert not self.stderr_thread.is_alive()
 
         super(AsyncJob, self).cleanup()
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1653,7 +1653,7 @@ def run_autotest(vm, session, control_path, timeout,
                                                   kwargs=kwargs)
                 bg.start()
 
-                while bg.isAlive():
+                while bg.is_alive():
                     logging.info("Autotest job did not end, start a round of "
                                  "migration")
                     vm.migrate(timeout=mig_timeout, protocol=mig_protocol)
@@ -2006,7 +2006,7 @@ class BackgroundTest(object):
         """
         Check whether the test is still alive.
         """
-        return self.thread.isAlive()
+        return self.thread.is_alive()
 
 
 def get_image_info(image_file):


### PR DESCRIPTION
threading.Thread.isAlive() has been removed in python 3.9,
and is_alive() has been supported since python 2.6

id: 1916085
Signed-off-by: Yanan Fu <yfu@redhat.com>