### PR TITLE
Revert "Fix outdated usage of numa_cell"

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -882,9 +882,9 @@ class VMXML(VMXMLBase):
                             nodexml_list.append(nodexml)
                         if numa_number is not None and numa_number > 0:
                             vmcpu_xml.xmltreefile.create_by_xpath('/numa')
-                            vmcpu_xml.numa_cell = vmcpu_xml.dicts_to_cells(nodexml_list)
+                            vmcpu_xml.numa_cell = nodexml_list
                         else:
-                            vmcpu_xml.set_numa_cell(vmcpu_xml.dicts_to_cells(nodexml_list))
+                            vmcpu_xml.set_numa_cell(nodexml_list)
                     else:
                         logging.warning("Guest numa could not be updated, expect "
                                         "failures if guest numa is checked")


### PR DESCRIPTION
This reverts commit 00b9939baafbd4f1f483909da08f7372e69d9956.

As it introduces below failure

type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.no_operation: ERROR: Attributes values should be str-type of int-type. (7.82 s)

```
avocado-vt/virttest/test-providers.d/downloads/io-github-autotest-libvirt/libvirt/tests/src/libvirt_vcpu_plug_unplug.py", line 296, in run
ERROR|     topology_correction=topology_correction)
ERROR|   File "/usr/local/lib/python3.6/site-packages/virttest/libvirt_xml/vm_xml.py", line 868, in set_vm_vcpus
ERROR|     vmcpu_xml.set_numa_cell(vmcpu_xml.dicts_to_cells(nodexml_list))
ERROR|   File "/usr/local/lib/python3.6/site-packages/virttest/libvirt_xml/vm_xml.py", line 1925, in dicts_to_cells
ERROR|     raise TypeError('Attributes values should be str-type of int-type.')
ERROR| TypeError: Attributes values should be str-type of int-type.
ERROR|
```