### PR TITLE
Add new cpu quota max value for cgroup2 test

### DIFF
--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -346,7 +346,8 @@ class CgroupTest(object):
                     # no need to check scheduler type, it's fixed for qemu
                     continue
                 if "quota" in schedinfo_item:
-                    if schedinfo_value in ["-1", "18446744073709551"]:
+                    if schedinfo_value in ["-1", "18446744073709551",
+                                           "17592186044415"]:
                         standardized_virsh_output_info[schedinfo_item] = "max"
                         continue
                 standardized_virsh_output_info[schedinfo_item] = schedinfo_value


### PR DESCRIPTION
Libvirt commit ed1ba69f5a starts to use '17592186044415' as max value
for cpu quota, this patch is to treat this value as 'max'.

Signed-off-by: Yi Sun <yisun@redhat.com>