### PR TITLE
passfd: Correct the library name for Python>=3.8

### DIFF
--- a/virttest/passfd_setup.py
+++ b/virttest/passfd_setup.py
@@ -8,7 +8,7 @@ from virttest import data_dir
 PYTHON_HEADERS = distutils.sysconfig.get_python_inc()
 PYTHON_VERSION = distutils.sysconfig.get_python_version()
 PYTHON_LIB = "python%s" % PYTHON_VERSION
-if float(PYTHON_VERSION) >= 3:
+if float(PYTHON_VERSION) >= 3 and float(PYTHON_VERSION) < 3.8:
     PYTHON_LIB += "m"
 
 OUTPUT_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
For Python>=3.8, abiflag `m` is no longer added [1] therefore we
have to update the compile option.

Reference:
[1] https://bugs.python.org/issue36844

Signed-off-by: Xu Han <xuhan@redhat.com>

ID: 1917860