### PR TITLE
Remove python 2.7 support in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.7"
     - "3.6"
     - "3.7"
     - "3.8"


### PR DESCRIPTION
python 2.7 is deprecated already, so just remove it
Moreover, this also align with avocado project

Signed-off-by: chunfuwen <chwen@redhat.com>