### PR TITLE
[PoC] nrunner support

### DIFF
--- a/avocado_vt/discovery.py
+++ b/avocado_vt/discovery.py
@@ -1,0 +1,59 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Authors: Cleber Rosa <crosa@redhat.com>
+#          Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Avocado VT plugin
+"""
+
+from virttest.compat import get_opt
+from .options import VirtTestOptionsProcess
+
+
+class DiscoveryMixIn:
+
+    def _get_parser(self):
+        options_processor = VirtTestOptionsProcess(self.config)
+        return options_processor.get_parser()
+
+    def _save_parser_cartesian_config(self, parser):
+        path = get_opt(self.config, 'vt.save_config')
+        if path is None:
+            return
+        with open(path, 'w') as cartesian_config:
+            cartesian_config.write("include %s\n" % parser.filename)
+            for statement in (parser.only_filters + parser.no_filters +
+                              parser.assignments):
+                cartesian_config.write("%s\n" % statement)
+
+    def convert_parameters(self, params):
+        # Evaluate the proper avocado-vt test name
+        test_name = None
+        if (get_opt(self.config, 'vt.config')
+                and get_opt(self.config, 'vt.short_names_when_config')):
+            test_name = params.get("shortname")
+        elif get_opt(self.config, 'vt.type') == "spice":
+            short_name_map_file = params.get("_short_name_map_file")
+            if "tests-variants.cfg" in short_name_map_file:
+                test_name = short_name_map_file["tests-variants.cfg"]
+        if test_name is None:
+            test_name = params.get("_short_name_map_file")["subtests.cfg"]
+        # We want avocado to inject params coming from its multiplexer into
+        # the test params. This will allow users to access avocado params
+        # from inside virt tests. This feature would only work if the virt
+        # test in question is executed from inside avocado.
+        params['id'] = test_name
+        test_parameters = {'name': test_name,
+                           'vt_params': params}
+        return test_parameters

--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -1,0 +1,48 @@
+from avocado.core.nrunner import Runnable
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult)
+from avocado.core.settings import settings
+
+from ..discovery import DiscoveryMixIn
+
+
+class VTResolver(Resolver, DiscoveryMixIn):
+
+    name = 'vt'
+    description = 'Test resolver for Avocado-VT tests'
+
+    def _parameters_to_runnable(self, params):
+        params = self.convert_parameters(params)
+        url = params.get('name')
+        vt_params = params.get('vt_params')
+
+        # Flatten the vt_params, discarding the attributes that are not
+        # scalars, and will not be used in the context of nrunner
+        for key in ('_name_map_file', '_short_name_map_file', 'dep'):
+            if key in vt_params:
+                del(vt_params[key])
+
+        return Runnable('avocado-vt', url, **vt_params)
+
+    def resolve(self, reference):
+        self.config = settings.as_dict()
+        try:
+            cartesian_parser = self._get_parser()
+            self._save_parser_cartesian_config(cartesian_parser)
+        except Exception as details:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.ERROR,
+                                       info=details)
+
+        cartesian_parser.only_filter(reference)
+
+        runnables = [self._parameters_to_runnable(_) for _ in
+                     cartesian_parser.get_dicts()]
+        if runnables:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.SUCCESS,
+                                       runnables)
+        else:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.NOTFOUND)

--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -1,0 +1,100 @@
+import multiprocessing
+import os
+import tempfile
+import time
+
+from avocado.core import nrunner
+from avocado_vt import utils
+from virttest import (bootstrap, data_dir, env_process, utils_env, utils_misc,
+                      utils_params)
+
+
+class FakeTest:
+
+    def __init__(self):
+        self.iteration = 1
+        self.logdir = tempfile.mkdtemp()
+        self.debugdir = tempfile.mkdtemp()
+        self.bindir = data_dir.get_root_dir()
+        self.virtdir = os.path.join(self.bindir, 'shared')
+        self.tmpdir = tempfile.mkdtemp()
+        self.outputdir = os.path.join(self.logdir, 'data')
+        os.mkdir(self.outputdir)
+
+    def verify_background_errors(self):
+        pass
+
+    def write_test_keyval(self, info):
+        pass
+
+
+class VTTestRunner(nrunner.BaseRunner):
+    """
+    Runner for Avocado-VT (aka VirtTest) tests
+
+    Runnable attributes usage:
+
+     * uri: name of VT test
+
+     * args: not used
+
+     * kwargs: all the VT specific parameters
+    """
+    DEFAULT_TIMEOUT = 86400
+
+    def _run_test_function(self):
+        """simplified version of avocado_vt.test.VirtTest._runTest()"""
+        params = utils_params.Params(**self.runnable.kwargs)
+        fake_test = FakeTest()
+        test_filter = bootstrap.test_filter
+        subtest_dirs = utils.find_subtest_dirs(params.get("other_tests_dirs", ""),
+                                               fake_test.bindir,
+                                               test_filter)
+        provider = params.get("provider", None)
+
+        if provider is None:
+            subtest_dirs += utils.find_generic_specific_subtest_dirs.params.get(
+                "vm_type", test_filter)
+        else:
+            subtest_dirs += utils.find_provider_subtest_dirs(provider,
+                                                             test_filter)
+        subtest_dir = None
+        t_types = params.get("type").split()
+        utils.insert_dirs_to_path(subtest_dirs)
+        test_modules = utils.find_test_modules(t_types, subtest_dirs)
+
+        for t_type in t_types:
+            test_module = test_modules[t_type]
+            run_func = utils_misc.get_test_entrypoint_func(t_type, test_module)
+            try:
+                env_filename = os.path.join(data_dir.get_tmp_dir(),
+                                            params.get("env", "env"))
+                env = utils_env.Env(env_filename, '1')
+                params = env_process.preprocess(fake_test, params, env)
+                run_func(fake_test, params, env)
+                env_process.postprocess(fake_test, params, env)
+            except Exception as e:
+                return {'result': 'error',
+                        'error': str(e)}
+        return {'result': 'pass'}
+
+    def run(self):
+        yield self.prepare_status('started')
+        run_result = self._run_test_function()
+        yield self.prepare_status('finished', run_result)
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-avocado-vt'
+    PROG_DESCRIPTION = 'nrunner application for Avocado-VT tests'
+    RUNNABLE_KINDS_CAPABLE = {
+        'avocado-vt': VTTestRunner
+    }
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ if __name__ == "__main__":
           packages=find_packages(exclude=('selftests*',)),
           include_package_data=True,
           entry_points={
+              'console_scripts': [
+                  'avocado-runner-avocado-vt = avocado_vt.plugins.vt_runner:main',
+                  ],
               'avocado.plugins.settings': [
                   'vt-settings = avocado_vt.plugins.vt_settings:VTSettings',
                   ],
@@ -75,6 +78,10 @@ if __name__ == "__main__":
               'avocado.plugins.resolver': [
                   'vt = avocado_vt.plugins.vt_resolver:VTResolver'
                   ],
+              'avocado.plugins.runnable.runner': [
+                  'vt = avocado_vt.plugins.vt_runner:VTRunner',
+                  ],
+
               },
           install_requires=requirements,
           )

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,9 @@ if __name__ == "__main__":
               'avocado.plugins.init': [
                   'vt-init = avocado_vt.plugins.vt_init:VtInit',
                   ],
+              'avocado.plugins.resolver': [
+                  'vt = avocado_vt.plugins.vt_resolver:VTResolver'
+                  ],
               },
           install_requires=requirements,
           )


### PR DESCRIPTION
This is a very early, and very limited, but still functional, implementation of a runner that plugs into Avocado's "nrunner" architecture.

If you're interested in trying it out, after bootstrapping Avocado-VT, you should be able to do:

```
$ avocado list --resolver boot 
avocado-vt io-github-autotest-qemu.boot
```

And to run tests:

```
$ avocado run --test-runner=nrunner boot /bin/true /bin/true /bin/true
JOB ID     : 22563e6ab3c701dfefc95b0eff5d25cabac0d6a3
JOB LOG    : /home/cleber/avocado/job-results/job-2021-01-26T13.39-22563e6/job.log
 (2/4) /bin/true: STARTED
 (3/4) /bin/true: STARTED
 (2/4) /bin/true: PASS (0.01 s)
 (3/4) /bin/true: PASS (0.01 s)
 (1/4) io-github-autotest-qemu.boot: STARTED
 (4/4) /bin/true: STARTED
 (4/4) /bin/true: PASS (0.01 s)
 (1/4) io-github-autotest-qemu.boot: PASS (20.28 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/cleber/avocado/job-results/job-2021-01-26T13.39-22563e6/results.html
JOB TIME   : 29.59 s
```