### PR TITLE
[WIP]Fix qemu convert no space

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2555,8 +2555,17 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
                                                               dist_img)
 
         # Mount the gluster disk and create the image.
-        process.run("mount -t glusterfs %s:%s /mnt; %s; umount /mnt"
-                    % (host_ip, vol_name, disk_cmd), shell=True)
+        #process.run("mount -t glusterfs %s:%s /mnt; %s; umount /mnt"
+        #            % (host_ip, vol_name, disk_cmd), shell=True)
+        ret = process.run("mount -t glusterfs %s:%s /mnt; %s"
+                          % (host_ip, vol_name, disk_cmd), shell=True, ignore_status=True)
+        if ret.exit_status:
+            os.remove("/mnt/%s" % dist_img)
+            os.system("umount /mnt")
+            raise exceptions.TestFail("Fail to execute command %s with output: %s" % (disk_cmd, ret))
+        else:
+            logging.debug("Umount /mnt")
+            os.system("umount /mnt")
 
         disk_params_src = {'source_protocol': disk_src_protocol,
                            'source_name': "%s/%s" % (vol_name, dist_img),


### PR DESCRIPTION
Originally qemu-img convert command and umount command are run in one shell, which
causes the final ret code is zero even though qemu-img convert has failed with an
error, like 'no space left', because the ret code is overlaped by umount command which
is often zero. And when that error happens, the gluster volume is not cleaned up which
may cause /tmp folder is full on gluster server host/vm and no new volume can be created.
So this fix is to throw out the qemu-img convert error and clean up the volume before
throwing.


Signed-off-by: Dan Zheng <dzheng@redhat.com>