### PR TITLE
[virttest/migration] Set default value to avoid TypeError

### DIFF
--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -56,7 +56,7 @@ class MigrationTest(object):
                                           "state at destination" % vm_state)
             logging.info("Guest state is '%s' at destination is as expected",
                          vm_state)
-            if "offline" not in params.get("migrate_options"):
+            if "offline" not in params.get("migrate_options", ""):
                 vm_uptime = vm.uptime(connect_uri=uri)
                 logging.info("uptime of migrated VM %s: %s", vm.name,
                              vm_uptime)


### PR DESCRIPTION
`migrate_options` might not have been set. Return empty string to avoid
tests failing with
"TypeError: argument of type 'NoneType' is not iterable"

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>