### PR TITLE
support arm in check_machine_type_arch

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3604,7 +3604,8 @@ def check_machine_type_arch(machine_type):
         return
     arch_machine_map = {'x86_64': ['pc', 'q35'],
                         'ppc64le': ['pseries'],
-                        's390x': ['s390-ccw-virtio']}
+                        's390x': ['s390-ccw-virtio'],
+                        'aarch64': ['arm64-mmio:virt', 'arm64-pci:virt']}
     arch = platform.machine()
     if machine_type not in arch_machine_map[arch]:
         raise exceptions.TestSkipError("This machine type '%s' is not "


### PR DESCRIPTION
avocado-vt supports 2 arm machine type: arm64-mmio:virt arm64-pci:virt

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>