### PR TITLE
Add a 64-bit build configuration for rss

### DIFF
--- a/virttest/shared/deps/rss/Makefile
+++ b/virttest/shared/deps/rss/Makefile
@@ -1,8 +1,10 @@
 all:
-	make rss.exe finish.exe
+	make rss.exe rss_amd64.exe finish.exe
 rss.exe:
-	i686-pc-mingw32-g++ rss.cpp -O2 -static-libgcc -lws2_32 -lshlwapi -mwindows -o rss.exe
+	i686-w64-mingw32-g++ rss.cpp -O2 -static-libgcc -lws2_32 -lshlwapi -mwindows -o rss.exe
+rss_amd64.exe:
+	x86_64-w64-mingw32-g++ rss.cpp -O2 -static-libgcc -lws2_32 -lshlwapi -mwindows -o rss_amd64.exe
 finish.exe:
-	i686-pc-mingw32-g++ finish.cpp -O2 -lws2_32 -o finish.exe
+	i686-w64-mingw32-g++ finish.cpp -O2 -lws2_32 -o finish.exe
 clean:
-	rm -rf rss.exe finish.exe
+	rm -rf rss.exe rss_amd64.exe finish.exe

--- a/virttest/shared/deps/rss/setuprss.bat
+++ b/virttest/shared/deps/rss/setuprss.bat
@@ -1,5 +1,23 @@
+rem Enable delayed expansion to be able to use !ERRORLEVEL!
+setlocal enabledelayedexpansion
 set rsspath=%1
-if [%1]==[] set rsspath=%~dp0\rss.exe
+
+if [%1]==[] (
+    echo "Guessing rss path to use based on processor architecture"
+    :: Not using the PROCESSOR_ARCHITECTURE environment variable directly here as there are situations in Win7
+    :: install where the installation will be x64 but the environment variables, and the file system at
+    :: that point, are in a 32-bit state and %PROCESSOR_ARCHITECTURE% will return x86 on AMD64 hardware.
+    :: Since this file is called during the unattended installation, it is best to access the variable from
+    :: the registry instead. More information: https://github.com/avocado-framework/avocado-vt/pull/2920#discussion_r579332634
+    reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v PROCESSOR_ARCHITECTURE | find /i "x86" > nul
+    if !ERRORLEVEL!==0 (
+        echo "Windows 32-bits detected"
+        set rsspath=%~dp0\rss.exe
+    ) else (
+        echo "Windows 64-bits detected"
+        set rsspath=%~dp0\rss_amd64.exe
+    )
+)
 copy %rsspath% C:\rss.exe
 
 net user Administrator /active:yes


### PR DESCRIPTION
When PowerShell is invoked from a 32-bit process running on a
64-bit OS some cmdlets are not accessible (e.g. `New-SmbShare`,
`Install-WindowsFeature` and others). With this change rss.exe or
rss64.exe will be installed depending on the detected bitness.