### PR TITLE
get_additional_feature_list: Update to get complete features

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -2047,7 +2047,8 @@ class VMCPUXML(base.LibvirtXMLBase):
         """
         cpu_xml = VMCPUXML()
         cpu_xml['model'] = domcaps_xml.get_hostmodel_name()
-        features = domcaps_xml.get_additional_feature_list('host-model')
+        features = domcaps_xml.get_additional_feature_list(
+                'host-model', ignore_features=None)
         feature_names = [name for f_list in [list(d.keys()) for d in features]
                          for name in f_list]
         for feature_name in feature_names:


### PR DESCRIPTION
The method get_additional_feature_list() got the features except
invtsc. But some cases need it for now, so add a parameter to
set whether to get it or not.

Signed-off-by: Yingshun Cui <yicui@redhat.com>