### PR TITLE
qdevices: Remove "--daemon" option on QSwtpmDev

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1931,7 +1931,7 @@ class QSwtpmDev(QDaemonDev):
         self.set_param('extra_options', extra_options)
 
     def start_daemon(self):
-        tpm_cmd = '%s socket --daemon' % self.get_param('binary')
+        tpm_cmd = '%s socket' % self.get_param('binary')
         tpm_cmd += ' --ctrl type=unixio,path=%s,mode=0600' % self.get_param('sock_path')
         tpm_cmd += ' --tpmstate dir=%s,mode=0600' % self.get_param('storage_path')
 


### PR DESCRIPTION
`aexpect.run_bg` will also run the shell command in the background, so
if swtpm running in the daemon mode, then "run_bg" will return an idle
process and the swtpm process is not controlled.

ID: 1932183
Signed-off-by: Yihuang Yu <yihyu@redhat.com>