### PR TITLE
fix No closing quotation error when volume has special characters

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -913,7 +913,7 @@ class PoolVolumeTest(object):
                         vols = pv.list_volumes()
                         for vol in vols:
                             # Ignore failed deletion here for deleting pool
-                            pv.delete_volume(vol)
+                            pv.delete_volume(repr(vol))
                 if not sp.delete_pool(pool_name):
                     raise exceptions.TestFail(
                         "Delete pool %s failed" % pool_name)


### PR DESCRIPTION
If volume name is like 'Auto-esx7.0-rhel7.9-special-characters~!@#$%^&*_=+,?><:;|."[]{}()`\-m',
when calling shlex.split, it will raise 'No closing quotation' error.

Reading the following answer, a repr could solve the problem and it works well
on both python2 and python3.
https://stackoverflow.com/questions/18935754/how-to-escape-special-characters-of-a-string-with-single-backslashes

After the fix:
>>> import shlex
>>> v1 = 'Auto-esx7.0-rhel7.9-special-characters~!@#$%^&*_=+,?><:;|."[]{}()`\-m'
>>> shlex.split('virsh dumpxml %s' % repr(v1))
['virsh', 'dumpxml', 'Auto-esx7.0-rhel7.9-special-characters~!@#$%^&*_=+,?><:;|."[]{}()`\\\\-m']

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>