### PR TITLE
v2v: fix incorrect vmx file path issue

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1792,7 +1792,7 @@ def get_esx_disk_source_info(vm_name, virsh_instance):
     :param v2v_virsh_instance: a virsh instance
     """
     def _parse_file_info(path):
-        res = re.search(r'\[(.*)\] (.*?)/(.*\.vmdk)', path)
+        res = re.search(r'\[(.*)\] (.*)/(.*\.vmdk)', path)
         if not res:
             return []
         return [res.group(i) for i in range(1, 4)]


### PR DESCRIPTION
The source file path may has nested directories. Let's use greedy re expression
for the path.

For example:
<source file='[esx6.0-matrix-backup] esx6.0/esx6.0-win10-x86_64/esx6.0-win10-x86_64.vmdk'/>

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>