### PR TITLE
Exclude pmsocat to install avocado-vt in python 2.7 env

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ recursive-include avocado_vt/conf.d *
 recursive-include virttest/test-providers.d *
 recursive-include virttest/backends *
 recursive-include virttest/shared *
+recursive-exclude virttest/shared/scripts/pmsocat *


### PR DESCRIPTION
It reports a SyntaxError when installing avocado-vt in python 2.7
env. And it's a script that can only be used in python 3 env, so
exlude it in MANIFEST.in.

Signed-off-by: Yingshun Cui <yicui@redhat.com>