### PR TITLE
Remove esx5.5 source from v2v jobs

### DIFF
--- a/virttest/backends/v2v/cfg/convert_source.cfg
+++ b/virttest/backends/v2v/cfg/convert_source.cfg
@@ -14,12 +14,6 @@ variants:
         vpx_password = VPX_PASSWORD_V2V_EXAMPLE
         esxi_password = ESXI_PASSWORD_V2V_EXAMPLE
         variants:
-            - esx_55:
-                datastore = VPX_55_DATASTORE_V2V_EXAMPLE
-                vpx_hostname = VPX_55_HOSTNAME_V2V_EXAMPLE
-                vpx_dc = VPX_55_DC_V2V_EXAMPLE
-                esx_hostname = ESX_55_HOSTNAME_V2V_EXAMPLE
-                vddk_libdir_src = MOUNT_SRC_VDDK65_LIB_DIR_V2V_EXAMPLE
             - esx_60:
                 datastore = VPX_60_DATASTORE_V2V_EXAMPLE
                 vpx_hostname = VPX_60_HOSTNAME_V2V_EXAMPLE


### PR DESCRIPTION
ESXi5.5 is not supported by v2v anymore

Signed-off-by: mxie91 <mxie@redhat.com>