### PR TITLE
Fix an instance of (conditionally) undefined variable

### DIFF
--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -115,7 +115,7 @@ def find_test_modules(test_types, subtest_dirs):
                               module_path)
                 subtest_dir = d
                 break
-        if subtest_dir is None:
+        else:
             msg = ("Could not find test file %s.py on test"
                    "dirs %s" % (test_type, subtest_dirs))
             raise exceptions.TestError(msg)


### PR DESCRIPTION
Some refactoring made it possible that this variable is never
previously defined leading to:

```
13:00:37 ERROR| Reproduced traceback from: /usr/lib/python3.8/site-packages/avocado/core/test.py:767
13:00:37 ERROR| Traceback (most recent call last):
13:00:37 ERROR|   File "/usr/lib/python3.8/site-packages/avocado_vt/test.py", line 309, in runTest
13:00:37 ERROR|     raise self.__status  # pylint: disable=E0702
13:00:37 ERROR|   File "/usr/lib/python3.8/site-packages/avocado_vt/test.py", line 255, in setUp
13:00:37 ERROR|     self._runTest()
13:00:37 ERROR|   File "/usr/lib/python3.8/site-packages/avocado_vt/test.py", line 361, in _runTest
13:00:37 ERROR|     test_modules = utils.find_test_modules(t_types, subtest_dirs)
13:00:37 ERROR|   File "/usr/lib/python3.8/site-packages/avocado_vt/utils.py", line 118, in find_test_modules
13:00:37 ERROR|     if subtest_dir is None:
13:00:37 ERROR| UnboundLocalError: local variable 'subtest_dir' referenced before assignment
```

The new way uses a python "loop-else" instead of relying on the
variable being set.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>