### PR TITLE
Compatibility with config files in early stages

### DIFF
--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -270,6 +270,8 @@ if hasattr(plugin_interfaces, 'Init'):
                                      help_msg=help_msg,
                                      default='/tmp')
 
+            settings.merge_with_configs()
+
             virt_loader = getattr(importlib.import_module('avocado_vt.loader'),
                                   'VirtTestLoader')
             loader.register_plugin(virt_loader)

--- a/selftests/.data/vt_test.conf
+++ b/selftests/.data/vt_test.conf
@@ -1,0 +1,5 @@
+[vt.common]
+# Make the temporary dir path persistent across jobs if needed.
+# By default the data in the temporary directory will be wiped after each test
+# in some cases and after each job in others.
+tmp_dir = /tmp

--- a/selftests/__init__.py
+++ b/selftests/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+#: The base directory for the avocado-vt source tree
+BASEDIR = os.path.dirname(os.path.abspath(__file__))
+BASEDIR = os.path.abspath(os.path.join(BASEDIR, os.path.pardir))

--- a/selftests/unit/test_vt_init.py
+++ b/selftests/unit/test_vt_init.py
@@ -1,0 +1,43 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+from selftests import BASEDIR
+
+
+class VtInitTest(unittest.TestCase):
+
+    @staticmethod
+    def _swap():
+        data_dir = os.path.join(BASEDIR, "selftests", ".data")
+        config_file = os.path.join(BASEDIR, "avocado_vt", "conf.d", "vt.conf")
+        config_test_file = os.path.join(data_dir, "vt_test.conf")
+        tmp, tmp_name = tempfile.mkstemp(suffix=".conf", dir=data_dir)
+        os.rename(config_test_file, tmp_name)
+        os.rename(config_file, config_test_file)
+        os.rename(tmp_name, config_file)
+
+    def setUp(self):
+        self._swap()
+
+    def test_early_settings(self):
+        """
+        This test checks the initialization of vt options in early stage.
+        When the `avocado.core.settings` is imported the vt plugin is
+        initialized.
+        """
+        settings = getattr(importlib.import_module('avocado.core.settings'),
+                           'settings')
+        tmp_dir = settings.as_dict().get('vt.common.tmp_dir', "")
+        address_pool_filename = getattr(importlib.import_module(
+            'virttest.utils_net'), 'ADDRESS_POOL_FILENAME')
+        self.assertEqual(tmp_dir, "/tmp")
+        self.assertEqual(address_pool_filename, "/tmp/address_pool")
+
+    def tearDown(self):
+        self._swap()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In early stage of avocado run, there is a time when the vt options are
created, but they are not synchronized with values from config files.
This can affect some of the global variables which are set during this
time. This commit ensures the synchronization right after the options
are registered.

Reference: #2912
Signed-off-by: Jan Richter <jarichte@redhat.com>