### PR TITLE
Fix the xmltreefile can not find the cpu mode issue

### DIFF
--- a/virttest/utils_libvirt/libvirt_cpu.py
+++ b/virttest/utils_libvirt/libvirt_cpu.py
@@ -38,7 +38,7 @@ def add_cpu_settings(vmxml, params):
     else:
         cpu_xml = vm_xml.VMCPUXML()
 
-    if cpu_xml.xmltreefile.find('mode'):
+    if cpu_xml.xmltreefile.getroot().get('mode'):
         cpu_mode = cpu_xml.mode
     else:
         cpu_mode = params.get("cpuxml_cpu_mode", "host-model")


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

Xmltreefile can not find the cpu mode although it exists in the domain xml,
change to use try except to check if cpu mode exists