### PR TITLE
ip_sniffing: update tshark version re expression

### DIFF
--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -289,7 +289,7 @@ class TSharkSniffer(Sniffer):
     # Supported versions by the class
     supported_versions = ()
     # Regexp to get the version
-    _re_version = re.compile(r"TShark \(Wireshark\) (\d+\.\d+\.\d+)")
+    _re_version = re.compile(r"TShark(?: \(Wireshark\))? (\d+\.\d+\.\d+)")
 
     @classmethod
     def is_supported(cls, session=None):
@@ -304,7 +304,7 @@ class TSharkSniffer(Sniffer):
 
     @classmethod
     def _get_version(cls, session):
-        cmd = "%s --version" % cls.command
+        cmd = "%s -v" % cls.command
         if session:
             out = session.cmd_output(cmd)
         else:


### PR DESCRIPTION
1) Tshark version string may don't have '(Wireshark)', we should update
the re expression about it.

example version output:
TShark 1.10.14 (Git Rev Unknown from unknown)
TShark (Wireshark) 2.6.2 (v2.6.2)
TShark (Wireshark) 3.4.2 (Git commit a889cf1b1bf9)
2) Update the tshark version command.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>