### PR TITLE
Resolve the lscpu have multi ":" in ouput

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -734,7 +734,7 @@ def get_cpu_info(session=None):
             output = session.cmd_output(cmd).splitlines()
         finally:
             session.close()
-    cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":")], output))
+    cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":", 1)], output))
     return cpu_info
 
 


### PR DESCRIPTION
For new os there is a line
"Vulnerability Itlb multihit:     KVM: Mitigation: VMX disabled"
Which will cause error for get_cpu_info:
"dictionary update sequence element #24 has length 4; 2 is required"

update to compatible this situation

Signed-off-by: Kyla Zhang <weizhan@redhat.com>