### PR TITLE
Nrunner support 

### DIFF
--- a/avocado_vt/discovery.py
+++ b/avocado_vt/discovery.py
@@ -1,0 +1,66 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Authors: Cleber Rosa <crosa@redhat.com>
+#          Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Avocado VT plugin
+"""
+
+from virttest.compat import get_opt
+from .options import VirtTestOptionsProcess
+
+
+class DiscoveryMixIn:
+
+    def _get_parser(self):
+        options_processor = VirtTestOptionsProcess(self.config)
+        return options_processor.get_parser()
+
+    def _save_parser_cartesian_config(self, parser):
+        path = get_opt(self.config, 'vt.save_config')
+        if path is None:
+            return
+        with open(path, 'w') as cartesian_config:
+            cartesian_config.write("include %s\n" % parser.filename)
+            for statement in (parser.only_filters + parser.no_filters +
+                              parser.assignments):
+                cartesian_config.write("%s\n" % statement)
+
+    def convert_parameters(self, params):
+        """
+        Evaluates the proper avocado-vt test name
+
+        :param params: cartesian config parameters
+        :type params: dict
+        :return: dict with test name and vt parameters
+        """
+
+        test_name = None
+        if (get_opt(self.config, 'vt.config')
+                and get_opt(self.config, 'vt.short_names_when_config')):
+            test_name = params.get("shortname")
+        elif get_opt(self.config, 'vt.type') == "spice":
+            short_name_map_file = params.get("_short_name_map_file")
+            if "tests-variants.cfg" in short_name_map_file:
+                test_name = short_name_map_file["tests-variants.cfg"]
+        if test_name is None:
+            test_name = params.get("_short_name_map_file")["subtests.cfg"]
+        # We want avocado to inject params coming from its multiplexer into
+        # the test params. This will allow users to access avocado params
+        # from inside virt tests. This feature would only work if the virt
+        # test in question is executed from inside avocado.
+        params['id'] = test_name
+        test_parameters = {'name': test_name,
+                           'vt_params': params}
+        return test_parameters

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -29,7 +29,7 @@ from virttest import standalone_test
 from virttest import storage
 from virttest.compat import get_opt, set_opt
 
-from .options import VirtTestOptionsProcess
+from .discovery import DiscoveryMixIn
 from .test import VirtTest
 
 
@@ -86,7 +86,7 @@ class NotAvocadoVTTest(object):
     """
 
 
-class VirtTestLoader(loader.TestLoader):
+class VirtTestLoader(loader.TestLoader, DiscoveryMixIn):
 
     """
     Avocado loader plugin to load avocado-vt tests
@@ -120,20 +120,6 @@ class VirtTestLoader(loader.TestLoader):
             else:
                 extra = vt_extra_params
             set_opt(self.config, 'vt.extra_params', extra)
-
-    def _get_parser(self):
-        options_processor = VirtTestOptionsProcess(self.config)
-        return options_processor.get_parser()
-
-    def _save_parser_cartesian_config(self, parser):
-        path = get_opt(self.config, 'vt.save_config')
-        if path is None:
-            return
-        with open(path, 'w') as cartesian_config:
-            cartesian_config.write("include %s\n" % parser.filename)
-            for statement in (parser.only_filters + parser.no_filters +
-                              parser.assignments):
-                cartesian_config.write("%s\n" % statement)
 
     def get_extra_listing(self):
         if get_opt(self.config, 'vt.list_guests'):
@@ -199,25 +185,7 @@ class VirtTestLoader(loader.TestLoader):
         # Create test_suite
         test_suite = []
         for params in (_ for _ in cartesian_parser.get_dicts()):
-            # Evaluate the proper avocado-vt test name
-            test_name = None
-            if (get_opt(self.config, 'vt.config')
-                    and get_opt(self.config, 'vt.short_names_when_config')):
-                test_name = params.get("shortname")
-            elif get_opt(self.config, 'vt.type') == "spice":
-                short_name_map_file = params.get("_short_name_map_file")
-                if "tests-variants.cfg" in short_name_map_file:
-                    test_name = short_name_map_file["tests-variants.cfg"]
-            if test_name is None:
-                test_name = params.get("_short_name_map_file")["subtests.cfg"]
-            # We want avocado to inject params coming from its multiplexer into
-            # the test params. This will allow users to access avocado params
-            # from inside virt tests. This feature would only work if the virt
-            # test in question is executed from inside avocado.
-            params['id'] = test_name
-            test_parameters = {'name': test_name,
-                               'vt_params': params}
-            test_suite.append((VirtTest, test_parameters))
+            test_suite.append((VirtTest, self.convert_parameters(params)))
         if which_tests is loader.DiscoverMode.ALL and not test_suite:
             return self._report_bad_discovery(url, "No matching tests",
                                               which_tests)

--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -1,0 +1,48 @@
+from avocado.core.nrunner import Runnable
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult)
+from avocado.core.settings import settings
+
+from ..discovery import DiscoveryMixIn
+
+
+class VTResolver(Resolver, DiscoveryMixIn):
+
+    name = 'vt'
+    description = 'Test resolver for Avocado-VT tests'
+
+    def _parameters_to_runnable(self, params):
+        params = self.convert_parameters(params)
+        url = params.get('name')
+        vt_params = params.get('vt_params')
+
+        # Flatten the vt_params, discarding the attributes that are not
+        # scalars, and will not be used in the context of nrunner
+        for key in ('_name_map_file', '_short_name_map_file', 'dep'):
+            if key in vt_params:
+                del(vt_params[key])
+
+        return Runnable('avocado-vt', url, **vt_params)
+
+    def resolve(self, reference):
+        self.config = settings.as_dict()
+        try:
+            cartesian_parser = self._get_parser()
+            self._save_parser_cartesian_config(cartesian_parser)
+        except Exception as details:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.ERROR,
+                                       info=details)
+
+        cartesian_parser.only_filter(reference)
+
+        runnables = [self._parameters_to_runnable(d) for d in
+                     cartesian_parser.get_dicts()]
+        if runnables:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.SUCCESS,
+                                       runnables)
+        else:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.NOTFOUND)

--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -1,3 +1,5 @@
+import warnings
+
 from avocado.core.nrunner import Runnable
 from avocado.core.plugin_interfaces import Resolver
 from avocado.core.resolver import (ReferenceResolution,
@@ -40,6 +42,11 @@ class VTResolver(Resolver, DiscoveryMixIn):
         runnables = [self._parameters_to_runnable(d) for d in
                      cartesian_parser.get_dicts()]
         if runnables:
+            warnings.warn("the vt nrunner is experimental and don't have all"
+                          " avocado-vt features")
+            if self.config["nrunner.max_parallel_tasks"] != 1:
+                warnings.warn("the vt nrunner can be run only with "
+                              "nrunner-max-parallel-tasks set to 1")
             return ReferenceResolution(reference,
                                        ReferenceResolutionResult.SUCCESS,
                                        runnables)

--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -1,0 +1,286 @@
+import logging
+import multiprocessing
+import os
+import pickle
+import sys
+import tempfile
+import time
+import traceback
+
+from avocado.core import exceptions, nrunner, output, test, teststatus, test_id
+from avocado.utils import genio, stacktrace, path
+
+from avocado_vt import utils
+from virttest import (bootstrap, data_dir, env_process, error_event, utils_env,
+                      utils_misc, utils_params, version, funcatexit)
+
+BG_ERR_FILE = "background-error.log"
+
+
+class VirtTest:
+
+    def __init__(self, queue, vt_params=None):
+        self.__vt_params = utils_params.Params(vt_params)
+        self.queue = queue
+        self.tmpdir = tempfile.mkdtemp()
+        self.logdir = os.path.join(self.tmpdir, 'results')
+        path.init_dir(self.logdir)
+        self.logfile = os.path.join(self.logdir, 'debug.log')
+        self.log = output.LOG_JOB
+        self.env_version = utils_env.get_env_version()
+        self.iteration = 0
+        self.background_errors = error_event.error_events_bus
+        # clear existing error events
+        self.background_errors.clear()
+        self.debugdir = self.logdir
+        self.bindir = data_dir.get_root_dir()
+        self.virtdir = os.path.join(self.bindir, 'shared')
+
+
+    @property
+    def params(self):
+        return self.__vt_params
+
+    def write_test_keyval(self, info):
+        pass
+
+    def __safe_env_save(self, env):
+        """
+        Treat "env.save()" exception as warnings
+
+        :param env: The virttest env object
+        :return: True on failure
+        """
+        try:
+            env.save()
+        except Exception as details:
+            try:
+                pickle.dumps(env.data)
+            except Exception:
+                self.log.warn("Unable to save environment: %s",
+                              stacktrace.str_unpickable_object(env.data))
+            else:
+                self.log.warn("Unable to save environment: %s (%s)", details,
+                              env.data)
+            return True
+        return False
+
+    def _start_logging(self):
+        """
+        Simple helper for adding a file logger to the root logger.
+        """
+        file_handler = logging.FileHandler(filename=self.logfile)
+        file_handler.setLevel(logging.DEBUG)
+
+        fmt = '%(asctime)s %(levelname)-5.5s| %(message)s'
+        formatter = logging.Formatter(fmt=fmt, datefmt='%H:%M:%S')
+
+        file_handler.setFormatter(formatter)
+        self.log.setLevel(logging.DEBUG)
+        self.log.addHandler(file_handler)
+        self.log.propagate = False
+        logging.root.addHandler(file_handler)
+
+    def verify_background_errors(self):
+        """
+        Verify if there are any errors that happened on background threads.
+        Logs all errors in the background_errors into background-error.log and
+        error the test.
+        """
+        err_file_path = os.path.join(self.logdir, BG_ERR_FILE)
+        bg_errors = self.background_errors.get_all()
+        error_messages = ["BACKGROUND ERROR LIST:"]
+        for index, error in enumerate(bg_errors):
+            error_messages.append(
+                "- ERROR #%d -\n%s" % (index, "".join(
+                    traceback.format_exception(*error)
+                )))
+        genio.write_file(err_file_path, '\n'.join(error_messages))
+        if bg_errors:
+            msg = ["Background error", "s are" if len(bg_errors) > 1 else " is",
+                   " detected, please refer to file: '%s' for more details." %
+                   BG_ERR_FILE]
+            self.error(''.join(msg))
+
+    def runTest(self):
+        try:
+            self._start_logging()
+            params = self.params
+
+            # If a dependency test prior to this test has failed, let's fail
+            # it right away as TestNA.
+            if params.get("dependency_failed") == 'yes':
+                raise exceptions.TestSkipError("Test dependency failed")
+
+            # Report virt test version
+            self.log.info(version.get_pretty_version_info())
+            # Report the parameters we've received and write them as keyvals
+            self.log.debug("Test parameters:")
+            keys = list(params.keys())
+            keys.sort()
+            for key in keys:
+                self.log.debug("    %s = %s", key, params[key])
+
+            # Warn of this special condition in related location in output & logs
+            if os.getuid() == 0 and params.get('nettype', 'user') == 'user':
+                self.log.warning("")
+                self.log.warning("Testing with nettype='user' while running "
+                                 "as root may produce unexpected results!!!")
+                self.log.warning("")
+
+            test_filter = bootstrap.test_filter
+            subtest_dirs = utils.find_subtest_dirs(params.get(
+                "other_tests_dirs", ""), self.bindir, test_filter)
+            provider = params.get("provider", None)
+
+            if provider is None:
+                subtest_dirs += utils.find_generic_specific_subtest_dirs.\
+                    params.get("vm_type", test_filter)
+            else:
+                subtest_dirs += utils.find_provider_subtest_dirs(provider,
+                                                                 test_filter)
+
+            # Get the test routine corresponding to the specified
+            # test type
+            self.log.debug("Searching for test modules that match 'type = %s' "
+                           "and 'provider = %s' on this cartesian dict",
+                           params.get("type"),
+                           params.get("provider", None))
+
+            t_types = params.get("type").split()
+            utils.insert_dirs_to_path(subtest_dirs)
+            test_modules = utils.find_test_modules(t_types, subtest_dirs)
+
+            # Open the environment file
+            env_filename = os.path.join(data_dir.get_tmp_dir(),
+                                        params.get("env", "env"))
+            env = utils_env.Env(env_filename, self.env_version)
+
+            test_passed = False
+            t_type = None
+
+
+            try:
+                try:
+                    # Pre-process
+                    try:
+                        params = env_process.preprocess(self, params, env)
+                    finally:
+                        self.__safe_env_save(env)
+
+                    # Run the test function
+                    for t_type in t_types:
+                        test_module = test_modules[t_type]
+                        run_func = utils_misc.get_test_entrypoint_func(
+                            t_type, test_module)
+                        try:
+                            run_func(self, params, env)
+                            self.verify_background_errors()
+                        finally:
+                            self.__safe_env_save(env)
+                    test_passed = True
+                    error_message = funcatexit.run_exitfuncs(env, t_type)
+                    if error_message:
+                        raise exceptions.TestWarn("funcatexit failed with: %s" %
+                                                  error_message)
+
+                except:  # nopep8 Old-style exceptions are not inherited from Exception()
+                    stacktrace.log_exc_info(sys.exc_info(), 'avocado.test')
+                    if t_type is not None:
+                        error_message = funcatexit.run_exitfuncs(env, t_type)
+                        if error_message:
+                            self.log.error(error_message)
+                    try:
+                        env_process.postprocess_on_error(self, params, env)
+                    finally:
+                        self.__safe_env_save(env)
+                    raise
+
+            finally:
+                # Post-process
+                try:
+                    try:
+                        params['test_passed'] = str(test_passed)
+                        env_process.postprocess(self, params, env)
+                    except:  # nopep8 Old-style exceptions are not inherited from Exception()
+
+                        stacktrace.log_exc_info(sys.exc_info(),
+                                                'avocado.test')
+                        if test_passed:
+                            raise
+                        self.log.error("Exception raised during postprocessing:"
+                                       " %s", sys.exc_info()[1])
+                finally:
+                    if self.__safe_env_save(env) or params.get("env_cleanup",
+                                                               "no") == "yes":
+                        env.destroy()  # Force-clean as it can't be stored
+
+        except Exception as e:
+            if params.get("abort_on_error") != "yes":
+                self.queue.put({'result': "ERROR", 'error': str(e)})
+            # Abort on error
+            self.log.info("Aborting job (%s)", e)
+            if params.get("vm_type") == "qemu":
+                for vm in env.get_all_vms():
+                    if vm.is_dead():
+                        continue
+                    self.log.info("VM '%s' is alive.", vm.name)
+                    for m in vm.monitors:
+                        self.log.info("It has a %s monitor unix socket at: %s",
+                                     m.protocol, m.filename)
+                    self.log.info("The command line used to start it was:\n%s",
+                                 vm.make_create_command())
+                self.queue.put({'result': "ERROR",
+                                'error': str(exceptions.JobError(
+                                    "Abort requested (%s)" % e))})
+        self.queue.put({'result': "PASS"})
+
+
+class VTTestRunner(nrunner.BaseRunner):
+    """
+    Runner for Avocado-VT (aka VirtTest) tests
+
+    Runnable attributes usage:
+
+     * uri: name of VT test
+
+     * args: not used
+
+     * kwargs: all the VT specific parameters
+    """
+    DEFAULT_TIMEOUT = 86400
+
+    def run(self):
+        yield self.prepare_status('started')
+        queue = multiprocessing.SimpleQueue()
+        vt_test = VirtTest(queue, self.runnable.kwargs)
+        process = multiprocessing.Process(target=vt_test.runTest)
+        process.start()
+        while True:
+            time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
+            if not queue.empty():
+                state = queue.get()
+                if state.get("result") in teststatus.user_facing_status:
+                    break
+            yield self.prepare_status('running')
+        state['status'] = 'finished'
+        state['logdir'] = vt_test.logdir
+        state['logfile'] = vt_test.logfile
+        state['time'] = time.monotonic()
+        yield state
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-avocado-vt'
+    PROG_DESCRIPTION = 'nrunner application for Avocado-VT tests'
+    RUNNABLE_KINDS_CAPABLE = {
+        'avocado-vt': VTTestRunner
+    }
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ if __name__ == "__main__":
           packages=find_packages(exclude=('selftests*',)),
           include_package_data=True,
           entry_points={
+              'console_scripts': [
+                  'avocado-runner-avocado-vt = avocado_vt.plugins.vt_runner:main',
+                  ],
               'avocado.plugins.settings': [
                   'vt-settings = avocado_vt.plugins.vt_settings:VTSettings',
                   ],
@@ -75,6 +78,10 @@ if __name__ == "__main__":
               'avocado.plugins.resolver': [
                   'vt = avocado_vt.plugins.vt_resolver:VTResolver'
                   ],
+              'avocado.plugins.runnable.runner': [
+                  'vt = avocado_vt.plugins.vt_runner:VTRunner',
+                  ],
+
               },
           install_requires=requirements,
           )

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,9 @@ if __name__ == "__main__":
               'avocado.plugins.init': [
                   'vt-init = avocado_vt.plugins.vt_init:VtInit',
                   ],
+              'avocado.plugins.resolver': [
+                  'vt = avocado_vt.plugins.vt_resolver:VTResolver'
+                  ],
               },
           install_requires=requirements,
           )


### PR DESCRIPTION
This is an early, and limited, but still functional, implementation of a runner that plugs into Avocado's "nrunner" architecture.
It is based on @clebergnu PoC #2904

If you're interested in trying it out, after bootstrapping Avocado-VT, you should be able to do:

```
$ avocado list --resolver boot 
avocado-vt io-github-autotest-qemu.boot
```

And to run tests:

```
$  avocado run --test-runner=nrunner --nrunner-max-parallel-tasks 1 boot /bin/true /bin/true /bin/true
JOB ID     : f5fcbe85af3398323fe8a482eea30bdfe3fd213a
JOB LOG    : /home/jarichte/avocado/job-results/job-2021-03-19T17.48-f5fcbe8/job.log
 (1/4) io-github-autotest-qemu.boot: STARTED
 (1/4) io-github-autotest-qemu.boot: PASS (22.31 s)
 (2/4) /bin/true: STARTED
 (2/4) /bin/true: PASS (0.01 s)
 (3/4) /bin/true: STARTED
 (3/4) /bin/true: PASS (0.01 s)
 (4/4) /bin/true: STARTED
 (4/4) /bin/true: PASS (0.01 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/jarichte/avocado/job-results/job-2021-03-19T17.48-f5fcbe8/results.html
JOB TIME   : 27.11 s
```