### PR TITLE
VirtTest: remove compatibility with legacy Avocado versions

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -153,13 +153,6 @@ class VirtTest(test.Test):
             # Report the parent's value in such case.
             return super(VirtTest, self).params
 
-    @params.setter
-    def params(self, value):
-        """
-        For compatibility with 36lts we need to support setter on params
-        """
-        self.__params_vt = value
-
     @property
     def avocado_params(self):
         """

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -188,18 +188,6 @@ class VirtTest(test.Test):
         """
         return None
 
-    def get_state(self):
-        """
-        Pre Avocado-60.0 used to override self.__params attribute and
-        requires special handling while reporting the state.
-
-        TODO: Remove when 52LTS is deprecated.
-        """
-        state = super(VirtTest, self).get_state()
-        if state["params"] == self.__params_vt:
-            state["params"] = self.avocado_params
-        return state
-
     def write_test_keyval(self, d):
         self.whiteboard = str(d)
 


### PR DESCRIPTION
Just a few long overdue compatibility cleanups. 