### PR TITLE
Nrunner support  [v2]

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -32,7 +32,7 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 88.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -100,9 +100,13 @@ Xunit output, among others.
 %{python3_sitelib}/avocado_vt*
 %{python3_sitelib}/avocado_framework_plugin_vt*
 %{python3_sitelib}/virttest*
+%{_bindir}/avocado-runner-avocado-vt
 
 
 %changelog
+* Thu May 24 2021 Jan Richter <jarichte@redhat.com> - 88.0-2
+- Experimental runner implementation for the nrunner architecture
+
 * Tue May 18 2021 Cleber Rosa <cleber@redhat.com> - 88.0-1
 - New release
 

--- a/avocado_vt/discovery.py
+++ b/avocado_vt/discovery.py
@@ -1,0 +1,64 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Authors: Cleber Rosa <crosa@redhat.com>
+#          Lucas Meneghel Rodrigues <lmr@redhat.com>
+
+"""
+Avocado VT plugin
+"""
+
+from virttest.compat import get_opt
+from .options import VirtTestOptionsProcess
+
+
+class DiscoveryMixIn:
+
+    def _get_parser(self):
+        options_processor = VirtTestOptionsProcess(self.config)
+        return options_processor.get_parser()
+
+    def _save_parser_cartesian_config(self, parser):
+        path = get_opt(self.config, 'vt.save_config')
+        if path is None:
+            return
+        with open(path, 'w') as cartesian_config:
+            cartesian_config.write("include %s\n" % parser.filename)
+            for statement in (parser.only_filters + parser.no_filters +
+                              parser.assignments):
+                cartesian_config.write("%s\n" % statement)
+
+    def convert_parameters(self, params):
+        """
+        Evaluates the proper avocado-vt test name and params.
+
+        :param params: cartesian config parameters
+        :type params: dict
+        :return: dict with test name and vt parameters
+        """
+        test_name = params.get("_short_name_map_file")["subtests.cfg"]
+        if (get_opt(self.config, 'vt.config')
+                and get_opt(self.config, 'vt.short_names_when_config')):
+            test_name = params.get("shortname")
+        elif get_opt(self.config, 'vt.type') == "spice":
+            short_name_map_file = params.get("_short_name_map_file")
+            if "tests-variants.cfg" in short_name_map_file:
+                test_name = short_name_map_file.get("tests-variants.cfg",
+                                                    test_name)
+        # We want avocado to inject params coming from its multiplexer into
+        # the test params. This will allow users to access avocado params
+        # from inside virt tests. This feature would only work if the virt
+        # test in question is executed from inside avocado.
+        params['id'] = test_name
+        test_parameters = {'name': test_name,
+                           'vt_params': params}
+        return test_parameters

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -29,7 +29,7 @@ from virttest import standalone_test
 from virttest import storage
 from virttest.compat import get_opt, set_opt
 
-from .options import VirtTestOptionsProcess
+from .discovery import DiscoveryMixIn
 from .test import VirtTest
 
 
@@ -86,7 +86,7 @@ class NotAvocadoVTTest(object):
     """
 
 
-class VirtTestLoader(loader.TestLoader):
+class VirtTestLoader(loader.TestLoader, DiscoveryMixIn):
 
     """
     Avocado loader plugin to load avocado-vt tests
@@ -120,20 +120,6 @@ class VirtTestLoader(loader.TestLoader):
             else:
                 extra = vt_extra_params
             set_opt(self.config, 'vt.extra_params', extra)
-
-    def _get_parser(self):
-        options_processor = VirtTestOptionsProcess(self.config)
-        return options_processor.get_parser()
-
-    def _save_parser_cartesian_config(self, parser):
-        path = get_opt(self.config, 'vt.save_config')
-        if path is None:
-            return
-        with open(path, 'w') as cartesian_config:
-            cartesian_config.write("include %s\n" % parser.filename)
-            for statement in (parser.only_filters + parser.no_filters +
-                              parser.assignments):
-                cartesian_config.write("%s\n" % statement)
 
     def get_extra_listing(self):
         if get_opt(self.config, 'vt.list_guests'):
@@ -199,25 +185,7 @@ class VirtTestLoader(loader.TestLoader):
         # Create test_suite
         test_suite = []
         for params in (_ for _ in cartesian_parser.get_dicts()):
-            # Evaluate the proper avocado-vt test name
-            test_name = None
-            if (get_opt(self.config, 'vt.config')
-                    and get_opt(self.config, 'vt.short_names_when_config')):
-                test_name = params.get("shortname")
-            elif get_opt(self.config, 'vt.type') == "spice":
-                short_name_map_file = params.get("_short_name_map_file")
-                if "tests-variants.cfg" in short_name_map_file:
-                    test_name = short_name_map_file["tests-variants.cfg"]
-            if test_name is None:
-                test_name = params.get("_short_name_map_file")["subtests.cfg"]
-            # We want avocado to inject params coming from its multiplexer into
-            # the test params. This will allow users to access avocado params
-            # from inside virt tests. This feature would only work if the virt
-            # test in question is executed from inside avocado.
-            params['id'] = test_name
-            test_parameters = {'name': test_name,
-                               'vt_params': params}
-            test_suite.append((VirtTest, test_parameters))
+            test_suite.append((VirtTest, self.convert_parameters(params)))
         if which_tests is loader.DiscoverMode.ALL and not test_suite:
             return self._report_bad_discovery(url, "No matching tests",
                                               which_tests)

--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -1,3 +1,5 @@
+import warnings
+
 from avocado.core.nrunner import Runnable
 from avocado.core.plugin_interfaces import Discoverer, Resolver
 from avocado.core.resolver import (ReferenceResolution,
@@ -38,6 +40,11 @@ class VTResolverUtils(DiscoveryMixIn):
         runnables = [self._parameters_to_runnable(d) for d in
                      cartesian_parser.get_dicts()]
         if runnables:
+            warnings.warn("The VT NextRunner is experimental and doesn't have "
+                          "current Avocado VT features")
+            if self.config.get("nrunner.max_parallel_tasks", 1) != 1:
+                warnings.warn("The VT NextRunner can be run only with "
+                              "nrunner-max-parallel-tasks set to 1")
             return ReferenceResolution(reference,
                                        ReferenceResolutionResult.SUCCESS,
                                        runnables)

--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -1,0 +1,76 @@
+from avocado.core.nrunner import Runnable
+from avocado.core.plugin_interfaces import Discoverer, Resolver
+from avocado.core.resolver import (ReferenceResolution,
+                                   ReferenceResolutionResult)
+from avocado.core.settings import settings
+from virttest.compat import get_opt
+
+from ..discovery import DiscoveryMixIn
+
+
+class VTResolverUtils(DiscoveryMixIn):
+
+    def _parameters_to_runnable(self, params):
+        params = self.convert_parameters(params)
+        uri = params.get('name')
+        vt_params = params.get('vt_params')
+
+        # Flatten the vt_params, discarding the attributes that are not
+        # scalars, and will not be used in the context of nrunner
+        for key in ('_name_map_file', '_short_name_map_file', 'dep'):
+            if key in vt_params:
+                del(vt_params[key])
+
+        return Runnable('avocado-vt', uri, **vt_params)
+
+    def _get_reference_resolution(self, reference):
+        self.config = settings.as_dict()
+        try:
+            cartesian_parser = self._get_parser()
+            self._save_parser_cartesian_config(cartesian_parser)
+        except Exception as details:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.ERROR,
+                                       info=details)
+        if reference != '':
+            cartesian_parser.only_filter(reference)
+
+        runnables = [self._parameters_to_runnable(d) for d in
+                     cartesian_parser.get_dicts()]
+        if runnables:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.SUCCESS,
+                                       runnables)
+        else:
+            return ReferenceResolution(reference,
+                                       ReferenceResolutionResult.NOTFOUND)
+
+
+class VTResolver(Resolver, VTResolverUtils):
+
+    name = 'vt'
+    description = 'Test resolver for Avocado-VT tests'
+
+    def resolve(self, reference):
+        """
+        It will resolve vt test references into resolutions.
+
+        It discovers the tests from cartesian config based on the specification
+        from the user.
+        """
+        return self._get_reference_resolution(reference)
+
+
+class VTDiscoverer(Discoverer, VTResolverUtils):
+
+    name = 'vt-discoverer'
+    description = 'Test discoverer for Avocado-VT tests'
+
+    def discover(self):
+        """It will discover vt test resolutions from cartesian config."""
+        self.config = settings.as_dict()
+        if (not get_opt(self.config, 'vt.config') and
+                not get_opt(self.config, 'list.resolver')):
+            return ReferenceResolution('', ReferenceResolutionResult.NOTFOUND)
+
+        return [self._get_reference_resolution('')]

--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -1,0 +1,280 @@
+import logging
+import multiprocessing
+import os
+import sys
+import tempfile
+import time
+import traceback
+
+from avocado.core import exceptions, nrunner, output
+from avocado.utils import stacktrace, path
+
+from avocado_vt import utils
+from virttest import (data_dir, env_process, error_event, utils_env, utils_misc,
+                      utils_params, version, funcatexit)
+
+
+def _send_message(msg, queue, message_type):
+    status = {'type': message_type, 'log': msg}
+    queue.put(status)
+
+
+class RunnerLogHandler(logging.Handler):
+
+    def __init__(self, queue, message_type):
+        """
+        Runner logger which will put every log message to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: :class: multiprocessing.SimpleQueue
+        :param message_type: type of the log message
+        :type message_type: string with possible values: {stdout, stderr, log}
+        """
+        super().__init__()
+        self.queue = queue
+        self.message_type = message_type
+
+    def emit(self, record):
+        msg = self.format(record)
+        _send_message(msg, self.queue, self.message_type)
+
+
+class StreamToQueue:
+
+    def __init__(self, queue, message_type):
+        """
+        Runner Stream which will transfer every message to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        :param message_type: type of the log
+        :type message_type: string
+        """
+        self.queue = queue
+        self.message_type = message_type
+
+    def write(self, buf):
+        _send_message(buf, self.queue, self.message_type)
+
+    def flush(self):
+        pass
+
+
+class VirtTest(utils.TestUtils):
+
+    def __init__(self, queue, runnable):
+        self.__vt_params = utils_params.Params(runnable.kwargs)
+        self.queue = queue
+        self.tmpdir = tempfile.mkdtemp()
+        self.logdir = os.path.join(self.tmpdir, 'results')
+        path.init_dir(self.logdir)
+        self.logfile = os.path.join(self.logdir, 'debug.log')
+        self.log = output.LOG_JOB
+        self.log_level = runnable.config.get('job.output.loglevel',
+                                             logging.DEBUG)
+        self.env_version = utils_env.get_env_version()
+        self.iteration = 0
+        self.background_errors = error_event.error_events_bus
+        # clear existing error events
+        self.background_errors.clear()
+        self.debugdir = self.logdir
+        self.bindir = data_dir.get_root_dir()
+        self.virtdir = os.path.join(self.bindir, 'shared')
+
+    @property
+    def params(self):
+        return self.__vt_params
+
+    def _start_logging(self):
+        """Simple helper for adding a file logger to the root logger."""
+        file_handler = logging.FileHandler(filename=self.logfile)
+        log_handler = RunnerLogHandler(self.queue, 'log')
+
+        fmt = ('%(asctime)s %(module)-16.16s L%(lineno)-.4d %('
+               'levelname)-5.5s| %(message)s')
+        formatter = logging.Formatter(fmt=fmt)
+
+        file_handler.setFormatter(formatter)
+        log_handler.setFormatter(formatter)
+        self.log.setLevel(self.log_level)
+        self.log.addHandler(file_handler)
+        self.log.addHandler(log_handler)
+        self.log.propagate = False
+        logging.root.addHandler(file_handler)
+        logging.root.addHandler(log_handler)
+        logging.root.setLevel(self.log_level)
+        output.LOG_UI.addHandler(RunnerLogHandler(self.queue, 'stdout'))
+
+        sys.stdout = StreamToQueue(self.queue, "stdout")
+        sys.stderr = StreamToQueue(self.queue, "stderr")
+
+    def run_test(self):
+        params = self.params
+        try:
+            self._start_logging()
+
+            # Report virt test version
+            self.log.info(version.get_pretty_version_info())
+            self._log_parameters()
+
+            # Warn of this special condition in related location in output & logs
+            if os.getuid() == 0 and params.get('nettype', 'user') == 'user':
+                self.log.warning("")
+                self.log.warning("Testing with nettype='user' while running "
+                                 "as root may produce unexpected results!!!")
+                self.log.warning("")
+
+            subtest_dirs = self._get_subtest_dirs()
+
+            # Get the test routine corresponding to the specified
+            # test type
+            self.log.debug("Searching for test modules that match 'type = %s' "
+                           "and 'provider = %s' on this cartesian dict",
+                           params.get("type"),
+                           params.get("provider", None))
+
+            t_types = params.get("type").split()
+            utils.insert_dirs_to_path(subtest_dirs)
+            test_modules = utils.find_test_modules(t_types, subtest_dirs)
+
+            # Open the environment file
+            env_filename = os.path.join(data_dir.get_tmp_dir(),
+                                        params.get("env", "env"))
+            env = utils_env.Env(env_filename, self.env_version)
+
+            test_passed = False
+            t_type = None
+
+            try:
+                try:
+                    # Pre-process
+                    try:
+                        params = env_process.preprocess(self, params, env)
+                    finally:
+                        self._safe_env_save(env)
+
+                    # Run the test function
+                    for t_type in t_types:
+                        test_module = test_modules[t_type]
+                        run_func = utils_misc.get_test_entrypoint_func(
+                            t_type, test_module)
+                        try:
+                            run_func(self, params, env)
+                            self.verify_background_errors()
+                        finally:
+                            self._safe_env_save(env)
+                    test_passed = True
+                    error_message = funcatexit.run_exitfuncs(env, t_type)
+                    if error_message:
+                        raise exceptions.TestWarn("funcatexit failed with: %s" %
+                                                  error_message)
+
+                except:  # nopep8 Old-style exceptions are not inherited from Exception()
+                    stacktrace.log_exc_info(sys.exc_info(), 'avocado.test')
+                    if t_type is not None:
+                        error_message = funcatexit.run_exitfuncs(env, t_type)
+                        if error_message:
+                            self.log.error(error_message)
+                    try:
+                        env_process.postprocess_on_error(self, params, env)
+                    finally:
+                        self._safe_env_save(env)
+                    raise
+
+            finally:
+                # Post-process
+                try:
+                    try:
+                        params['test_passed'] = str(test_passed)
+                        env_process.postprocess(self, params, env)
+                    except:  # nopep8 Old-style exceptions are not inherited from Exception()
+
+                        stacktrace.log_exc_info(sys.exc_info(),
+                                                'avocado.test')
+                        if test_passed:
+                            raise
+                        self.log.error("Exception raised during postprocessing:"
+                                       " %s", sys.exc_info()[1])
+                finally:
+                    if self._safe_env_save(env) or params.get("env_cleanup",
+                                                              "no") == "yes":
+                        env.destroy()  # Force-clean as it can't be stored
+
+        except Exception as e:
+            try:
+                if params.get("abort_on_error") != "yes":
+                    raise
+                # Abort on error
+                logging.info("Aborting job (%s)", e)
+                if params.get("vm_type") == "qemu":
+                    for vm in env.get_all_vms():
+                        if vm.is_dead():
+                            continue
+                        logging.info("VM '%s' is alive.", vm.name)
+                        for m in vm.monitors:
+                            logging.info("It has a %s monitor unix socket at:"
+                                         " %s", m.protocol, m.filename)
+                        logging.info("The command line used to start it was:"
+                                     "\n%s", vm.make_create_command())
+                    raise exceptions.JobError("Abort requested (%s)" % e)
+            finally:
+                self.queue.put({'type': 'stderr',
+                                'log': traceback.format_exc().encode('utf-8')})
+                self.queue.put({'status': 'finished', 'result': 'error'})
+        self.queue.put({'status': 'finished', 'result': 'pass'})
+
+
+class VTTestRunner(nrunner.BaseRunner):
+    """
+    Runner for Avocado-VT (aka VirtTest) tests
+
+    Runnable attributes usage:
+
+     * uri: name of VT test
+
+     * args: not used
+
+     * kwargs: all the VT specific parameters
+    """
+    DEFAULT_TIMEOUT = 86400
+
+    def run(self):
+        yield self.prepare_status('started')
+        try:
+            queue = multiprocessing.SimpleQueue()
+            vt_test = VirtTest(queue, self.runnable)
+            process = multiprocessing.Process(target=vt_test.run_test)
+            process.start()
+            while True:
+                time.sleep(nrunner.RUNNER_RUN_CHECK_INTERVAL)
+                if queue.empty():
+                    yield self.prepare_status('running',)
+                else:
+                    message = queue.get()
+                    if message.get('status') == 'finished':
+                        yield self.prepare_status('finished', message)
+                        break
+                    else:
+                        yield self.prepare_status('running', message)
+        except Exception:
+            yield self.prepare_status('running',
+                                      {'type': 'stderr',
+                                       'log': traceback.format_exc().encode(
+                                           'utf-8')})
+            yield self.prepare_status('finished', {'result': 'error'})
+
+
+class RunnerApp(nrunner.BaseRunnerApp):
+    PROG_NAME = 'avocado-runner-avocado-vt'
+    PROG_DESCRIPTION = 'nrunner application for Avocado-VT tests'
+    RUNNABLE_KINDS_CAPABLE = {
+        'avocado-vt': VTTestRunner
+    }
+
+
+def main():
+    nrunner.main(RunnerApp)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,12 @@ if __name__ == "__main__":
               'avocado.plugins.init': [
                   'vt-init = avocado_vt.plugins.vt_init:VtInit',
                   ],
+              'avocado.plugins.resolver': [
+                  'avocado-vt = avocado_vt.plugins.vt_resolver:VTResolver'
+                  ],
+              'avocado.plugins.discoverer': [
+                  'avocado-vt = avocado_vt.plugins.vt_resolver:VTDiscoverer'
+                  ],
               },
           install_requires=["netifaces", "simplejson", "six", "netaddr",
                             "aexpect", "avocado-framework>=68.0"]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ if __name__ == "__main__":
           packages=find_packages(exclude=('selftests*',)),
           include_package_data=True,
           entry_points={
+              'console_scripts': [
+                  'avocado-runner-avocado-vt = avocado_vt.plugins.vt_runner:main',
+                  ],
               'avocado.plugins.settings': [
                   'vt-settings = avocado_vt.plugins.vt_settings:VTSettings',
                   ],
@@ -59,6 +62,9 @@ if __name__ == "__main__":
                   ],
               'avocado.plugins.discoverer': [
                   'avocado-vt = avocado_vt.plugins.vt_resolver:VTDiscoverer'
+                  ],
+              'avocado.plugins.runnable.runner': [
+                  'avocado-vt = avocado_vt.plugins.vt_runner:VTTestRunner',
                   ],
               },
           install_requires=["netifaces", "simplejson", "six", "netaddr",


### PR DESCRIPTION
This is an early, and limited, but still functional, implementation of a runner that plugs into Avocado's "nrunner" architecture.
It is based on @clebergnu PoC #2904

If you're interested in trying it out, after bootstrapping Avocado-VT, you should be able to do:

```
$ avocado list --resolver boot 
avocado-vt io-github-autotest-qemu.boot
```

And to run tests:

```
$  avocado run --test-runner=nrunner --nrunner-max-parallel-tasks 1 boot /bin/true /bin/true /bin/true
JOB ID     : f5fcbe85af3398323fe8a482eea30bdfe3fd213a
JOB LOG    : /home/jarichte/avocado/job-results/job-2021-03-19T17.48-f5fcbe8/job.log
 (1/4) io-github-autotest-qemu.boot: STARTED
 (1/4) io-github-autotest-qemu.boot: PASS (22.31 s)
 (2/4) /bin/true: STARTED
 (2/4) /bin/true: PASS (0.01 s)
 (3/4) /bin/true: STARTED
 (3/4) /bin/true: PASS (0.01 s)
 (4/4) /bin/true: STARTED
 (4/4) /bin/true: PASS (0.01 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/jarichte/avocado/job-results/job-2021-03-19T17.48-f5fcbe8/results.html
JOB TIME   : 27.11 s
```

---
Changes from v1 (#2961)
* split some VirtTest functionality into a common location