### PR TITLE
Fix: pylint check not working

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,7 @@
 Sphinx==1.3b1
 # inspektor (static and style checks)
 pylint==1.9.3; python_version <= '2.7'
-pylint==2.3.0; python_version >= '3.4'
+pylint==2.7.2; python_version >= '3.6'
 inspektor==0.5.2
 autotest>=0.16.2; python_version < '3.0'
 aexpect==1.6.0

--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -793,6 +793,7 @@ fdc
 
         # Remove some devices
         # Remove based on aid
+        # pylint: disable=E1111
         out = qdev.remove('__6')
         self.assertEqual(out, None, 'Failed to remove device:\n%s\nRepr:\n%s'
                          % ('hba1__0', qdev.str_long()))
@@ -802,6 +803,7 @@ fdc
                           False)
 
         # Remove device which contains other devices (recursive)
+        # pylint: disable=E1111
         out = qdev.remove('hba1')
         self.assertEqual(out, None, 'Failed to remove device:\n%s\nRepr:\n%s'
                          % ('hba1', qdev.str_long()))

--- a/virttest/element_tree.py
+++ b/virttest/element_tree.py
@@ -961,6 +961,7 @@ class iterparse(object):
 
     try:
         iter
+        # pylint: disable=E0301
 
         def __iter__(self):
             return self

--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -5,7 +5,11 @@ IP sniffing facilities
 import threading
 import logging
 import re
-from collections import Iterable
+
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 import aexpect
 from aexpect.remote import handle_prompts

--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -364,6 +364,7 @@ class Disk(base.TypedDeviceBase):
                      'total_iops_sec', 'read_iops_sec', 'write_iops_sec')
 
         def __init__(self, virsh_instance=base.base.virsh):
+            # pylint: disable=E1133
             for slot in self.__all_slots__:
                 if slot in base.base.LibvirtXMLBase.__all_slots__:
                     continue    # don't add these

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -2737,7 +2737,7 @@ class VMCPUTuneXML(base.LibvirtXMLBase):
         iothread_period:      int
         iothread_quota:       int
         global_period:        int
-        global_quota:         int       
+        global_quota:         int
     """
 
     __slots__ = ('vcpupins', 'emulatorpin', 'shares', 'period', 'quota',
@@ -2758,6 +2758,7 @@ class VMCPUTuneXML(base.LibvirtXMLBase):
         accessors.XMLElementList('iothreadscheds', self, parent_xpath='/',
                                  marshal_from=self.marshal_from_iothreadscheds,
                                  marshal_to=self.marshal_to_iothreadscheds)
+        # pylint: disable=E1133
         for slot in self.__all_slots__:
             if slot in ('shares', 'period', 'quota', 'emulator_period',
                         'emulator_quota', 'iothread_period', 'iothread_quota',

--- a/virttest/propcan.py
+++ b/virttest/propcan.py
@@ -289,6 +289,7 @@ class PropCan(PropCanBase):
 
     def __len__(self):
         length = 0
+        # pylint: disable=E1133
         for key in self.__all_slots__:
             # special None/False value handling
             if self.__contains__(key):
@@ -314,6 +315,7 @@ class PropCan(PropCanBase):
 
     def keys(self):
         # special None/False value handling
+        # pylint: disable=E1133
         return [key for key in self.__all_slots__
                 if self.__contains__(key)]
 

--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -61,7 +61,7 @@ class _VirtioPort(object):
         """
         Convert to text.
         """
-        return ("%s,%s,%s,%s,%d" % ("Socket", self.name, self.is_console,
+        return ("%s,%s,%s,%s,%s" % ("Socket", self.name, self.is_console,
                                     self.hostfile, self.is_open()))
 
     def __getstate__(self):

--- a/virttest/utils_backup.py
+++ b/virttest/utils_backup.py
@@ -398,7 +398,7 @@ def clean_checkpoints(vm_name, clean_metadata=True, ignore_status=True):
                                         ignore_status=ignore_status)
 
 
-def enable_inc_backup_for_vm(vm, libvirt_ver=(7,0,0)):
+def enable_inc_backup_for_vm(vm, libvirt_ver=(7, 0, 0)):
     """
     For now, libvirt doesn't enable incremental backup by default. We
     need to edit vm's xml to make sure it's supported.


### PR DESCRIPTION
Version of pylint is too low and causing errors like:
`module 'isort' has no attribute 'SortImports'` which blocks pylint
check for all modules.
This commit should fix it.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>