### PR TITLE
qcontainer: Support virtio-serial-ccw on s390x

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2537,6 +2537,8 @@ class DevContainer(object):
             if not bus or bus == '<new>':
                 if bus_type == 'virtio-serial-device':
                     pci_bus = {'type': 'virtio-bus'}
+                elif bus_type == 'virtio-serial-ccw':
+                    pci_bus = None
                 else:
                     pci_bus = {'aobject': 'pci.0'}
                 if bus != '<new>':


### PR DESCRIPTION
Support to boot a guest with virtio-serial-ccw device on s390x host

ID: 1941879
Signed-off-by: Nini Gu <ngu@redhat.com>