### PR TITLE
qcontainer: fix machine type extra params error

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -144,8 +144,10 @@ class DevContainer(object):
                              allow_output_check="combined",
                              shell=True,
                              verbose=False)
-        # Some architectures (arm) require machine type to be always set
-        failed_pattern = r'(?:kvm_init_vcpu.*failed)|(?:machine specified)'
+        # Some architectures (arm) require machine type to be always set and some
+        # hardware/firmware restrictions cause we need to set machine type.
+        failed_pattern = r'(?:kvm_init_vcpu.*failed)|(?:machine specified)' \
+                         r'|(?:appending -machine)'
         if result.exit_status and re.search(failed_pattern, result.stdout_text):
             self.__workaround_machine_type = True
             basic_qemu_cmd = "%s -machine none" % qemu_binary


### PR DESCRIPTION
When machine_type needs to add parameters, the simplest qemu instance will
report an error. add failed pattern to fix it.

ID: 1942374 
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>