### PR TITLE
 Preserve monitor connections for any preserved vms across test runs

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1676,16 +1676,17 @@ def postprocess(test, params, env):
         logging.info("Sosreport for remote host: %s", sosreport_path)
     living_vms = [vm for vm in env.get_all_vms() if vm.is_alive()]
     # Close all monitor socket connections of living vm.
-    for vm in living_vms:
-        if hasattr(vm, "monitors"):
-            for m in vm.monitors:
-                try:
-                    m.close()
-                except Exception:
-                    pass
-        # Close the serial console session, as it'll help
-        # keeping the number of filedescriptors used by avocado-vt honest.
-        vm.cleanup_serial_console()
+    if not params.get_boolean("keep_env_vms", False):
+        for vm in living_vms:
+            if hasattr(vm, "monitors"):
+                for m in vm.monitors:
+                    try:
+                        m.close()
+                    except Exception:
+                        pass
+            # Close the serial console session, as it'll help
+            # keeping the number of filedescriptors used by avocado-vt honest.
+            vm.cleanup_serial_console()
 
     libvirtd_inst = None
     vm_type = params.get("vm_type")

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -489,6 +489,9 @@ class Monitor(object):
         """
         Return True if the monitor is responsive.
         """
+        if self._socket.fileno() < 0:
+            logging.warning("Monitor socket is already closed")
+            return False
         try:
             self.verify_responsive()
             return True


### PR DESCRIPTION
This is an addition to the original implementation of vm persistence
that preserves the vm objects, i.e. PR: Optional vm persistence #2105.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>