### PR TITLE
virttest.remote: Change default log_function for remote_login

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -12,6 +12,7 @@ import tempfile
 
 import aexpect
 from aexpect.remote import *
+from aexpect.remote import remote_login as aexpect_remote_login
 
 from avocado.core import exceptions
 from avocado.utils import process
@@ -20,6 +21,24 @@ from virttest import data_dir
 from virttest import utils_logfile
 from virttest.remote_commander import remote_master
 from virttest.remote_commander import messenger
+
+
+def remote_login(client, host, port, username, password, prompt, linesep="\n",
+                 log_filename=None, log_function=None, timeout=10,
+                 interface=None, identity_file=None,
+                 status_test_command="echo $?", verbose=False, bind_ip=None,
+                 preferred_authenticaton='password',
+                 user_known_hosts_file='/dev/null'):
+    """
+    Aexpect's remote_login with a better default log_function
+    """
+    if log_function is None:
+        log_function = utils_logfile.log_line
+    return aexpect_remote_login(client, host, port, username, password,
+                                prompt, linesep, log_filename, log_function,
+                                timeout, interface, identity_file,
+                                status_test_command, verbose, bind_ip,
+                                preferred_authenticaton, user_known_hosts_file)
 
 
 def ssh_login_to_migrate(client, host, port, username, password, prompt, linesep="\n",


### PR DESCRIPTION
The old remote_login used a `utils_logfile.log_line` log_function by
default, making it convenient to set the output log file. Let's bring
back the default by changing `None` to our log function.

This can change the log_function in case people explicitly select
log_function to None but it should not matter as the function is only
used when `log_filename` is set. So the only effect would be when one
chooses to set the `log_filename` but deliberately wanted to disable
logging via the log_function, which should be very rare.

Fixes: #2822