### PR TITLE
Fix the cpu info get in guest

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -731,7 +731,9 @@ def get_cpu_info(session=None):
         output = process.run(cmd, ignore_status=True).stdout_text.splitlines()
     else:
         try:
-            output = session.cmd_output(cmd).splitlines()
+            output_raw = session.cmd_output(cmd)
+            output = re.sub('\n[\s]+', '', output_raw).splitlines()
+            logging.info("output is %s" % output)
         finally:
             session.close()
     cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":", 1)], output))


### PR DESCRIPTION
As there are several lines in the lscpu output for some attribute, directly splitline will get wrong pair info
Reduce the \n+space before splitlines
e.g.
Vulnerability Mds:               Mitigation; Clear CPU buffers; SMT Host state u
                                 nknown

Signed-off-by: Kyla Zhang <weizhan@redhat.com>
before
```
# avocado run --vt-type libvirt guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem
JOB ID     : 0aa182dc4f1f1e30703442d32d57e8d9e94770da
JOB LOG    : /root/avocado/job-results/job-2021-04-01T07.05-0aa182d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem: ERROR: dictionary update sequence element #28 has length 1; 2 is required (49.79 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 50.51 s
```
after
```
# avocado run --vt-type libvirt guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem
JOB ID     : b099fe125017a9d23a7d4fef34060215e3d7060c
JOB LOG    : /root/avocado/job-results/job-2021-04-01T08.28-b099fe1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem: PASS (52.00 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 52.69 s
```