### PR TITLE
qemu_vm/qemu_devices: deprecate short-form boolean options

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2596,7 +2596,7 @@ class DevContainer(object):
 
         # Arm lists "isa-serial" as supported but can't use it,
         # fallback to "-serial"
-        legacy_cmd = " -serial unix:'%s',server,nowait" % file_name
+        legacy_cmd = " -serial unix:'%s',server=on,wait=off" % file_name
         legacy_dev = qdevices.QStringDevice('SER-%s' % serial_id,
                                             cmdline=legacy_cmd)
         arm_serial = (serial_type == 'isa-serial'
@@ -2652,8 +2652,8 @@ class DevContainer(object):
             chardev_param.update({'to': params.get('chardev_to')})
         if 'socket' in backend:  # tcp_socket & unix_socket
             chardev_param.update(
-                {'server': params.get('chardev_server', 'yes'),
-                 'nowait': params.get('chardev_nowait', 'yes')})
+                {'server': params.get('chardev_server', 'on'),
+                 'wait': params.get('chardev_wait', 'off')})
         elif backend in ['spicevmc', 'spiceport']:
             chardev_param.update(
                 {'debug': params.get('chardev_debug'),

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1560,7 +1560,7 @@ class CharDevice(QCustomDevice):
             special_opts.append("signal")
 
         elif backend in ["socket"]:
-            common_opts += ["server", "nowait", "reconnect"]
+            common_opts += ["server", "wait", "reconnect"]
             special_opts = ["host", "port", "to", "ipv4",
                             "ipv6", "nodelay", "path"]
 
@@ -1580,17 +1580,12 @@ class CharDevice(QCustomDevice):
         :param params: chardev test params.
         :return dict: formated params only include suppprt options.
         """
-        for opt in ["server", "telnet", "nowait",
-                    "ipv4", "ipv6", "nodelay"]:
-            if params.get(opt) in ["yes", "on", True]:
-                params[opt] = "NO_EQUAL_STRING"
-            elif opt in params:
-                del params[opt]
-        for opt in ["mux", "signal"]:
-            if params.get(opt) in ["yes", "on", True]:
-                params[opt] = True
-            elif params.get(opt) in ["no", "off", False]:
-                params[opt] = False
+        for opt in ["server", "telnet", "wait",
+                    "ipv4", "ipv6", "nodelay", "mux", "signal"]:
+            if params.get(opt) in ["yes", "on"]:
+                params[opt] = "on"
+            elif params.get(opt) in ["no", "off"]:
+                params[opt] = 'off'
             elif opt in params:
                 del params[opt]
 
@@ -1618,15 +1613,12 @@ class CharDevice(QCustomDevice):
             if addr_type == "inet":
                 sock_params = ["telnet", "ipv4", "ipv6", "nodelay"]
             else:
-                sock_params = ["server", "nowait"]
+                sock_params = ["server", "wait"]
 
             for param in sock_params:
                 if self.get_param(param) is None:
                     continue
                 value = True if self.get_param(param) else False
-                if param == "nowait":
-                    value = not value
-                    param = "wait"
                 args["backend"]["data"][param] = value
             return args
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -557,8 +557,8 @@ class VM(virt_vm.BaseVM):
             cmd = " -chardev socket"
             cmd += _add_option("id", default_id)
             cmd += _add_option("path", filename)
-            cmd += _add_option("server", "NO_EQUAL_STRING")
-            cmd += _add_option("nowait", "NO_EQUAL_STRING")
+            cmd += _add_option("server", "on")
+            cmd += _add_option("wait", "off")
             cmd += " -device isa-debugcon"
             cmd += _add_option("chardev", default_id)
             cmd += _add_option("iobase", "0x402")
@@ -574,8 +574,8 @@ class VM(virt_vm.BaseVM):
             dev.set_param('backend', 'socket')
             dev.set_param('id', chardev_id)
             dev.set_param("path", filename)
-            dev.set_param("server", 'NO_EQUAL_STRING')
-            dev.set_param("nowait", 'NO_EQUAL_STRING')
+            dev.set_param("server", 'on')
+            dev.set_param("wait", 'off')
             devices.insert(dev)
             if '-mmio:' in params.get('machine_type'):
                 dev = QDevice('virtio-serial-device')
@@ -1043,13 +1043,14 @@ class VM(virt_vm.BaseVM):
             elif optget("spice_port") != "no":
                 set_value("port=%s", "spice_port")
 
-            set_value("password=%s", "spice_password", "disable-ticketing")
+            set_value("password=%s", "spice_password", "disable-ticketing=on")
             ip_ver = optget("listening_addr")
             if ip_ver:
                 host_ip = utils_net.get_host_ip_address(self.params, ip_ver)
                 spice_options['spice_addr'] = host_ip
-            set_yes_no_value(
-                "disable_copy_paste", yes_value="disable-copy-paste")
+            set_yes_no_value("disable_copy_paste",
+                             yes_value="disable-copy-paste=on",
+                             no_value="disable-copy-paste=off")
             set_value("addr=%s", "spice_addr")
 
             if optget("spice_ssl") == "yes":
@@ -1119,8 +1120,10 @@ class VM(virt_vm.BaseVM):
             set_value("agent-mouse=%s", "spice_agent_mouse")
             set_value("playback-compression=%s", "spice_playback_compression")
 
-            set_yes_no_value("spice_ipv4", yes_value="ipv4")
-            set_yes_no_value("spice_ipv6", yes_value="ipv6")
+            set_yes_no_value("spice_ipv4",
+                             yes_value="ipv4=on", no_value="ipv4=off")
+            set_yes_no_value("spice_ipv6",
+                             yes_value="ipv6=on", no_value="ipv6=off")
 
             return " -spice %s" % (",".join(spice_opts))
 


### PR DESCRIPTION
From qemu6.0, short-form boolean options are deprecated, options
such as "server" or "nowait", correct them to "server=on" and
"wait=off", and also make correction for some -spice options

id: 1945036
Signed-off-by: Qianqian Zhu <qizhu@redhat.com>