### PR TITLE
Fix for the cpu info be more robust

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -736,7 +736,12 @@ def get_cpu_info(session=None):
             logging.info("output is %s" % output)
         finally:
             session.close()
-    cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":", 1)], output))
+    for line in output:
+        try:
+            key, value = line.split(':')
+            cpu_info[key.strip()] = value.strip()
+        except ValueError:
+            logging.debug('LINE: {} cannot be split.'.format(line))
     return cpu_info
 
 


### PR DESCRIPTION
Since the output of the lscpu command can be multiline and key:value
pairs might not be on the same line, the more robust solution for
building the dict is used to skip the lines that may be invalid
key:pair lines and log this action under debug level.

Signed-off-by: Kamil Varga <kvarga@redhat.com>