### PR TITLE
virttest: add function to get cache memory for given OS

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2320,6 +2320,28 @@ def get_free_mem(session, os_type):
     return int(free)
 
 
+def get_cache_mem(session, os_type):
+    """
+    Get cache memory for given OS.
+
+    :param session: shell Object.
+    :param os_type: os type (eg. linux or windows)
+
+    :return: memory cache M-bytes
+    """
+    if os_type == "windows":
+        cmd_get_cache = 'powershell -command "get-ciminstance -classname'
+        cmd_get_cache += ' win32_perfrawdata_perfos_memory |select CacheBytes"'
+        output = session.cmd_output(cmd_get_cache)
+        cache = re.findall("\d+", output)[0]
+    else:
+        cache = (get_mem_info(session, 'Cached') +
+                 get_mem_info(session, 'Buffers'))
+        cache = "%s kB" % cache
+    cache = int(normalize_data_size(cache, order_magnitude="M"))
+    return cache
+
+
 def get_mem_info(session=None, attr='MemTotal'):
     """
     Get memory information attributes in host/guest

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -512,6 +512,22 @@ class MemoryBaseTest(object):
         finally:
             session.close()
 
+    @classmethod
+    def get_guest_cache_mem(cls, vm):
+        """
+        Guest OS reported cache memory size in MB.
+
+        :param vm: VM Object
+        :return: memory cache report by guest OS in MB
+        """
+        os_type = vm.params.get("os_type")
+        timeout = float(vm.params.get("login_timeout", 600))
+        try:
+            session = vm.wait_for_login(timeout=timeout)
+            return utils_misc.get_cache_mem(session, os_type)
+        finally:
+            session.close()
+
     def get_session(self, vm):
         """
         Get connection to VM.


### PR DESCRIPTION
Get cache memory of guest,including windows and linux os.
ID: 1946456
Signed-off-by: Xiaoling Gao <xiagao@redhat.com>