### PR TITLE
v2v: add '--nvram' when convertion target is to_libvirt

### DIFF
--- a/virttest/backends/v2v/cfg/convert_destination.cfg
+++ b/virttest/backends/v2v/cfg/convert_destination.cfg
@@ -30,6 +30,7 @@ variants:
         pool_name = v2v_dir
         pool_target = v2v_dir_pool
         output_storage = ${pool_name}
+        vir_domain_undefine_nvram = yes
     - dest_rhev:
         # Output source of ovirt engine, storage and network
         output_mode = rhev


### PR DESCRIPTION
'--nvram' has no harm no mattter whether it's a uefi guest or not.
so place the configuration here for all to_libvirt cases.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>