### PR TITLE
Add support to check if backup job canceled

### DIFF
--- a/virttest/utils_backup.py
+++ b/virttest/utils_backup.py
@@ -55,6 +55,19 @@ class BackupTLSError(BackupError):
         return "Backup TLS failure: %s" % self.error_info
 
 
+class BackupCanceledError(BackupError):
+
+    """
+    Class of backup canceled exception
+    """
+
+    def __init__(self):
+        BackupError.__init__(self)
+
+    def __str__(self):
+        return "Backup job canceled"
+
+
 def create_checkpoint_xml(cp_params, disk_param_list=None):
     """
     Create a checkpoint xml
@@ -433,3 +446,20 @@ def enable_inc_backup_for_vm(vm, libvirt_ver=(7, 0, 0)):
     virsh.define(tmp_vm_xml)
     vmxml_updated = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
     return vmxml_updated
+
+
+def is_backup_canceled(vm_name):
+    """
+    Check if a backup job canceled.
+
+    :param vm_name: vm's name
+    :return: True means a backup job is ccanceled, False means not.
+    """
+    virsh_output = virsh.domjobinfo(vm_name,
+                                    extra="--completed",
+                                    debug=True).stdout_text
+    if virsh_output:
+        virsh_output = virsh_output.lower()
+        if "backup" in virsh_output and "cancel" in virsh_output:
+            return True
+    return False

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1294,15 +1294,16 @@ def domifstat(name, interface, **dargs):
     return command("domifstat %s %s" % (name, interface), **dargs)
 
 
-def domjobinfo(name, **dargs):
+def domjobinfo(name, extra="", **dargs):
     """
     Get domain job information.
 
     :param name: VM name
+    :param extra: extra options to pass to command
     :param dargs: standardized virsh function API keywords
     :return: CmdResult instance
     """
-    return command("domjobinfo %s" % name, **dargs)
+    return command("domjobinfo %s %s" % (name, extra), **dargs)
 
 
 def edit(options, **dargs):


### PR DESCRIPTION
There are 3 parts in this commit:
1. Add a new BackupCanceledError exception.
2. Add 'extra' in virsh.domjobinfo to allow it take more params
such as '--complete' when backup job canceled.
3. Add a 'is_backup_canceled' method to check if backup job
just canceled.

Signed-off-by: Yi Sun <yisun@redhat.com>