### PR TITLE
Deprecate "Kernel synchronization delay fuzzing" flag for win10

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -39,7 +39,7 @@
     check_guest_bsod = yes
 
     # Set verifier flags for windows guests
-    Win10, Win2016, Win2019:
+    Win2016, Win2019:
         windows_verifier_flags = "0x009209bb"
 
     Win8..1, Win2012..r2:


### PR DESCRIPTION
This check is deprecated starting in Windows 10 Insider Preview
Build 19042 and above.

id: 1944490

Signed-off-by: Yu Wang <wyu@redhat.com>