### PR TITLE
Fix error of inspektor in travis check

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,15 +1,8 @@
 Sphinx==1.3b1
 # inspektor (static and style checks)
-pylint==1.9.3; python_version <= '2.7'
-pylint==2.7.2; python_version >= '3.6'
+pylint>=2.8.0; python_version >= '3.6'
 inspektor==0.5.2
-autotest>=0.16.2; python_version < '3.0'
 aexpect==1.6.0
 simplejson==3.8.0
 netaddr==0.7.19
-zipp==1.2.0; python_version < '3.0'
 netifaces>=0.10.5
-argparse==1.3.0; python_version < '2.7'
-logutils==0.3.3; python_version < '2.7'
-importlib==1.0.3; python_version < '2.7'
-unittest2==1.0.0; python_version < '2.7'


### PR DESCRIPTION
- Update version of pylint to >=2.8.0
- Remove requirements of python 2.7 since travis check on python
2.7 had been removed.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>