### PR TITLE
tmp_fix: Enable incremental backup in RHEL9

### DIFF
--- a/virttest/utils_backup.py
+++ b/virttest/utils_backup.py
@@ -398,7 +398,7 @@ def clean_checkpoints(vm_name, clean_metadata=True, ignore_status=True):
                                         ignore_status=ignore_status)
 
 
-def enable_inc_backup_for_vm(vm, libvirt_ver=(7, 0, 0)):
+def enable_inc_backup_for_vm(vm, libvirt_ver=(9, 9, 9)):
     """
     For now, libvirt doesn't enable incremental backup by default. We
     need to edit vm's xml to make sure it's supported.


### PR DESCRIPTION
Incremental backup not enabled in rhel9 by default. But it's
already enabled in rhel8. So we need this tmp fix to enable it.
And this fix won't effect rhel8 since the extra xml has no
side effect.

Signed-off-by: Yi Sun <yisun@redhat.com>