### PR TITLE
libvirt_misc: new function to parse result

### DIFF
--- a/virttest/utils_libvirt/libvirt_misc.py
+++ b/virttest/utils_libvirt/libvirt_misc.py
@@ -1,0 +1,25 @@
+"""
+Virtualization test - utility functions for libvirt
+
+:copyright: 2021 Red Hat Inc.
+"""
+
+import re
+import logging
+
+
+def convert_to_dict(content, pattern=r'(\d+) +(\S+)'):
+    """
+    Put the content into a dict according to the pattern.
+
+    :param content: str, the string to be parsed
+    :param pattern: str, regex for parsing the command output
+    :return: dict, the dict contains matched result
+    """
+
+    info_dict = {}
+    info_list = re.findall(pattern, content, re.M)
+    for info in info_list:
+        info_dict[info[0]] = info[1]
+    logging.debug("The dict converted is:\n%s", info_dict)
+    return info_dict


### PR DESCRIPTION
Some virsh commands have output in same or similar format. So this
function is to used as an unified one to run and parse the result
to a dict. For example, the commands are virsh.vcpupin, virsh.emulatorpin,
virsh.iothreadinfo and so on.

Signed-off-by: Dan Zheng <dzheng@redhat.com>