### PR TITLE
Drop usage of migration capabilities in qdev container comparisons

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -457,7 +457,7 @@ class DevContainer(object):
                        "_DevContainer__state", "caps", "allow_hotplugged_vm",
                        "_DevContainer__iothread_manager",
                        "_DevContainer__iothread_supported_devices",
-                       "temporary_image_snapshots"):
+                       "temporary_image_snapshots", "mig_params"):
                 continue
             if key not in qdev2 or qdev2[key] != value:
                 return False


### PR DESCRIPTION
After multiple resets of vms with the same command line (and thus parameters)
I had to investigate why I keep getting "VM params in env don't match requested"
a lengthy debugging revealed the problem is in 'mig_params` not being found in
the second container dictionary because:

<virttest.qemu_capabilities.Capabilities object at 0x7f95e57af430>
!= <virttest.qemu_capabilities.Capabilities object at 0x7f95e7ed2b80>

The `mig_params` which was modified in some incompatible way somewhere in the
last versions should thus be ignored for the comparison.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>