### PR TITLE
MigrationTest: Enhance post_migration_check to check disk and network

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -386,8 +386,8 @@ def create_partition_linux(session, did, size, start,
         driver = "pci"
         if platform.machine() == "s390x":
             driver = "css0"
-        o = session.cmd('ls /sys/dev/block -l | grep "/%s" | grep "%s"' %
-                        (driver, did))
+        o = session.cmd('ls /sys/dev/block -l | grep "/%s" | grep "%s" '
+                        '--color=never' % (driver, did))
         return set(o.splitlines())
 
     size = utils_numeric.normalize_data_size(size, order_magnitude="M") + "M"


### PR DESCRIPTION
Add network accessibility and disk I/O checks as common checkpoints.

Disk partition checking does not work in remote vm session.
It reports an error - ERROR: Shell command failed:
"yes|mkfs.ext4 -F '/dev/\x1b[01;31m\x1b[Kvdb\x1b[m\x1b[K1'".
So update to no longer highlight the matching strings for the command
line in _list_disk_partitions().

Signed-off-by: Yingshun Cui <yicui@redhat.com>