### PR TITLE
Add vhostuser disk support in libvirt.create_disk_xml

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1636,6 +1636,9 @@ def create_disk_xml(params):
             source_attrs = {'file': source_file}
             if slice_in_source:
                 source_attrs = {'file': input_source_file}
+        elif type_name == "vhostuser":
+            source_file = params.get("source_file", "")
+            source_attrs = {'type': 'unix', 'path': source_file}
         elif type_name == "block":
             source_file = params.get("source_file", "")
             source_attrs = {'dev': source_file}


### PR DESCRIPTION
vhostuser disk is newly introduced backend storage
```
vhostuser disk looks like as below:
    <disk type='vhostuser' device='disk' snapshot='no'>
      <driver name='qemu' type='raw'/>
      <source type='unix' path='/tmp/vhost.sock'/>
      <target dev='vdb' bus='virtio'/>
    </disk>
```
Signed-off-by: chunfuwen <chwen@redhat.com>