### PR TITLE
Resolve the lscpu have multi ":" in ouput in utils_misc

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1413,7 +1413,7 @@ def get_cpu_info(session=None):
             output = session.cmd_output(cmd).splitlines()
         finally:
             session.close()
-    cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":")], output))
+    cpu_info = dict(map(lambda x: [i.strip() for i in x.split(":", 1)], output))
     return cpu_info
 
 


### PR DESCRIPTION
same with https://github.com/avocado-framework/avocado-vt/pull/2948
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

```
JOB ID     : 4f0c5bdacca7afac4d9a43a87cafa74e3de3f6e1
JOB LOG    : /root/avocado/job-results/job-2021-05-06T03.08-4f0c5bd/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_cputune.normal_test.wo_cachetune: PASS (7.32 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 7.85 s
```