### PR TITLE
Support image convert disable

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2589,13 +2589,15 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
         exp_path = res["export_dir"]
         mnt_path = res["mount_dir"]
         params["selinux_status_bak"] = res["selinux_status_bak"]
-        dist_img = params.get("source_dist_img", "nfs-img")
+        dist_img = os.path.basename(blk_source)
+        if image_convert:
+            dist_img = params.get("source_dist_img", "nfs-img")
 
-        # Convert first disk to gluster disk path
-        disk_cmd = ("qemu-img convert -f %s -O %s %s %s/%s" %
-                    (src_disk_format, disk_format,
-                     blk_source, exp_path, dist_img))
-        process.run(disk_cmd, ignore_status=False)
+            # Convert first disk to nfs disk path
+            disk_cmd = ("qemu-img convert -f %s -O %s %s %s/%s" %
+                        (src_disk_format, disk_format,
+                         blk_source, exp_path, dist_img))
+            process.run(disk_cmd, ignore_status=False)
 
         # Change image ownership
         if image_owner_group:
@@ -2616,7 +2618,8 @@ def set_vm_disk(vm, params, tmp_dir=None, test=None):
         disk_params_src = {'source_file': src_file_path}
         params["source_file"] = src_file_path
         src_file_list.append(src_file_path)
-        params["source_file_list"] = src_file_list
+        if image_convert:
+            params["source_file_list"] = src_file_list
     elif disk_src_protocol == 'rbd':
         mon_host = params.get("mon_host")
         if image_convert:


### PR DESCRIPTION
This is to make the command 'qemu-img convert' optional for netfs.
Because image_convert is True as default, this change will not
impact the existing invoke codes. The reason to change this is
because in most cases there is no need to do the image convert
which increases the migration duration. After this, the user
invokes set_vm_disk() with image_convert='no' to avoid converting
the image.

Signed-off-by: Dan Zheng <dzheng@redhat.com>