### PR TITLE
qdevices: fix chardev hotplug with wrong parameter value

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1618,7 +1618,7 @@ class CharDevice(QCustomDevice):
             for param in sock_params:
                 if self.get_param(param) is None:
                     continue
-                value = True if self.get_param(param) else False
+                value = True if self.get_param(param) == 'on' else False
                 args["backend"]["data"][param] = value
             return args
 


### PR DESCRIPTION
short-form boolean options are deprecated, options such as "server"
or "nowait" use server=on" and "wait=off" now, the qemu command line
was updated with commit ce145bc4a0b231b6a65a58d77e832aeda5a8fda7,
make it work with device hotplug too.

id:1958490
Signed-off-by: Yanan Fu <yfu@redhat.com>