### PR TITLE
cirrus-ci: Disable Python2 checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,23 +60,3 @@ centos_8_1_task:
     *list_scr
   dry_run_script:
     *dry_run_scr
-
-centos_7_task:
-  env:
-    PYTHON: python2
-    matrix:
-      - AVOCADO_SRC:
-      - AVOCADO_SRC: avocado-framework<70.0
-    matrix:
-      - SETUP: setup.py develop --user
-      - SETUP: -m pip install .
-  container:
-    image: quay.io/avocado-framework/avocado-vt-ci-centos-7
-  setup_script:
-    *setup_scr
-  bootstrap_script:
-    *bootstrap_scr
-  list_script:
-    *list_scr
-  dry_run_script:
-    *dry_run_scr

--- a/contrib/containers/ci/centos-7.docker
+++ b/contrib/containers/ci/centos-7.docker
@@ -1,5 +1,0 @@
-FROM centos:7.6.1810
-LABEL description "CentOS 7 image used on integration checks, such as cirrus-ci"
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum -y install git tcpdump nc iproute gcc python-devel qemu-kvm qemu-img python2-pip
-RUN yum -y clean all


### PR DESCRIPTION
This is a part of https://github.com/avocado-framework/avocado-vt/issues/2963

Signed-off-by: Xu Han <xuhan@redhat.com>