### PR TITLE
Update create_hostdev_xml to create hostdev with teaming

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1419,7 +1419,8 @@ def check_iface(iface_name, checkpoint, extra="", **dargs):
 
 
 def create_hostdev_xml(pci_id, boot_order=None,
-                       dev_type="pci", managed="yes", alias=None):
+                       dev_type="pci", managed="yes", alias=None,
+                       teaming=None):
     """
     Create a hostdev configuration file; supported hostdev types:
     a. pci
@@ -1435,6 +1436,7 @@ def create_hostdev_xml(pci_id, boot_order=None,
     :param dev_type: type of hostdev
     :param managed: managed of hostdev
     :param alias: alias name of hostdev
+    :param teaming: teaming setting of hostdev
     :return: hostdev device object
     """
     hostdev_xml = hostdev.Hostdev()
@@ -1445,6 +1447,8 @@ def create_hostdev_xml(pci_id, boot_order=None,
         hostdev_xml.boot_order = boot_order
     if alias:
         hostdev_xml.alias = dict(name=alias)
+    if teaming:
+        hostdev_xml.teaming = eval(teaming)
 
     # Create attributes dict for device's address element
     logging.info("pci_id/device id is %s" % pci_id)


### PR DESCRIPTION
Update create_hostdev_xml function to create a hostdev device
with 'teaming'.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

depends on:  https://github.com/avocado-framework/avocado-vt/pull/3052

Test result:
` (1/1) type_specific.io-github-autotest-libvirt.sriov_net_failover.hotplug_hostdev_iface_with_teaming: PASS (119.34 s)`
