### PR TITLE
Fix audio device delete failure issue

### DIFF
--- a/virttest/libvirt_xml/devices/audio.py
+++ b/virttest/libvirt_xml/devices/audio.py
@@ -1,0 +1,41 @@
+"""
+audio device support class(es)
+
+https://libvirt.org/formatdomain.html#audio-devices
+"""
+
+from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml.devices import base
+
+
+class Audio(base.UntypedDeviceBase):
+
+    __slots__ = ('id', 'type', 'attrs', 'input_attrs',
+                 'input_settings', 'output_attrs', 'output_settings')
+
+    def __init__(self, virsh_instance=base.base.virsh):
+        accessors.XMLAttribute('id', self,
+                               parent_xpath='/',
+                               tag_name='audio',
+                               attribute='id')
+        accessors.XMLAttribute('type', self,
+                               parent_xpath='/',
+                               tag_name='audio',
+                               attribute='type')
+        accessors.XMLElementDict('attrs', self,
+                                 parent_xpath='/',
+                                 tag_name='audio')
+        accessors.XMLElementDict('input_attrs', self,
+                                 parent_xpath='/',
+                                 tag_name='input')
+        accessors.XMLElementDict('input_settings', self,
+                                 parent_xpath='/input',
+                                 tag_name='settings')
+        accessors.XMLElementDict('output_attrs', self,
+                                 parent_xpath='/',
+                                 tag_name='output')
+        accessors.XMLElementDict('output_settings', self,
+                                 parent_xpath='/output',
+                                 tag_name='settings')
+        super(Audio, self).__init__(device_tag='audio',
+                                    virsh_instance=virsh_instance)

--- a/virttest/libvirt_xml/devices/librarian.py
+++ b/virttest/libvirt_xml/devices/librarian.py
@@ -10,7 +10,7 @@ from virttest.libvirt_xml import base
 # Avoid accidental names like __init__, librarian, and/or other support modules
 DEVICE_TYPES = ['disk', 'filesystem', 'controller', 'lease',
                 'hostdev', 'redirdev', 'smartcard', 'interface', 'input',
-                'hub', 'graphics', 'video', 'parallel', 'serial', 'console',
+                'hub', 'graphics', 'video', 'audio', 'parallel', 'serial', 'console',
                 'channel', 'sound', 'watchdog', 'memballoon', 'rng', 'vsock',
                 'seclabel', 'address', 'emulator', 'panic', 'memory', 'filterref',
                 'iommu', 'tpm']


### PR DESCRIPTION
Unknown/unsupported type 'audio', supported types will thrown if
there is no this attribute added

Signed-off-by: chunfuwen <chwen@redhat.com>