### PR TITLE
Add nvram, redirfilter and shmem device support

### DIFF
--- a/virttest/libvirt_xml/devices/librarian.py
+++ b/virttest/libvirt_xml/devices/librarian.py
@@ -11,6 +11,7 @@ from virttest.libvirt_xml import base
 DEVICE_TYPES = ['disk', 'filesystem', 'controller', 'lease',
                 'hostdev', 'redirdev', 'smartcard', 'interface', 'input',
                 'hub', 'graphics', 'video', 'audio', 'parallel', 'serial', 'console',
+                'nvram', 'redirfilter', 'shmem',
                 'channel', 'sound', 'watchdog', 'memballoon', 'rng', 'vsock',
                 'seclabel', 'address', 'emulator', 'panic', 'memory', 'filterref',
                 'iommu', 'tpm']

--- a/virttest/libvirt_xml/devices/nvram.py
+++ b/virttest/libvirt_xml/devices/nvram.py
@@ -1,0 +1,27 @@
+"""
+nvram device support class(es)
+  <nvram>
+    <address type='spapr-vio' reg='0x00003000'/>
+  </nvram>
+https://libvirt.org/formatdomain.html#nvram-device
+"""
+
+from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml.devices import base
+
+
+class Nvram(base.UntypedDeviceBase):
+
+    __slots__ = ('address_type', 'address_reg')
+
+    def __init__(self, virsh_instance=base.base.virsh):
+        accessors.XMLAttribute('address_type', self,
+                               parent_xpath='/',
+                               tag_name='address',
+                               attribute='type')
+        accessors.XMLAttribute('address_reg', self,
+                               parent_xpath='/',
+                               tag_name='address',
+                               attribute='reg')
+        super(Nvram, self).__init__(device_tag='nvram',
+                                    virsh_instance=virsh_instance)

--- a/virttest/libvirt_xml/devices/redirfilter.py
+++ b/virttest/libvirt_xml/devices/redirfilter.py
@@ -1,0 +1,52 @@
+"""
+Filter out certain devices from redirection
+  <redirfilter>
+    <usbdev class='0x08' vendor='0x1234' product='0xbeef' version='2.56' allow='yes'/>
+    <usbdev allow='no'/>
+  </redirfilter
+https://libvirt.org/formatdomain.html#redirected-devices
+"""
+
+from virttest.libvirt_xml import accessors, xcepts
+from virttest.libvirt_xml.devices import base
+
+
+class Redirfilter(base.base.LibvirtXMLBase):
+    """
+    Interface redirfilter xml class.
+
+    Properties:
+    usbdev:
+    list. usbdev element dict list
+    """
+    __slots__ = ("usbdevs", )
+
+    def __init__(self, virsh_instance=base.base.virsh):
+        accessors.XMLElementList(property_name='usbdevs',
+                                 libvirtxml=self,
+                                 parent_xpath='/',
+                                 marshal_from=self.marshal_from_usbdev,
+                                 marshal_to=self.marshal_to_usbdev)
+        super(Redirfilter, self).__init__(virsh_instance=virsh_instance)
+        self.xml = '<redirfilter/>'
+
+    @staticmethod
+    def marshal_from_usbdev(item, index, libvirtxml):
+        """Convert a dictionary into a tag + attributes"""
+        del index           # not used
+        del libvirtxml      # not used
+        if not isinstance(item, dict):
+            raise xcepts.LibvirtXMLError("Expected a dictionary of parameter "
+                                         "attributes, not a %s"
+                                         % str(item))
+            # return copy of dict, not reference
+        return ('usbdev', dict(item))
+
+    @staticmethod
+    def marshal_to_usbdev(tag, attr_dict, index, libvirtxml):
+        """Convert a tag + attributes into a dictionary"""
+        del index                    # not used
+        del libvirtxml               # not used
+        if tag != 'usbdev':
+            return None              # skip this one
+        return dict(attr_dict)       # return copy of dict, not reference@

--- a/virttest/libvirt_xml/devices/shmem.py
+++ b/virttest/libvirt_xml/devices/shmem.py
@@ -1,0 +1,61 @@
+"""
+shared memory device support class(es)
+
+<devices>
+  <shmem name='my_shmem0' role='peer'>
+    <model type='ivshmem-plain'/>
+    <size unit='M'>4</size>
+    <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+  </shmem>
+  <shmem name='shmem_server'>
+    <model type='ivshmem-doorbell'/>
+    <size unit='M'>2</size>
+    <server path='/tmp/socket-shmem'/>
+    <msi vectors='32' ioeventfd='on'/>
+  </shmem>
+</devices>
+
+https://libvirt.org/formatdomain.html#shared-memory-device
+"""
+
+from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml.devices import base
+
+
+class Shmem(base.UntypedDeviceBase):
+
+    __slots__ = ('name', 'role', 'model_attrs',
+                 'size', 'size_unit', 'pci_addr_attrs', 'server_attrs', 'msi_attrs', )
+
+    def __init__(self, virsh_instance=base.base.virsh):
+        accessors.XMLAttribute('name', self,
+                               parent_xpath='/',
+                               tag_name='shmem',
+                               attribute='name')
+        accessors.XMLAttribute('role', self,
+                               parent_xpath='/',
+                               tag_name='shmem',
+                               attribute='role')
+        accessors.XMLElementDict('model_attrs', self,
+                                 parent_xpath='/',
+                                 tag_name='model')
+        accessors.XMLElementInt('size',
+                                self, parent_xpath='/',
+                                tag_name='size')
+        accessors.XMLAttribute(property_name="size_unit",
+                               libvirtxml=self,
+                               forbidden=None,
+                               parent_xpath='/',
+                               tag_name='size',
+                               attribute='unit')
+        accessors.XMLElementDict('pci_addr_attrs', self,
+                                 parent_xpath='/',
+                                 tag_name='address')
+        accessors.XMLElementDict('server_attrs', self,
+                                 parent_xpath='/',
+                                 tag_name='server')
+        accessors.XMLElementDict('msi_attrs', self,
+                                 parent_xpath='/output',
+                                 tag_name='msi')
+        super(Shmem, self).__init__(device_tag='shmem',
+                                    virsh_instance=virsh_instance)


### PR DESCRIPTION
This is subsequent follow-ups requests from hanhan in PR: https://github.com/avocado-framework/avocado-vt/pull/3056

Signed-off-by: chunfuwen <chwen@redhat.com>