### PR TITLE
utils_sriov: Add a function to set VF's mac

### DIFF
--- a/virttest/utils_sriov.py
+++ b/virttest/utils_sriov.py
@@ -62,6 +62,21 @@ def set_vf(pci_addr, vf_no=4, session=None):
     return not s
 
 
+def set_vf_mac(ethname, mac_addr, vf_idx=0, session=None):
+    """
+    Set mac address for VF
+
+    :param ethname: The name of the network interface
+    :param mac_addr: The mac address to be set
+    :param vf_idx: The index of VF
+    :param session: The session object to the host
+    :return: The command status and output
+    """
+    cmd = "ip link set {0} vf {1} mac {2}".format(ethname, vf_idx, mac_addr)
+    return utils_misc.cmd_status_output(
+            cmd, shell=True, verbose=True, session=session)
+
+
 def add_or_del_connection(params, session=None, is_del=False):
     """
     Add/Delete connections


### PR DESCRIPTION
This PR adds a function to set VF's mac address.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.sriov_net_failover.hotplug_hostdev_iface_with_teaming: PASS (103.56 s)`
