### PR TITLE
Add one method get_backingstore_list into Disk

### DIFF
--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -231,6 +231,20 @@ class Disk(base.TypedDeviceBase):
             setattr(new_one, key, value)
         return new_one
 
+    def get_backingstore_list(self):
+        """
+        Usage: get source file attribute from backingStore
+            test_disk = Disk()
+            backingstore_list = test_disk.get_backingstore_list()
+            source_file_list = [elem.find('source').get('file') or elem.find('source').get('name') for elem in backingstore_list]
+
+        :return: a disk backingstore list where each element is primitive virttest.element_tree._ElementInterface object
+        """
+        backingstore_list = []
+        for elem in self.xmltreefile.getiterator('backingStore'):
+            backingstore_list.append(elem)
+        return backingstore_list
+
     def new_drivermetadata(self, **dargs):
         """
         Return a new DriverMetadata instance and set properties from dargs


### PR DESCRIPTION
The method is to help get backstore list from disk, then
get relative elements from backstore list,such as source file

Signed-off-by: chunfuwen <chwen@redhat.com>