### PR TITLE
[virttest/migration] Add default value to avoid TypeError

### DIFF
--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -129,7 +129,7 @@ class MigrationTest(object):
                 server_session.close()
         if s_ping != 0:
             if uri:
-                if "offline" in params.get("migrate_options"):
+                if "offline" in params.get("migrate_options", ""):
                     logging.info("Offline Migration: %s will not responded to "
                                  "ping as expected", vm.name)
                     return


### PR DESCRIPTION
`migrate_options` might not be set. Use empty string to avoid tests
failing with
"TypeError: argument of type 'NoneType' is not iterable"

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>