### PR TITLE
Modify parent bus for virtio-blk-ccw on s390x

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2043,7 +2043,7 @@ class DevContainer(object):
         elif fmt == 'virtio-blk-device':
             dev_parent = {'type': 'virtio-bus'}
         elif fmt == 'virtio-blk-ccw':   # For IBM s390 platform
-            dev_parent = {'type': 'virtio-bus'}
+            dev_parent = {'type': 'virtual-css'}
         else:
             dev_parent = {'type': fmt}
 


### PR DESCRIPTION
Virtual_block:modify dev_parent bus from virtio-bus to virtual-css bus
since when doing the hotplug action, the pluggable bus is the ccs bus
on s390x

ID:1964477

Signed-off-by: Boqiao Fu <bfu@redhat.com>