### PR TITLE
Modify virtiofsd daemon and qemu cmd decouple

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -160,24 +160,26 @@ def preprocess_fs_source(test, params, fs_name, vm_process_status=None):
                               process_fs_sources()
     """
     fs_type = params.get('fs_source_type', 'mount')
+    fs_source_user_config = params.get('fs_source_user_config', 'no')
     # mount: A host directory to mount in the vm.
     if fs_type == 'mount':
-        fs_source = params.get('fs_source_dir')
-        base_dir = params.get("fs_source_base_dir", data_dir.get_data_dir())
-        if not os.path.isabs(fs_source):
-            fs_source = os.path.join(base_dir, fs_source)
+        if fs_source_user_config == "no":
+            fs_source = params.get('fs_source_dir')
+            base_dir = params.get("fs_source_base_dir", data_dir.get_data_dir())
+            if not os.path.isabs(fs_source):
+                fs_source = os.path.join(base_dir, fs_source)
 
-        create_fs_source = False
-        if params.get("force_create_fs_source") == "yes":
-            create_fs_source = True
-        elif params.get("create_fs_source") == "yes" and not os.path.exists(fs_source):
-            create_fs_source = True
+            create_fs_source = False
+            if params.get("force_create_fs_source") == "yes":
+                create_fs_source = True
+            elif params.get("create_fs_source") == "yes" and not os.path.exists(fs_source):
+                create_fs_source = True
 
-        if create_fs_source:
-            if os.path.exists(fs_source):
-                shutil.rmtree(fs_source, ignore_errors=True)
-            logging.info("Create filesystem source %s." % fs_source)
-            os.makedirs(fs_source)
+            if create_fs_source:
+                if os.path.exists(fs_source):
+                    shutil.rmtree(fs_source, ignore_errors=True)
+                logging.info("Create filesystem source %s." % fs_source)
+                os.makedirs(fs_source)
     else:
         test.cancel('Unsupport the type of filesystem "%s"' % fs_type)
 

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2994,6 +2994,7 @@ class DevContainer(object):
         driver = params["fs_driver"]
         target = params["fs_target"]
         fs_type = params.get('fs_source_type', 'mount')
+        fs_source_user_config = params.get('fs_source_user_config', 'no')
 
         if fs_type == 'mount':
             source = params.get("fs_source_dir")
@@ -3008,13 +3009,18 @@ class DevContainer(object):
 
         devices = []
         if driver == "virtio-fs":
-            binary = params.get("fs_binary", "/usr/libexec/virtiofsd")
-            extra_options = params.get("fs_binary_extra_options")
-            enable_debug_mode = params.get('fs_enable_debug_mode', 'no') == "yes"
-            sock_path = os.path.join(data_dir.get_tmp_dir(),
-                                     '-'.join((self.vmname, name, 'virtiofsd.sock')))
-            vfsd = qdevices.QVirtioFSDev(name, binary, sock_path,
-                                         source, extra_options, enable_debug_mode)
+            if fs_source_user_config == "yes":
+                sock_path = params.get("fs_source_user_sock_path")
+                vfsd = qdevices.QDaemonDev('virtiofs', aobject=name,
+                                           child_bus=qdevices.QUnixSocketBus(sock_path, name))
+            else:
+                binary = params.get("fs_binary", "/usr/libexec/virtiofsd")
+                extra_options = params.get("fs_binary_extra_options")
+                enable_debug_mode = params.get('fs_enable_debug_mode', 'no') == "yes"
+                sock_path = os.path.join(data_dir.get_tmp_dir(),
+                                         '-'.join((self.vmname, name, 'virtiofsd.sock')))
+                vfsd = qdevices.QVirtioFSDev(name, binary, sock_path,
+                                             source, extra_options, enable_debug_mode)
             devices.append(vfsd)
 
             char_params = Params()


### PR DESCRIPTION
Since some customer scenarios need to set the capability
of the shell env before starting the daemon.
So modify virtiofsd daemon and qemu cmd decoupled,
Allow users to set the daemon more flexibly.

ID: 1966468
Signed-off-by: Zhenyu Zhang <zhenyzha@redhat.com>