### PR TITLE
libvirt_vmxml: Add a method to remove vm's devices of a given type

### DIFF
--- a/virttest/utils_libvirt/libvirt_vmxml.py
+++ b/virttest/utils_libvirt/libvirt_vmxml.py
@@ -6,6 +6,8 @@ http://libvirt.org/formatdomain.html
 
 import logging
 
+from virttest.libvirt_xml import vm_xml
+
 
 def set_vm_attrs(vmxml, vm_attrs):
     """
@@ -21,3 +23,19 @@ def set_vm_attrs(vmxml, vm_attrs):
     vmxml.xmltreefile.write()
     vmxml.sync()
     return vmxml
+
+
+def remove_vm_devices_by_type(vm, device_type):
+    """
+    Remove devices of a given type.
+
+    :param vm: The vm object.
+    :param device_type: Type of devices should be removed.
+    """
+    vm_was_running = vm.is_alive()
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+    vmxml.remove_all_device_by_type(device_type)
+    vmxml.sync()
+
+    if vm_was_running:
+        vm.start()


### PR DESCRIPTION
Add support to clear up vm's devices of a given type.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Test result:
```
JOB LOG    : /root/avocado/job-results/job-2021-06-06T21.04-846db45/job.log
 (1/1) type_specific.io-github-autotest-libvirt.sriov_net_failover.hotplug_hostdev_device_with_teaming: PASS (99.11 s)
```
