### PR TITLE
v2v: make getting disk count more flexible

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1026,6 +1026,26 @@ class VMXML(VMXMLBase):
         return 0
 
     @staticmethod
+    def get_disk_count_by_expr(vm_name, exprs, virsh_instance=base.virsh):
+        """
+        Get count of VM's disks.
+
+        :param vm_name: Name of defined vm.
+        :param exprs: A list or string of attribute and value expression for disks.
+            if it's a string, the expression must be delimited by ','.
+            e.g. device==cdrom, type!=network
+        """
+        vmxml = VMXML.new_from_dumpxml(vm_name, virsh_instance=virsh_instance)
+        if isinstance(exprs, str):
+            exprs = exprs.split(',')
+        if not isinstance(exprs, list):
+            raise TypeError('exprs must be a string or a list')
+        disks = vmxml.get_disk_all_by_expr(*exprs)
+        if disks is not None:
+            return len(disks)
+        return 0
+
+    @staticmethod
     def get_disk_attr(vm_name, target, tag, attr, virsh_instance=base.virsh):
         """
         Get value of disk tag attribute for a given target dev.

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1219,8 +1219,8 @@ def v2v_cmd(params, auto_clean=True, cmd_only=False, interaction=False):
             params['_iface_list'] = iface_info
 
             # Get disk count
-            disk_count = vm_xml.VMXML.get_disk_count(
-                vm_name, virsh_instance=v2v_virsh)
+            disk_count = vm_xml.VMXML.get_disk_count_by_expr(
+                vm_name, 'device!=cdrom', virsh_instance=v2v_virsh)
             params['_disk_count'] = disk_count
 
             if input_mode == 'vmx':


### PR DESCRIPTION
The old vmxml.get_disk_all cannot filter some disks which will make
the code more complcated. Let's create a new function get_disk_count_by_expr
to only count the expected disks.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>