### PR TITLE
tpm dev: new attribute persistent_state

### DIFF
--- a/virttest/libvirt_xml/devices/tpm.py
+++ b/virttest/libvirt_xml/devices/tpm.py
@@ -35,12 +35,14 @@ class Tpm(base.UntypedDeviceBase):
             string. backend type
         version:
             string. backend version
+        persistent_state:
+            string. backend persistent_state
         path:
             string. device path
         secret:
             string. encryption secret
         """
-        __slots__ = ('backend_type', 'backend_version', 'device_path', 'encryption_secret')
+        __slots__ = ('backend_type', 'backend_version', 'persistent_state', 'device_path', 'encryption_secret')
 
         def __init__(self, virsh_instance=base.base.virsh):
             accessors.XMLAttribute(property_name="backend_type",
@@ -53,6 +55,11 @@ class Tpm(base.UntypedDeviceBase):
                                    parent_xpath='/',
                                    tag_name='backend',
                                    attribute='version')
+            accessors.XMLAttribute(property_name="persistent_state",
+                                   libvirtxml=self,
+                                   parent_xpath='/',
+                                   tag_name='backend',
+                                   attribute='persistent_state')
             accessors.XMLAttribute(property_name="device_path",
                                    libvirtxml=self,
                                    parent_xpath='/',

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2317,6 +2317,7 @@ def create_tpm_dev(params):
     tpm_model = params.get("tpm_model", 'tpm-crb')
     backend_type = params.get("backend_type")
     backend_version = params.get("backend_version")
+    persistent_state = params.get("persistent_state")
     encryption_secret = params.get("encryption_secret")
     device_path = params.get("device_path")
 
@@ -2327,6 +2328,8 @@ def create_tpm_dev(params):
         tpm_backend.backend_type = backend_type
         if backend_version:
             tpm_backend.backend_version = backend_version
+        if persistent_state:
+            tpm_backend.persistent_state = persistent_state
         if encryption_secret:
             tpm_backend.encryption_secret = encryption_secret
         if device_path:


### PR DESCRIPTION
Add new attribute persistent_state for tpm device, supported from
libvirt 7.0.0.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>