### PR TITLE
nfs: Update to restart the services

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -234,10 +234,9 @@ class Nfs(object):
         service and exportfs too.
         """
         if self.nfs_setup:
-            if not self.nfs_service.status():
-                logging.debug("Restart NFS service.")
-                self.rpcbind_service.restart()
-                self.nfs_service.restart()
+            logging.debug("Restart NFS service.")
+            self.rpcbind_service.restart()
+            self.nfs_service.restart()
 
             if not utils_misc.check_isdir(self.export_dir, session=self.session):
                 utils_misc.make_dirs(self.export_dir, session=self.session)


### PR DESCRIPTION
To avoid the problem of NFS sever not working properly,
restarting the nfs-server and rpcbind at the beginning of the
setup().

Signed-off-by: Yingshun Cui <yicui@redhat.com>