### PR TITLE
cgroup2: Use correct path to read cpu.shares and io.bfq.weight

### DIFF
--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -224,7 +224,8 @@ class CgroupTest(object):
         if virsh_cmd == "blkiotune":
             weight_file_name = CGROUP_V2_BLKIO_FILE_MAPPING["weight"]
             iomax_file_name = CGROUP_V2_BLKIO_FILE_MAPPING["wiops"]
-            path_to_weight = os.path.join(cgroup_path, weight_file_name)
+            path_to_weight = os.path.join(cgroup_path.split("libvirt")[0],
+                                          weight_file_name)
             with open(path_to_weight, 'r') as weight_file:
                 weight_value = re.search(r'\d+', weight_file.read())
                 if weight_value:
@@ -257,7 +258,10 @@ class CgroupTest(object):
                         cg_file_name = cg_file_name.replace("<iothreadX>", iothread_dirs[0])
                     else:
                         continue
-                with open(os.path.join(cgroup_path, cg_file_name), 'r') as cg_file:
+                cg_dir = cgroup_path
+                if cg_key == "cpu_shares":
+                    cg_dir = cgroup_path.split("libvirt")[0]
+                with open(os.path.join(cg_dir, cg_file_name), 'r') as cg_file:
                     list_index = 0
                     cg_file_values = cg_file.read().strip().split()
                     if "period" in cg_key:


### PR DESCRIPTION
After libvirt commit 184245f53b 'vircgroup: introduce nested cgroup
to properly work with systemd'. All vm's cgroup params will be in
a 'libvirt' sub-dir in /sys/fs/cgroup/vm.scope/. But 'cpu.shares'
and 'io.bfq.weight' still stay in the vm's root dir (vm.scope dir).
So this patch is to make sure using correct path to read 'cpu.shares'
and 'io.bfq.weight' files.

Signed-off-by: Yi Sun <yisun@redhat.com>