### PR TITLE
qemu_monitor: Introduce "query_cpu_model_expansion" in QMPMonitor

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -3557,3 +3557,15 @@ class QMPMonitor(Monitor):
         cmd = "query-block-exports"
         self.verify_supported_cmd(cmd)
         return self.cmd(cmd)
+
+    def query_cpu_model_expansion(self, cpu_model):
+        """
+        Query all properties with the provided CPU model.
+
+        :param cpu_model: CPU model supported by qemu
+        :return: A list of all properties
+        """
+        cmd = "query-cpu-model-expansion"
+        self.verify_supported_cmd(cmd)
+        return self.cmd(cmd, {"type": "full",
+                              "model": {"name": cpu_model}})["model"]["props"]


### PR DESCRIPTION
"query-cpu-model-expansion" will return all properties with the provided
CPU model, add it in QMPMonitor and then we can query which features are
supported of the specific CPU model.

ID: 1970784, 1970785, 1970786
Signed-off-by: Yihuang Yu <yihyu@redhat.com>