### PR TITLE
Extra Params: restore support for command line --vt-extra-params

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -207,7 +207,7 @@ class VTRun(CLI):
         add_option(parser=vt_compat_group_qemu,
                    dest='vt.extra_params',
                    arg='--vt-extra-params',
-                   nargs='*',
+                   action='append',
                    help=help_msg)
 
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)

--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -68,8 +68,9 @@ if hasattr(plugin_interfaces, 'Init'):
                                      help_msg=help_msg)
 
             help_msg = "List of 'key=value' pairs passed to cartesian parser."
-            settings.register_option(section, key='extra_params', nargs='*',
-                                     default=None, help_msg=help_msg)
+            settings.register_option(section, key='extra_params', nargs='+',
+                                     key_type=list, default=[],
+                                     help_msg=help_msg)
 
             help_msg = ("Also list the available guests (this option ignores "
                         "the --vt-config and --vt-guest-os)")


### PR DESCRIPTION
The action being given to the "--vt-extra-params", by omission, was
"store".  That caused every entry to override the previous one.  What
we really need, to have a list of options, is "append".

While at it, let's change the number of arguments, because it does
not make any sense to have "--vt-extra-params" with zero arguments.

Signed-off-by: Cleber Rosa <crosa@redhat.com>