### PR TITLE
CI: add complete boot tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,9 +2,9 @@ env:
   CIRRUS_CLONE_DEPTH: 1
   VT_TYPE: qemu
 
-fedora_33_task:
+fedora_34_task:
   container:
-    image: quay.io/avocado-framework/avocado-vt-ci-fedora-33
+    image: quay.io/avocado-framework/avocado-vt-ci-fedora-34
   env:
     PYTHON: python3
     matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,6 @@ fedora_34_task:
   container:
     image: quay.io/avocado-framework/avocado-vt-ci-fedora-34
   env:
-    PYTHON: python3
     matrix:
       # Get deps from setup.py (therefor pip version of avocado)
       - AVOCADO_SRC:
@@ -24,27 +23,26 @@ fedora_34_task:
   build_script:
     - (echo $SETUP | grep -v PYPI_UPLOAD) || make pypi
   setup_script: &setup_scr
-    - $PYTHON --version
-    - test -z $AVOCADO_SRC || $PYTHON -m pip install $AVOCADO_SRC
-    - $PYTHON $SETUP
+    - python3 --version
+    - test -z $AVOCADO_SRC || python3 -m pip install $AVOCADO_SRC
+    - python3 $SETUP
   bootstrap_script: &bootstrap_scr
-    - $PYTHON -m avocado vt-bootstrap --vt-type=$VT_TYPE --vt-skip-verify-download-assets --yes-to-all
+    - python3 -m avocado vt-bootstrap --vt-type=$VT_TYPE --vt-skip-verify-download-assets --yes-to-all
   list_script: &list_scr
-    - $PYTHON -m avocado list --vt-save-config=/tmp/config --vt-type=$VT_TYPE -- boot | tee /tmp/list
+    - python3 -m avocado list --vt-save-config=/tmp/config --vt-type=$VT_TYPE -- boot | tee /tmp/list
     - test $VT_TYPE == "qemu" || test $(wc -l < /tmp/list) -gt 50
     - test $VT_TYPE == "libvirt" || test $(wc -l < /tmp/list) -eq 1
-    - $PYTHON -m avocado list --vt-config=/tmp/config --vt-type=$VT_TYPE -- boot | tee /tmp/list_from_config
+    - python3 -m avocado list --vt-config=/tmp/config --vt-type=$VT_TYPE -- boot | tee /tmp/list_from_config
     - diff /tmp/list /tmp/list_from_config
-    - $PYTHON -m avocado vt-list-guests --vt-type=$VT_TYPE
-    - $PYTHON -m avocado vt-list-archs --vt-type=$VT_TYPE
+    - python3 -m avocado vt-list-guests --vt-type=$VT_TYPE
+    - python3 -m avocado vt-list-archs --vt-type=$VT_TYPE
   dry_run_script: &dry_run_scr
-    - $PYTHON -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
+    - python3 -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
 
 centos_8_1_task:
   container:
     image: quay.io/avocado-framework/avocado-vt-ci-centos-8.1
   env:
-    PYTHON: python3
     matrix:
       - AVOCADO_SRC:
       - AVOCADO_SRC: avocado-framework<70.0

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,7 @@ env:
 fedora_34_task:
   container:
     image: quay.io/avocado-framework/avocado-vt-ci-fedora-34
+    kvm: true
   env:
     matrix:
       # Get deps from setup.py (therefor pip version of avocado)
@@ -38,6 +39,8 @@ fedora_34_task:
     - python3 -m avocado vt-list-archs --vt-type=$VT_TYPE
   dry_run_script: &dry_run_scr
     - python3 -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
+  run_boot_script: &run_boot_scr
+    - test $VT_TYPE == "libvirt" || PATH=$HOME/.local/bin:$PATH python3 -m avocado --show all run --vt-type=$VT_TYPE --vt-extra-params nettype=user -- io-github-autotest-qemu.boot
 
 centos_8_1_task:
   container:

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -207,7 +207,7 @@ class VTRun(CLI):
         add_option(parser=vt_compat_group_qemu,
                    dest='vt.extra_params',
                    arg='--vt-extra-params',
-                   nargs='*',
+                   action='append',
                    help=help_msg)
 
         supported_uris = ", ".join(SUPPORTED_LIBVIRT_URIS)

--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -68,8 +68,9 @@ if hasattr(plugin_interfaces, 'Init'):
                                      help_msg=help_msg)
 
             help_msg = "List of 'key=value' pairs passed to cartesian parser."
-            settings.register_option(section, key='extra_params', nargs='*',
-                                     default=None, help_msg=help_msg)
+            settings.register_option(section, key='extra_params', nargs='+',
+                                     key_type=list, default=[],
+                                     help_msg=help_msg)
 
             help_msg = ("Also list the available guests (this option ignores "
                         "the --vt-config and --vt-guest-os)")

--- a/contrib/containers/ci/fedora-34.docker
+++ b/contrib/containers/ci/fedora-34.docker
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:34
 LABEL description "Fedora image used on integration checks, such as cirrus-ci"
 RUN dnf -y install make python3-wheel python3-pip git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
 RUN dnf -y clean all

--- a/contrib/containers/ci/fedora-34.docker
+++ b/contrib/containers/ci/fedora-34.docker
@@ -2,3 +2,6 @@ FROM fedora:34
 LABEL description "Fedora image used on integration checks, such as cirrus-ci"
 RUN dnf -y install make python3-wheel python3-pip git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
 RUN dnf -y clean all
+RUN mkdir -p /var/lib/avocado/data/avocado-vt/images/ /root/avocado/data/avocado-vt/images/
+RUN curl -s https://avocado-project.org/data/assets/jeos/27/jeos-27-64.qcow2.xz | xz -d > /var/lib/avocado/data/avocado-vt/images/jeos-27-x86_64.qcow2
+RUN ln /var/lib/avocado/data/avocado-vt/images/jeos-27-x86_64.qcow2 /root/avocado/data/avocado-vt/images/jeos-27-x86_64.qcow2


### PR DESCRIPTION
This greatly improves coverage by actually running a complete boot test, using the KVM support on Cirrus CI.  It's currently only supported for the QEMU backend, because further setup would be necessary for the libvirt backend.