### PR TITLE
avocado_vt/plugins/vt_joblock.py: remove compatibility with LTS 36.0

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -137,7 +137,3 @@ class VTJobLock(Pre, Post):
     def post_tests(self, job):
         if self.lock_file is not None:
             os.unlink(self.lock_file)
-
-    # compatibility with older versions, including 36.0 LTS
-    pre = pre_tests
-    post = post_tests


### PR DESCRIPTION
This is a version that is not supported anymore, so that compatibility
should not be here anymore.

Signed-off-by: Cleber Rosa <crosa@redhat.com>