### PR TITLE
CPU: Fixup 'lscpu' command's output inconsistent issue

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -727,9 +727,10 @@ def get_cpu_info(session=None):
     :return: A dirt of cpu information
     """
     cpu_info = {}
-    cmd = "lscpu"
+    cmd = "lscpu | tee"
     if session is None:
-        output = process.run(cmd, ignore_status=True).stdout_text.splitlines()
+        output = process.run(cmd, shell=True,
+                             ignore_status=True).stdout_text.splitlines()
     else:
         try:
             output_raw = session.cmd_output(cmd)


### PR DESCRIPTION
The output of 'lscpu' on remote host is different from that on
the local host since util-linux-2.37.

Signed-off-by: Yingshun Cui <yicui@redhat.com>