### PR TITLE
Nrunner logging fix

### DIFF
--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -14,8 +14,9 @@ from virttest import (data_dir, env_process, error_event, utils_env, utils_misc,
                       utils_params, version, funcatexit)
 
 
-def _send_message(msg, queue, message_type):
-    status = {'type': message_type, 'log': msg}
+def _send_message(msg, queue, message_type, encoding='utf-8'):
+    status = {'type': message_type, 'log': msg.encode(encoding),
+              'encoding': encoding}
     queue.put(status)
 
 


### PR DESCRIPTION
In the newest avocado, after [#4629](https://github.com/avocado-framework/avocado/pull/4629), the nrunner messages have to be sent as bytes. This makes avocado-vt nrunner compatible with those changes.

Reference: #3106
Signed-off-by: Jan Richter <jarichte@redhat.com>