### PR TITLE
Add sharebacking attribute to disk xml

### DIFF
--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -18,6 +18,8 @@ class Disk(base.TypedDeviceBase):
             string, how exposted to guest
         rawio:
             string (yes/no), disk needs rawio capability
+        sharebacking:
+            string (yes/no), support share base image of transient disk
         sgio:
             string, "filtered" or "unfiltered"
         snapshot:
@@ -75,7 +77,7 @@ class Disk(base.TypedDeviceBase):
                  'address', 'boot', 'loadparm', 'readonly', 'transient', 'share', 'model',
                  'mirror', 'ready', 'iotune', 'source', 'blockio', 'geometry',
                  'wwn', 'serial', 'vendor', 'product', 'encryption', 'auth',
-                 'reservations', 'backingstore', 'drivermetadata')
+                 'reservations', 'backingstore', 'drivermetadata', 'sharebacking')
 
     def __init__(self, type_name='file', virsh_instance=base.base.virsh):
         accessors.XMLAttribute('device', self, parent_xpath='/',
@@ -84,6 +86,8 @@ class Disk(base.TypedDeviceBase):
                                tag_name='disk', attribute='model')
         accessors.XMLAttribute('rawio', self, parent_xpath='/',
                                tag_name='disk', attribute='rawio')
+        accessors.XMLAttribute('sharebacking', self, parent_xpath='/',
+                               tag_name='transient', attribute='shareBacking')
         accessors.XMLAttribute('sgio', self, parent_xpath='/',
                                tag_name='disk', attribute='sgio')
         accessors.XMLAttribute('snapshot', self, parent_xpath='/',


### PR DESCRIPTION
Add support for the following libvirt new features:
```
v7.4.0

qemu: Add support for sharing base image of <transient/> disks

Users can use <transient shareBacking='yes'/> to tell the qemu driver
 to never open the base image in write mode thus multiple VMs can share
the same image. Note that the disk will be hotplugged during startup.
```

Signed-off-by: Ma Xinjian <maxj.fnst@fujitsu.com>