### PR TITLE
capability_xml: Add 'iommu' to CapabilityXML

### DIFF
--- a/virttest/libvirt_xml/capability_xml.py
+++ b/virttest/libvirt_xml/capability_xml.py
@@ -26,7 +26,7 @@ class CapabilityXML(base.LibvirtXMLBase):
 
     __slots__ = ('uuid', 'guest_capabilities', 'cpu_count', 'arch', 'model',
                  'vendor', 'feature_list', 'power_management_list',
-                 'cpu_topology', 'cells_topology')
+                 'cpu_topology', 'cells_topology', 'iommu')
     __schema_name__ = "capability"
 
     def __init__(self, virsh_instance=base.virsh):
@@ -62,6 +62,11 @@ class CapabilityXML(base.LibvirtXMLBase):
                                  forbidden=['del'],
                                  parent_xpath='/host/cpu',
                                  tag_name='topology')
+        accessors.XMLElementDict(property_name="iommu",
+                                 libvirtxml=self,
+                                 forbidden=['del'],
+                                 parent_xpath='/host',
+                                 tag_name='iommu')
         accessors.XMLElementNest(property_name='cells_topology',
                                  libvirtxml=self,
                                  parent_xpath='/host',


### PR DESCRIPTION
Add 'iommu' to CapabilityXML class.

Signed-off-by: Yingshun Cui <yicui@redhat.com>


**Test result:**
`(1/1) type_specific.io-github-autotest-libvirt.sriov.capabilities.intel_iommu: PASS (3.50 s)`