### PR TITLE
virt_vm: allow use a serial connection when remote login failed

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -521,7 +521,7 @@ def session_handler(func):
                 vm.connect_uri = uri
                 vm.session = vm.wait_for_serial_login()
             else:
-                vm.session = vm.wait_for_login()
+                vm.session = vm.wait_for_login(serial=True)
             return func(vm, *args, **kwargs)
         finally:
             if vm.session:


### PR DESCRIPTION
Some cases test with vm without nic need a serial session, make
it is available.

id: 1968402

Signed-off-by: Yanan Fu <yfu@redhat.com>