### PR TITLE
Fix travis CI failure issue

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2552,8 +2552,7 @@ class VirtIface(propcan.PropCan, object):
 
     def __getstate__(self):
         state = {}
-        # pylint: disable=E1133
-        for key in self.__class__.__all_slots__:
+        for key in self.__class__.__all_slots__:  # pylint: disable=E1133
             if key in self:
                 state[key] = self[key]
         return state
@@ -3459,6 +3458,7 @@ def get_ip_address_by_interface(ifname, ip_ver="ipv4", linklocal=False):
     :param linklocal: Whether ip address is local or remote
     :raise NetError: When failed to fetch IP address (ioctl raised IOError.).
     """
+    # pylint: disable=I1101
     if ip_ver == "ipv6":
         ver = netifaces.AF_INET6
         linklocal_prefix = "fe80"


### PR DESCRIPTION
E1135:407,27: Disk.IOTune.__init__: Value 'base.base.LibvirtXMLBase.__all_slots__' doesn't support membership test
Global check FAIL
************* Module virttest.utils_net
E1133:2555,19: VirtIface.__getstate__: Non-iterable value self.__class__.__all_slots__ is used in an iterating context
I1101:3462,14: get_ip_address_by_interface: Module 'netifaces' has no 'AF_INET6' member, but source is unavailable. Consider adding this module to extension-pkg-allow-list if you want to perform analysis based on run-time introspection of living objects.
I1101:3465,14: get_ip_address_by_interface: Module 'netifaces' has no 'AF_INET' member, but source is unavailable. Consider adding this module to extension-pkg-allow-list if you want to perform analysis based on run-time introspection of living objects.
I1101:3467,11: get_ip_address_by_interface: Module 'netifaces' has no 'ifaddresses' member, but source is unavailable. Consider adding this module to extension-pkg-allow-list if you want to perform analysis based on run-time introspection of living objects.
Global check FAIL
Signed-off-by: chunfuwen <chwen@redhat.com>