### PR TITLE
Default serial run for vt nrunner

### DIFF
--- a/avocado_vt/conf.d/vt.conf
+++ b/avocado_vt/conf.d/vt.conf
@@ -1,3 +1,8 @@
+[nrunner]
+# The avocado-vt cannot be run in parallel,
+# when this value will be >1 the vt tests won't be resolved.
+max_parallel_tasks = 1
+
 [vt.setup]
 # Backup image before testing (if not already backed up)
 #backup_image_before_test = True

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -108,6 +108,10 @@ If there are missing requirements, please install them and re-run `vt-bootstrap`
           recognize test cases for your test backend or for test cases
           to run correctly.
 
+.. warning:: When you bootstrap avocado-vt the parallel run of avocado nrunner
+             will be disabled by default, because the avocado-vt doesn't support
+             parallel tests. If you run test suite without vt tests,  you can
+             enable parallel run by `nrunner.max_parallel_tasks` config variable.
 
 First steps with Avocado-VT
 ===========================


### PR DESCRIPTION
The avocado plan for near future to change default runner form legacy to
nrunner. It is necessary to prepare avocado-vt for this change. The vt
nrunner doesn't support parallel run, and it is necessary to set
`--nrunner-max-parallel-tasks` to 1 before each run with nrunner. This
might be frustrating when the nrunner becomes the default  avocado
runner. This commit sets  `--nrunner-max-parallel-tasks` to 1 as default
when the avcodo-vt is bootstrapped. So it won’t be necessary to set that
variable each time the avocado-vt is run.

Reference: #3030
Signed-off-by: Jan Richter <jarichte@redhat.com>