### PR TITLE
libvirt: Add managed to modify_vm_iface()

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3542,6 +3542,7 @@ def modify_vm_iface(vm_name, oper, iface_dict, index=0, virsh_instance=virsh):
     iface_backend = iface_dict.get('backend')
     iface_mac = iface_dict.get('mac')
     iface_mtu = iface_dict.get('mtu')
+    iface_managed = iface_dict.get('managed')
     iface_alias = iface_dict.get('alias')
     iface_teaming = iface_dict.get('teaming')
     iface_virtualport_type = iface_dict.get('virtualport_type')
@@ -3603,6 +3604,8 @@ def modify_vm_iface(vm_name, oper, iface_dict, index=0, virsh_instance=virsh):
         iface.mac_address = iface_mac
     if iface_mtu:
         iface.mtu = eval(iface_mtu)
+    if iface_managed:
+        iface.managed = iface_managed
     if iface_alias:
         iface.alias = eval(iface_alias)
     if iface_teaming:


### PR DESCRIPTION
Add interface managed to modify_vm_iface().

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test result:**
```
>>> iface = interface.Interface('network')
>>> iface.xml=libvirt.modify_vm_iface("avocado-vt-vm1", "get_xml", {'managed': 'yes'})
>>> print(iface)
<?xml version='1.0' encoding='UTF-8'?>
<interface managed="yes" type="network">
      <mac address="52:54:00:26:58:7e" />
      <source network="default" />
      <model type="virtio" />
      <address bus="0x01" domain="0x0000" function="0x0" slot="0x00" type="pci" />
    </interface>
>>> iface.xml=libvirt.modify_vm_iface("avocado-vt-vm1", "get_xml", {'managed': 'no'})
>>> print(iface)
<?xml version='1.0' encoding='UTF-8'?>
<interface managed="no" type="network">
      <mac address="52:54:00:26:58:7e" />
      <source network="default" />
      <model type="virtio" />
      <address bus="0x01" domain="0x0000" function="0x0" slot="0x00" type="pci" />
    </interface>
>>> iface.xml=libvirt.modify_vm_iface("avocado-vt-vm1", "get_xml", {})
>>> print(iface)
<?xml version='1.0' encoding='UTF-8'?>
<interface type="network">
      <mac address="52:54:00:26:58:7e" />
      <source network="default" />
      <model type="virtio" />
      <address bus="0x01" domain="0x0000" function="0x0" slot="0x00" type="pci" />
    </interface>
>>> 

```