### PR TITLE
libvirt_cgroup: Set max_mem_value when PAGE_SIZE is 65536

### DIFF
--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -174,7 +174,14 @@ class CgroupTest(object):
                             dev_list.append(dev_num)
         elif virsh_cmd == "memtune":
             cgroup_path = self.get_cgroup_path("memory")
-            max_mem_value = "9223372036854771712"
+            cmd = "getconf PAGE_SIZE"
+            page_size = process.run(cmd, ignore_status=True, shell=True).stdout_text.strip()
+            logging.debug("page_size is %d" % int(page_size))
+            if int(page_size) == 65536:
+                max_mem_value = "9223372036854710272"
+            else:
+                max_mem_value = "9223372036854771712"
+            logging.debug("max_mem_value is %s" % max_mem_value)
             for cg_key, cg_file_name in list(CGROUP_V1_MEM_FILE_MAPPING.items()):
                 with open(os.path.join(cgroup_path, cg_file_name), 'r') as cg_file:
                     cg_file_value = cg_file.read().strip()


### PR DESCRIPTION
The default value of cgroup memory is set to PAGE_COUNTER_MAX, which is
LONG_MAX/PAGE_SIZE on 64-bit platform.
When the paltform`s PAGE_SIZE is diferent, the default value of cgroup memory is diferent,
such as 4k and 64k has the different default values:
0x7ffffffffffff000(pagesize=4k)
0x7fffffffffff0000(pagesize= 64k)

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Fix tp-libvirt guest_resource_control.control_cgroup..memtune..positive for aarch64
Before
```
[root@hpe-moonshot-02-c21 avocado_vt]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio guest_resource_control.control_cgroup..memtune..positive
JOB ID     : af784ff734c424bc09fcc310b198b2999f8eefbd
JOB LOG    : /root/avocado/job-results/job-2021-07-13T03.38-af784ff/job.log
 (01/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.memtune.hard_limit.positive: FAIL: memtune checking failed. (14.11 s)
 (02/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.memtune.soft_limit.positive: FAIL: memtune checking failed. (11.15 s)
 (03/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.memtune.swap_hard_limit.positive: FAIL: memtune checking failed. (11.31 s)
 (04/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.live.memtune.hard_limit.positive: FAIL: memtune checking failed. (14.63 s)
 (05/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.live.memtune.soft_limit.positive: FAIL: memtune checking failed. (11.15 s)
 (06/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.live.memtune.swap_hard_limit.positive: FAIL: memtune checking failed. (20.92 s)
 (07/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.current.memtune.hard_limit.positive: FAIL: memtune checking failed. (14.77 s)
 (08/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.current.memtune.soft_limit.positive: FAIL: memtune checking failed. (11.54 s)
 (09/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.current.memtune.swap_hard_limit.positive: FAIL: memtune checking failed. (11.18 s)
 (10/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_shutdown.config.memtune.hard_limit.positive: FAIL: memtune checking failed. (42.38 s)
 (11/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_shutdown.config.memtune.soft_limit.positive: FAIL: memtune checking failed. (38.19 s)
 (12/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_shutdown.config.memtune.swap_hard_limit.positive: FAIL: memtune checking failed. (40.89 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 12 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 243.20 s
```
After the fix
```
[root@hpe-moonshot-02-c21 avocado-vt]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio guest_resource_control.control_cgroup..memtune..positive
JOB ID     : c987978a40f38d18929f78b64bd1b66079396d09
JOB LOG    : /root/avocado/job-results/job-2021-07-13T03.19-c987978/job.log
 (01/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.memtune.hard_limit.positive: PASS (13.09 s)
 (02/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.memtune.soft_limit.positive: PASS (10.30 s)
 (03/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.memtune.swap_hard_limit.positive: PASS (19.66 s)
 (04/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.live.memtune.hard_limit.positive: PASS (13.38 s)
 (05/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.live.memtune.soft_limit.positive: PASS (10.37 s)
 (06/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.live.memtune.swap_hard_limit.positive: PASS (10.11 s)
 (07/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.current.memtune.hard_limit.positive: PASS (13.90 s)
 (08/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.current.memtune.soft_limit.positive: PASS (19.95 s)
 (09/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.current.memtune.swap_hard_limit.positive: PASS (10.23 s)
 (10/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_shutdown.config.memtune.hard_limit.positive: PASS (49.10 s)
 (11/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_shutdown.config.memtune.soft_limit.positive: PASS (34.50 s)
 (12/12) type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_shutdown.config.memtune.swap_hard_limit.positive: PASS (42.79 s)
RESULTS    : PASS 12 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 248.36 s
```