### PR TITLE
Change the order to deal with install conflict time waste

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1215,12 +1215,10 @@ def setup_ovs_vhostuser(hp_num, tmpdir, br_name, port_names,
                   clean_ovs=True)
 
     # Install openvswitch
-    if process.system("yum info openvswitch", ignore_status=True) == 0:
-        utils_package.package_install("openvswitch")
-    if process.system("yum info openvswitch2.11", ignore_status=True) == 0:
-        utils_package.package_install("openvswitch2.11")
-    if process.system("yum info openvswitch2.15", ignore_status=True) == 0:
-        utils_package.package_install("openvswitch2.15")
+    for pkg in ["openvswitch2.15", "openvswitch2.11", "openvswitch"]:
+        if process.system("yum info %s" % pkg, ignore_status=True) == 0:
+            utils_package.package_install(pkg)
+            break
 
     # Init ovs
     ovs = factory(openvswitch.OpenVSwitch)(tmpdir)


### PR DESCRIPTION
avoid the error below:
```
Problem: problem with installed package openvswitch2.11-2.11.3-89.el8fdp.x86_64
- package openvswitch2.15-2.15.0-24.el8fdp.x86_64 conflicts with openvswitch2.11 provided by openvswitch2.11-2.11.3-89.el8fdp.x86_64
```
before
```
virtual_network.iface_options.iface_type.type_vhostuser.queue_size_check: PASS (344.19 s)
```
after
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_vhostuser.queue_size_check: PASS (42.14 s)
```
Signed-off-by: Kyla Zhang <weizhan@redhat.com>