### PR TITLE
virsh.py: add undefine "--nvram" option for aarch64

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -31,6 +31,7 @@ import select
 import locale
 import base64
 import inspect
+import platform
 
 from functools import wraps
 
@@ -1556,6 +1557,10 @@ def undefine(name, options=None, **dargs):
     cmd = "undefine %s" % name
     if options is not None:
         cmd += " %s" % options
+
+    if platform.machine() == "aarch64":
+        if options is None or "--nvram" not in options:
+            cmd += " --nvram"
 
     logging.debug("Undefine VM %s", name)
     return command(cmd, **dargs)


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
[root@hpe-moonshot-02-c20 ~]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> managedsave.libvirt_guests.positive_test.parallel_shutdown.shutdown_on_shutdown.ignore_on_boot \
> managedsave.libvirt_guests.negative_test.no_parallel_shutdown \
> virsh.managedsave.functional_test.undefine
JOB ID     : b866299512b1f56d41269122b7957ae526213504
JOB LOG    : /root/avocado/job-results/job-2021-07-22T04.39-b866299/job.log
 (1/3) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.parallel_shutdown.shutdown_on_shutdown.ignore_on_boot: PASS (109.95 s)
 (2/3) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.negative_test.no_parallel_shutdown: ERROR: Command 'virt-clone --original 'avocado-vt-vm1' --name 'avocado-vt-vm2' --auto-clone' failed.\nstdout: b''\nstderr: b"ERROR    Invalid name for new guest: Guest name 'avocado-vt-vm2' is already in use.\n"\nadditional_info: None (9.91 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.managedsave.functional_test.undefine: FAIL: Guest can't be undefine with managed-save option (44.92 s)
RESULTS    : PASS 1 | ERROR 1 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 165.48 s
```
Test guests undefine failed. 
```
[root@hpe-moonshot-02-c20 ~]# virsh list --all
 Id   Name             State
---------------------------------
 -    avocado-vt-vm1   shut off
 -    avocado-vt-vm2   shut off
 -    avocado-vt-vm3   shut off

```

After
```
[root@hpe-moonshot-02-c20 avocado_vt]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> managedsave.libvirt_guests.positive_test.parallel_shutdown.shutdown_on_shutdown.ignore_on_boot \
> managedsave.libvirt_guests.negative_test.no_parallel_shutdown \
> virsh.managedsave.functional_test.undefine
JOB ID     : 33303a043f8a0f64d22d023497e0d900ea3f1d79
JOB LOG    : /root/avocado/job-results/job-2021-07-22T04.32-33303a0/job.log
 (1/3) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.parallel_shutdown.shutdown_on_shutdown.ignore_on_boot: PASS (109.99 s)
 (2/3) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.negative_test.no_parallel_shutdown: PASS (80.21 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.managedsave.functional_test.undefine: PASS (45.51 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 236.46 s
```