### PR TITLE
Revert "nfs: Update to restart the services"

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -234,9 +234,10 @@ class Nfs(object):
         service and exportfs too.
         """
         if self.nfs_setup:
-            logging.debug("Restart NFS service.")
-            self.rpcbind_service.restart()
-            self.nfs_service.restart()
+            if not self.nfs_service.status():
+                logging.debug("Restart NFS service.")
+                self.rpcbind_service.restart()
+                self.nfs_service.restart()
 
             if not utils_misc.check_isdir(self.export_dir, session=self.session):
                 utils_misc.make_dirs(self.export_dir, session=self.session)


### PR DESCRIPTION
This reverts commit 3d3f48c78219fa1786df6b2db3d84170df4248b6.
NFS mount bug has been resolved and previous commit has caused
problems for others.

Signed-off-by: Yingshun Cui <yicui@redhat.com>