### PR TITLE
utils_misc: fix 'TestSetupError' attribute error

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -926,9 +926,9 @@ def safe_rmdir(path, timeout=10, session=None):
                 raise
             time.sleep(step)
         except (aexpect.ShellTimeoutError, aexpect.ShellError) as info:
-            raise exceptions.TestSetupError("Failed to remove directory "
-                                            "%s from remote machine: %s "
-                                            % (path, info))
+            raise exceptions.TestSetupFail("Failed to remove directory "
+                                           "%s from remote machine: %s "
+                                           % (path, info))
 
     if not success:
         raise OSError(39,


### PR DESCRIPTION
'avocado.core.exceptions' has no attribute 'TestSetupError', it should
be 'TestSetupFail'.

id: 1986658 

Signed-off-by: Yanan Fu <yfu@redhat.com>