### PR TITLE
Fix the issue in modify_vm_iface()

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3531,6 +3531,7 @@ def modify_vm_iface(vm_name, oper, iface_dict, index=0, virsh_instance=virsh):
         iface = xml_devices[iface_index]
     except IndexError:
         iface = interface.Interface(iface_type)
+        xml_devices.append(iface)
 
     iface_driver = iface_dict.get('driver')
     driver_host = iface_dict.get('driver_host')


### PR DESCRIPTION
When there is no interface device in the vm xml, it will create a new one.
But in previous code, it forget to add it into the vm xml. If the oper is
"update_iface", the function will not work as expected.

Signed-off-by: Yalan <yalzhang@redhat.com>