### PR TITLE
Ignore Error when trying to get an unset attribuite of an xml obj

### DIFF
--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -72,12 +72,14 @@ class LibvirtXMLBase(propcan.PropCanBase):
             try:
                 dict_1[slot] = getattr(self, slot)
             except (xcepts.LibvirtXMLNotFoundError,
-                    xcepts.LibvirtXMLAccessorError):
+                    xcepts.LibvirtXMLAccessorError,
+                    AttributeError):
                 pass  # Unset virtual values won't have keys
             try:
                 dict_2[slot] = getattr(other, slot)
             except (xcepts.LibvirtXMLNotFoundError,
-                    xcepts.LibvirtXMLAccessorError):
+                    xcepts.LibvirtXMLAccessorError,
+                    AttributeError):
                 pass  # Unset virtual values won't have keys
         return dict_1 == dict_2
 


### PR DESCRIPTION
When comparing 2 xml objects, we're comparing values of attributes
of all_slots. But we don't always set value to all those attributes,
and trying to get value of an unset attribute would meet
`AttributeError`. Therefore ignore the error.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>