### PR TITLE
VT resolver fix

### DIFF
--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -12,9 +12,8 @@ from ..discovery import DiscoveryMixIn
 
 class VTResolverUtils(DiscoveryMixIn):
 
-    def __init__(self):
-
-        self.config = settings.as_dict()
+    def __init__(self, config):
+        self.config = config or settings.as_dict()
         self.cartesian_parser = self._get_parser()
         self._save_parser_cartesian_config(self.cartesian_parser)
 
@@ -51,7 +50,7 @@ class VTResolverUtils(DiscoveryMixIn):
                                        ReferenceResolutionResult.NOTFOUND)
 
 
-class VTResolver(Resolver, VTResolverUtils):
+class VTResolver(VTResolverUtils, Resolver):
 
     name = 'vt'
     description = 'Test resolver for Avocado-VT tests'


### PR DESCRIPTION
The #3126 PR isn't compatible with avocado changes in
https://github.com/avocado-framework/avocado/pull/4746/commits/43286b5fa3083fc0d3fb4381a4a40024d120eb81 this incompatibility of avocado and avocado-vt broke vt resolver. This
commit fixes the problems.

Signed-off-by: Jan Richter <jarichte@redhat.com>