### PR TITLE
To support a test case about disable dns and dhcp

### DIFF
--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -163,27 +163,34 @@ class DhcpHostXML(base.LibvirtXMLBase):
 class DNSXML(base.LibvirtXMLBase):
 
     """
-    IP address block, optionally containing DHCP range information
+    DNS block, contains configuration information for the network's DNS server
 
     Properties:
+        enable:
+            String, 'yes' or 'no'. Set to "no", then no DNS server
+            will be set by libvirt for this network
         txt:
             Dict. keys: name, value
-        forwarder:
+        forwarders:
             List
+        dns_forward:
+            String, 'yes' or 'no'
         srv:
             Dict. keys: service, protocol, domain,
             target, port, priority, weight
-        hosts:
+        host:
             List of host name
     """
 
-    __slots__ = ('dns_forward', 'txt', 'forwarders', 'srv',
+    __slots__ = ('enable', 'dns_forward', 'txt', 'forwarders', 'srv',
                  'host')
 
     def __init__(self, virsh_instance=base.virsh):
         """
         Create new IPXML instance based on address/mask
         """
+        accessors.XMLAttribute('enable', self, parent_xpath='/',
+                               tag_name='dns', attribute='enable')
         accessors.XMLElementDict('txt', self,
                                  parent_xpath='/',
                                  tag_name='txt')

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1821,6 +1821,8 @@ def create_net_xml(net_name, params):
     Create a new network or update an existed network xml
     """
     dns_dict = {}
+    disable_dns = 'yes' == params.get("disable_dns", "no")
+    disable_dhcp = 'yes' == params.get("disable_dhcp", "no")
     host_dict = {}
     net_bridge = params.get("net_bridge", '{}')
     net_forward = params.get("net_forward", '{}')
@@ -1864,6 +1866,8 @@ def create_net_xml(net_name, params):
             netxml.del_ip()
         else:
             netxml = network_xml.NetworkXML(net_name)
+        if disable_dns:
+            dns_dict['enable'] = "no"
         if net_dns_forward:
             dns_dict["dns_forward"] = net_dns_forward
         if net_dns_txt:
@@ -1934,10 +1938,11 @@ def create_net_xml(net_name, params):
         if net_ip_address:
             ipxml = network_xml.IPXML(net_ip_address,
                                       net_ip_netmask)
-            if dhcp_start_ipv4 and dhcp_end_ipv4:
-                range_4 = network_xml.RangeXML()
-                range_4.attrs = {"start": dhcp_start_ipv4,
-                                 "end": dhcp_end_ipv4}
+            if not disable_dhcp:
+                if dhcp_start_ipv4 and dhcp_end_ipv4:
+                    range_4 = network_xml.RangeXML()
+                    range_4.attrs = {"start": dhcp_start_ipv4,
+                                     "end": dhcp_end_ipv4}
                 ipxml.dhcp_ranges = range_4
             if tftp_root:
                 ipxml.tftp_root = tftp_root


### PR DESCRIPTION
Network can be set as dns disabled or dhcp disabled. Set
<dns enable='no'/> can disable the dns function of the vm. And
delete the dhcp range can disable dhcp for the network.

Signed-off-by: Yalan <yalzhang@redhat.com>