### PR TITLE
qemu_vm: update smp_pattern to match maxcpus

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -582,7 +582,7 @@ class VM(virt_vm.BaseVM):
 
         def add_smp(devices):
             smp_str = " -smp %d" % self.cpuinfo.smp
-            smp_pattern = "smp .*n\[,maxcpus=cpus\].*"
+            smp_pattern = "smp .*\[,maxcpus=cpus\].*"
             if devices.has_option(smp_pattern):
                 smp_str += ",maxcpus=%d" % self.cpuinfo.maxcpus
             if self.cpuinfo.cores != 0:


### PR DESCRIPTION
QEMU help info about smp change with QEMU6.1:
1. old:
-smp [cpus=]n[,maxcpus=cpus][,cores=cores][,threads=threads]...
2. new:
-smp [[cpus=]n][,maxcpus=cpus][,sockets=sockets][,dies=dies]...

so update the patter to match maxcpus for all.

id: 1988915
Signed-off-by: Yanan Fu <yfu@redhat.com>