### PR TITLE
libvirt_keywrap: handle hexdump when token unavailable

### DIFF
--- a/virttest/utils_libvirt/libvirt_keywrap.py
+++ b/virttest/utils_libvirt/libvirt_keywrap.py
@@ -40,7 +40,7 @@ class ProtectedKeyHelper(object):
         attr_path = os.path.join(self.sysfs, some_key_attribute)
         error, output = cmd_status_output(cmd="hexdump %s" % attr_path,
                                           session=self.session)
-        if error:
+        if error or "No such device" in output:
             logging.debug("Error reading from %s: %s", attr_path, output)
             return None
         return output


### PR DESCRIPTION
Commit 3bcc957a800ea465db407a783ee4633b453864c6 switched to usage
of `hexdump`. Unfortunately, `hexdump` doesn't set error code
if no token can be read and instead just notifies
"hexdump: /sys/devices/virtual/misc/pkey/protkey/protkey_aes_128: No
such device".

Check for substring in output to handle this as if error code was set.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>