### PR TITLE
Remove parameters of file_transfer in Linux.cfg and Windows.cfg

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux.cfg
+++ b/virttest/shared/cfg/guest-os/Linux.cfg
@@ -36,9 +36,6 @@
         time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'
         time_filter_re = "(?:TIME: \w\w\w )(.{19})(?:\.\d\d)"
         time_format = "%m/%d/%Y %H:%M:%S"
-    file_transfer:
-        tmp_dir = /tmp/
-        clean_cmd = rm -f
     nicdriver_unload:
         readlink_command = readlink -e
         sys_path = "/sys/class/net/%s/device/driver"

--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -238,9 +238,6 @@
         check_machine_type_cmd = "wmic csproduct get Version"
         virtio_blk, virtio_net:
             vio_driver_chk_cmd = 'driverquery /si | find "Red Hat"'
-    file_transfer:
-        tmp_dir = C:\
-        clean_cmd = del /q /f
     sysprep:
         shell_client = telnet
         shell_port = 23


### PR DESCRIPTION
Move the specific parameters of test cases into tp-qemu.

ID: 1987211
Signed-off-by: Yihuang Yu <yihyu@redhat.com>