### PR TITLE
Update marshal_from function to support setup_attrs

### DIFF
--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -120,6 +120,10 @@ class IPXML(base.LibvirtXMLBase):
         """
         if isinstance(item, DhcpHostXML):
             return 'host', item
+        elif isinstance(item, dict):
+            host = DhcpHostXML()
+            host.setup_attrs(**item)
+            return 'host', host
         else:
             raise xcepts.LibvirtXMLError("Expected a list of ip dhcp host "
                                          "instances, not a %s" % str(item))

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -2315,6 +2315,10 @@ class NumaCellXML(base.LibvirtXMLBase):
         """
         if isinstance(item, CellCacheXML):
             return 'cache', item
+        elif isinstance(item, dict):
+            cache = CellCacheXML()
+            cache.setup_attrs(**item)
+            return 'cache', cache
         else:
             raise xcepts.LibvirtXMLError("Expected a list of cell cache "
                                          "instances, not a %s" % str(item))


### PR DESCRIPTION
For XMLElementList accessor that has subclass, we need marshal_from
function to accept dict as arguments to support function setup_attrs

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>