### PR TITLE
Redefine the logger to avoid excessive output at the LOG_UI

### DIFF
--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -34,6 +34,9 @@ from virttest.standalone_test import SUPPORTED_NIC_MODELS
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
 
 
+LOG = logging.getLogger('avocado.vt.options')
+
+
 class VirtTestOptionsProcess(object):
 
     """
@@ -124,8 +127,8 @@ class VirtTestOptionsProcess(object):
                             'config vt.qemu.qemu_bin')
         if (get_opt(self.config, 'vt.config') and
                 get_opt(self.config, 'vt.qemu.qemu_bin') is None):
-            logging.info("Config provided and no %s set. Not trying "
-                         "to automatically set qemu bin.", qemu_bin_setting)
+            LOG.info("Config provided and no %s set. Not trying "
+                     "to automatically set qemu bin.", qemu_bin_setting)
         else:
             (qemu_bin_path, qemu_img_path, qemu_io_path,
              qemu_dst_bin_path) = standalone_test.find_default_qemu_paths(
@@ -146,8 +149,8 @@ class VirtTestOptionsProcess(object):
                             'config vt.qemu.qemu_img')
         if (get_opt(self.config, 'vt.config') and
                 get_opt(self.config, 'vt.qemu.bin') is None):
-            logging.info("Config provided and no %s set. Not trying "
-                         "to automatically set qemu bin", qemu_img_setting)
+            LOG.info("Config provided and no %s set. Not trying "
+                     "to automatically set qemu bin", qemu_img_setting)
         else:
             (_, qemu_img_path,
              _, _) = standalone_test.find_default_qemu_paths(
@@ -191,7 +194,7 @@ class VirtTestOptionsProcess(object):
             elif get_opt(self.config, 'vt.common.nettype') == 'user':
                 self.cartesian_parser.assign("nettype", "user")
         else:
-            logging.info("Config provided, ignoring %s", nettype_setting)
+            LOG.info("Config provided, ignoring %s", nettype_setting)
 
     def _process_monitor(self):
         if not get_opt(self.config, 'vt.config'):
@@ -202,7 +205,7 @@ class VirtTestOptionsProcess(object):
             elif get_opt(self.config, 'vt.qemu.monitor') == 'human':
                 self.cartesian_parser.assign("monitor_type", "human")
         else:
-            logging.info("Config provided, ignoring monitor setting")
+            LOG.info("Config provided, ignoring monitor setting")
 
     def _process_smp(self):
         smp_setting = 'config vt.qemu.smp'
@@ -220,12 +223,12 @@ class VirtTestOptionsProcess(object):
                     raise ValueError("Invalid %s '%s'. Valid value: (1, 2, "
                                      "or integer)" % get_opt(self.config, 'vt.qemu.smp'))
         else:
-            logging.info("Config provided, ignoring %s", smp_setting)
+            LOG.info("Config provided, ignoring %s", smp_setting)
 
     def _process_arch(self):
         if get_opt(self.config, 'vt.config'):
             arch_setting = "option --vt-arch or config vt.common.arch"
-            logging.info("Config provided, ignoring %s", arch_setting)
+            LOG.info("Config provided, ignoring %s", arch_setting)
             return
 
         arch = get_opt(self.config, 'vt.common.arch')
@@ -247,7 +250,7 @@ class VirtTestOptionsProcess(object):
                 self.cartesian_parser.only_filter(get_opt(self.config,
                                                           'vt.common.machine_type'))
         else:
-            logging.info("Config provided, ignoring %s", machine_type_setting)
+            LOG.info("Config provided, ignoring %s", machine_type_setting)
 
     def _process_image_type(self):
         image_type_setting = 'config vt.qemu.image_type'
@@ -260,7 +263,7 @@ class VirtTestOptionsProcess(object):
                 self.cartesian_parser.assign("image_format",
                                              get_opt(self.config, 'vt.qemu.image_type'))
         else:
-            logging.info("Config provided, ignoring %s", image_type_setting)
+            LOG.info("Config provided, ignoring %s", image_type_setting)
 
     def _process_nic_model(self):
         nic_model_setting = 'config vt.qemu.nic_model'
@@ -272,7 +275,7 @@ class VirtTestOptionsProcess(object):
                 self.cartesian_parser.assign(
                     "nic_model", get_opt(self.config, 'vt.qemu.nic_model'))
         else:
-            logging.info("Config provided, ignoring %s", nic_model_setting)
+            LOG.info("Config provided, ignoring %s", nic_model_setting)
 
     def _process_disk_buses(self):
         disk_bus_setting = 'config vt.qemu.disk_bus'
@@ -285,7 +288,7 @@ class VirtTestOptionsProcess(object):
                                   get_opt(self.config, 'vt.qemu.disk_bus'),
                                   SUPPORTED_DISK_BUSES))
         else:
-            logging.info("Config provided, ignoring %s", disk_bus_setting)
+            LOG.info("Config provided, ignoring %s", disk_bus_setting)
 
     def _process_vhost(self):
         nettype_setting = 'config vt.qemu.nettype'
@@ -306,7 +309,7 @@ class VirtTestOptionsProcess(object):
                                         vhost_setting,
                                         get_opt(self.config, 'vt.qemu.vhost')))
         else:
-            logging.info("Config provided, ignoring %s", vhost_setting)
+            LOG.info("Config provided, ignoring %s", vhost_setting)
 
     def _process_qemu_sandbox(self):
         sandbox_setting = 'config vt.qemu.sandbox'
@@ -314,7 +317,7 @@ class VirtTestOptionsProcess(object):
             if get_opt(self.config, 'vt.qemu.sandbox') == "off":
                 self.cartesian_parser.assign("qemu_sandbox", "off")
         else:
-            logging.info("Config provided, ignoring %s", sandbox_setting)
+            LOG.info("Config provided, ignoring %s", sandbox_setting)
 
     def _process_qemu_defconfig(self):
         defconfig_setting = 'config vt.qemu.sandbox'
@@ -322,7 +325,7 @@ class VirtTestOptionsProcess(object):
             if get_opt(self.config, 'vt.qemu.defconfig') == "no":
                 self.cartesian_parser.assign("defconfig", "no")
         else:
-            logging.info("Config provided, ignoring %s", defconfig_setting)
+            LOG.info("Config provided, ignoring %s", defconfig_setting)
 
     def _process_malloc_perturb(self):
         self.cartesian_parser.assign("malloc_perturb",
@@ -375,7 +378,7 @@ class VirtTestOptionsProcess(object):
         guest_os_setting = 'option --vt-guest-os'
 
         if get_opt(self.config, 'vt.type') == 'spice':
-            logging.info("Ignoring predefined OS: %s", guest_os_setting)
+            LOG.info("Ignoring predefined OS: %s", guest_os_setting)
             return
 
         if not get_opt(self.config, 'vt.config'):
@@ -390,7 +393,7 @@ class VirtTestOptionsProcess(object):
             self.cartesian_parser.only_filter(
                 get_opt(self.config, 'vt.guest_os') or defaults.DEFAULT_GUEST_OS)
         else:
-            logging.info("Config provided, ignoring %s", guest_os_setting)
+            LOG.info("Config provided, ignoring %s", guest_os_setting)
 
     def _process_restart_vm(self):
         if not get_opt(self.config, 'vt.config'):

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -59,10 +59,10 @@ from virttest.staging import service
 try:
     import PIL.Image
 except ImportError:
-    logging.warning('No python imaging library installed. PPM image '
-                    'conversion to JPEG disabled. In order to enable it, '
-                    'please install python-imaging or the equivalent for your '
-                    'distro.')
+    logging.getLogger('avocado.app').warning(
+        'No python imaging library installed. PPM image conversion to JPEG '
+        'disabled. In order to enable it, please install python-imaging or the '
+        'equivalent for your distro.')
 
 _screendump_thread = None
 _screendump_thread_termination_event = None

--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -12,8 +12,8 @@ import base64
 try:
     import json
 except ImportError:
-    logging.warning("Could not import json module. "
-                    "virt agent functionality disabled.")
+    logging.getLogger('avocado.app').warning(
+        "Could not import json module. virt agent functionality disabled.")
 
 from avocado.utils import process
 

--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -22,10 +22,10 @@ try:
     from PIL import ImageFont
 except ImportError:
     Image = None
-    logging.warning('No python imaging library installed. Screendump '
-                    'and Windows guest BSOD detection are disabled. '
-                    'In order to enable it, please install python-imaging or '
-                    'the equivalent for your distro.')
+    logging.getLogger('avocado.app').warning(
+        'No python imaging library installed. Screendump and Windows guest BSOD'
+        ' detection are disabled. In order to enable it, please install '
+        'python-imaging or the equivalent for your distro.')
 # Prevent logs pollution
 if Image is not None:
     for _logger_name in logging.root.manager.loggerDict:

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -19,8 +19,8 @@ import six
 try:
     import json
 except ImportError:
-    logging.warning("Could not import json module. "
-                    "QMP monitor functionality disabled.")
+    logging.getLogger('avocado.app').warning(
+        "Could not import json module. QMP monitor functionality disabled.")
 
 from . import passfd_setup
 from . import utils_misc

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -70,8 +70,9 @@ VIRSH_COMMAND_GROUP_CACHE_NO_DETAIL = False
 try:
     VIRSH_EXEC = path.find_command("virsh")
 except path.CmdNotFoundError:
-    logging.warning("Virsh executable not set or found on path, "
-                    "virsh module will not function normally")
+    logging.getLogger('avocado.app').warning(
+        "Virsh executable not set or found on path, virsh module will not "
+        "function normally")
     VIRSH_EXEC = '/bin/true'
 
 

--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -62,8 +62,9 @@ VIRTADMIN_COMMAND_GROUP_CACHE_NO_DETAIL = False
 try:
     VIRTADMIN_EXEC = path.find_command("virt-admin")
 except path.CmdNotFoundError:
-    logging.warning("virt-admin executable not set or found on path, "
-                    "virtadmin-admin module will not function normally")
+    logging.getLogger('avocado.app').warning(
+        "virt-admin executable not set or found on path, virtadmin-admin module"
+        " will not function normally")
     VIRTADMIN_EXEC = '/bin/true'
 
 


### PR DESCRIPTION
As we discussed at avocado-framework/avocado#4797 and #3169, the
current logger will display a lot of excessive output on the LOG_UI. These
outputs are the same as debug.log, they should only be in logs if we
don't use verbose mode, so this is unexpected behavior. Beraldo Leal
provides a good solution in #3169, the code works for me, so I
borrowed his solution to solve this problem accordingly.
    
Some VT modules will use "logging.warning" to print messages outside
the class/function, so when import these modules, the logging.RootLogger
will be initialized before the test execution, which will make the
RootLogger is out of control. Use the LOG_UI is a better choice.

Signed-off-by: Beraldo Leal <bleal@redhat.com>
Signed-off-by: Yihuang Yu <yihyu@redhat.com>