### PR TITLE
vm_xml/set_memoryBacking_tag: add memfd support

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1712,7 +1712,8 @@ class VMXML(VMXMLBase):
 
     @staticmethod
     def set_memoryBacking_tag(vm_name, hpgs=True, nosp=False, locked=False,
-                              virsh_instance=base.virsh, access_mode=None):
+                              virsh_instance=base.virsh, access_mode=None,
+                              memfd=False):
         """
         let the guest using hugepages.
         """
@@ -1723,6 +1724,8 @@ class VMXML(VMXMLBase):
         if hpgs:
             hpgs = VMHugepagesXML()
             mb_xml.hugepages = hpgs
+        if memfd:
+            mb_xml.source_type = "memfd"
         if access_mode is not None:
             mb_xml.access_mode = access_mode
         # Set memoryBacking to the new instance.


### PR DESCRIPTION
Add new parameter to allow for 'memfd' source type.
Per default, the value is not set.

A sample xml will look like:
```
  <memoryBacking>
    <source type="memfd" />
    <access mode="shared" />
  </memoryBacking>
```
Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>