### PR TITLE
VTDiscoverer fix

### DIFF
--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -65,7 +65,7 @@ class VTResolver(VTResolverUtils, Resolver):
         return self._get_reference_resolution(reference)
 
 
-class VTDiscoverer(Discoverer, VTResolverUtils):
+class VTDiscoverer(VTResolverUtils, Discoverer):
 
     name = 'vt-discoverer'
     description = 'Test discoverer for Avocado-VT tests'


### PR DESCRIPTION
The c0430a30d0050eed1205a03161b581f38fd4a61c broke the initialization of
VTDiscoverer. Because of this change, the `avocado list --resolver` and
`avocado run --vt-config` commands not working with nrunner. This is the
fix of that problem.

Signed-off-by: Jan Richter <jarichte@redhat.com>