### PR TITLE
Cirrus CI: workaround for Avocado 91.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ fedora_34_task:
     - python3 -m avocado vt-list-guests --vt-type=$VT_TYPE
     - python3 -m avocado vt-list-archs --vt-type=$VT_TYPE
   dry_run_script: &dry_run_scr
-    - python3 -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
+    - PATH=~/.local/bin:$PATH python3 -m avocado --show all run --vt-type=$VT_TYPE --dry-run -- io-github-autotest-qemu.boot
   run_boot_script: &run_boot_scr
     - test $VT_TYPE == "libvirt" || PATH=$HOME/.local/bin:$PATH python3 -m avocado --show all run --vt-type=$VT_TYPE --vt-extra-params nettype=user -- io-github-autotest-qemu.boot
 


### PR DESCRIPTION
Avocado 91.0 adds a job check for missing runners, that is, when a
runner is not found, the job is aborted.

While other fixes will be included in Avocado 92.0, this will allow
Cirrus CI jobs to find "avocado-runner-dry-run", and hopefully restore
the passing state of jobs currently failing with:

   Avocado job failed: JobError: Could not find runners for runnable(s) of kind(s): dry-run

Signed-off-by: Cleber Rosa <crosa@redhat.com>