### PR TITLE
libvirt: Add more log to check_result() when patterns are found

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1284,11 +1284,16 @@ def check_result(result,
         elif expected_match:
             if isinstance(expected_match, (str, unicode)):
                 expected_match = [expected_match]
-            if not any(re.search(patt, stdout)
-                       for patt in expected_match):
+            search_result = [re.search(patt, stdout)
+                             for patt in expected_match]
+            if not any(search_result):
                 raise exceptions.TestFail("Expect should match with one of %s,"
                                           "but failed with: %s" %
                                           (expected_match, all_msg))
+            else:
+                logging.debug('Found expected content:\n%s',
+                              [r.group(0) for r in search_result
+                               if r is not None])
 
 
 def check_exit_status(result, expect_error=False):


### PR DESCRIPTION
There was no log when patterns are found.Logging found info could
make output more clear.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>