### PR TITLE
 Additional log files for vt-runner

### DIFF
--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -34,6 +34,7 @@ class VirtTest(utils.TestUtils):
         # clear existing error events
         self.background_errors.clear()
         self.debugdir = self.logdir
+        self.outputdir = path.init_dir(self.logdir, 'data')
         self.bindir = data_dir.get_root_dir()
         self.virtdir = os.path.join(self.bindir, 'shared')
 


### PR DESCRIPTION
This commit copies content from the temporary vt logdir to the avocado
test-results. This will bring more useful debug files about test
runtime, which are available on legacy runner.

Reference: #3213
Signed-off-by: Jan Richter <jarichte@redhat.com>