### PR TITLE
from_domcapabilities: Update to specify features' policy

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -2195,10 +2195,9 @@ class VMCPUXML(base.LibvirtXMLBase):
         cpu_xml['model'] = domcaps_xml.get_hostmodel_name()
         features = domcaps_xml.get_additional_feature_list(
                 'host-model', ignore_features=None)
-        feature_names = [name for f_list in [list(d.keys()) for d in features]
-                         for name in f_list]
-        for feature_name in feature_names:
-            cpu_xml.add_feature(feature_name)
+        for feature in features:
+            for feature_name, feature_policy in feature.items():
+                cpu_xml.add_feature(feature_name, policy=feature_policy)
 
         return cpu_xml
 


### PR DESCRIPTION
The policy of some features may be 'disable', so update the policy
when adding a feature.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Before fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.hypervisor_cpu_compare.cpu_xml.f_domcapa_xml: FAIL: Expect success but got:\n (6.89 s)`

**After the fix:**
`1/1) type_specific.io-github-autotest-libvirt.virsh.hypervisor_cpu_compare.cpu_xml.f_domcapa_xml: PASS (6.42 s)`
