### PR TITLE
doc: Add section about custom images

### DIFF
--- a/docs/source/DownloadableImages.rst
+++ b/docs/source/DownloadableImages.rst
@@ -85,3 +85,12 @@ Then it'll compress it using xz, to save space and speed up downloads for
     $ xz jeos-file.qcow2.xz jeos-file.qcow2
 
 As mentioned, the script is supposed to help you with the process.
+
+Custom image
+============
+
+If you want to use a custom image, please keep the following in mind:
+
+1. Per default configuration, the root account in the guests has a specific password. For example, Linux guests expect the password as defined in `virttest/shared/cfg/guest-os/Linux.cfg`.
+2. The guest user's console configuration can have impact on the test code. We recommend to set `TERM=dumb` in case of `bash`. This suppresses control characters.
+


### PR DESCRIPTION
We've found that recently we had to make sure our test images
have `export TERM=dumb` for consoles to suppress control characters
that broke tests.

Add a new section to contain topics that users should keep
in mind when using their own images.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>