### PR TITLE
qdevices.py: add chardev parameters

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2663,6 +2663,10 @@ class DevContainer(object):
             chardev_param.update({'path': file_name})
             if (backend == 'pipe' and params.get('auto_create_pipe', 'yes') == "yes"):
                 process.system("mkfifo %s" % file_name)
+            if backend == 'unix_socket':
+                chardev_param.update(
+                    {'abstract': params.get('chardev_abstract'),
+                     'tight': params.get('chardev_tight')})
         elif backend in ['udp', 'tcp_socket']:
             chardev_param.update(
                 {'host': params['chardev_host'],

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1586,7 +1586,8 @@ class CharDevice(QCustomDevice):
         elif backend in ["socket"]:
             common_opts += ["server", "wait", "reconnect"]
             special_opts = ["host", "port", "to", "ipv4",
-                            "ipv6", "nodelay", "path"]
+                            "ipv6", "nodelay", "path",
+                            "abstract", "tight"]
 
         elif backend == 'udp':
             special_opts = ["host", "port", "localaddr",

--- a/virttest/shared/deps/serial/serial_host_send_receive.py
+++ b/virttest/shared/deps/serial/serial_host_send_receive.py
@@ -222,6 +222,9 @@ def main():
     chardev_type = options.type
     if options.socket:
         device = options.socket
+        # support abstract unix socket address
+        if '@' in device:
+            device = device.replace('@', '\0')
     else:
         parser.error("Please set -s parameter.")
 


### PR DESCRIPTION
ID: 1986691

abstract=on|off specifies the use of the abstract
socket namespace, rather than the filesystem. Optional,
defaults to false. tight=on|off sets the socket length
of abstract sockets to their minimum, rather than the
full sun_path length. Optional, defaults to true.

related tp-qemu patch: [tp-qemu/3008](https://github.com/autotest/tp-qemu/pull/3008)

Signed-off-by: Nana Liu <nanliu@redhat.com>