### PR TITLE
Fix the polkit setup

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -39,7 +39,6 @@ from virttest import storage
 from virttest import utils_libguestfs
 from virttest import qemu_storage
 from virttest import utils_libvirtd
-from virttest import utils_split_daemons
 from virttest import data_dir
 from virttest import utils_net
 from virttest import nfs
@@ -1295,8 +1294,6 @@ def preprocess(test, params, env):
         # work on connect_uri as default behavior.
         os.environ['LIBVIRT_DEFAULT_URI'] = connect_uri
         if params.get("setup_libvirt_polkit") == "yes":
-            if utils_split_daemons.is_modular_daemon():
-                params.update({"conf_path": "/etc/libvirt/virtqemud.conf"})
             pol = test_setup.LibvirtPolkitConfig(params)
             try:
                 pol.setup()
@@ -1306,9 +1303,6 @@ def preprocess(test, params, env):
                 logging.error(str(e))
             except Exception as e:
                 logging.error("Unexpected error: '%s'" % str(e))
-            if libvirtd_inst is None:
-                libvirtd_inst = utils_libvirtd.Libvirtd("virtqemud")
-            libvirtd_inst.restart()
 
     # Execute any pre_commands
     if params.get("pre_command"):


### PR DESCRIPTION
With split daemon, if we're going to enable polkit access control
with the modular daemons it needs to be enabled on all of them
at once. The original code only enable polkit on qemud.conf. So
fix it.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>