### PR TITLE
Make pool target path adjustable in PoolVolumeTest

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -893,7 +893,7 @@ class PoolVolumeTest(object):
     """Test class for storage pool or volume"""
 
     def __init__(self, test, params):
-        self.tmpdir = data_dir.get_data_dir()
+        self.tmpdir = params.get('customize_pool_target_path') or data_dir.get_data_dir()
         self.params = params
         self.selinux_bak = ""
 


### PR DESCRIPTION
The avocado_data path may don't have correct permission settings for
v2v operation, and the unconfigurable path is inconvenient to use.
It's better to add custom param to make the path configurable.

[stderr] stderr: 'error: Failed to start domain 'esx6.5-win2016-x86_64'
error: internal error: process exited while connecting to monitor: 2021-09-22T08:27:59.579473Z qemu-kvm: -blockdev {"driver":"file","filename":"/root/avocado/data/avocado-vt/v2v_dir_pool/esx6.5-win2016-x86_64-sda","node-name":"libvirt-2-storage","auto-read-only":true,"discard":"unmap"}: Could not open '/root/avocado/data/avocado-vt/v2v_dir_pool/esx6.5-win2016-x86_64-sda': Permission denied

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>