### PR TITLE
v2v: make images into default image path when converting vm to libvirt

### DIFF
--- a/virttest/backends/v2v/cfg/convert_destination.cfg
+++ b/virttest/backends/v2v/cfg/convert_destination.cfg
@@ -30,6 +30,7 @@ variants:
         pool_name = v2v_dir
         pool_target = v2v_dir_pool
         output_storage = ${pool_name}
+        customize_pool_target_path = /var/lib/libvirt/images
         vir_domain_undefine_nvram = yes
     - dest_rhev:
         # Output source of ovirt engine, storage and network


### PR DESCRIPTION
The data_dir.get_data_dir() will have permission issue for v2v
operations. It should always use default libvirt image path for testing.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>