### PR TITLE
Increase timeout for monitor commands

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -772,7 +772,7 @@ class HumanMonitor(Monitor):
     """
 
     PROMPT_TIMEOUT = 60
-    CMD_TIMEOUT = 120
+    CMD_TIMEOUT = 900
 
     def __init__(self, vm, name, monitor_params, suppress_exceptions=False):
         """


### PR DESCRIPTION
Under heavy load, saving large Windows 10 VMs (dozens of GBs) can
lead to timeout errors.

This is similar to what was done in 9e24834.

Signed-off-by: Samir Aguiar <samir.aguiar@intra2net.com>