### PR TITLE
libvirt_vm: using module name as logger namespace

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -8,7 +8,7 @@ from __future__ import division
 import time
 import string
 import os
-import logging
+import logging as log
 import fcntl
 import re
 import shutil
@@ -34,6 +34,11 @@ from virttest import xml_utils
 from virttest import utils_selinux
 from virttest import test_setup
 from virttest import utils_package
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def normalize_connect_uri(connect_uri):

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -7,7 +7,7 @@ Utility classes and functions to handle Virtual Machine creation using qemu.
 from __future__ import division
 import time
 import os
-import logging
+import logging as log
 import fcntl
 import re
 import random
@@ -48,6 +48,11 @@ from virttest import error_event
 from virttest.qemu_devices import qdevices, qcontainer
 from virttest.qemu_devices.utils import DeviceError
 from virttest.qemu_capabilities import Flags
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class QemuSegFaultError(virt_vm.VMError):


### PR DESCRIPTION
As discussed in multiple threads in Avocado project, we are using this
new logging approach to avoid touching on the root logger since July.
The next LTS is counting on that and we need to adapt the logging calls
here to use its own namespace.

This is just an test/experiment to see how things will behave here. I'm
choosing this file because is the one with more logging calls.

Signed-off-by: Beraldo Leal <bleal@redhat.com>