### PR TITLE
Add a possibility to customize VT tests via pre-run hooks

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -202,6 +202,10 @@ class VirtTest(test.Test, utils.TestUtils):
 
     def _runTest(self):
         params = self.params
+        if params.get("test_pre_hook"):
+            self.log.info(f"Executing VT test pre-hook from {params['test_pre_hook']}")
+            with open(params["test_pre_hook"]) as f:
+                exec(f.read())
 
         # Report virt test version
         logging.info(version.get_pretty_version_info())


### PR DESCRIPTION
This solves remaining process-isolation issues and background described in 

https://github.com/avocado-framework/avocado-vt/issues/3239

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>