### PR TITLE
Lyf2

### DIFF
--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -16,7 +16,7 @@ PACKAGE_MANAGERS = ['apt-get',
                     'zypper',
                     'dnf']
 
-PKG_MGR_TIMEOUT = 300
+PKG_MGR_TIMEOUT = 380
 
 
 class RemotePackageMgr(object):

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -893,7 +893,7 @@ class PoolVolumeTest(object):
     """Test class for storage pool or volume"""
 
     def __init__(self, test, params):
-        self.tmpdir = data_dir.get_data_dir()
+        self.tmpdir = params.get('customize_pool_target_path') or data_dir.get_data_dir()
         self.params = params
         self.selinux_bak = ""
 


### PR DESCRIPTION
The reason is that in rhel8.2 the time is set to be short, so the so the test doesn't finished in time, it will cause the failure.

The python file is /var/tmp/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/utils_package.py

The python code is :
 `PKG_MGR_TIMEOUT = 300`

From the result log, the failure is about yum install cpuid*.rpm, so at the begin, i try to install rpm software manually, but when i test the case, it causes the failure again. So it doesn't the real reason.

Then I look through many code about all project. Then I begin to try to modify the source code about the time.

I have done many expreiment. And the results have proved the reason.

**8.2**
============== SUCCESS ========= 400 ======================================
JOB ID : a827a27e848ddf6c035ae8047a6910b1659ab984 
JOB LOG : /root/avocado/job-results/job-2021-10-01T09.52-a827a27/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: 
PASS (396.60 s) RESULTS : *PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 397.79 s

================== FAILED ========= 300 =======================
JOB ID : 38196519bd42e38ddb2f9e9c2949371f81527945 
JOB LOG : /root/avocado/job-results/job-2021-10-01T09.20-3819651/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: ERROR: Timeout expired while waiting for shell command to complete: 'yum install -y cpuid*' (output: 'Updating Subscription Management repositories.\nUnable to read consumer identity\nThis system is not registered to Red Hat Subscription Management. You can u... (38.28 s) RESULTS : 
PASS 0 | *ERROR 1* | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 39.47 s

=========== SUCCESS ======== 400 ===============================
JOB ID : a1bf604f81ba161d7f1b24ab5cb6f9b0bd576b3d 
JOB LOG : /root/avocado/job-results/job-2021-10-01T10.01-a1bf604/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: 
PASS (396.34 s) RESULTS : *PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 397.53 s

=================== SUCCESS ========= 397 ==============================
JOB ID : 84698dba8effbc866bb31503a2def13282640e56 
JOB LOG : /root/avocado/job-results/job-2021-10-01T10.19-84698db/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: 
PASS (399.03 s) RESULTS : *PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 400.22 s

======================== SUCCESS ========= 380 ======================
JOB ID : daf2c6bfa71ead2be7d913cdac52506d0bed8f07 
JOB LOG : /root/avocado/job-results/job-2021-10-01T10.26-daf2c6b/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: 
PASS (396.04 s) RESULTS : *PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 397.23 s

================== FAILED ========= 300 =============================
JOB ID : 511f81b1f5b2fe07cbc38dee530408767e291d6f 
JOB LOG : /root/avocado/job-results/job-2021-10-01T10.34-511f81b/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: ERROR: Timeout expired while waiting for shell command to complete: 'yum install -y cpuid*' (output: "Updating Subscription Management repositories.\nUnable to read consumer identity\nThis system is not registered to Red Hat Subscription Management. You can u... (357.79 s) RESULTS : 
PASS 0 | *ERROR 1* | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 358.99 s

================= SUCCESS ========= 370 =====================
JOB ID : 64f094c9ecb5c0c42dcb596f35b333ad712e7892 
JOB LOG : /root/avocado/job-results/job-2021-10-01T10.42-64f094c/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: 
PASS (396.11 s) RESULTS : *PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 397.31 s

================ FAILED ========= 340 ================
JOB ID : 191a139d74b90b0c5b81c5b3a74a094ab98368f5 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.09-191a139/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: |ERROR: Timeout expired while waiting for shell command to complete: 'yum install -y cpuid*' (output: "Updating Subscription Management repositories.\nUnable to read consumer identity\nThis system is not registered to Red Hat Subscription Management. You can u... (368.52 s) RESULTS : 
PASS 0 | *ERROR 1* | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 369.72 s

================== FAILED ========= 350 =====================
JOB ID : ced5815a12005d6c8e35dab5191acfa06ba0cb54 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.21-ced5815/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: ERROR: Timeout expired while waiting for shell command to complete: 'yum install -y cpuid*' (output: "Updating Subscription Management repositories.\nUnable to read consumer identity\nThis system is not registered to Red Hat Subscription Management. You can u... (377.80 s) RESULTS : 
PASS 0 | *ERROR 1* | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 378.99 s

==================== FAILED ========= 360 ==================
JOB ID : 36c7da47d137d829df526121e1f4943aa45dcea4 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.28-36c7da4/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: ERROR: Timeout expired while waiting for shell command to complete: 'yum install -y cpuid*' (output: "Updating Subscription Management repositories.\nUnable to read consumer identity\nThis system is not registered to Red Hat Subscription Management. You can u... (387.11 s) RESULTS : 
PASS 0 | *ERROR 1* | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 388.31 s

=================================================================================================


**8.5**
================== SUCCESS ========= 300 ===================
JOB ID : e2fe0aafd5daca10b0e9f08e4aa143a930234924 
JOB LOG : /root/avocado/job-results/job-2021-10-01T10.41-e2fe0aa/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: PASS (41.11 s) RESULTS : 
*PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 42.36 s

=================== SUCCESS ========= 40 ====================
JOB ID : a16a4f182c8a6f7388f88e485aa16564866c3cbe 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.13-a16a4f1/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: PASS (38.39 s) RESULTS : 
*PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 39.62 s

=============== SUCCESS ========= 30 =========
JOB ID : 605bd4b23d1241b1017545573002b9da729c8cf4 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.21-605bd4b/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: PASS (37.51 s) RESULTS : 
*PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 38.75 s

============== SUCCESS ========= 20 ===============
JOB ID : 2139cac831c1923f173ccdce3c7372fecc4c570d 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.27-2139cac/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: PASS (40.27 s) RESULTS : 
*PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 41.51 s

=========== FAILED ========= 10 ================
JOB ID : 45ffe8dc7e6bd8d15638e6726a6da577ac454990 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.29-45ffe8d/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: ERROR: Timeout expired while waiting for shell command to complete: 'yum install -y cpuid*.rpm' (output: 'Updating Subscription Management repositories.\nUnable to read consumer identity\n\nThis system is not registered with an entitlement server. You can use... (32.96 s) RESULTS : 
PASS 0 | *ERROR 1* | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 34.20 s

======== SUCCESS ========= 15 ===========
JOB ID : a5c52972969e1b4d9358f606922cbfa25f03e654 
JOB LOG : /root/avocado/job-results/job-2021-10-01T11.31-a5c5297/job.log (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: 
PASS (38.57 s) RESULTS : *PASS 1* | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 JOB TIME : 39.78 s

=================================================================================================


So the final result is that we can modify the source python code about the time.

If a script test does not require 300 seconds, such as RHEL8.5, which currently tests in 15 seconds or so, then it will only use 15 seconds; However, if the experiment is conducted on RHEL8.2, the test time is around 370 seconds, so 300 seconds is far from enough.
 So we can simply set the scheduled script execution time to be greater than or equal to 370 seconds, so the test can run correctly. 