### PR TITLE
Removal experimental warning of vt nrunner

### DIFF
--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -38,8 +38,6 @@ class VTResolverUtils(DiscoveryMixIn):
         runnables = [self._parameters_to_runnable(d) for d in
                      cartesian_parser.get_dicts()]
         if runnables:
-            warnings.warn("The VT NextRunner is experimental and doesn't have "
-                          "current Avocado VT features")
             if self.config.get("nrunner.max_parallel_tasks", 1) != 1:
                 warnings.warn("The VT NextRunner can be run only with "
                               "nrunner-max-parallel-tasks set to 1")


### PR DESCRIPTION
After the #3226 and [avocado/#4908](https://github.com/avocado-framework/avocado/pull/4908) the vt nrunner has almost every legacy
features and becomes to be the default runner for vt tests. Let's remove
the warning about experimental manner of vt nrunner.

Signed-off-by: Jan Richter <jarichte@redhat.com>