### PR TITLE
Fixup: xml missing from definition of VMPerfXML.EventXML

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -3607,6 +3607,7 @@ class VMPerfXML(base.LibvirtXMLBase):
                                    attribute='enabled')
             super(VMPerfXML.EventXML, self).__init__(
                 virsh_instance=virsh_instance)
+            self.xml = '<event/>'
 
         def update(self, attr_dict):
             for attr, value in list(attr_dict.items()):


### PR DESCRIPTION
Set default xml to EventXML instance to fix the issue of xml missing.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>