### PR TITLE
qemu_vm: change the smp pattern to match maxcpus correctly

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -586,7 +586,7 @@ class VM(virt_vm.BaseVM):
 
         def add_smp(devices):
             smp_str = " -smp %d" % self.cpuinfo.smp
-            smp_pattern = "smp .*\[,maxcpus=cpus\].*"
+            smp_pattern = "smp .*\[,maxcpus=.*\].*"
             if devices.has_option(smp_pattern):
                 smp_str += ",maxcpus=%d" % self.cpuinfo.maxcpus
             if self.cpuinfo.cores != 0:


### PR DESCRIPTION
Upstream qemu change with commit 553dc36b38, it tweak
[, maxcpus=cpus] to [, maxcpus=maxcpus] in qemu-options

id: 2013885

Signed-off-by: Yanan Fu <yfu@redhat.com>