### PR TITLE
libvirt_nested: not control daemon

### DIFF
--- a/virttest/utils_libvirt/libvirt_nested.py
+++ b/virttest/utils_libvirt/libvirt_nested.py
@@ -4,8 +4,8 @@ from avocado.core import exceptions
 from avocado.utils import process
 
 from virttest import cpu
-from virttest import utils_libvirtd
 from virttest import utils_package
+
 
 LOG = logging.getLogger('avocado.' + __name__)
 
@@ -23,8 +23,6 @@ def install_virt_pkgs(vm_session):
     if not pkg_mgr.install():
         raise exceptions.TestError("Package '%s' installation "
                                    "fails" % pkg_names)
-    libvirtd = utils_libvirtd.Libvirtd(session=vm_session)
-    libvirtd.restart()
 
 
 def enable_nested_virt_on_host():


### PR DESCRIPTION
Previous restarting libvirtd daemon method requires to recognize if the
environment is a monolithic vs modular daemons as default. But after
the libvirt packages are installed in L1 guest, those daemons are not
expected to be started automatically. So preovious restarting method
can not work correctly on right daemons. To make the right daemons
start correctly, it is easy to reboot the vm directly or explicitly
restart it by name in certain case which will be more flexible. So
this fix is to remove that part and leave the control to the invoker.

Signed-off-by: Dan Zheng <dzheng@redhat.com>