### PR TITLE
is_modular_daemon: update to check if daemons are enabled

### DIFF
--- a/virttest/utils_split_daemons.py
+++ b/virttest/utils_split_daemons.py
@@ -415,7 +415,7 @@ def is_modular_daemon(session=None):
                    "virtnwfilterd.socket", "virtsecretd.socket",
                    "virtstoraged.socket", "virtproxyd.socket"]
 
-        if any([service.Factory.create_service(d, run=runner).status()
+        if any([service.Factory.create_service(d, run=runner).is_enabled()
                 for d in daemons]):
             IS_MODULAR_DAEMON[host_key] = True
         else:


### PR DESCRIPTION
Even in a modular daemons environment, all virt*d.socket may not
be running, so update to check if the daemons are enabled.

Signed-off-by: Yingshun Cui <yicui@redhat.com>