### PR TITLE
backends: add new test type virttools

### DIFF
--- a/virttest/backends/virttools/cfg/drivers.cfg
+++ b/virttest/backends/virttools/cfg/drivers.cfg
@@ -1,0 +1,3 @@
+# Configuration files for some special variables in specific uri.
+variants:
+    - qemu:

--- a/virttest/backends/virttools/cfg/tests-shared.cfg
+++ b/virttest/backends/virttools/cfg/tests-shared.cfg
@@ -1,0 +1,34 @@
+# Copy this file to tests-shared.cfg and edit it.
+#
+# This file contains the base test set definitions, shared among single host
+# and multi host jobs.
+
+# Virtualization type (qemu or libvirt)
+vm_type = libvirt
+# The hypervisor uri (default, qemu://hostname/system, etc.)
+# where default or unset means derive from installed system
+connect_uri = default
+
+# Include the base config files.
+include base.cfg
+include subtests.cfg
+include host.cfg
+include machines.cfg
+include guest-os.cfg
+include guest-hw.cfg
+include cdkeys.cfg
+include virtio-win.cfg
+# Include special variable for specific driver.
+include drivers.cfg
+
+# Modify/comment the following lines if you wish to modify the paths of the
+# image files, ISO files or qemu binaries.
+#
+# As for the defaults:
+# * qemu and qemu-img are expected to be found under /usr/bin/qemu-kvm and
+#   /usr/bin/qemu-img respectively.
+
+# Uncomment the following lines to enable abort-on-error mode:
+#abort_on_error = yes
+#kill_vm.* ?= no
+#kill_unresponsive_vms.* ?= no

--- a/virttest/backends/virttools/cfg/tests.cfg
+++ b/virttest/backends/virttools/cfg/tests.cfg
@@ -1,0 +1,26 @@
+# File reserved for avocado-vt use, don't modify.
+include tests-shared.cfg
+
+variants:
+    - @virttools_quick:
+        start_vm = no
+        virt_install_binary = /usr/bin/virt-install
+        qemu_img_binary = /usr/bin/qemu-img
+        hvm_or_pv = hvm
+        use_os_variant = yes
+        use_os_type = yes
+        only qcow2
+        only virtio_net
+        only virtio_blk
+        only smp2
+        only no_9p_export
+        only no_virtio_rng
+        only no_pci_assignable
+        only (image_backend=filesystem)
+        only smallpages
+        only default_bios
+        only bridge
+
+
+
+only virttools_quick

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -36,7 +36,8 @@ recommended_programs = {'qemu': [('qemu-kvm', 'kvm'), ('qemu-img',),
                         'openvswitch': [],
                         'lvsb': [('semanage',), ('getfattr',), ('restorecon',), ('virt-sandbox')],
                         'v2v': [],
-                        'libguestfs': [('perl',)]}
+                        'libguestfs': [('perl',)],
+                        'virttools': []}
 
 mandatory_programs = {'qemu': basic_program_requirements + ['gcc'],
                       'spice': basic_program_requirements + ['gcc'],
@@ -44,7 +45,11 @@ mandatory_programs = {'qemu': basic_program_requirements + ['gcc'],
                       'openvswitch': basic_program_requirements,
                       'lvsb': ['virt-sandbox', 'virt-sandbox-service', 'virsh'],
                       'v2v': basic_program_requirements,
-                      'libguestfs': basic_program_requirements}
+                      'libguestfs': basic_program_requirements,
+                      'virttools': basic_program_requirements + ['virt-install',
+                                                                 'virt-clone',
+                                                                 'virt-manager',
+                                                                 'virt-xml']}
 
 mandatory_headers = {'qemu': ['Python.h', 'types.h', 'socket.h', 'unistd.h'],
                      'spice': [],
@@ -52,7 +57,8 @@ mandatory_headers = {'qemu': ['Python.h', 'types.h', 'socket.h', 'unistd.h'],
                      'openvswitch': [],
                      'v2v': [],
                      'lvsb': [],
-                     'libguestfs': []}
+                     'libguestfs': [],
+                     'virttools': []}
 
 first_subtest = {'qemu': ['unattended_install', 'steps'],
                  'spice': ['unattended_install', 'steps'],
@@ -60,7 +66,8 @@ first_subtest = {'qemu': ['unattended_install', 'steps'],
                  'openvswitch': ['unattended_install'],
                  'v2v': ['unattended_install'],
                  'libguestfs': ['unattended_install'],
-                 'lvsb': []}
+                 'lvsb': [],
+                 'virttools': []}
 
 last_subtest = {'qemu': ['shutdown'],
                 'spice': ['shutdown'],
@@ -68,7 +75,8 @@ last_subtest = {'qemu': ['shutdown'],
                 'openvswitch': ['shutdown'],
                 'v2v': ['shutdown'],
                 'libguestfs': ['shutdown'],
-                'lvsb': []}
+                'lvsb': [],
+                'virttools': []}
 
 test_filter = ['__init__', 'cfg', 'dropin.py']
 

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -26,7 +26,7 @@ def _variant_only_file(filename):
 #: value.  See :func:`avocado_vt.plugins.vt.add_basic_vt_options` and
 #: class:`avocado_vt.options.VirtTestOptionsProcess` for usage examples.
 SUPPORTED_TEST_TYPES = [
-    'qemu', 'libvirt', 'libguestfs', 'openvswitch', 'v2v', 'lvsb', 'spice']
+    'qemu', 'libvirt', 'libguestfs', 'openvswitch', 'v2v', 'lvsb', 'spice', 'virttools']
 
 SUPPORTED_LIBVIRT_URIS = ['qemu:///system', 'lxc:///']
 SUPPORTED_LIBVIRT_DRIVERS = ['qemu', 'lxc', 'xen']

--- a/virttest/test-providers.d/io-github-autotest-libvirt.ini
+++ b/virttest/test-providers.d/io-github-autotest-libvirt.ini
@@ -8,3 +8,5 @@ subdir: libguestfs/
 subdir: lvsb/
 [v2v]
 subdir: v2v/
+[virttools]
+subdir: virttools/


### PR DESCRIPTION
Adds a new test type 'virttools' intended to be used for tools offered by the 'virt-manager' repository:

- virt-manager
- virt-clone
- virt-install
- virt-xml

A passing test case for this new type is available in https://github.com/autotest/tp-libvirt/pull/3923

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>