### PR TITLE
[WIP]migration: Add RPC driver for multiple hosts migration

### DIFF
--- a/virttest/vt_agent/run_server.py
+++ b/virttest/vt_agent/run_server.py
@@ -1,0 +1,43 @@
+import logging
+import os
+import sys
+import time
+
+import service_manager
+
+basedir = os.path.dirname(__file__)
+logs_dir = os.path.join(basedir, 'logs')
+
+server_host = sys.argv[1]
+server_port = sys.argv[2]
+
+
+if __name__ == '__main__':
+    os.makedirs(logs_dir, 0o777, True)
+    timestamp = time.strftime("%Y-%b-%d-%H:%M:%S")
+    logfile = os.path.join(logs_dir, "server_daemon_%s.log" % timestamp)
+    fmt = '%(asctime)s [%(levelname)-5.5s] - %(message)s'
+    logging.basicConfig(level=logging.DEBUG, format=fmt,
+                        handlers=[logging.FileHandler(logfile),
+                                  logging.StreamHandler()]
+                        )
+
+    target = os.path.join(logs_dir, "latest")
+    if os.path.exists(target):
+        os.unlink(target)
+    os.symlink(logfile, target)
+
+    logging.info("Listening on port %s.", server_port)
+    services = service_manager.init_services()
+
+    try:
+        addr = (server_host, int(server_port))
+        server = service_manager.RPCServer(addr)
+        server.register_services(services)
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logging.warn("Keyboard interrupt received, exiting.")
+        sys.exit(0)
+    except Exception as e:
+        logging.error(e, exc_info=True)
+        sys.exit(-1)

--- a/virttest/vt_agent/service_manager.py
+++ b/virttest/vt_agent/service_manager.py
@@ -1,0 +1,117 @@
+import inspect
+import logging
+import sys
+import traceback
+import os
+import imp
+
+from xmlrpc.server import SimpleXMLRPCServer
+from xmlrpc.client import Fault
+from xmlrpc.client import dumps
+from xmlrpc.client import loads
+
+
+class ServiceError(Exception):
+    pass
+
+
+class Services(object):
+    def __init__(self):
+        self._services = {}
+
+    def register_service(self, name, service):
+        self._services[name] = service
+
+    def get_service(self, name):
+        try:
+            return self._services[name]
+        except KeyError:
+            raise ServiceError("No support service '%s'." % name)
+
+    def __iter__(self):
+        for name, service in self._services.items():
+            yield name, service
+
+
+def init_services(mod_dirs=["services"]):
+    services = Services()
+    for mod_dir in mod_dirs:
+        basedir = os.path.dirname(__file__)
+        services_dir = os.path.join(basedir, mod_dir)
+        service_mods = [os.path.join(services_dir, m[:-3])
+                        for m in os.listdir(services_dir) if m.endswith(".py")]
+        modules = []
+
+        for service in service_mods:
+            f, p, d = imp.find_module(service)
+            modules.append(imp.load_module(service, f, p, d))
+            f.close()
+
+        for service in modules:
+            name = os.path.split(service.__dict__["__name__"])[-1]
+            services.register_service(name, service)
+    return services
+
+
+class _CustomsSimpleXMLRPCServer(SimpleXMLRPCServer):
+    def _marshaled_dispatch(self, data, dispatch_method=None, path=None):
+        try:
+            params, method = loads(data, use_builtin_types=self.use_builtin_types)
+
+            # generate response
+            if dispatch_method is not None:
+                response = dispatch_method(method, params)
+            else:
+                response = self._dispatch(method, params)
+            # wrap response in a singleton tuple
+            response = (response,)
+            response = dumps(response, methodresponse=1,
+                             allow_none=self.allow_none,
+                             encoding=self.encoding)
+        except Fault as fault:
+            response = dumps(fault, allow_none=self.allow_none,
+                             encoding=self.encoding)
+        except:
+            # report exception back to server
+            exc_type, exc_value, exc_tb = sys.exc_info()
+
+            tb_info = traceback.format_exception(exc_type, exc_value,
+                                                 exc_tb.tb_next)
+            tb_info = "".join([_ for _ in tb_info])
+            try:
+                mod = exc_type.__dict__.get("__module__", "")
+                if mod:
+                    _exc_type = ".".join((mod, exc_type.__name__))
+                    _exc_value = exc_value.__dict__
+                else:
+                    _exc_type = exc_type.__name__
+                    _exc_value = str(exc_value)
+                response = dumps(Fault((_exc_type, _exc_value), tb_info),
+                                 encoding=self.encoding,
+                                 allow_none=self.allow_none)
+                logging.error(tb_info)
+            finally:
+                # Break reference cycle
+                exc_type = exc_value = exc_tb = None
+
+        return response.encode(self.encoding, 'xmlcharrefreplace')
+
+
+class RPCServer(object):
+    def __init__(self, addr=()):
+        self._server = _CustomsSimpleXMLRPCServer(addr, allow_none=False,
+                                                  use_builtin_types=False)
+
+    def register_services(self, services):
+        for name, service in services:
+            members = [_ for _ in inspect.getmembers(service)]
+            for member in members:
+                member_name = member[0]
+                member_obj = member[1]
+                if inspect.isfunction(member_obj):
+                    function_name = ".".join((name, member_name))
+                    logging.info("Registers service: %s", function_name)
+                    self._server.register_function(member_obj, function_name)
+
+    def serve_forever(self):
+        self._server.serve_forever()

--- a/virttest/vt_agent/services/service_test_setup.py
+++ b/virttest/vt_agent/services/service_test_setup.py
@@ -1,0 +1,49 @@
+import os
+
+from virttest.utils_misc import *
+from avocado.utils.process import *
+
+from avocado.utils import process
+
+from virttest import utils_misc
+from virttest import env_process
+
+
+def get_kvm_version(enable_kvm=True):
+    if os.path.exists("/dev/kvm"):
+        return os.uname()[2]
+    else:
+        if enable_kvm:
+            return None
+
+
+def get_kvm_userspace_version(params):
+    kvm_userspace_ver_cmd = params.get("kvm_userspace_ver_cmd", "")
+    if kvm_userspace_ver_cmd:
+        try:
+            kvm_userspace_version = process.run(
+                kvm_userspace_ver_cmd, shell=True).stdout_text.strip()
+        except process.CmdError:
+            kvm_userspace_version = "Unknown"
+    else:
+        qemu_path = utils_misc.get_qemu_binary(params)
+        kvm_userspace_version = env_process._get_qemu_version(qemu_path)
+        qemu_dst_path = utils_misc.get_qemu_dst_binary(params)
+        if qemu_dst_path and qemu_dst_path != qemu_path:
+            kvm_userspace_version = env_process._get_qemu_version(qemu_dst_path)
+    return kvm_userspace_version
+
+
+def process_command(params, bindir, command, command_noncritical):
+    # Export environment vars
+    for k in params:
+        os.putenv("KVM_TEST_%s" % k, str(params[k]))
+    # Execute commands
+    try:
+        process.system("cd %s; %s" % (bindir, command), shell=True)
+    except process.CmdError as e:
+        if command_noncritical:
+            return str(e)
+        else:
+            return False
+    return True

--- a/virttest/vt_agent/services/service_vm.py
+++ b/virttest/vt_agent/services/service_vm.py
@@ -1,0 +1,98 @@
+import os
+import signal
+import time
+import logging
+
+from virttest import data_dir
+
+from avocado.utils.process import kill_process_tree as _kill_process_tree
+from avocado.utils.process import pid_exists
+from avocado.utils import process
+from avocado.utils.astring import to_text
+
+from virttest.utils_misc import *
+
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def get_testlog_filename(instance):
+    return os.path.join(data_dir.get_tmp_dir(), "testlog-%s" % instance)
+
+
+def kill_process_tree(pid, sig=signal.SIGKILL, send_sigcont=True, timeout=0):
+    """Signal a process and all of its children.
+
+    If the process does not exist -- return.
+
+    :param pid: The pid of the process to signal.
+    :param sig: The signal to send to the processes.
+    :param send_sigcont: Send SIGCONT to allow destroying stopped processes
+    :param timeout: How long to wait for the pid(s) to die
+                    (negative=infinity, 0=don't wait,
+                    positive=number_of_seconds)
+    """
+    try:
+        return _kill_process_tree(pid, sig, send_sigcont, timeout)
+    except TypeError:
+        LOG.warning("Trying to kill_process_tree with timeout but running"
+                    " old Avocado without it's support. Sleeping for 10s "
+                    "instead.")
+        # Depending on the Avocado version this can either return None or
+        # list of killed pids.
+        ret = _kill_process_tree(pid, sig, send_sigcont)    # pylint: disable=E1128
+        if timeout != 0:
+            # Use fixed 10s wait when no support for timeout in Avocado
+            time.sleep(10)
+            if pid_exists(pid):
+                raise RuntimeError("Failed to kill_process_tree(%s)" % pid)
+        return ret
+
+
+def get_nic_device_name(nic_params):
+    return process.run(nic_params.get("device_name").split(':', 1)[1], shell=True).stdout_text
+
+
+def get_pid(pid):
+    """
+    Return the VM's PID.  If the VM is dead return None.
+
+    :note: This works under the assumption that self.process.get_pid()
+    :return: the PID of the parent shell process.
+    """
+    try:
+        cmd = "ps --ppid=%d -o pid=" % pid
+        children = process.run(cmd, verbose=False, ignore_status=True).stdout_text.split()
+        return int(children[0])
+    except (TypeError, IndexError, ValueError):
+        return None
+
+
+def get_qemu_threads(pid):
+    """
+    Return the list of qemu SPIDs
+
+    :return: the list of qemu SPIDs
+    """
+    try:
+        return os.listdir("/proc/%d/task" % pid)
+    except Exception:
+        return []
+
+
+def get_serial_console_filename(instance, name=None):
+    if name:
+        return os.path.join(data_dir.get_tmp_dir(),
+                            "serial-%s-%s" % (name, instance))
+    return os.path.join(data_dir.get_tmp_dir(),
+                        "serial-%s" % instance)
+
+
+def get_qemu_version(qemu_binary):
+    return process.run("%s -version" % qemu_binary, verbose=False,
+                       ignore_status=True, shell=True).stdout_text.split(',')[0]
+
+
+def get_support_cpu_model(qemu_binary):
+    return to_text(process.run("%s -cpu \\?" % qemu_binary, verbose=False,
+                               ignore_status=True, shell=True).stdout, errors='replace')

--- a/virttest/vt_node.py
+++ b/virttest/vt_node.py
@@ -1,0 +1,61 @@
+# This module provides VT Node interfaces
+import socket
+
+
+from virttest import vt_proxy
+
+
+class NodeError(Exception):
+    pass
+
+
+class Node(object):
+    def __init__(self, params, name):
+        self.params = params
+        self._name = name
+        _address = self.hostname if self.hostname else self.address
+        _uri = "http://%s:%s/" % (_address, self.proxy_port)
+        _hostname = socket.gethostname()
+        self._uri = None if self.hostname == _hostname else _uri
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def proxy(self):
+        return vt_proxy.get_server_proxy(self._uri)
+
+    @property
+    def hostname(self):
+        node_hostname = self.params.get("node_hostname")
+        if node_hostname:
+            return node_hostname
+        return self.address
+
+    @property
+    def address(self):
+        node_address = self.params.get("node_address")
+        if node_address:
+            return node_address
+        return self.hostname
+
+    @property
+    def proxy_port(self):
+        return self.params.get("node_proxy_port", "8000")
+
+    @property
+    def username(self):
+        return self.params.get("node_username", "root")
+
+    @property
+    def password(self):
+        return self.params.get("node_password")
+
+    @property
+    def shell_port(self):
+        return self.params.get("node_shell_port", "22")
+
+    @property
+    def shell_prompt(self):
+        return self.params.get("node_shell_prompt", "#")

--- a/virttest/vt_proxy.py
+++ b/virttest/vt_proxy.py
@@ -1,0 +1,60 @@
+from xmlrpc import client
+
+from virttest.utils_agent import service_manager
+
+
+class ServerProxyError(Exception):
+    pass
+
+
+def _importer(name, root_package=False, relative_globals=None, level=0):
+    return __import__(name, locals=None, globals=relative_globals,
+                      fromlist=[] if root_package else [None], level=level)
+
+
+class _ClientMethod:
+    def __init__(self, send, name):
+        self.__send = send
+        self.__name = name
+
+    def __getattr__(self, name):
+        return _ClientMethod(self.__send, "%s.%s" % (self.__name, name))
+
+    def __call__(self, *args):
+        try:
+            return self.__send(self.__name, args)
+        except client.Fault as e:
+            if "." in e.faultCode[0]:
+                root_mod = ".".join(e.faultCode[0].split(".")[:-1])
+                exc_type = e.faultCode[0].split(".")[-1]
+            kargs = e.faultCode[1]
+            if isinstance(kargs, dict):
+                raise getattr(_importer(root_mod), exc_type)(**kargs)
+            elif isinstance(kargs, str):
+                raise eval(e.faultCode[0])(kargs)
+
+
+class _ClientServerProxy(client.ServerProxy):
+    def __getattr__(self, name):
+        return _ClientMethod(self._ServerProxy__request, name)
+
+
+class ClientServerProxy(object):
+    def __init__(self, uri):
+        self._proxy = _ClientServerProxy(uri, allow_none=True,
+                                         use_builtin_types=True)
+
+    def __getattr__(self, name):
+        return getattr(self._proxy, name)
+
+
+class LocalServerProxy(object):
+    def __init__(self):
+        self._services = service_manager.init_services()
+
+    def __getattr__(self, name):
+        return self._services.get_service(name)
+
+
+def get_server_proxy(uri=None):
+    return ClientServerProxy(uri) if uri else LocalServerProxy()


### PR DESCRIPTION
Server Host:
```
# hostname
server.host.com
# python -m run_server server.host.com 8000
2021-12-09 22:00:07,502 [INFO ] - Listening on port 8000.
2021-12-09 22:00:07,662 [WARNI] - No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
2021-12-09 22:00:07,730 [WARNI] - No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
2021-12-09 22:00:07,807 [INFO ] - Registers service: service_test_setup.add_identities_into_ssh_agent
2021-12-09 22:00:07,807 [INFO ] - Registers service: service_test_setup.add_ker_cmd
2021-12-09 22:00:07,807 [INFO ] - Registers service: service_test_setup.archive_as_tarball
2021-12-09 22:00:07,807 [INFO ] - Registers service: service_test_setup.asterisk_passwd
...
2021-12-09 22:00:07,826 [INFO ] - Registers service: service_vm.verify_dmesg
2021-12-09 22:00:07,826 [INFO ] - Registers service: service_vm.verify_running_as_root
2021-12-09 22:00:07,826 [INFO ] - Registers service: service_vm.wait_for
2021-12-09 22:00:07,826 [INFO ] - Registers service: service_vm.write_keyval
2021-12-09 22:00:07,826 [INFO ] - Registers service: service_vm.write_pid
```

Client Host:
```
# hostname
client.host.com
# python
>>> from virttest import vt_node
>>> remote_params = {}
>>> remote_params["node_hostname"] = "server.host.com"
>>> remote_params["node_proxy_port"] = "8000"
>>> remote_node = vt_node.Node(remote_params, "remote_node")
>>> local_params = {}
>>> local_params["node_hostname"] = "client.host.com"
>>> local_node = vt_node.Node(local_params, "local_node")
>>> remote_node.proxy.service_test_setup.cmd_status_output("hostname")
[0, 'server.host.com']
>>> local_node.proxy.service_test_setup.cmd_status_output("hostname")
(0, 'client.host.com')
>>> remote_node.proxy.service_test_setup.find_command("ifconfig")
'/sbin/ifconfig'
>>> local_node.proxy.service_test_setup.find_command("ifconfig")
'/sbin/ifconfig'
```




Signed-off-by: Yongxue Hong <yhong@redhat.com>