### PR TITLE
Libvirtd: Add all_daemons param

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1789,7 +1789,7 @@ def postprocess(test, params, env):
                 pol = test_setup.LibvirtPolkitConfig(params)
                 pol.cleanup()
                 if libvirtd_inst is None:
-                    libvirtd_inst = utils_libvirtd.Libvirtd()
+                    libvirtd_inst = utils_libvirtd.Libvirtd(all_daemons=True)
                 libvirtd_inst.restart()
             except test_setup.PolkitConfigCleanupError as e:
                 err += "\nPolkit cleanup: %s" % str(e).replace('\\n', '\n  ')

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2089,7 +2089,7 @@ class LibvirtPolkitConfig(object):
         """
         self._setup_libvirtd()
         # restart libvirtd or split daemon after the setup
-        libvirtd = utils_libvirtd.Libvirtd()
+        libvirtd = utils_libvirtd.Libvirtd(all_daemons=True)
         libvirtd.restart()
         # Use 'testacl' if unprivileged_user in cfg contains string 'EXAMPLE',
         # and if user 'testacl' is not exist on host, create it for test.

--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -32,15 +32,18 @@ class Libvirtd(object):
     Class to manage libvirtd service on host or guest.
     """
 
-    def __init__(self, service_name=None, session=None):
+    def __init__(self, service_name=None, session=None, all_daemons=False):
         """
         Initialize an service object for libvirtd.
 
         :params service_name: Service name such as virtqemud or libvirtd.
-            If service_name is None, all sub daemons will be operated when
-            modular daemon environment is enabled. Otherwise,if service_name is
-            a single string, only the given daemon/service will be operated.
+            If service_name is None or 'libvirt' and all_daemons is True,
+            all sub daemons will be operated when modular daemon environment is
+            enabled. Otherwise, if service_name is a single string, only the
+            given daemon/service will be operated.
         :params session: An session to guest or remote host.
+        :params all_daemons: Whether to operate all daemons when modular daemons
+            are enabled. It only works if service_name is None or 'libvirtd'.
         """
         self.session = session
         if self.session:
@@ -49,6 +52,7 @@ class Libvirtd(object):
         else:
             runner = process.run
 
+        self.all_daemons = all_daemons
         self.daemons = []
         self.service_list = []
 
@@ -61,11 +65,12 @@ class Libvirtd(object):
         if libvirt_version.version_compare(5, 6, 0, self.session):
             if utils_split_daemons.is_modular_daemon(session=self.session):
                 if self.service_name in ["libvirtd", "libvirtd.service"]:
-                    self.service_list = ['virtqemud', 'virtproxyd',
-                                         'virtnetworkd', 'virtinterfaced',
-                                         'virtnodedevd', 'virtsecretd',
-                                         'virtstoraged', 'virtnwfilterd']
                     self.service_name = "virtqemud"
+                    if self.all_daemons:
+                        self.service_list = ['virtqemud', 'virtproxyd',
+                                             'virtnetworkd', 'virtinterfaced',
+                                             'virtnodedevd', 'virtsecretd',
+                                             'virtstoraged', 'virtnwfilterd']
                 elif self.service_name == "libvirtd.socket":
                     self.service_name = "virtqemud.socket"
                 elif self.service_name in ["libvirtd-tcp.socket", "libvirtd-tls.socket"]:

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3738,13 +3738,14 @@ def customize_libvirt_config(params,
     # Hardcode config_type to virtqemud under modularity daemon mode when config_type="libvirtd"
     # On the contrary, hardcode it to "libvirtd" when config_type="virt*d".
     # Otherwise accept config_type as it is.
+    modular_daemons = ["virtqemud", "virtproxyd", "virtnetworkd",
+                       "virtstoraged", "virtinterfaced", "virtnodedevd",
+                       "virtnwfilterd", "virtsecretd"]
     if utils_split_daemons.is_modular_daemon():
         if config_type in ["libvirtd"]:
             config_type = "virtqemud"
     else:
-        if config_type in ["virtqemud", "virtproxyd", "virtnetworkd",
-                           "virtstoraged", "virtinterfaced", "virtnodedevd",
-                           "virtnwfilterd", "virtsecretd"]:
+        if config_type in modular_daemons:
             config_type = "libvirtd"
     config_list_support = ["libvirtd", "qemu", "sysconfig", "guestconfig",
                            "virtqemud", "virtproxyd", "virtnetworkd",
@@ -3757,6 +3758,7 @@ def customize_libvirt_config(params,
     else:
         LOG.debug("The '%s' config file will be updated.", config_type)
 
+    daemon_name = config_type if config_type in modular_daemons else None
     if not is_recover:
         target_conf = None
         # Handle local
@@ -3769,7 +3771,7 @@ def customize_libvirt_config(params,
         LOG.debug("The '%s' config file is updated with:\n %s",
                   target_conf.conf_path, params)
         if restart_libvirt:
-            libvirtd = utils_libvirtd.Libvirtd()
+            libvirtd = utils_libvirtd.Libvirtd(daemon_name)
             libvirtd.restart()
         obj_conf = target_conf
     else:
@@ -3778,7 +3780,7 @@ def customize_libvirt_config(params,
         # Handle local libvirtd
         config_object.restore()
         if restart_libvirt:
-            libvirtd = utils_libvirtd.Libvirtd()
+            libvirtd = utils_libvirtd.Libvirtd(daemon_name)
             libvirtd.restart()
         obj_conf = config_object
 


### PR DESCRIPTION
By default, we only need to operate 'virtqemud' in modular daemons
mode now. So add a new param to determine whether to process all
sub-daemons.

Signed-off-by: Yingshun Cui <yicui@redhat.com>