### PR TITLE
rng_required_qemu: use lazy assignment for rng required_qemu

### DIFF
--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -439,7 +439,7 @@ variants:
         #period_virtio-rng-pci =
         variants:
              - rng_builtin:
-                 required_qemu = [4.2, )
+                 required_qemu ~= [4.2, )
                  backend_rng0 = rng-builtin
                  backend_type = builtin
              - rng_random:


### PR DESCRIPTION
Use lazy assignment for rng required_qemu to avoid overwriting the
configuration in case level.

ID: 1974032

Signed-off-by: ybduan <yduan@redhat.com>