### PR TITLE
Update the version of the aexpect to the latest available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2; python_version < '3.0'
-aexpect>=1.6.0;python_version >= '3.0'
+aexpect>=1.6.3;python_version >= '3.0'
 aexpect>1.5.0; python_version < '3.0'
 simplejson>=3.5.3
 netaddr<=0.7.19; python_version < '3.0'


### PR DESCRIPTION
Since some new tests introduced changes in the aexpect repo, this
commit is about updating the required version to make sure the
tests are running on the latest aexpect version to succed.

Signed-off-by: Kamil Varga <kvarga@redhat.com>