### PR TITLE
Fixup inspekt check failure

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,6 +1,6 @@
 Sphinx==1.3b1
 # inspektor (static and style checks)
-pylint>=2.8.0; python_version >= '3.6'
+pylint==2.11.1; python_version >= '3.6'
 inspektor==0.5.2
 aexpect==1.6.0
 simplejson==3.8.0


### PR DESCRIPTION
Inspekt check will fail until a new version releases, so fix pylint
version to a stable version as a workaround.

Signed-off-by: Yingshun Cui <yicui@redhat.com>