### PR TITLE
Update the unit of tc burst

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4553,9 +4553,11 @@ def check_class_rules(ifname, rule_id, bandwidth):
             assert ceil_check == int(bandwidth["peak"]) * 8
         if "burst" in bandwidth:
             if tc_htb.group(6) == 'M':
-                tc_burst = int(tc_htb.group(5)) * 1024
-            else:
+                tc_burst = int(tc_htb.group(5)) * 1000
+            elif tc_htb.group(6) == 'K':
                 tc_burst = int(tc_htb.group(5))
+            else:
+                tc_burst = int(tc_htb.group(5)) / 1000
             assert tc_burst == int(bandwidth["burst"])
     except AssertionError:
         stacktrace.log_exc_info(sys.exc_info())


### PR DESCRIPTION
For ovs bridge type interface, when we set bandwidth, the unit of
burst value in tc is b, take this situation into account. And correct
the unit conversion(refer to https://bugzilla.redhat.com/show_bug.cgi?id=1510237#c23 
the unit should be 1000. not 1024).

Signed-off-by: Yalan <yalzhang@redhat.com>