### PR TITLE
Bump the aexpect version to 1.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2; python_version < '3.0'
-aexpect>=1.6.3;python_version >= '3.0'
+aexpect==1.6.2;python_version >= '3.0'
 aexpect>1.5.0; python_version < '3.0'
 simplejson>=3.5.3
 netaddr<=0.7.19; python_version < '3.0'


### PR DESCRIPTION
This reverts commit c6d915d3bf08d4cc5693018db4a29f1dc6656020.
The aexpect 1.6.3 has problem which blocks virt-v2v testing on
windows guests.

The defective commit is only applied to some rare cases. Compared
the impact to virt-v2v, it's worth reverting it and wait following
PR to be merged, then bump it to the new aexpect version.

The aexpect PR:
https://github.com/avocado-framework/aexpect/pull/90