### PR TITLE
Compatibility with Avocado

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,6 +67,7 @@ avocado_devel_task:
   container:
     image: quay.io/avocado-framework/avocado-vt-ci-fedora-34
     kvm: true
+  allow_failures: $AVOCADO_SRC == 'git+https://github.com/avocado-framework/avocado#egg=avocado_framework'
   env:
     matrix:
       # Latest Avocado

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,10 +10,10 @@ fedora_34_task:
     matrix:
       # Get deps from setup.py (therefor pip version of avocado)
       - AVOCADO_SRC:
-      # Latest LTS release is 82.x
+      # Older LTS release is 82.x
       - AVOCADO_SRC: avocado-framework<83.0
-      # Latest Avocado from git
-      - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+      # Latest LTS release is 92.x
+      - AVOCADO_SRC: avocado-framework<93.0
     matrix:
       - SETUP: setup.py develop --user
       - SETUP: -m pip install .
@@ -21,7 +21,7 @@ fedora_34_task:
     matrix:
       - VT_TYPE: qemu
       - VT_TYPE: libvirt
-  build_script:
+  build_script: &build_scr
     - (echo $SETUP | grep -v PYPI_UPLOAD) || make pypi
   setup_script: &setup_scr
     - python3 --version
@@ -47,12 +47,43 @@ centos_8_1_task:
     image: quay.io/avocado-framework/avocado-vt-ci-centos-8.1
   env:
     matrix:
-      - AVOCADO_SRC:
+      # Older LTS release is 82.x
       - AVOCADO_SRC: avocado-framework<83.0
-      - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+      # Latest LTS release is 92.x
+      - AVOCADO_SRC: avocado-framework<93.0
     matrix:
       - SETUP: setup.py develop --user
       - SETUP: -m pip install .
+  setup_script:
+    *setup_scr
+  bootstrap_script:
+    *bootstrap_scr
+  list_script:
+    *list_scr
+  dry_run_script:
+    *dry_run_scr
+
+avocado_devel_task:
+  container:
+    image: quay.io/avocado-framework/avocado-vt-ci-fedora-34
+    kvm: true
+  env:
+    matrix:
+      # Latest Avocado
+      - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado#egg=avocado_framework
+      # 82lts tree (from where new 82.x releases will come)
+      - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado@82lts#egg=avocado_framework
+      # 92lts tree (from where new 92.x releases will come)
+      - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado@92lts#egg=avocado_framework
+    matrix:
+      - SETUP: setup.py develop --user
+      - SETUP: -m pip install .
+      - SETUP: -m pip install PYPI_UPLOAD/*.whl
+    matrix:
+      - VT_TYPE: qemu
+      - VT_TYPE: libvirt
+  build_script:
+    *build_scr
   setup_script:
     *setup_scr
   bootstrap_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,7 @@ centos_8_1_task:
   env:
     matrix:
       - AVOCADO_SRC:
-      - AVOCADO_SRC: avocado-framework<70.0
+      - AVOCADO_SRC: avocado-framework<83.0
       - AVOCADO_SRC: git+https://github.com/avocado-framework/avocado#egg=avocado_framework
     matrix:
       - SETUP: setup.py develop --user

--- a/setup.py
+++ b/setup.py
@@ -44,14 +44,6 @@ class Clean(clean):
                 shutil.rmtree(e)
 
 
-def pre_post_plugin_type():
-    try:
-        from avocado.core.plugin_interfaces import JobPreTests as Pre
-        return 'avocado.plugins.result_events'
-    except ImportError:
-        return 'avocado.plugins.job.prepost'
-
-
 if __name__ == "__main__":
     setup(name='avocado-framework-plugin-vt',
           version=VERSION,
@@ -77,7 +69,7 @@ if __name__ == "__main__":
                   'vt-list-guests = avocado_vt.plugins.vt_list_guests:VTListGuests',
                   'vt-list-archs = avocado_vt.plugins.vt_list_archs:VTListArchs',
                   ],
-              pre_post_plugin_type(): [
+              'avocado.plugins.result_events': [
                   'vt-joblock = avocado_vt.plugins.vt_joblock:VTJobLock',
                   ],
               'avocado.plugins.init': [
@@ -94,6 +86,6 @@ if __name__ == "__main__":
                   ],
               },
           install_requires=["netifaces", "simplejson", "six", "netaddr",
-                            "aexpect", "avocado-framework>=68.0"],
+                            "aexpect", "avocado-framework>=82.1"],
           cmdclass={'clean': Clean},
           )


### PR DESCRIPTION
Hi Avocado-VT developers and maintainers,

This is a PR that needs a bit of special attention from you.  While it looks just like CI level updates, it proposes a decoupling between the development branch of Avocado and Avocado-VT.  This should allow for Avocado to develop new features faster, while still considering compatibility between Avocado and Avocado-VT.

A couple of important points:

1) Every new Avocado development sprint includes a week for stabilization and bug fixes.  If changes are introduced in the latest Avocado development that causes a compatibility issue, there would still be one week to work on bringing back compatibility.

2) The goal continues to be having all Avocado and Avocado-VT regular releases compatible, but that will depend on available resources.  Compromise scenarios may be:
2.1) Every "even" release is compatible (or every odd release, effectively every 2 releases)
2.2) Only LTS versions are compatible

This is also an invitation for developers to work on this specific area and make the primary goal a reality. If we fail to have compatibility achieved for every release, we need to understand the resource limitations and settle on one of the other scenarios (every couple of
releases or LTS releases).

@luckyh @chunfuwen @pevogam (and everyone else) feedback is very welcome here!