### PR TITLE
Bump the aexpect version to 1.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autotest>=0.16.2; python_version < '3.0'
-aexpect>=1.6.3;python_version >= '3.0'
+aexpect>=1.6.4;python_version >= '3.0'
 aexpect>1.5.0; python_version < '3.0'
 simplejson>=3.5.3
 netaddr<=0.7.19; python_version < '3.0'


### PR DESCRIPTION
aexpect 1.6.3 has a problem which blocks the nc client. It was fixed
in 1.6.4. so let's bump it to the new version.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>