### PR TITLE
Fix the get_host_ip_address()

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3510,7 +3510,8 @@ def get_host_ip_address(params=None, ip_ver="ipv4", linklocal=False):
         net_dev = get_default_gateway(iface_name=True)
     LOG.warning("No IP address of host was provided, using IP address"
                 " on %s interface", net_dev)
-    return get_ip_address_by_interface(net_dev, ip_ver, linklocal)
+    single_dev = net_dev.split('\n')[0].strip()
+    return get_ip_address_by_interface(single_dev, ip_ver, linklocal)
 
 
 def get_all_ips():


### PR DESCRIPTION
Sometimes there are 2 default gateway on the host, which cause the
get_ip_address_by_interface() to fail with value error. Update it
to pass a single interface name.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>