### PR TITLE
Workaround for removal of "allow_output_check" parameter

### DIFF
--- a/virttest/libvirt_installer.py
+++ b/virttest/libvirt_installer.py
@@ -43,7 +43,7 @@ class LIBVIRTBaseInstaller(base_installer.BaseInstaller):
         if os.path.isdir(self.rpmbuild_path):
             process.system("rm -rf %s/*" % self.rpmbuild_path)
         LOG.debug("Build libvirt rpms")
-        process.system("make rpm", allow_output_check="combined")
+        process.system("make rpm")
 
     def _install_phase_package_verify(self):
         """
@@ -67,7 +67,7 @@ class LIBVIRTBaseInstaller(base_installer.BaseInstaller):
         package_install_cmd += " --replacefiles --oldpackage"
         package_install_cmd += " %s/RPMS/%s/libvirt*" % (self.rpmbuild_path,
                                                          platform.machine())
-        process.system(package_install_cmd, allow_output_check="combined")
+        process.system(package_install_cmd)
 
     def _install_phase_init(self):
         """
@@ -76,7 +76,7 @@ class LIBVIRTBaseInstaller(base_installer.BaseInstaller):
         :return: None
         """
         LOG.debug("Initialize installed libvirt package")
-        process.system("service libvirtd restart", allow_output_check="combined")
+        process.system("service libvirtd restart")
 
     def _install_phase_init_verify(self):
         """
@@ -85,8 +85,8 @@ class LIBVIRTBaseInstaller(base_installer.BaseInstaller):
         :return: None
         """
         LOG.debug("Check libvirt package install")
-        process.system("service libvirtd status", allow_output_check="combined")
-        process.system("virsh capabilities", allow_output_check="combined")
+        process.system("service libvirtd status")
+        process.system("virsh capabilities")
 
     def uninstall(self):
         '''

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -143,14 +143,14 @@ class DevContainer(object):
                % qemu_binary)
         result = process.run(cmd, timeout=10,
                              ignore_status=True,
-                             allow_output_check="combined",
                              shell=True,
                              verbose=False)
         # Some architectures (arm) require machine type to be always set and some
         # hardware/firmware restrictions cause we need to set machine type.
         failed_pattern = r'(?:kvm_init_vcpu.*failed)|(?:machine specified)' \
                          r'|(?:appending -machine)'
-        if result.exit_status and re.search(failed_pattern, result.stdout_text):
+        output = result.stdout_text + result.stderr_text
+        if result.exit_status and re.search(failed_pattern, output):
             self.__workaround_machine_type = True
             basic_qemu_cmd = "%s -machine none" % qemu_binary
         else:

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -757,7 +757,6 @@ def command(cmd, **dargs):
     quiet = dargs.get('quiet', False)
     unprivileged_user = dargs.get('unprivileged_user', None)
     timeout = dargs.get('timeout', None)
-    allow_output_check = dargs.get('allow_output_check', None)
 
     # Check if this is a VirshPersistent method call
     if session_id:
@@ -809,7 +808,6 @@ def command(cmd, **dargs):
         # Raise exception if ignore_status is False
         ret = process.run(cmd, timeout=timeout, verbose=debug,
                           ignore_status=ignore_status,
-                          allow_output_check=allow_output_check,
                           shell=True)
         # Mark return as not coming from persistent virsh session
         ret.from_session_id = None


### PR DESCRIPTION
The allow_output_check parameter on the avocado.utils.process.run()
method was meant for use by the "--allow-output-check" feature, but
given it was public API, using it was fair game.

To the best of my knowledge, the parameter is not really needed in
Avocado-VT (it was a nice to have).

Reference: https://github.com/avocado-framework/avocado-vt/issues/3299
Signed-off-by: Cleber Rosa <crosa@redhat.com>