### PR TITLE
Fix get iface error

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3885,7 +3885,7 @@ def get_default_gateway(iface_name=False, session=None):
     :rtype: string
     """
     if iface_name:
-        cmd = "ip route | awk '/default/ { print $5 }'"
+        cmd = "ip route | awk '/default.*proto/ { print $5 }'"
     else:
         cmd = "ip route | awk '/default/ { print $3 }'"
     try:


### PR DESCRIPTION
resolve the get method as ip route may display like this

default via 10.73.11.254 dev eno1
default via 10.73.11.254 dev eno1 proto dhcp metric 100

which cause error from "addr = netifaces.ifaddresses(ifname).get(ver)" like
ValueError: You must specify a valid interface name.

Signed-off-by: Kyla Zhang <weizhan@redhat.com>