### PR TITLE
cartesian_config: can't replace variable with names with "-"

### DIFF
--- a/selftests/unit/test_cartesian_config.py
+++ b/selftests/unit/test_cartesian_config.py
@@ -387,25 +387,36 @@ class CartesianConfigTest(unittest.TestCase):
                     var += a
                     var <= b
                     system = 2
-                    ddd = ${tests + str(int(system) + 3)}4
-                    error = ${tests + str(system + 3)}4
-                    s.* ?= ${tests + "ahoj"}4
+                    variable-name-with-dashes = sampletext
+                    ddd = tests variant is ${tests}
+                    dashes = show ${variable-name-with-dashes}
+                    error = ${tests + str(int(system) + 3)}4
+                    s.* ?= ${tests}ahoj4
                     s.* ?+= c
                     s.* ?<= d
                     system += 4
                     var += "test"
+                    1st = 1
+                    starts_with_number = index ${1st}
+                    not_a_substitution = ${}
             """,
                               [
                                   {'_name_map_file': {'<string>': '(tests=system1)'},
                                    '_short_name_map_file': {'<string>': 'system1'},
-                                   'ddd': 'system154',
+                                   'variable-name-with-dashes': 'sampletext',
+                                   'ddd': 'tests variant is system1',
+                                   'dashes': 'show sampletext',
                                    'dep': [],
-                                   'error': '${tests + str(system + 3)}4',
+                                   'error': '${tests + str(int(system) + 3)}4',
                                    'name': '(tests=system1)',
                                    'shortname': 'system1',
                                    'system': 'dsystem1ahoj4c4',
                                    'tests': 'system1',
-                                   'var': 'b2atest'},
+                                   'var': 'b2atest',
+                                   '1st': '1',
+                                   'starts_with_number': 'index 1',
+                                   'not_a_substitution': '${}',
+                                   },
                               ],
                               True)
 

--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -610,11 +610,11 @@ def _substitution(value, d):
             match = match_substitute.search(value, start)
             while match:
                 d_flat = _drop_suffixes(d)
-                val = eval(match.group(1), None, d_flat)
+                val = d_flat[match.group(1)]
                 st += value[start:match.start()] + str(val)
                 start = match.end()
                 match = match_substitute.search(value, start)
-        except Exception:
+        except KeyError:
             pass
         st += value[start:len(value)]
         return st

--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -606,10 +606,10 @@ def _substitution(value, d):
     if "$" in value:
         start = 0
         st = ""
+        d_flat = _drop_suffixes(d)
         try:
             match = match_substitute.search(value, start)
             while match:
-                d_flat = _drop_suffixes(d)
                 val = d_flat[match.group(1)]
                 st += value[start:match.start()] + str(val)
                 start = match.end()


### PR DESCRIPTION
Value substitutions of variables with a "-" are now parsed properly.
The scope of the ignored exception has been minimized to KeyError so other possible exceptions are not masked.

ID: 2027950