### PR TITLE
libvirt_xml/devices/watchdog: move try_modprobe function here

### DIFF
--- a/virttest/libvirt_xml/devices/watchdog.py
+++ b/virttest/libvirt_xml/devices/watchdog.py
@@ -4,6 +4,8 @@ watchdog device support class(es)
 http://libvirt.org/formatdomain.html#elementsWatchdog
 """
 
+import aexpect
+
 from virttest.libvirt_xml import accessors
 from virttest.libvirt_xml.devices import base
 
@@ -29,3 +31,21 @@ class Watchdog(base.UntypedDeviceBase):
                                  tag_name='alias')
         super(Watchdog, self).__init__(device_tag='watchdog',
                                        virsh_instance=virsh_instance)
+
+    def try_modprobe(self, session):
+        """
+        Tries to load watchdog kernel module
+
+        :param session: guest session
+        :return: False if module can't be loaded
+        """
+        handled_types = {"ib700": "ib700wdt", "diag288": "diag288_wdt"}
+        if self.model_type not in handled_types.keys():
+            return False
+        module = handled_types.get(self.model_type)
+        try:
+            session.cmd("modprobe %s" % module)
+        except aexpect.ShellCmdError:
+            session.close()
+            return False
+        return True


### PR DESCRIPTION
In order for watchdog to be functional it might be necessary to load
the corresponding kernel module.
Move this function from tp-libvirt watchdog test here to make
it available for more tests.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>