### PR TITLE
vm_xml: Support getting dict type cpu feature

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -2041,6 +2041,17 @@ class VMCPUXML(base.LibvirtXMLBase):
             feature_list.append(feature_node)
         return feature_list
 
+    def get_dict_type_feature(self):
+        """
+        Get dict type cpu feature list.
+
+        :return: Dict, CPU feature. For example {"name1":"policy1","name2":"policy2"}
+        """
+        feature_dict = {}
+        for feature in self.get_feature_list():
+            feature_dict[feature.get('name')] = feature.get('policy')
+        return feature_dict
+
     def get_feature_index(self, name):
         """
         Get the feature's index in the feature list by given name


### PR DESCRIPTION
 A PR to add function that support getting dict type cpu feature

Signed-off-by: nanli <nanli@redhat.com>

**Test result** : /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 vcpu_misc.positive_test.managedsave_restore --vt-connect-uri qemu:///system
JOB ID     : d4757db9f7971041b571fa4e6521cc1b8ca2f0f2
JOB LOG    : /root/avocado/job-results/job-2021-12-20T17.59-d4757db/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.managedsave_restore: PASS (5.22 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 5.63 s
