### PR TITLE
`_save_log_dir` removal

### DIFF
--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -15,10 +15,12 @@ class VirtTest(test.VirtTest):
 
     def __init__(self, queue, runnable):
         self.queue = queue
+        base_logdir = getattr(runnable, 'output_dir', None)
         vt_params = runnable.kwargs
         vt_params['job_env_cleanup'] = 'no'
         kwargs = {'name': TestID(1, runnable.uri),
                   'config': runnable.config,
+                  'base_logdir': base_logdir,
                   'vt_params': vt_params}
         super().__init__(**kwargs)
 
@@ -67,7 +69,8 @@ class VirtTest(test.VirtTest):
                                "in `debug.log` for details.")
             self.queue.put(messages.StderrMessage.get(traceback.format_exc()))
         finally:
-            self._save_log_dir()
+            if 'avocado_test_' in self.logdir:
+                self._save_log_dir()
             self.queue.put(messages.FinishedMessage.get(status, fail_reason))
 
 


### PR DESCRIPTION
After the changes in
https://github.com/avocado-framework/avocado/pull/5179 the avocado
spawners are managing the test output dir. Because of this change,
avocado-vt doesn't have to save results after the test because the
avocado spawner will manage that. This will save the resources and also
make test-results available during the test runtime on avocado
`ProcesSpawner`.

Signed-off-by: Jan Richter <jarichte@redhat.com>