### PR TITLE
libvirt : Add more timeout to get device name

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -551,7 +551,7 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
             _iscsi.login()
             # The device doesn't necessarily appear instantaneously, so give
             # about 5 seconds for it to appear before giving up
-            iscsi_device = utils_misc.wait_for(_iscsi.get_device_name, 5, 0, 1,
+            iscsi_device = utils_misc.wait_for(_iscsi.get_device_name, 10, 0, 1,
                                                "Searching iscsi device name.")
             if iscsi_device:
                 LOG.debug("iscsi device: %s", iscsi_device)


### PR DESCRIPTION
* Add draft pr for storage related issue:  Give more timeout to get device name.

     Issue id : LIBVIRTAT-11378/11379/7504/5860/

* Signed-off-by: nanli nanli@redhat.com

* Test results :
/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 vcpu_misc.positive_test.managedsave_restore --vt-connect-uri qemu:///system
JOB ID : 94b232838f0a0d7dd1b54c65c300621f14bbf192
JOB LOG : /root/avocado/job-results/job-2021-12-15T15.10-94b2328/job.log
(1/1) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.managedsave_restore: PASS (4.64 s)
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 5.07 s