### PR TITLE
The unit of burst should be 1024 not 1000

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4554,11 +4554,9 @@ def check_class_rules(ifname, rule_id, bandwidth):
             assert ceil_check == int(bandwidth["peak"]) * 8
         if "burst" in bandwidth:
             if tc_htb.group(6) == 'M':
-                tc_burst = int(tc_htb.group(5)) * 1000
-            elif tc_htb.group(6) == 'K':
-                tc_burst = int(tc_htb.group(5))
+                tc_burst = int(tc_htb.group(5)) * 1024
             else:
-                tc_burst = int(tc_htb.group(5)) / 1000
+                tc_burst = int(tc_htb.group(5))
             assert tc_burst == int(bandwidth["burst"])
     except AssertionError:
         stacktrace.log_exc_info(sys.exc_info())


### PR DESCRIPTION
After confirmed with developers, the correct unit for burst should
be 1024 not 1000. Update it accordingly, refer to
https://bugzilla.redhat.com/show_bug.cgi?id=1510237#c27

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>