### PR TITLE
qdevices: Tweaks the way of starting daemon

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -169,7 +169,7 @@ class QBaseDevice(object):
 
     def __eq__(self, dev2, dynamic=True):
         """ :return: True when devs are similar, False when different. """
-        if not isinstance(dev2, QBaseDevice):
+        if not isinstance(dev2, type(self)):
             return False
         check_attrs = ['cmdline_nd', 'hotplug_hmp_nd', 'hotplug_qmp_nd']
         try:

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1868,8 +1868,7 @@ class QDaemonDev(QBaseDevice):
         return self.get_aid()
 
     def cmdline(self):
-        """Start daemon command line."""
-        self.start_daemon()
+        """Start command line."""
         return ''
 
     def __eq__(self, other):


### PR DESCRIPTION
1. Decouple the method "start_daemon()" from the method "cmdline()"
since there is no such cmdline is used for qemu binary to start
in fact and it is not reasonable from the logical side, but calling
the start_daemon method to run it.

2. For comparing the type of instance between dev2 and self,
the previous design compares the base class, not the type
of self, it maybe should compare the current type of self
to conform to the normal flow.

ID: 2039158
Signed-off-by: Yongxue Hong <yhong@redhat.com>