### PR TITLE
CI updates: cirrus, gha and requirements-travis.txt

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,9 +2,9 @@ env:
   CIRRUS_CLONE_DEPTH: 1
   VT_TYPE: qemu
 
-fedora_34_task:
+fedora_35_task:
   container:
-    image: quay.io/avocado-framework/avocado-vt-ci-fedora-34
+    image: quay.io/avocado-framework/avocado-vt-ci-fedora-35
     kvm: true
   env:
     matrix:
@@ -65,7 +65,7 @@ centos_8_1_task:
 
 avocado_devel_task:
   container:
-    image: quay.io/avocado-framework/avocado-vt-ci-fedora-34
+    image: quay.io/avocado-framework/avocado-vt-ci-fedora-35
     kvm: true
   allow_failures: $AVOCADO_SRC == 'git+https://github.com/avocado-framework/avocado#egg=avocado_framework'
   env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.1]
       fail-fast: false
 
     steps:
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.1]
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,24 @@ on:
 
 jobs:
 
+  static-checks:
+    name: Static checks
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check signed-off-by
+        run: ./selftests/signedoff-check.sh
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y make
+      - name: Install dependencies
+        run: pip install -r requirements-travis.txt
+      - name: Run tests
+        run: make check
+
+
   travis-check:
 
     name: Python ${{ matrix.python-version }}
@@ -52,12 +70,6 @@ jobs:
          echo "/tmp/dummy_bin" >> $GITHUB_PATH
       - name: Setup Avocado-vt for functional tests
         run: AVOCADO_LOG_DEBUG=yes avocado vt-bootstrap --vt-skip-verify-download-assets --yes-to-all
-      - name: Run tests
-        run: inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E1003,W605 --disable-style W605,W606,E501,E265,W601,E402,E722,E741 --exclude avocado-libs,scripts/github --no-license-check
-      - name: Run spellchecker
-        run: pylint --errors-only --disable=all --ignore=avocado-libs --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
-      - name: Check signed-off-by
-        run: ./selftests/signedoff-check.sh
       - run: echo "This job's status is ${{ job.status }}."
 
   package-build:

--- a/contrib/containers/ci/fedora-30.docker
+++ b/contrib/containers/ci/fedora-30.docker
@@ -1,4 +1,0 @@
-FROM fedora:30
-LABEL description "Fedora image used on integration checks, such as cirrus-ci"
-RUN dnf -y install git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
-RUN dnf -y clean all

--- a/contrib/containers/ci/fedora-35.docker
+++ b/contrib/containers/ci/fedora-35.docker
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:35
 LABEL description "Fedora image used on integration checks, such as cirrus-ci"
 RUN dnf -y install make python3-wheel python3-pip git xz tcpdump nc iproute iputils gcc python3-devel qemu-kvm qemu-img
 RUN dnf -y clean all

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,9 +1,9 @@
 Sphinx==1.3b1
 # inspektor (static and style checks)
-pylint>=2.8.0; python_version >= '3.6'
+pylint==2.12.2
 inspektor==0.5.3
-aexpect==1.6.0
+aexpect==1.6.4
 simplejson==3.8.0
 netaddr==0.7.19
-netifaces>=0.10.5
-pyenchant
+netifaces==0.11.0
+pyenchant==3.2.2


### PR DESCRIPTION
 * Cirrus CI: add dockerfile for Fedora 35
    
This dockerfile is the source for the pre-built container at https://quay.io/repository/avocado-framework/avocado-vt-ci-fedora-35
Remove old dockerfiles.

* CI: add test on Python 3.10.1
* `requirements-travis.txt`: update and use fixed versions