### PR TITLE
utils_misc: add more informative error description to set_winutils_letter

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2477,7 +2477,11 @@ def set_winutils_letter(session, cmd, label="WIN_UTILS"):
     :param label: volume label of WIN_UTILS.iso
     """
     if label in cmd:
-        return cmd.replace(label, get_winutils_vol(session))
+        volume = get_winutils_vol(session)
+        if volume is not None:
+            return cmd.replace(label, get_winutils_vol(session))
+        else:
+            raise ValueError("Failed to set winutils letter due to missing volume ID.")
     return cmd
 
 


### PR DESCRIPTION
`set_winutils_letter` fails with an error (see below please) if `None` instead of string containing volume ID is returned by `get_winutils_vol` and then passed as an argument to `replace` function:

```
20:02:22 ERROR|     return cmd.replace(label, get_winutils_vol(session))
20:02:22 ERROR| TypeError: replace() argument 2 must be str, not None
```

PR adds more descriptive error message.

id: 2041500

Signed-off-by: Lukas Kotek <lkotek@redhat.com>