### PR TITLE
customize_libvirt_config: Check if log dir exists

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3792,6 +3792,15 @@ def customize_libvirt_config(params,
         remote.scp_to_remote(server_ip, '22', server_user, server_pwd,
                              local_path, local_path, limit="",
                              log_filename=None, timeout=600, interface=None)
+
+        # It fails to start some daemons with a non-existent log directory，
+        # so create one to avoid this problem.
+        with utils_config.get_conf_obj(config_type) as config:
+            log_outputs_list = config.log_outputs.split(':')
+            if 'file' in log_outputs_list:
+                log_file_path = log_outputs_list[log_outputs_list.index('file') + 1]
+                cmd = "ls {0} || mkdir -p {0}".format(os.path.dirname(log_file_path))
+                remote_old.run_remote_cmd(cmd, extra_params, ignore_status=False)
         if restart_libvirt:
             remotely_control_libvirtd(server_ip, server_user, server_pwd,
                                       action='restart', status_error='no')


### PR DESCRIPTION
It fails to start virtqemud with a non-existent log directory
in the latest libvirt, so create dirs if need.

Signed-off-by: Yingshun Cui <yicui@redhat.com>