### PR TITLE
customize_libvirt_config: Fix LibvirtConfigUnknownKeyError issue

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3796,8 +3796,8 @@ def customize_libvirt_config(params,
         # It fails to start some daemons with a non-existent log directory，
         # so create one to avoid this problem.
         with utils_config.get_conf_obj(config_type) as config:
-            log_outputs_list = config.log_outputs.split(':')
-            if 'file' in log_outputs_list:
+            if 'log_outputs' in config and 'file:' in config.log_outputs:
+                log_outputs_list = config.log_outputs.split(':')
                 log_file_path = log_outputs_list[log_outputs_list.index('file') + 1]
                 cmd = "ls {0} || mkdir -p {0}".format(os.path.dirname(log_file_path))
                 remote_old.run_remote_cmd(cmd, extra_params, ignore_status=False)


### PR DESCRIPTION
It was introduced by 6275087334d. There's no 'log_outputs' in some
config_type.

Signed-off-by: Yingshun Cui <yicui@redhat.com>


**Test results:**
```
JOB LOG    : /root/avocado/job-results/job-2022-01-23T20.15-9b8be49/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.stress.vm.iozone_with_set_max_downtime.with_postcopy: PASS (137.93 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.live_migration.native_tls.migrate_x509_no.default_x509_zero.by_shared.p2p_live.without_postcopy: PASS (185.99 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 324.65 s
```
