### PR TITLE
test_setup: restore correct original_config in TransparentHugePageConfig

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1277,7 +1277,7 @@ def preprocess(test, params, env):
             libvirtd_inst.restart()
 
     if params.get("setup_thp") == "yes":
-        thp = test_setup.TransparentHugePageConfig(test, params)
+        thp = test_setup.TransparentHugePageConfig(test, params, env)
         thp.setup()
 
     if params.get("setup_ksm") == "yes":
@@ -1758,7 +1758,7 @@ def postprocess(test, params, env):
 
     if params.get("setup_thp") == "yes":
         try:
-            thp = test_setup.TransparentHugePageConfig(test, params)
+            thp = test_setup.TransparentHugePageConfig(test, params, env)
             thp.cleanup()
         except Exception as details:
             err += "\nTHP cleanup: %s" % str(details).replace('\\n', '\n  ')


### PR DESCRIPTION
1. The 'original_config' be used to restore in cleanup() should be the config
   before setup, it is incorrect to get a new 'original_config' with a new
   TransparentHugePageConfig instance when doing cleanup.
2. Logically, khugepaged_test doesn't belong to setup(), so move it
   out. It can be called on demand.

id: 1654144
Signed-off-by: Yanan Fu <yfu@redhat.com>