### PR TITLE
v2v: fix multiple version compare issue

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1968,7 +1968,7 @@ def multiple_versions_compare(interval):
 
     :param interval: An interval is a string representation of a
     """
-    re_pkg_name = r'(.*?)-(?=\d+\.?)+'
+    re_pkg_name = r',?(.*?)-(?=\d+\.?)+'
     versions = interval.split(';')
     # ';' is used to split multiple pkgs.
     for ver_i in versions:


### PR DESCRIPTION
When the version is like "[,virt-v2v-1.43.1-5)", the function
multiple_versions_compare cannot get correct package name.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>