### PR TITLE
verify_dmesg: don't fail on expected messages

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -35,6 +35,7 @@ filesystem
 filename
 cpu
 env
+environ
 cgroup
 ip
 rtype

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1882,12 +1882,14 @@ def postprocess(test, params, env):
     if params.get("verify_host_dmesg", "yes") == "yes":
         dmesg_log_file = params.get("host_dmesg_logfile", "host_dmesg.log")
         level = params.get("host_dmesg_level", 3)
+        expected_host_dmesg = params.get("expected_host_dmesg", "")
         ignore_result = params.get("host_dmesg_ignore", "no") == "yes"
         dmesg_log_file = utils_misc.get_path(test.debugdir, dmesg_log_file)
         try:
             utils_misc.verify_dmesg(dmesg_log_file=dmesg_log_file,
                                     ignore_result=ignore_result,
-                                    level_check=level)
+                                    level_check=level,
+                                    expected_dmesg=expected_host_dmesg)
         except exceptions.TestFail as details:
             err += "\nHost dmesg verification failed: %s" % details
 

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -578,9 +578,16 @@ env_cleanup = no
 
 # Verify host dmesg in postprocess.
 verify_host_dmesg = yes
+# Comma separated list of regular expressions enclosed with "'" whose
+# matches are to be ignored during verification, for example: 'x.*', 'y.*'
+expected_host_dmesg =
 
 # Verify guest dmesg in postprocess.
 verify_guest_dmesg = yes
+# Comma separated list of regular expressions enclosed with "'" whose
+# matches are to be ignored during verification, for example: 'x.*', 'y.*'
+expected_guest_dmesg =
+
 #level_check: level of severity of issues to be checked
 # 1-emerg, 2-emerg,alert, 3-emerg,alert,crit, etc
 guest_dmesg_level = 3

--- a/virttest/unittests/test_utils_misc.py
+++ b/virttest/unittests/test_utils_misc.py
@@ -1,0 +1,21 @@
+import unittest
+import logging
+
+from virttest import utils_misc
+
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+class TestDmesgFilter(unittest.TestCase):
+    def test__remove_dmesg_matches(self):
+        messages = "msg_1\nmsg_2\nmsg_3\nmsg_4"
+        expected_dmesg = "'^msg_1$', '^msg_4$'"
+        result = utils_misc._remove_dmesg_matches(messages, expected_dmesg)
+        self.assertTrue(len(result), 2)
+        self.assertTrue('msg_2' in result)
+        self.assertTrue('msg_3' in result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3191,7 +3191,7 @@ def monotonic_time():
 
 
 def verify_dmesg(dmesg_log_file=None, ignore_result=False, level_check=3,
-                 session=None):
+                 session=None, expected_dmesg=""):
     """
     Find host/guest call trace in dmesg log.
 
@@ -3205,12 +3205,107 @@ def verify_dmesg(dmesg_log_file=None, ignore_result=False, level_check=3,
                         4 - emerg,alert,crit,err
                         5 - emerg,alert,crit,err,warn
     :param session: session object to guest
+    :param expected_dmesg: single string comma separated list of
+                           regular expressions whose matches are to be
+                           ignored during verification, e.g. "'x.*', 'y.*'"
     :param return: if ignore_result=True, return True if no errors/crash
                    observed, False otherwise.
     :param raise: if ignore_result=False, raise TestFail exception on
                   observing errors/crash
     """
-    cmd = "dmesg -T -l %s|grep ." % ",".join(map(str, xrange(0, int(level_check))))
+    environ, output, status = __get_kernel_messages(level_check, session)
+    if status == 0:
+        unexpected_messages = _remove_dmesg_matches(output, expected_dmesg)
+        err = __log_full_dmesg(dmesg_log_file, environ, output)
+        if session:
+            session.cmd("dmesg -C")
+        else:
+            process.system("dmesg -C", ignore_status=True)
+        if not ignore_result and unexpected_messages:
+            raise exceptions.TestFail(err)
+        if unexpected_messages:
+            LOG.debug(err)
+        return False
+    return True
+
+
+def __log_full_dmesg(dmesg_log_file, environ, output):
+    """
+    Logs all dmesg messages
+
+    :param dmesg_log_file: if given, messages will be written into this file
+    :param environ: (guest|host)
+    :param output: messages
+    :return: string for test log
+    """
+    err = "Found unexpected failures in %s dmesg log" % environ
+    d_log = "dmesg log:\n%s" % output
+    if dmesg_log_file:
+        with open(dmesg_log_file, "w+") as log_f:
+            log_f.write(d_log)
+        err += " Please check %s dmesg log %s." % (environ, dmesg_log_file)
+    else:
+        err += " Please check %s dmesg log in debug log." % environ
+        LOG.debug(d_log)
+    return err
+
+
+def _remove_dmesg_matches(messages="", expected_dmesg=""):
+    """
+    Removes all messages that match certain regular expressions
+
+    :param messages: single (possibly multi-line) string
+    :param expected_dmesg: single string comma separated list of
+                           regular expressions whose matches are to be
+                           ignored during verification, e.g. "'x.*', 'y.*'"
+    :return: The subset of `messages` that doesn't match
+    """
+    if not expected_dmesg:
+        return messages
+
+    __messages = messages.split('\n')
+    if '' in __messages:
+        __messages.remove('')
+
+    __expected = expected_dmesg.strip("\" ").split(",")
+    expected_messages = [x.strip(" '") for x in __expected]
+    filtered_messages = __messages
+
+    for expected_regex in expected_messages:
+        not_matching = [x for x in __messages
+                        if not re.findall(expected_regex, x)]
+        filtered_messages = __intersec(filtered_messages, not_matching)
+    return filtered_messages
+
+
+def __intersec(list1, list2):
+    """
+    Returns a new list containing the elements that are present
+    in both without any specific order.
+
+    :param list1: some list
+    :param list2: some list
+    :return: unordered list, the intersection of the input lists
+    """
+
+    return [x for x in list1 if x in list2]
+
+
+def __get_kernel_messages(level_check=3, session=None):
+    """
+    Reads kernel messages for all levels up to certain level.
+    See details in function `verify_dmesg`
+
+    :param level_check: level of severity of issues to be checked
+    :param session: guest
+    :return: 3-tuple (environ, output, status)
+            environ: (guest|host) indicating where the messages
+                     have been read from
+            output: multi-line string containing all read messages
+            status: exit code of read command
+    """
+    cmd = "dmesg -T -l %s|grep ." % ",".join(
+        map(str, xrange(0, int(level_check))))
     if session:
         environ = "guest"
         status, output = session.cmd_status_output(cmd)
@@ -3220,24 +3315,7 @@ def verify_dmesg(dmesg_log_file=None, ignore_result=False, level_check=3,
                           verbose=False, shell=True)
         status = out.exit_status
         output = out.stdout_text
-    if status == 0:
-        err = "Found failures in %s dmesg log" % environ
-        d_log = "dmesg log:\n%s" % output
-        if dmesg_log_file:
-            with open(dmesg_log_file, "w+") as log_f:
-                log_f.write(d_log)
-            err += " Please check %s dmesg log %s." % (environ, dmesg_log_file)
-        else:
-            err += " Please check %s dmesg log in debug log." % environ
-            LOG.debug(d_log)
-        if session:
-            session.cmd("dmesg -C")
-        else:
-            process.system("dmesg -C", ignore_status=True)
-        if not ignore_result:
-            raise exceptions.TestFail(err)
-        return False
-    return True
+    return environ, output, status
 
 
 def add_ker_cmd(kernel_cmdline, kernel_param, remove_similar=False):

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1016,10 +1016,12 @@ class BaseVM(object):
         elif(len(self.virtnet) > 0 and self.virtnet[0].nettype != "macvtap" and
              not connect_uri):
             self.session = self.wait_for_login()
+        expected_guest_dmesg = self.params.get("expected_guest_dmesg", "")
         return utils_misc.verify_dmesg(dmesg_log_file=dmesg_log_file,
                                        ignore_result=ignore_result,
                                        level_check=level,
-                                       session=self.session)
+                                       session=self.session,
+                                       expected_dmesg=expected_guest_dmesg)
 
     def verify_bsod(self, scrdump_file):
         # For windows guest


### PR DESCRIPTION
If a kernel message intentionally has a critical level to warn
customers early of future changes in the kernel with critical
impact, `verify_dmesg` and therefore a test run would currently
fail when checking for kernel messages with at least critical level.

Add a way to configure regular expressions whose matches will be
ignored when verifying kernel messages. The default behavior is left
untouched.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>