### PR TITLE
libvirt_vm: allow for skipping pm-utils installation

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2971,7 +2971,8 @@ class VM(virt_vm.BaseVM):
         session.close()
 
     def prepare_guest_agent(self, prepare_xml=True, channel=True, start=True,
-                            source_path=None, target_name='org.qemu.guest_agent.0'):
+                            source_path=None, target_name='org.qemu.guest_agent.0',
+                            with_pm_utils=True):
         """
         Prepare qemu guest agent on the VM.
 
@@ -2981,6 +2982,7 @@ class VM(virt_vm.BaseVM):
         :param start: Whether install and start the qemu-ga service
         :param source_path: Source path of the guest agent channel
         :param target_name: Target name of the guest agent channel
+        :param with_pm_utils: Determines if to install pm-utils
         """
         if prepare_xml:
             if self.is_alive():
@@ -3011,7 +3013,8 @@ class VM(virt_vm.BaseVM):
         if not self.is_alive():
             self.start()
 
-        self.install_package('pm-utils', ignore_status=True, timeout=15)
+        if with_pm_utils:
+            self.install_package('pm-utils', ignore_status=True, timeout=15)
         self.install_package('qemu-guest-agent')
 
         self.set_state_guest_agent(start)


### PR DESCRIPTION
Though highly recommended to be used with the qemu guest agent,
the pm-utils package might not be available or the test scenario
might not want to install it.

Add a parameter to the `prepare_guest_agent` function to allow for
tests to skip the pm-utils installation. This speeds up testing
where pm-utils is not available.

Make installation of pm-utils the default option in order to
keep default behavior as-is and not require any changes from
consuming code.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>