### PR TITLE
Discoverer with the Job API

### DIFF
--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -71,9 +71,9 @@ class VTDiscoverer(Discoverer, VTResolverUtils):
 
     def discover(self):
         """It will discover vt test resolutions from cartesian config."""
-        self.config = settings.as_dict()
+        self.config = self.config or settings.as_dict()
         if (not get_opt(self.config, 'vt.config') and
                 not get_opt(self.config, 'list.resolver')):
-            return ReferenceResolution('', ReferenceResolutionResult.NOTFOUND)
+            return [ReferenceResolution('', ReferenceResolutionResult.NOTFOUND)]
 
         return [self._get_reference_resolution('')]


### PR DESCRIPTION
When the user sets `vt.config` config variable by command line,
everything works fine, but when this variable is set by Job API the
`Discoverer` won't discover tests from the `vt.config` and test
references are empty. This commit will fix that.

Signed-off-by: Jan Richter <jarichte@redhat.com>