### PR TITLE
DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12

### DIFF
--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -1,5 +1,3 @@
-import importlib
-
 from avocado.core import plugin_interfaces
 from avocado.core.loader import loader
 from avocado.core.settings import settings
@@ -14,6 +12,7 @@ from virttest.standalone_test import (SUPPORTED_DISK_BUSES,
                                       SUPPORTED_NIC_MODELS,
                                       SUPPORTED_TEST_TYPES,
                                       find_default_qemu_paths)
+from virttest._wrappers import import_module
 
 if hasattr(plugin_interfaces, 'Init'):
     class VtInit(plugin_interfaces.Init):
@@ -273,6 +272,6 @@ if hasattr(plugin_interfaces, 'Init'):
 
             settings.merge_with_configs()
 
-            virt_loader = getattr(importlib.import_module('avocado_vt.loader'),
+            virt_loader = getattr(import_module('avocado_vt.loader'),
                                   'VirtTestLoader')
             loader.register_plugin(virt_loader)

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -25,6 +25,7 @@ from avocado.core.plugin_interfaces import CLI
 from virttest.compat import get_settings_value, add_option
 from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 from ..loader import VirtTestLoader
+from virttest._wrappers import load_source
 
 
 # The original virt-test runner supports using autotest from a git checkout,
@@ -40,9 +41,7 @@ if 'AUTOTEST_PATH' in os.environ:
     if not os.path.exists(SETUP_MODULES_PATH):
         raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
                                "%s missing." % SETUP_MODULES_PATH)
-    import imp
-    SETUP_MODULES = imp.load_source('autotest_setup_modules',
-                                    SETUP_MODULES_PATH)
+    SETUP_MODULES = load_source('autotest_setup_modules', SETUP_MODULES_PATH)
     SETUP_MODULES.setup(base_path=CLIENT_DIR,
                         root_module_name="autotest.client")
 

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -259,6 +259,7 @@ class VirtTest(test.Test, utils.TestUtils):
                         run_func = utils_misc.get_test_entrypoint_func(
                             t_type, test_module)
                         try:
+                            # pylint: disable-next=E1102
                             run_func(self, params, env)
                             self.verify_background_errors()
                         finally:

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -16,7 +16,6 @@
 Avocado VT plugin
 """
 
-import imp
 import os
 import sys
 import pipes
@@ -34,6 +33,7 @@ from virttest import utils_env
 from virttest import utils_params
 from virttest import utils_misc
 from virttest import version
+from virttest._wrappers import load_source
 
 from avocado_vt import utils
 
@@ -54,8 +54,7 @@ if 'AUTOTEST_PATH' in os.environ:
     if not os.path.exists(SETUP_MODULES_PATH):
         raise EnvironmentError("Although AUTOTEST_PATH has been declared, "
                                "%s missing." % SETUP_MODULES_PATH)
-    SETUP_MODULES = imp.load_source('autotest_setup_modules',
-                                    SETUP_MODULES_PATH)
+    SETUP_MODULES = load_source('autotest_setup_modules', SETUP_MODULES_PATH)
     SETUP_MODULES.setup(base_path=CLIENT_DIR,
                         root_module_name="autotest.client")
 

--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -12,7 +12,6 @@
 # Copyright: Red Hat Inc. 2020
 # Author: Cleber Rosa <crosa@redhat.com>
 
-import imp
 import logging
 import os
 import pickle
@@ -24,6 +23,7 @@ from avocado.utils import genio, stacktrace
 
 from virttest import asset, bootstrap
 from virttest import data_dir
+from virttest._wrappers import import_module
 
 BG_ERR_FILE = "background-error.log"
 
@@ -125,9 +125,7 @@ def find_test_modules(test_types, subtest_dirs):
                    "dirs %s" % (test_type, subtest_dirs))
             raise exceptions.TestError(msg)
         # Load the test module
-        f, p, d = imp.find_module(test_type, [subtest_dir])
-        test_modules[test_type] = imp.load_module(test_type, f, p, d)
-        f.close()
+        test_modules[test_type] = import_module(test_type, subtest_dir)
     return test_modules
 
 

--- a/selftests/unit/test_wrappers.py
+++ b/selftests/unit/test_wrappers.py
@@ -1,0 +1,190 @@
+import os
+import sys
+import unittest
+import random
+from string import ascii_lowercase as ascii_lc
+
+from time import sleep
+from copy import deepcopy
+from abc import ABC
+from concurrent.futures import ThreadPoolExecutor, wait
+
+from virttest import _wrappers
+
+
+def create_module(name, inner_val, path=''):
+    """ Creates a module with a variable in it named inner_variable whose
+        value is equal to the one set
+        :param name: name of the module
+        :type name: String
+        :param inner_val: value that will be assigned to inner_variable
+        :type inner_val: Int
+        :param path: path to the module
+        :type path: String
+    """
+    module_code = """# This is a file created during virttest._wrappers tests
+# This file should be deleted once the tests are finished
+inner_variable = %s
+""" % inner_val
+    if path != '' and not os.path.isdir(path):
+        os.makedirs(path)
+    with open(os.path.join(path, f"{name}.py"), 'w') as new_module:
+        new_module.write(module_code)
+
+
+def check_imported_module(testcase, name, module, value):
+    """ Wraps general checks that are repeated across almost all tests.
+    """
+    testcase.assertIsNotNone(module)
+    testcase.assertEqual(module.inner_variable, value)
+    testcase.assertTrue(module in sys.modules.values())
+    testcase.assertTrue(module is sys.modules[name])
+
+
+class baseImportTests(ABC):
+    _tmp_in_module_name = "tmp_module_in"
+    _tmp_sub_module_name = "tmp_module_sub"
+    _tmp_sub_module_dir = "_wrappers_tests_mods"
+    _aux_sub_mod_dir = "_wrappers_aux_test_mods"
+    _subdir_inner_val = 1
+    _indir_inner_val = 0
+
+    @classmethod
+    def setUpClass(cls):
+        create_module(cls._tmp_in_module_name, cls._indir_inner_val)
+        create_module(cls._tmp_sub_module_name, cls._subdir_inner_val,
+                      cls._tmp_sub_module_dir)
+        os.makedirs(cls._aux_sub_mod_dir)
+        # Wait a bit so the import mechanism cache can be refreshed
+        sleep(2)
+
+    @classmethod
+    def tearDownClass(cls):
+        def rm_subdir(subdir):
+            # Remove inner __pycache__
+            sub_pycache_dir = os.path.join(subdir, "__pycache__")
+            if os.path.exists(sub_pycache_dir):
+                for pycache_file in os.listdir(sub_pycache_dir):
+                    os.remove(os.path.join(sub_pycache_dir, pycache_file))
+                os.rmdir(sub_pycache_dir)
+            # Remove sub-module files
+            for tmp_sub_mod in os.listdir(subdir):
+                os.remove(os.path.join(subdir, tmp_sub_mod))
+            # Finally delete created directory
+            os.rmdir(subdir)
+
+        rm_subdir(cls._tmp_sub_module_dir)
+        rm_subdir(cls._aux_sub_mod_dir)
+        # And the file created in the exec dir
+        os.remove(f"{cls._tmp_in_module_name}.py")
+
+    def _compare_mods(self, one, other):
+        self.assertEqual(one.__name__, other.__name__)
+        self.assertEqual(one.__spec__.origin, other.__spec__.origin)
+
+    def test_import_from_subdir(self):
+        """ Imports a module that's in another directory """
+        pre_sys_path = deepcopy(sys.path)
+        self._check_import(self._tmp_sub_module_name, self._subdir_inner_val,
+                           self._tmp_sub_module_dir)
+        self.assertEqual(pre_sys_path, sys.path)
+
+    def test_import_just_created(self):
+        """ Creates modules repeatedly and checks it can import them
+            without waiting any time
+        """
+        n_repeats = 10
+        for i in range(n_repeats):
+            mod_name = f"tmp_rep_mod_{i}"
+            # Create module
+            create_module(mod_name, i, self._tmp_sub_module_dir)
+            # Import and check
+            self._check_import(mod_name, i, self._tmp_sub_module_dir)
+
+    def test_import_from_dir(self):
+        """ Imports a module that's in the same directory """
+        pre_sys_path = deepcopy(sys.path)
+        self._check_import(self._tmp_in_module_name, self._indir_inner_val)
+        self.assertEqual(pre_sys_path, sys.path)
+
+
+class ImportModuleTest(baseImportTests, unittest.TestCase):
+
+    def _check_import(self, name, value, path=''):
+        """ Wraps the import checking workflow used in some tests """
+        module = _wrappers.import_module(name, path)
+        check_imported_module(self, name, module, value)
+
+    def test_import_from_pythonpath(self):
+        """ Imports a module that's in the python path """
+        # Import os which is also being used in the other tests
+        module = _wrappers.import_module('os')
+        self.assertIsNotNone(module)
+        self._compare_mods(module, os)
+
+    def test_import_from_builtins(self):
+        """ Imports a module that's in the python path """
+        # Import os which is also being used in the other tests
+        import pwd
+        module = _wrappers.import_module('pwd')
+        self.assertIsNotNone(module)
+        self._compare_mods(module, pwd)
+
+    def test_thread_safety(self):
+        """ Create 5 pairs of modules. Each pair consists of two equally named
+            files with a different inner value, and saved in different
+            directories.
+        """
+        def check_routine(module_check_data):
+            module = _wrappers.import_module(module_check_data["name"],
+                                             module_check_data["path"])
+            val = module.inner_variable
+            return val
+
+        def check(module_val, module_data):
+            self.assertEqual(module_val, module_data["value"])
+
+        def get_random_name(length=20):
+            return "".join([random.choice(ascii_lc) for _ in range(length)])
+
+        check_mod_names = [get_random_name() for _ in range(50)]
+        check_import_data = []
+        for mod_name in check_mod_names:
+            value = random.randint(0, 100)
+            create_module(mod_name, value, self._aux_sub_mod_dir)
+            in_dir = {"name": mod_name, "value": value,
+                      "path": self._aux_sub_mod_dir}
+            value = random.randint(0, 100)
+            create_module(mod_name, value, self._tmp_sub_module_dir)
+            sub_dir = {"name": mod_name, "value": value,
+                       "path": self._tmp_sub_module_dir}
+            # We don't want to test if two modules with the same name
+            # are imported safely in the same execution.
+            # We want to test that sys.path priorities are not mixed up
+            # So select only one
+            check_import_data.append(random.choice([in_dir, sub_dir]))
+        results = []
+        with ThreadPoolExecutor(max_workers=len(check_mod_names)) as executor:
+            for mod_data in check_import_data:
+                results.append(executor.submit(check_routine, mod_data))
+        wait(results)
+        for res, mod_data in zip(results, check_import_data):
+            check(res.result(), mod_data)
+
+
+class LoadSourceTest(baseImportTests, unittest.TestCase):
+
+    def _check_import(self, name, value, path=''):
+        path = os.path.join(path, f"{name}.py")
+        module = _wrappers.load_source(name, path)
+        check_imported_module(self, name, module, value)
+
+    def test_mismatching_names(self):
+        # test that importing a module mismatching the file name works good
+        module = _wrappers.load_source("name", f"{self._tmp_in_module_name}.py")
+        check_imported_module(self, "name", module, self._indir_inner_val)
+
+    def test_no_existing_file(self):
+        # Assert an error is launched if a non existing file is imported
+        with self.assertRaises(FileNotFoundError):
+            self._check_import('os', None, 'os.py')

--- a/virttest/_wrappers.py
+++ b/virttest/_wrappers.py
@@ -1,0 +1,72 @@
+""" The file contains some wrappers of common python base-package workflow
+    sets that can be repeated throughout the avocado-vt code.
+    Please, remember that it is a private module.
+    Please, use this module ONLY from other virttest/avocado-vt modules.
+"""
+
+import sys
+import importlib
+from importlib.machinery import (SourceFileLoader, SOURCE_SUFFIXES,
+                                 SourcelessFileLoader, BYTECODE_SUFFIXES,
+                                 ExtensionFileLoader, EXTENSION_SUFFIXES)
+
+
+_LOADERS = ((SourceFileLoader, SOURCE_SUFFIXES),
+            (SourcelessFileLoader, BYTECODE_SUFFIXES),
+            (ExtensionFileLoader, EXTENSION_SUFFIXES))
+
+
+def _load_from_spec(spec):
+    """ Just for code refactoring, it takes a module spec and does the needed
+        things so as to import it into the execution environment.
+        :param spec: module spec.
+        :type spec: ModSpec
+        :returns : Imported module instance
+    """
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def import_module(name, path=None):
+    """ Imports a module named <name> to the execution environment.
+        If the module is not in the PYTHONPATH or the local path,
+        its path can be determined by the <path> argument.
+        :param name: Name of the module that is going to be imported
+        :type name: String
+        :param path: Path in which the module is located.
+                          If None, it will find the module in the current dir
+                          and the PYTHONPATH.
+        :type path: String, list of strings or  None
+        :returns: The imported module
+    """
+    if path is None:
+        if name in sys.builtin_module_names:
+            spec = importlib.machinery.BuiltinImporter.find_spec(name, path)
+            return _load_from_spec(spec)
+        path = sys.path
+    elif isinstance(path, str):
+        path = [path]
+
+    for entry in path:
+        finder = importlib.machinery.FileFinder(entry, *_LOADERS)
+        spec = finder.find_spec(name)
+        if spec is not None:
+            break
+    else:
+        raise ImportError(f"Couldn't find any module named {name}")
+    return _load_from_spec(spec)
+
+
+def load_source(name, path):
+    """ Imports the contents of a source file from <path> to the
+        execution environment inside a module named <name>.
+        :param name: Name of the module that is going to be imported
+        :type name: String
+        :param path: Path of the source file being imported.
+        :type path: String
+        :returns: The imported module
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    return _load_from_spec(spec)

--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -1,10 +1,10 @@
 import logging
-import imp
 
 from avocado.utils import process
 
 from .. import propcan, xml_utils, virsh
 from ..libvirt_xml import xcepts
+from .._wrappers import import_module
 
 
 class LibvirtXMLBase(propcan.PropCanBase):
@@ -408,9 +408,7 @@ def load_xml_module(path, name, type_list):
     if name not in type_list:
         raise xcepts.LibvirtXMLError(errmsg)
     try:
-        filename, pathname, description = imp.find_module(name,
-                                                          [path])
-        mod_obj = imp.load_module(name, filename, pathname, description)
+        mod_obj = import_module(name, path)
         # Enforce capitalized class names
         return getattr(mod_obj, name.capitalize())
     except TypeError as detail:
@@ -421,5 +419,5 @@ def load_xml_module(path, name, type_list):
     except AttributeError as detail:
         raise xcepts.LibvirtXMLError("Can't find class %s in %s module in "
                                      "%s: %s"
-                                     % (name.capitalize(), name, pathname,
+                                     % (name.capitalize(), name, path,
                                         str(detail)))

--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -9,7 +9,6 @@ Created on Dec 6, 2013
 
 import os
 import sys
-import imp
 import importlib
 import select
 import time
@@ -746,7 +745,10 @@ class CommanderSlaveCmds(CommanderSlave):
         :return: module.run().return
         """
         assert os.path.isfile(test_path)
-        module = imp.load_source('ext_test', test_path)
+        spec = importlib.util.spec_from_file_location('ext_test', test_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules['ext_test'] = module
+        spec.loader.exec_module(module)
         assert hasattr(module, "run")
         run = getattr(module, "run")
         helper = Helper(self)

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -18,7 +18,6 @@ More specifically:
 
 from __future__ import division
 import glob
-import imp
 import locale
 import logging
 import os
@@ -61,6 +60,7 @@ from virttest import utils_package
 from virttest.utils_iptables import Iptables
 from virttest import data_dir
 from virttest.staging import utils_memory
+from virttest._wrappers import import_module
 
 # Get back to importing submodules
 # This is essential for accessing these submodules directly from
@@ -1812,9 +1812,7 @@ def run_virt_sub_test(test, params, env, sub_type=None, tag=None):
         raise exceptions.TestError("Could not find test file %s.py "
                                    "on directories %s" % (sub_type, subtest_dirs))
 
-    f, p, d = imp.find_module(sub_type, [subtest_dir])
-    test_module = imp.load_module(sub_type, f, p, d)
-    f.close()
+    test_module = import_module(sub_type, subtest_dir)
     # Run the test function
     run_func = utils_misc.get_test_entrypoint_func(sub_type, test_module)
     if tag is not None:

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1817,7 +1817,7 @@ def run_virt_sub_test(test, params, env, sub_type=None, tag=None):
     run_func = utils_misc.get_test_entrypoint_func(sub_type, test_module)
     if tag is not None:
         params = params.object_params(tag)
-    run_func(test, params, env)
+    run_func(test, params, env)  # pylint: disable=E1102
 
 
 def get_readable_cdroms(params, session):


### PR DESCRIPTION
Code changes in this PR work on the imp deprecation issue (#3323). It's divided in two commits:
1.  The `virttest._wrappers` module is created. The functionality needed for carrying on dynamic imports is added, as well as some related unittests.
2. The code from `avocado_vt` and `virttests` is changed from using imp/importlib to the new method.

Note:
The modules from `virttest.remote_commander` are not using `_wrappers.import_module`, but `importlib`. This has been left in this way since it can't be assumed that virttest is installed in the remote system in which the import is going to take place.

ID: 2042377