### PR TITLE
v2v: remove rhv-proxy option if v2v doesn't support it

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -466,6 +466,12 @@ class Target(object):
         if rhv_upload_opts:
             options += ' %s' % rhv_upload_opts
 
+        has_rhv_proxy_ver = '[virt-v2v-1.45.99-1,)'
+        # Remove rhv-proxy option from cmd
+        if not multiple_versions_compare(has_rhv_proxy_ver) and '-oo rhv-proxy' in options:
+            rhv_proxy_option = "(-oo rhv-proxy=(\S+))\s*|(-oo rhv-proxy)(?!=)"
+            options = re.sub(rhv_proxy_option, '', options)
+
         return options
 
     def _get_local_options(self):


### PR DESCRIPTION
Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>