### PR TITLE
virsh: Update detach_disk to use EventTracker.wait_event

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -1830,21 +1830,23 @@ def attach_disk(name, source, target, extra="", **dargs):
     return command(cmd, **dargs)
 
 
-def detach_disk(name, target, extra="", wait_remove_event=False, event_timeout=7, **dargs):
+@EventTracker.wait_event
+def detach_disk(name, target, extra="", wait_for_event=False,
+                event_type="device-removed", event_timeout=10, **dargs):
     """
     Detach a disk from VM.
 
     :param name: name of guest
     :param target: target of disk device
-    :param wait_remove_event: wait until device_remove event comes
+    :param extra: additional arguments to command
+    :param wait_for_event: wait until device_remove event comes
+    :param event_type: type of the event
     :param event_timeout: timeout for virsh event command
     :param dargs: standardized virsh function API keywords
     :return: CmdResult object
     """
     detach_cmd = "detach-disk --domain %s --target %s %s" % (name, target, extra)
     detach_cmd_rv = command(detach_cmd, **dargs)
-    if wait_remove_event:
-        event(domain=name, event='device-removed', event_timeout=event_timeout, **dargs)
 
     return detach_cmd_rv
 


### PR DESCRIPTION
    The event monitor should be started before executing virsh command.


Signed-off-by: nanli <nanli@redhat.com>