### PR TITLE
utils_net: additional checks for arp table parsing

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3315,9 +3315,15 @@ def parse_arp(session=None, timeout=60.0, **dargs):
             arp_cache = arp_file.read()
 
     for line in arp_cache.splitlines():
-        mac = line.split()[3]
-        ip = line.split()[0]
-        flag = line.split()[2]
+        parsed_elements = line.split()
+        try:
+            mac = parsed_elements[3]
+            ip = parsed_elements[0]
+            flag = parsed_elements[2]
+        except IndexError:
+            # Check if data is missing
+            raise OSError("Read invalid data from %s host arp file" %
+                          "remote" if session else "local")
 
         # Skip the header
         if mac.count(":") != 5:

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3306,13 +3306,15 @@ def parse_arp(session=None, timeout=60.0, **dargs):
     :return: dict mapping MAC to IP
     """
     ret = {}
-    func = process.getoutput
+    arp_file_path = "/proc/net/arp"
     if session:
-        func = session.cmd_output
-    arp_cache = func('cat /proc/net/arp', timeout=timeout,
-                     **dargs).strip().split('\n')
+        arp_cache = session.cmd_output("cat %s" % arp_file_path,
+                                       timeout=timeout, **dargs)
+    else:
+        with open(arp_file_path, 'r') as arp_file:
+            arp_cache = arp_file.read()
 
-    for line in arp_cache:
+    for line in arp_cache.splitlines():
         mac = line.split()[3]
         ip = line.split()[0]
         flag = line.split()[2]


### PR DESCRIPTION
Adding additional check when parsing the arp table (reading /proc/net/arp).
Previously the method was not checking whether the read line was empty/parseable or not.

ID: 2053188