### PR TITLE
compressed qemu-nbd: dependencies development for testcase

### DIFF
--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -382,7 +382,7 @@ class _FilterConfigGatherer(object):
             :type params: Ordered Dict
             :return: Ordered Dict
         """
-        _config_gatherers = {}
+        _config_gatherers = {"compress": cls._compress}
         filter_params = params.object_params(filter_name)
         filter_type = filter_params.get("image_filter_driver_type")
         # Calls the adequate function for us
@@ -394,6 +394,13 @@ class _FilterConfigGatherer(object):
                                       "support hasn't been implemented for "
                                       f"{filter_type} filter yet.")
         return gather_func(filter_params)
+
+    @staticmethod
+    def _compress(params):
+        """ Gives an empty OrderedDict (as compress filter doesn't have
+            specific attributes related to the filter)
+        """
+        return collections.OrderedDict({"driver": "compress"})
 
 
 class _ParameterAssembler(string.Formatter):

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -269,6 +269,15 @@ def _get_image_meta(image, params, root_dir):
             meta['file'].update({
                 k: v[1] for k, v in six.iteritems(mapping) if v[0]
             })
+    filters = params.get("image_filter_drivers", "").split()
+    # Stack them reversed, so the first filter on the list
+    # will be on top of the rest of filters
+    for img_filter in filters[::-1]:
+        tmp_meta = collections.OrderedDict()
+        tmp_meta["file"] = meta
+        meta = tmp_meta
+        filter_cfg = _FilterConfigGatherer.gather(img_filter, params)
+        meta.update(filter_cfg)
 
     return meta
 
@@ -345,6 +354,46 @@ def get_image_repr(image, params, root_dir, representation=None):
 
         func = mapping["json"] if image_secret or access_needed else mapping["filename"]
     return func(image, params, root_dir)
+
+
+class _FilterConfigGatherer(object):
+    """ This class can be used to gather filter-specific configuration
+        from test params to generate fully-valid image_meta dicts.
+        The filter-specific image_meta should be obtained by calling
+        the gather class method.
+        This class should contain as much private methods as filters that
+        should be supported for image_meta generation. In other words,
+        each supported filter should contain a _<filter_type> implemented
+        in this class as well as a "<filter_type>": <cfg_gather_func> key/value
+        entry in the _config_gatherers dict from the gather method.
+    """
+
+    @classmethod
+    def gather(cls, filter_name, params):
+        """ Gathers filter-specific config from params and collects
+            them properly on an OrderedDict.
+            This method is in charge of calling the appropriate private
+            class method
+            :param filter_name: Name/id of the filter for which data is being
+                                gathered
+            :type filter_name: str
+            :param params: Collection of parameters from which data will be
+                           gathered
+            :type params: Ordered Dict
+            :return: Ordered Dict
+        """
+        _config_gatherers = {}
+        filter_params = params.object_params(filter_name)
+        filter_type = filter_params.get("image_filter_driver_type")
+        # Calls the adequate function for us
+        try:
+            gather_func = _config_gatherers[filter_type]
+        except KeyError:
+            # Filter is not supported
+            raise NotImplementedError("Image configuration meta generation "
+                                      "support hasn't been implemented for "
+                                      f"{filter_type} filter yet.")
+        return gather_func(filter_params)
 
 
 class _ParameterAssembler(string.Formatter):

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -968,3 +968,11 @@ nvdimm_uuid = ""
 
 # Set granularity for a bitmap(Only works when adding a new bitmap to an image)
 # bitmap_granularity = "131072"
+
+# Set below params to use the compress filter by imageopts on a image.
+# image_filter_drivers: to set a list of image_filter_driver ids/names
+#                       that will be stacked in left-to-right order.
+# image_filter_driver_type_<filter_id>: to set the type of filter associated
+#                                       to the given id.
+# image_filter_driver_<arg>_<filter_id>: to set the value of a param of the
+#                                        given filter

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -974,5 +974,10 @@ nvdimm_uuid = ""
 #                       that will be stacked in left-to-right order.
 # image_filter_driver_type_<filter_id>: to set the type of filter associated
 #                                       to the given id.
+# supported filter driver types: compress
 # image_filter_driver_<arg>_<filter_id>: to set the value of a param of the
 #                                        given filter
+# Example to use image opts for filters:
+# image_filter_drivers = comp1
+# image_filter_driver_type_comp1 = compress
+# compress filter doesnt have params


### PR DESCRIPTION
This pull request is trying to merge 3 commits that implement the dependencies that a test case had on virttest (see bz-2047527).
The first two commits add the code needed to support image-opt generation for storage filters. More specifically, the first commit adds the needed backbone for image-opt generation for filters, and the second commit adds the needed support for the compress filter. Support for more filters can be easily added by adding a new private function named `_<filter_type>` into `_FilterConfigGatherer` class which reads params and returns an `OrderedDict` containing the key/value pairs that are meaningful to that filter.
The last commit adds the needed changes so the `nbd` module uses the image opts when a filter is used when exporting an image.

I'm not adding the bz ID info since I'm adding it in the provider pull request, since the bz is related to the test case development and not the development of its dependencies.

ID: 2047527