### PR TITLE
usbdev: changes in how parameters are parsed

### DIFF
--- a/selftests/unit/unittest_data/testcfg.huge/base.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/base.cfg
@@ -77,7 +77,7 @@ usb_max_port = 2
 usb_devices = tablet1
 # USB device type, run following command to see device list on your host.
 # `qemu-kvm -device \? 2>&1 | grep "bus USB"`
-usb_type_tablet1 = usb-tablet
+usbdev_type_tablet1 = usb-tablet
 # USB Controller type which device uses.
 usb_controller_tablet1 = uhci
 

--- a/selftests/unit/unittest_data/testcfg.huge/subtests.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/subtests.cfg
@@ -1950,7 +1950,7 @@ variants:
                 only usb_storage, usb_host
             - usb_kbd:
                 only usb_boot, usb_reboot, usb_hotplug
-                usb_type_testdev = "usb-kbd"
+                usbdev_type_testdev = "usb-kbd"
                 info_usb_name = "QEMU USB Keyboard"
                 vendor_id = "0627"
                 product_id = "0001"
@@ -1958,7 +1958,7 @@ variants:
                 product = "QEMU USB Keyboard"
             - usb_mouse:
                 only usb_boot, usb_reboot, usb_hotplug
-                usb_type_testdev = "usb-mouse"
+                usbdev_type_testdev = "usb-mouse"
                 info_usb_name = "QEMU USB Mouse"
                 vendor_id = "0627"
                 product_id = "0001"
@@ -1966,7 +1966,7 @@ variants:
                 product = "QEMU USB Mouse"
             - usb_tablet:
                 only usb_boot, usb_reboot, usb_hotplug
-                usb_type_testdev = "usb-tablet"
+                usbdev_type_testdev = "usb-tablet"
                 info_usb_name = "QEMU USB Tablet"
                 vendor_id = "0627"
                 product_id = "0001"
@@ -1974,7 +1974,7 @@ variants:
                 product = "QEMU USB Tablet"
             - usb_ccid:
                 only usb_boot, usb_reboot, usb_hotplug
-                usb_type_testdev = "usb-ccid"
+                usbdev_type_testdev = "usb-ccid"
                 info_usb_name = "QEMU USB CCID"
                 vendor_id = "08e6"
                 product_id = "4433"
@@ -1982,7 +1982,7 @@ variants:
                 product = "QEMU USB CCID"
             - usb_audio:
                 only usb_boot, usb_reboot, usb_hotplug
-                usb_type_testdev = usb-audio
+                usbdev_type_testdev = usb-audio
                 info_usb_name = "QEMU USB Audio"
                 vendor_id = "46f4"
                 product_id = "0002"
@@ -1990,7 +1990,7 @@ variants:
                 product = "QEMU USB Audio"
             - usb_hub:
                 only usb_boot, usb_reboot, usb_hotplug
-                usb_type_testdev = usb-hub
+                usbdev_type_testdev = usb-hub
                 info_usb_name = "QEMU USB Hub"
                 vendor_id = "(0000|0409)"
                 product_id = "(0000|55aa)"

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1597,34 +1597,35 @@ class DevContainer(object):
                                       params.get('pci_addr'))
 
     # USB Device related methods
-    def usb_by_variables(self, usb_name, usb_type, controller_type, bus=None,
-                         port=None, serial=None, dev_options=None):
+    def usb_by_variables(self, usb_name, usbdev_type, controller_type,
+                         usbdev_bus=None, usbdev_port=None, usbdev_serial=None,
+                         dev_options=None):
         """
         Creates usb-devices by variables.
         :param usb_name: usb name
-        :param usb_type: usb type (usb-tablet, usb-serial, ...)
+        :param usbdev_type: usb type (usb-tablet, usb-serial, ...)
         :param controller_type: type of the controller (uhci, ehci, xhci, ...)
-        :param bus: the bus name (my_bus.0, ...)
-        :param port: port specification (4, 4.1.2, ...)
-        :param serial: serial specification (1234, d1, ...)
-        :param dev_options: device options dict of usb_type
+        :param usbdev_bus: the bus name (my_bus.0, ...)
+        :param usbdev_port: port specification (4, 4.1.2, ...)
+        :param usbdev_serial: serial specification (1234, d1, ...)
+        :param dev_options: device options dict of usbdev_type
         :return: QDev device
         """
-        if not self.has_device(usb_type):
+        if not self.has_device(usbdev_type):
             raise exceptions.TestSkipError("usb device %s not available"
-                                           % usb_type)
+                                           % usbdev_type)
         if self.has_option('device'):
-            device = qdevices.QDevice(usb_type, aobject=usb_name)
+            device = qdevices.QDevice(usbdev_type, aobject=usb_name)
             device.set_param('id', 'usb-%s' % usb_name)
-            device.set_param('bus', bus)
-            device.set_param('port', port)
-            device.set_param('serial', serial)
+            device.set_param('bus', usbdev_bus)
+            device.set_param('port', usbdev_port)
+            device.set_param('serial', usbdev_serial)
             if dev_options:
                 for opt_name, opt_value in dev_options.items():
                     device.set_param(opt_name, opt_value)
             device.parent_bus += ({'type': controller_type},)
         else:
-            if "tablet" in usb_type:
+            if "tablet" in usbdev_type:
                 device = qdevices.QStringDevice('usb-%s' % usb_name,
                                                 cmdline='-usbdevice %s' % usb_name)
             else:
@@ -1641,8 +1642,8 @@ class DevContainer(object):
         :return: QDev device
         """
         dev_options = {}
-        usb_type = params.get("usb_type")
-        if usb_type == "usb-host":
+        usbdev_type = params.get("usbdev_type")
+        if usbdev_type == "usb-host":
             dev_options["hostbus"] = params.get("usbdev_option_hostbus")
             dev_options["hostaddr"] = params.get("usbdev_option_hostaddr")
             dev_options["hostport"] = params.get("usbdev_option_hostport")
@@ -1654,10 +1655,10 @@ class DevContainer(object):
                 dev_options["productid"] = "0x%s" % productid
 
         return self.usb_by_variables(usb_name,
-                                     usb_type,
+                                     usbdev_type,
                                      params.get("usb_controller"),
-                                     params.get("bus"),
-                                     params.get("port"),
+                                     params.get("usbdev_bus"),
+                                     params.get("usbdev_port"),
                                      params.get("usbdev_serial"),
                                      dev_options)
 

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -136,12 +136,14 @@ usb_max_port = 6
 
 # USB device object names (whitespace separated)
 usb_devices = tablet1
+# Configuration parameters related to usb devices (and not controllers)
+# use the usbdev_* preffix instead of the usb_* one as controllers do.
 # USB device type, run following command to see device list on your host.
 # `qemu-kvm -device \? 2>&1 | grep "bus USB"`
-usb_type_tablet1 = usb-tablet
+usbdev_type_tablet1 = usb-tablet
 # USB Controller type which device uses.
 usb_controller = ehci
-usb_bus = usb1.0
+usbdev_bus = usb1.0
 #use xhci as the default controller on ppc platform.
 pseries:
     usb_controller = xhci


### PR DESCRIPTION
usb device related parameters as bus or port were not being parsed correctly. The goal of this commit is twofold:

1. Corrects the way that usb-device parameters is parsed
2. Leverages the code change to use a more straightforward keyword for usb devices (i.e. it uses `usbdev_port/bus` instead of `usb_port/bus` for a better understanding of the configuration parameter target).

This changes should fix #3351. Making updates in tp-qemu cfgs is needed. 