### PR TITLE
qcontainer: Support reuse the existing vTPM device

### DIFF
--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -922,7 +922,7 @@ nvdimm_uuid = ""
 # tpm_model = "tpm-spapr"
 # tpm_type = "passthrough"
 # tpm_version = "1.2" # only for qemu command line
-
+# tpm_overwrite = no # Overwrite existing TPM state by re-initializing it
 
 # Add extra params for dimm devices
 #dimm_extra_params = "label-size=128k slot=1"


### PR DESCRIPTION
Currently, VMs will generate a new vTPM device when running each TPM
test case. In the life cycle of the VM, the TPM device(s) of the VM
should be unique, and then the VM can be regarded as a real trusted
operating system.

ID: 2060233
Signed-off-by: Yihuang Yu <yihyu@redhat.com>