### PR TITLE
Get the first interface name

### DIFF
--- a/virttest/utils_sriov.py
+++ b/virttest/utils_sriov.py
@@ -151,7 +151,8 @@ def get_iface_name(pci_id, session=None):
                                                       session=session)
     if status:
         raise exceptions.TestError("Unable to get iface name of %s." % pci_id)
-    return iface_name
+    iface_name_single = iface_name.split()[0]
+    return iface_name_single
 
 
 def set_vf(pci_addr, vf_no=4, session=None, timeout=60):


### PR DESCRIPTION
As kernel updates, the case will get error like
"Get nic enp94s0f0np0\neth0\neth1 operstate error". In fact, only
first one "enp94s0f0np0" is what we want, update the script to
support it.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>