### PR TITLE
utils_misc: fix get no extend_l2 value in get_image_info function

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2885,6 +2885,9 @@ def get_image_info(image_file):
                 elif line.find("lazy refcounts") != -1:
                     lazy_refcounts = line.split(':')[-1].strip()
                     image_info_dict['lcounts'] = lazy_refcounts
+                elif line.find("extended l2") != -1:
+                    extended_l2 = line.split(':')[-1].strip()
+                    image_info_dict['extended l2'] = extended_l2
         return image_info_dict
     except (KeyError, IndexError, process.CmdError) as detail:
         raise exceptions.TestError("Fail to get information of %s:\n%s" %


### PR DESCRIPTION
Signed-off-by: nanli <nanli@redhat.com>

**Test result**
/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockcopy_options.positive_test.extended_l2_on.encrypt_disk --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID : 7d62c328bb9cf8e141aa663750b802a04a947442
JOB LOG : /root/avocado/job-results/job-2022-03-07T06.48-7d62c32/job.log
(1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.extended_l2_on.encrypt_disk: PASS (61.62 s)
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0