### PR TITLE
Fix avocado-vt issue:https://github.com/avocado-framework/avocado-vt/…

### DIFF
--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -18,7 +18,7 @@ from avocado.utils import process
 
 import six
 
-from virttest.utils_misc import log_line
+from virttest.utils_logfile import log_line
 from virttest.utils_version import VersionInterval
 
 LOG = logging.getLogger('avocado.' + __name__)


### PR DESCRIPTION
…issues/3391

Error running method "initialize" of plugin "vt-init": cannot import name 'log_line' when
import from virttest import utils_misc in python terminal

virttest/utils_logfile.py and virttest/utils_misc.py duplicate the same code :
def log_line(filename, line) implementation
need change virttest/ip_sniffing.py to import log_line from virttest/utils_logfile.py

Signed-off-by: chunfuwen <chwen@redhat.com>