### PR TITLE
Add 'vdpa' to spell.ignore

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -1950,6 +1950,7 @@ vepa
 versionable
 versioned
 versioning
+vdpa
 VFs
 vfstype
 vga


### PR DESCRIPTION
The spell check fails because of 'vdpa' in docstring.

Signed-off-by: Yingshun Cui <yicui@redhat.com>