### PR TITLE
Log improvement for qemu testing

### DIFF
--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -195,13 +195,15 @@ class TestUtils:
         """
         err_file_path = os.path.join(self.logdir, BG_ERR_FILE)
         bg_errors = self.background_errors.get_all()
-        error_messages = ["BACKGROUND ERROR LIST:"]
+        error_messages = []
         for index, error in enumerate(bg_errors):
             error_messages.append(
                 "- ERROR #%d -\n%s" % (index, "".join(
                     traceback.format_exception(*error)
                     )))
-        genio.write_file(err_file_path, '\n'.join(error_messages))
+        if error_messages:
+            error_messages.insert(0, "BACKGROUND ERROR LIST:")
+            genio.write_file(err_file_path, '\n'.join(error_messages))
         if bg_errors:
             msg = ["Background error"]
             msg.append("s are" if len(bg_errors) > 1 else " is")

--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -9,11 +9,7 @@ import time
 import logging
 import random
 import base64
-try:
-    import json
-except ImportError:
-    logging.getLogger('avocado.app').warning(
-        "Could not import json module. virt agent functionality disabled.")
+import json
 
 from avocado.utils import process
 

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1150,8 +1150,6 @@ class DevContainer(object):
             :param cmd: If set uses "-M $cmd" to force this machine type
             :return: List of added devices (including default buses)
             """
-            LOG.warn('Using Q35 machine which is not yet fully tested on '
-                     'avocado-vt. False errors might occur.')
             devices = []
             bus = (qdevices.QPCIEBus('pcie.0', 'PCIE', root_port_type,
                                      'pci.0', pcie_root_port_params),

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -6,6 +6,7 @@ Interfaces to the QEMU monitor.
 
 from __future__ import division
 
+import json
 import logging
 import os
 import re
@@ -15,12 +16,6 @@ import threading
 import time
 
 import six
-
-try:
-    import json
-except ImportError:
-    logging.getLogger('avocado.app').warning(
-        "Could not import json module. QMP monitor functionality disabled.")
 
 from . import passfd_setup
 from . import utils_misc

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3219,10 +3219,11 @@ class VM(virt_vm.BaseVM):
                 raise e
 
             LOG.debug("VM appears to be alive with PID %s", self.get_pid())
-            # Record vcpu infos in debug log
+
             is_preconfig = params.get_boolean("qemu_preconfig")
             if not is_preconfig:
-                self.get_vcpu_pids(debug=True)
+                LOG.debug("vCPUs appear to be alive with Thread-IDs %s",
+                          ", ".join([str(tid) for tid in self.vcpu_threads]))
             vhost_thread_pattern = params.get("vhost_thread_pattern",
                                               r"\w+\s+(\d+)\s.*\[vhost-%s\]")
             self.vhost_threads = self.get_vhost_threads(vhost_thread_pattern)


### PR DESCRIPTION
* qcontainer: remove the warning of q35
* remove the import check of json module
* utils_net: init ovs instance only if needed
* ~~qemu_vm: remove the log of QDevice/QBus specification~~
* don't create `background-error.log` until there was any bg_err
* qemu_vm: only log thread-id of vcpus for debugging

Signed-off-by: Xu Han <xuhan@redhat.com>