### PR TITLE
Update vt runner after avocado changesNrunner update

### DIFF
--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -1,12 +1,16 @@
 import warnings
 
-from avocado.core.nrunner import Runnable
 from avocado.core.plugin_interfaces import Discoverer, Resolver
 from avocado.core.resolver import (ReferenceResolution,
                                    ReferenceResolutionResult)
 from avocado.core.settings import settings
 
 from ..discovery import DiscoveryMixIn
+
+try:
+    from avocado.core.nrunner import Runnable
+except ImportError:
+    from avocado.core.nrunner.runnable import Runnable
 
 
 class VTResolverUtils(DiscoveryMixIn):

--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -5,7 +5,6 @@ from avocado.core.plugin_interfaces import Discoverer, Resolver
 from avocado.core.resolver import (ReferenceResolution,
                                    ReferenceResolutionResult)
 from avocado.core.settings import settings
-from virttest.compat import get_opt
 
 from ..discovery import DiscoveryMixIn
 
@@ -72,8 +71,5 @@ class VTDiscoverer(Discoverer, VTResolverUtils):
     def discover(self):
         """It will discover vt test resolutions from cartesian config."""
         self.config = self.config or settings.as_dict()
-        if (not get_opt(self.config, 'vt.config') and
-                not get_opt(self.config, 'list.resolver')):
-            return [ReferenceResolution('', ReferenceResolutionResult.NOTFOUND)]
 
         return [self._get_reference_resolution('')]


### PR DESCRIPTION
Avocado did a lot of refactorings which made runners standalone plugins
and change some runner paths. This commit update vt runner to be
compatible with those changes and the lts version as well.

Reference: https://github.com/avocado-framework/avocado/pull/5307, https://github.com/avocado-framework/avocado/pull/5326
Signed-off-by: Jan Richter <jarichte@redhat.com>