### PR TITLE
utils_net.get_net_if_addrs_win: Correct IP patterns

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1499,8 +1499,8 @@ def get_net_if_addrs_win(session, mac_addr):
     ip_address = get_windows_nic_attribute(session, "macaddress",
                                            mac_addr, "IPAddress",
                                            global_switch="nicconfig")
-    return {"ipv4": re.findall('(\d+\.\d+\.\d+\.\d+)"', ip_address),
-            "ipv6": re.findall('(fe80.*?)"', ip_address)}
+    return {"ipv4": re.findall(r'"(\d+\.\d+\.\d+\.\d+)"', ip_address),
+            "ipv6": re.findall(r'"(\w+:[^\s,"]+)"', ip_address)}
 
 
 def get_net_if_and_addrs(runner=None):


### PR DESCRIPTION
IPv6 addresses contain remote address and linklocal address, the old
pattern cannot capture both of them, Correct the pattern to make sure
all IPv6 types will be collected.

ID: 2074848
Signed-off-by: Yihuang Yu <yihyu@redhat.com>