### PR TITLE
replace netaddr with ipaddress

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -32,7 +32,7 @@
 Summary: Avocado Virt Test Plugin
 Name: avocado-plugins-vt
 Version: 98.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -69,7 +69,7 @@ Xunit output, among others.
 %package -n python3-%{name}
 Summary: %{summary}
 Requires: python3, python3-devel, python3-avocado >= 51.0, python3-aexpect
-Requires: python3-netaddr, python3-netifaces, python3-simplejson
+Requires: python3-netifaces, python3-simplejson
 %{?python_provide:%python_provide python3-%{srcname}}
 %description -n python3-%{name}
 Avocado Virt Test is a plugin that lets you execute virt-tests
@@ -104,6 +104,9 @@ Xunit output, among others.
 
 
 %changelog
+* Thu Jul 20 2022 Xu Han <xuhan@redhat.com> - 98.0-2
+- Removed python3-netaddr dependency
+
 * Thu Jul 14 2022 Cleber Rosa <crosa@redhat.com> - 98.0-1
 - New release
 

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -30,7 +30,7 @@ Pip is useful when it comes to python dependencies, but it fails
 in non-python ones. List of non-python requirements based on Fedora
 package names is::
 
-    $ dnf install xz tcpdump iproute iputils gcc glibc-headers nc git python-netaddr python-devel
+    $ dnf install xz tcpdump iproute iputils gcc glibc-headers nc git python-devel
 
 Then you can get Avocado-VT via pip::
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -4,6 +4,5 @@ pylint==2.12.2
 inspektor==0.5.3
 aexpect==1.6.4
 simplejson==3.8.0
-netaddr==0.7.19
 netifaces==0.11.0
 pyenchant==3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,5 @@ autotest>=0.16.2; python_version < '3.0'
 aexpect>=1.6.4;python_version >= '3.0'
 aexpect>1.5.0; python_version < '3.0'
 simplejson>=3.5.3
-netaddr<=0.7.19; python_version < '3.0'
-netaddr>=0.7.19; python_version >= '3.0'
 zipp<=1.2.0; python_version < '3.0'
 netifaces>=0.10.5

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
                   'avocado-vt = avocado_vt.plugins.vt_runner:VTTestRunner',
                   ],
               },
-          install_requires=["netifaces", "simplejson", "six", "netaddr",
-                            "aexpect", "avocado-framework>=82.1"],
+          install_requires=["netifaces", "simplejson", "six", "aexpect",
+                            "avocado-framework>=82.1"],
           cmdclass={'clean': Clean},
           )

--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -6,11 +6,11 @@ This file has the functions that helps
 * To create gluster uri which can be used as disk image file path.
 """
 
+import ipaddress
 import logging
 import os
 import re
 import socket
-import netaddr
 
 from avocado.utils import process
 from avocado.utils import path as utils_path
@@ -362,9 +362,14 @@ def create_gluster_uri(params, stripped=False):
             gluster_port = params.get("gluster_port")
             port = ":%s" % gluster_port if gluster_port else ""
 
-            # [IPv6 address]
-            server = "[%s]" % gluster_server if netaddr.valid_ipv6(
-                                gluster_server) else gluster_server
+            server = gluster_server
+            try:
+                # [IPv6 address]
+                ipaddress.IPv6Address(gluster_server)
+            except ipaddress.AddressValueError:
+                pass
+            else:
+                server = "[%s]" % gluster_server
 
             host = "%s%s" % (server, port)
 

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -8,7 +8,7 @@ import random
 import math
 import shutil
 import platform
-import netaddr
+import ipaddress
 import six
 import resource
 
@@ -1475,7 +1475,7 @@ class PciAssignable(object):
         if (not self.start_addr_PF) or (not self.net_mask):
             raise exceptions.TestSetupFail(
                 "No IP / netmask found, please populate starting IP address for PF devices in configuration file")
-        ip_addr = netaddr.IPAddress(self.start_addr_PF)
+        ip_addr = ipaddress.ip_address(self.start_addr_PF)
         for PF in pf_devices:
             ifname = utils_misc.get_interface_from_pci_id(PF)
             ip_assign = "ifconfig %s %s netmask %s up" % (

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -12,12 +12,12 @@ import shelve
 import signal
 import sys
 import netifaces
-import netaddr
 import platform
 import uuid
 import hashlib
 import shutil
 import json
+import ipaddress as pyipaddr
 
 import aexpect
 from aexpect import remote
@@ -3381,7 +3381,7 @@ def verify_ip_address_ownership(ip, macs, timeout=60.0, devs=None,
             pass
         return False
 
-    ip_ver = netaddr.IPAddress(ip).version
+    ip_ver = pyipaddr.ip_address(ip).version
 
     func = process.getoutput
     dargs = dict()
@@ -3442,7 +3442,7 @@ def gen_ipv4_addr(network_num="10.0.0.0", network_prefix="24", exclude_ips=[]):
                         str(1))
         exclude_ips.add(('.'.join(network_num.split('.')[0:3]) + ".%s" %
                          str(255)))
-    network = netaddr.IPNetwork("%s/%s" % (network_num, network_prefix))
+    network = pyipaddr.ip_network("%s/%s" % (network_num, network_prefix))
     for ip_address in network:
         if str(ip_address) not in exclude_ips:
             yield str(ip_address)
@@ -3592,7 +3592,7 @@ def get_linux_ipaddr(session, nic):
     out = session.cmd_output_safe(cmd)
     addrs = re.findall(rex, out, re.M)
     addrs = map(lambda x: x[1].split('/')[0], addrs)
-    addrs = map(lambda x: netaddr.IPAddress(x), addrs)
+    addrs = map(lambda x: pyipaddr.ip_address(x), addrs)
     ipv4_addr = list(filter(lambda x: x.version == 4, addrs))
     ipv6_addr = list(filter(lambda x: x.version == 6, addrs))
     ipv4_addr = str(ipv4_addr[0]) if ipv4_addr else None
@@ -3606,7 +3606,7 @@ def windows_mac_ip_maps(session):
     """
     def str2ipaddr(str_ip):
         try:
-            return netaddr.IPAddress(str_ip)
+            return pyipaddr.ip_address(str_ip)
         except Exception:
             pass
         return None

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1001,7 +1001,7 @@ class AvocadoGuest(object):
             if self.session.cmd_status(cmd, timeout=self.timeout) != 0:
                 LOG.error("Failed to restart libvirtd inside guest")
                 return False
-            pip_pack = ['setuptools', 'netifaces', 'aexpect', 'netaddr']
+            pip_pack = ['setuptools', 'netifaces', 'aexpect']
             cmd = ""
             for each in pip_pack:
                 cmd = "%s install %s --upgrade" % (self.pip_bin, each)


### PR DESCRIPTION
Since Python 3.3+ provides `ipaddress` as the standard library for
IPv4/IPv6 manipulation, let's replace the third-party one (`netaddr`)
with it for a better maintainability.

Signed-off-by: Xu Han <xuhan@redhat.com>