### PR TITLE
tpm.py: optimize pcrbank part to support setup_attr

### DIFF
--- a/virttest/libvirt_xml/devices/tpm.py
+++ b/virttest/libvirt_xml/devices/tpm.py
@@ -92,11 +92,18 @@ class Tpm(base.UntypedDeviceBase):
             Tpm active_pcr_banks xml class.
 
             Elements:
-            pcrbank_list: list of elements
+            sha1: supported element sha1
+            sha256: supported element sha256
+            sha384: supported element sha384
+            sha512: supported element sha512
+            pcrbank_list: list of any customized elements. It does not support setup_attrs().
             """
-            __slots__ = ('pcrbank_list',)
+            __slots__ = ('sha1', 'sha256', 'sha384', 'sha512', 'pcrbank_list')
 
             def __init__(self, virsh_instance=base.base.virsh):
+                for slot in ('sha1', 'sha256', 'sha384', 'sha512'):
+                    accessors.XMLElementBool(slot, self, parent_xpath='/',
+                                             tag_name=slot)
                 accessors.AllForbidden(property_name="pcrbank_list",
                                        libvirtxml=self)
                 super(self.__class__, self).__init__(virsh_instance=virsh_instance)


### PR DESCRIPTION
Add XMLElementBool of 'sha1,sha256,sha284,sha512' for easy configure
entry, to support setup_attr of tpm device. Keep previous add/delete/etc
pcrbank_list methods for old cases and custom usage.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>