### PR TITLE
qemu_vm: Support virtio-iommu

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1591,6 +1591,19 @@ class VM(virt_vm.BaseVM):
                 'aw-bits': params.get('iommu_aw_bits')}
             devices.insert(QDevice('intel-iommu', iommu_params))
 
+        # Add device virtio-iommu, it must be added before any virtio devices
+        if (params.get_boolean('virtio_iommu') and
+                devices.has_device('virtio-iommu-pci')):
+            iommu_params = {"pcie_direct_plug":
+                            params.get("virtio_iommu_direct_plug", "yes")}
+            virtio_iommu_extra_params = params.get("virtio_iommu_extra_params")
+            if virtio_iommu_extra_params:
+                for extra_param in virtio_iommu_extra_params.strip(",").split(","):
+                    key, value = extra_param.split('=')
+                    iommu_params[key] = value
+            devices.insert(
+                QDevice('virtio-iommu-pci', iommu_params, parent_bus=pci_bus))
+
         vga = params.get("vga")
         if vga:
             devices.insert(add_vga(devices, vga))

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -105,6 +105,10 @@ flexible_nic_index = no
 # iommu_pt = on/off
 # iommu_aw_bits = <uint8>
 
+# Add device virtio-iommu-pci
+# virtio_iommu = yes
+# virtio_iommu_direct_plug = yes
+
 # Enable guest iommu (intel_iommu=on) in guest kernel cmd line
 # This parameter only support intel platform so the default
 # value is set to None.


### PR DESCRIPTION
Since qemu-7.0, a new iommu device named "virtio-iommu" has been
introduced to manage Direct Memory Access (DMA), the default behavior
is insert it into the pci(e).0 bus before all virtio devices, insert it
into pcie-root-port should also work so users can modify the parameters
to make it insert into pcie-root-port.

ID: 2087062
Signed-off-by: Yihuang Yu <yihyu@redhat.com>