### PR TITLE
Support custom libvirt log filters

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1014,9 +1014,11 @@ def preprocess(test, params, env):
             # By default log the info level
             log_level = params.get("libvirtd_debug_level", "2")
             log_file = params.get("libvirtd_debug_file", "")
+            log_filters = params.get("libvirtd_debug_filters", "2:*")
             libvirtd_debug_log = test_setup.LibvirtdDebugLog(test,
                                                              log_level,
-                                                             log_file)
+                                                             log_file,
+                                                             log_filters)
             libvirtd_debug_log.enable()
 
     setup_pb = False

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -774,9 +774,12 @@ virtinstall_extra_args = ""
 # Params for enable/disable Libvirtd debug logs by default it is
 # enabled and retrieve logs for fail and error tests, the logs
 # are saved in default debug dir
+# Advanced log filters setting can refer to:
+# https://libvirt.org/kbase/debuglogs.html#example-filter-settings
 enable_libvirtd_debug_log = "yes"
 libvirtd_debug_level = "2"
 libvirtd_debug_file = ""
+libvirtd_debug_filters = "2:*"
 libvirtd_log_cleanup = "yes"
 
 #Define one flexbit whether enable split daemons feature, default is disable

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2466,16 +2466,18 @@ class LibvirtdDebugLog(object):
     and log file path("libvirtd_debug_file") can be controlled.
     """
 
-    def __init__(self, test, log_level="1", log_file=""):
+    def __init__(self, test, log_level="1", log_file="", log_filters="1:*"):
         """
         initialize variables
 
         :param test: Test object
         :param log_level: debug level for libvirtd log
         :param log_file: debug file path
+        :param log_filters: log filters for libvirtd log
         """
         self.log_level = log_level
         self.log_file = log_file
+        self.log_filters = log_filters
         self.test = test
         self.daemons_dict = {}
         self.daemons_dict["libvirtd"] = {
@@ -2537,6 +2539,7 @@ class LibvirtdDebugLog(object):
             value.get("conf")["log_level"] = self.log_level
             value.get("conf")["log_outputs"] = '"%s:file:%s"' % (self.log_level,
                                                                  self.log_file)
+            value.get("conf")["log_filters"] = '"%s"' % self.log_filters
             value.get("daemon").restart()
 
     def disable(self):


### PR DESCRIPTION
"libvirtd_debug_level" can only custom the global log level to
collect all logs. Sometimes, users only want to capture
specific log information. Introduce a new parameter to custom
log filters, it can also reduce the log file size.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>