### PR TITLE
guest-hw: remove nfs settings

### DIFF
--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -402,8 +402,8 @@ variants image_backend:
         image_raw_device = yes
     - remote_nfs:
         storage_type = nfs
-        nfs_mount_dir = /mnt/nfs_images
-        nfs_mount_options = rw
+        #nfs_mount_dir = /mnt/nfs_images
+        #nfs_mount_options = rw
         # Please update nfs_mount_src base your nfs server
         #nfs_mount_src = 192.168.12.10:/vol/s2imagetest
     - local_nfs:


### PR DESCRIPTION
comment out remote_nfs expose settings, define them
    in user cases.

Signed-off-by: Aihua Liang <aliang@redhat.com>
id:2094709