### PR TITLE
[minor fix] Cut out '-pci' from the namespace of virtio-rng device params

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -932,7 +932,7 @@ class VM(virt_vm.BaseVM):
                 parent_bus = None
             if devices.has_device(dev_type):
                 rng_pci = QDevice(dev_type, parent_bus=parent_bus)
-                set_dev_params(rng_pci, rng_params, None, dev_type)
+                set_dev_params(rng_pci, rng_params, None, 'virtio-rng')
 
                 rng_dev = qdevices.QCustomDevice(dev_type="object",
                                                  backend="backend")

--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -435,8 +435,8 @@ variants:
     - virtio_rng:
         no Host_RHEL.m5 Host_RHEL.m6.u0 Host_RHEL.m6.u1 Host_RHEL.m6.u2 Host_RHEL.m6.u3 Host_RHEL.m6.u4 Host_RHEL.m6.u5
         virtio_rngs += " rng0"
-        #max-bytes_virtio-rng-pci =
-        #period_virtio-rng-pci =
+        #max-bytes_virtio-rng =
+        #period_virtio-rng =
         variants:
              - rng_builtin:
                  required_qemu ~= [4.2, )


### PR DESCRIPTION
'virtio-rng-pci' is one type of virtio rng devices, the real name is not
unique, we have "virtio-rng-pci", "virtio-rng-pci-non-transitional",
"virtio-rng-pci-transitional", etc. And the device name in some
platforms is not the same. So we should not use the params namespace
"xxx_virtio-rng-pci", otherwise we need to configure the same virtio-rng
device with different parameters in diff platforms.

ID: 2098066
Signed-off-by: Yihuang Yu <yihyu@redhat.com>