### PR TITLE
libvirt_cgroup: add functions for cpusset.cpus

### DIFF
--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -456,3 +456,27 @@ class CgroupTest(object):
         """
         virsh_output_dict = self.get_virsh_output_dict(vm_name, virsh_cmd)
         return self.get_standardized_virsh_info(virsh_cmd, virsh_output_dict)
+
+    def reset_cpuset_cpus(self, value):
+        """
+        Reset the cpuset.cpus file to the specified content
+
+        :param value: to be set
+        """
+        if self.is_cgroup_v2_enabled():
+            return
+        LOG.debug("Reset /sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus to %s", value)
+        cmd = "echo %s > /sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus" % value
+        process.run(cmd, ignore_status=False, shell=True)
+
+    def get_cpuset_cpus(self):
+        """
+        Get the cpuset.cpus file content
+
+        :return: str, the value of cpuset.cpus content
+        """
+        if self.is_cgroup_v2_enabled():
+            return
+        LOG.debug("Get /sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus value")
+        cmd = "cat /sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus"
+        return process.run(cmd, ignore_status=False, shell=True).stdout_text.strip()


### PR DESCRIPTION
Signed-off-by: Dan Zheng <dzheng@redhat.com>