### PR TITLE
fetch_attrs:Handle XMLElementBool type value

### DIFF
--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -380,7 +380,10 @@ class LibvirtXMLBase(propcan.PropCanBase):
                     # of dict-type attrs to target slot
                     elif isinstance(value[0], LibvirtXMLBase):
                         value = [v.fetch_attrs() for v in value]
-                attrs[key] = value
+                # If the element is bool type, only return value when
+                # it's True
+                if value is not False:
+                    attrs[key] = value
 
         return attrs
 


### PR DESCRIPTION
A value of XMLElementBool means the tag exists when the value is
True, doesn't exist when it's False. Therefore the False value
should not be returned when calling the function fetch_attrs()

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>