### PR TITLE
Add debug print to check_cmd_output function

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3896,6 +3896,7 @@ def check_cmd_output(cmd, content, err_ignore=False, session=None):
     s, cmd_output = utils_misc.cmd_status_output(cmd, shell=True,
                                                  ignore_status=err_ignore, session=session)
     pattern_list = [content] if not isinstance(content, list) else content
+    LOG.debug('Ran command "%s" with output "%s"', cmd, cmd_output)
     for item in pattern_list:
         if not re.search(r'%s' % item, cmd_output):
             if err_ignore:


### PR DESCRIPTION
In file virttest/utils_test/libvirt.py in function check_cmd_output a
debug log print has been added, to help with debugging. It shows you
what is the command that has been run and what is the output of the
command.

I just thought this would be helpful when I was debugging an issue and
needed to know what exectly avocado is executing.

It could save time by not having to add debugging printsouts.