### PR TITLE
Remove the check for config object

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3783,8 +3783,6 @@ def customize_libvirt_config(params,
             libvirtd.restart()
         obj_conf = target_conf
     else:
-        if not isinstance(config_object, utils_config.LibvirtConfigCommon):
-            return None
         # Handle local libvirtd
         config_object.restore()
         if restart_libvirt:


### PR DESCRIPTION
If config type is 'qemu', the config object should be
'LibvirtQemuConfig'. So need to remove this check.

Signed-off-by: cliping <lcheng@redhat.com>