### PR TITLE
Fix a guest undefine failure

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -683,11 +683,8 @@ class VMXML(VMXMLBase):
 
     def undefine(self, options=None, virsh_instance=base.virsh):
         """Undefine this VM with libvirt retaining XML in instance"""
-        try:
-            nvram = getattr(getattr(self, "os"), "nvram")
-        except xcepts.LibvirtXMLNotFoundError:
-            nvram = None
-
+        os_attrs = self.os.fetch_attrs()
+        nvram = any([os_attrs.get('os_firmware') == "efi", os_attrs.get('nvram')])
         if nvram:
             if options is None:
                 options = "--nvram"


### PR DESCRIPTION
Update undefine() to work well with guest with os_firmwork setting.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

test result on 9.x:
` (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: PASS (53.28 s)
`