### PR TITLE
libvirt_xml/vm_xml: modify remove_all_boots to remove all boot elements

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1759,10 +1759,10 @@ class VMXML(VMXMLBase):
 
     def remove_all_boots(self):
         """
-        Remove all OS boots
+        Remove all boot elements
         """
         try:
-            self.xmltreefile.remove_by_xpath('/os/boot', remove_all=True)
+            self.xmltreefile.remove_by_xpath('//boot', remove_all=True)
         except (AttributeError, TypeError):
             pass  # Element already doesn't exist
         self.xmltreefile.write()


### PR DESCRIPTION
`remove_all_boots` currently only removes the single `/os/boot` and not
the device element that let's us define boot order et al.

Let's remove all boot elements to have the function do what
it name suggests. This fixes also some cases that fail
if the guest definition is using the device specific boot element,
e.g. boot_integration.by_qemu_on_s390.boot_dev.check_menu.

The function is currently only used in the tp-libvirt by the
following test scripts so this patch will require successful
test runs for acceptance:

- libvirt/tests/src/bios/boot_integration.py
- libvirt/tests/src/bios/virsh_boot.py
- libvirt/tests/src/bios/boot_order_seabios.py
- libvirt/tests/src/virtual_network/iface_network.py

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>