### PR TITLE
Remove pm-utils as dependence package since guest-agent doesn't need it

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2973,7 +2973,7 @@ class VM(virt_vm.BaseVM):
 
     def prepare_guest_agent(self, prepare_xml=True, channel=True, start=True,
                             source_path=None, target_name='org.qemu.guest_agent.0',
-                            with_pm_utils=True):
+                            with_pm_utils=False):
         """
         Prepare qemu guest agent on the VM.
 


### PR DESCRIPTION
Remove pm-utils as dependence package since guest-agent doesn't need it
In guest_agent, finding that pm-utils package can be not installed without additional repository config,
but all cases related to guest agent pass

Signed-off-by: chunfuwen <chwen@redhat.com>