### PR TITLE
qemu_vm: Avoid overwrite existing virtio properties

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2760,8 +2760,10 @@ class VM(virt_vm.BaseVM):
             attr_info = [None, params["keyboard_layout"], None]
             add_qemu_option(devices, "k", [attr_info])
 
-        # Add options for all virtio devices
-        virtio_devices = filter(lambda x: re.search(r"(?:^virtio-)|(?:^vhost-)",
+        # Add options for virtio devices which match the pattern
+        virtio_dev_filter = params.get("virtio_dev_filter",
+                                       "(?:^virtio-)|(?:^vhost-)")
+        virtio_devices = filter(lambda x: re.search(virtio_dev_filter,
                                                     x.get_param('driver', '')),
                                 devices)
         for device in virtio_devices:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2778,7 +2778,7 @@ class VM(virt_vm.BaseVM):
                 "ats": params.get("virtio_dev_ats"),
                 "aer": params.get("virtio_dev_aer")}
             for key, value in properties_to_be_set.items():
-                if value and key in dev_properties:
+                if key not in device.params and value and key in dev_properties:
                     device.set_param(key, value)
 
         # set tag for pcic

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -122,6 +122,10 @@ flexible_nic_index = no
 # Set guest kernel iommu option (iommu=off/force/pt e.g.)
 # guest_iommu_option = pt
 
+# Specify a filter to make virtio_dev_xxx params only handle those devices
+# The following filter will capture all devices except balloon and iommu devices
+# virtio_dev_filter = '^(?:(?:virtio-)|(?:vhost-))(?!(?:balloon)|(?:user))'
+
 # List of block device object names (whitespace separated)
 images = image1
 # List of block device object names with order (whitespace separated)


### PR DESCRIPTION
1. "virtio_dev_xxx" are global settings for virtio devices, but they will
    always be set if we define them, even if the device has set these
    properties. The property setting by the device should be higher than
the global one.
2. `virtio_dev_xxx` will set properties to whole virtio devices, but some
    devices cannot work well that property such as "vhost-user-fs-pci" +
    "iommu_platform", so the new parameter `virtio_dev_filter` can filter
    out some devices which we want to set those properties.


ID: 2111781
Signed-off-by: Yihuang Yu <yihyu@redhat.com>