### PR TITLE
utils_zcrypt: enable driver handling in VMs

### DIFF
--- a/virttest/utils_zcrypt.py
+++ b/virttest/utils_zcrypt.py
@@ -216,28 +216,34 @@ def _echo(value, sysfs):
         ))
 
 
-def load_vfio_ap():
+def load_vfio_ap(session=None):
     """
     Loads the passthrough module
 
+    :param session: VM guest session; the command will be run on the
+                    host if None
     :return: None
     """
-    err, out = process.getstatusoutput("modprobe vfio_ap",
-                                       timeout=CMD_TIMEOUT,
-                                       verbose=VERBOSE)
+    err, out = cmd_status_output("modprobe vfio_ap", shell=True,
+                                 session=session,
+                                 timeout=CMD_TIMEOUT,
+                                 verbose=VERBOSE)
     if err:
         raise RuntimeError("Couldn't load vfio_ap: %s" % out)
 
 
-def unload_vfio_ap():
+def unload_vfio_ap(session=None):
     """
     Unloads the passthrough module
 
+    :param session: VM guest session; the command will be run on the
+                    host if None
     :return: None
     """
-    err, out = process.getstatusoutput("rmmod vfio_ap",
-                                       timeout=CMD_TIMEOUT,
-                                       verbose=VERBOSE)
+    err, out = cmd_status_output("rmmod vfio_ap", shell=True,
+                                 session=session,
+                                 timeout=CMD_TIMEOUT,
+                                 verbose=VERBOSE)
     if err:
         raise RuntimeError("Couldn't unload vfio_ap: %s" % out)
 


### PR DESCRIPTION
Change the vfio_ap load functions to be run inside of a VM.
This is needed to test crypto passthrough in a nested setup.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>