### PR TITLE
Update "--nvram" to "--keep-nvram" during undefine

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -296,13 +296,15 @@ class VM(virt_vm.BaseVM):
         """
         Undefine the VM.
         """
-        # If the current machine contains nvram, we have to set --nvram
+        # If the current machine contains nvram, we have to set --keep-nvram
+        # Adding "--keep-nvram" can undefine a vm with nvram successfully and
+        # also skip the reset process during next boot
         if self.params.get("vir_domain_undefine_nvram") == "yes":
             if options is None:
-                options = "--nvram"
+                options = "--keep-nvram"
             else:
-                if "--nvram" not in options:
-                    options += " --nvram"
+                if "nvram" not in options:
+                    options += " --keep-nvram"
         try:
             virsh.undefine(self.name, options=options, uri=self.connect_uri,
                            ignore_status=False)

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -687,9 +687,9 @@ class VMXML(VMXMLBase):
         nvram = any([os_attrs.get('os_firmware') == "efi", os_attrs.get('nvram')])
         if nvram:
             if options is None:
-                options = "--nvram"
-            if "--nvram" not in options:
-                options += " --nvram"
+                options = "--keep-nvram"
+            if "nvram" not in options:
+                options += "--keep-nvram"
 
         return virsh_instance.remove_domain(self.vm_name, options)
 

--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -589,7 +589,7 @@ class MigrationTest(object):
         vm.connect_uri = desturi
         if vm.exists():
             if vm.is_persistent():
-                vm.undefine(options='--nvram')
+                vm.undefine(options='--keep-nvram')
             if vm.is_alive():
                 # If vm on remote host is unaccessible
                 # graceful shutdown may cause confused


### PR DESCRIPTION
For UEFI guest, we can not undefine it successfully without any nvram
options. With "--nvram", it will delete the nvram file when undefine the
guest. When we define the guest again, it will reset before normal
boot. As serail login will input something during the reset process, it
will trigger the guest wait for some manual intervention which cause auto
case to fail. Update "--nvram" to "--keep-nvram" to workaround it.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>