### PR TITLE
Fix travis ci failure due to setuptool install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
           fetch-depth: 0
       - name: Install avocado libs
         working-directory: ./avocado-libs
-        run: pip install -e .
+        run: |
+         python -m pip install --upgrade pip
+         pip install 'setuptools-rust==1.1.2'
+         pip install -e .
       - name: Finish installing dependencies
         run: |
          pip install -e .


### PR DESCRIPTION
Fix travis ci failure due to setuptool install

When install avocado framework, it needs required package: setuptool
But  ModuleNotFoundError: No module named 'setuptools_rust' if not proper pip is used

Signed-off-by: chunfuwen <chwen@redhat.com>