### PR TITLE
virttest/migration: improve error message when do_cancel fails

### DIFF
--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -739,6 +739,8 @@ class MigrationTest(object):
             return pid
 
         pid = utils_misc.wait_for(_get_pid, 30)
+        if not pid:
+            raise exceptions.TestError("Migration is not running, won't cancel.")
         if utils_misc.safe_kill(pid, sig):
             LOG.info("Succeed to cancel migration: [%s].", pid.strip())
         else:


### PR DESCRIPTION
If migration is not running (crashed or completed) when trying
to cancel, we'll get a an error from further down in the code,
more specifically from the type cast in `process.safe_kill`.

I've observed two possible test errors:
1. ValueError: invalid literal for int() with base 10: ''
2. TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

However, when we call cancel we usually want to test the behavior
of cancellation and possibly retrying. In these cases, now print
a specific error message about the migration not running.

If the test log shows the migration had already finished, we
can try to slow down the migration with things like decreasing
the bandwidth or creating dirty memory pages.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>