### PR TITLE
dimm: get accurate device params and distinguish attributes by dimm_type

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2904,20 +2904,27 @@ class DevContainer(object):
         """
         Create pc-dimm device from params.
         """
-        params = params.object_params("dimm")
+        # Ensure get accurate params for dimm device, avoid irrelevant params
+        # be used by mistake.
+        dimm_params = Params()
+        suffix = '_dimm'
+        for key in list(params.keys()):
+            if key.endswith(suffix):
+                new_key = key.rsplit(suffix)[0]
+                dimm_params[new_key] = params[key]
+
         dimm_type = "nvdimm" if params.get("nv_backend") else "pc-dimm"
-        attrs = qdevices.Dimm.__attributes__[:]
-        dev = qdevices.Dimm(params=params.copy_from_keys(attrs),
+        attrs = qdevices.Dimm.__attributes__[dimm_type][:]
+        dimm_uuid = dimm_params.get("uuid")
+        if 'uuid' in attrs and dimm_uuid:
+            try:
+                dimm_params['uuid'] = str(uuid.UUID(dimm_uuid))
+            except ValueError:
+                if dimm_uuid == '<auto>':
+                    dimm_params['uuid'] = str(uuid.uuid5(uuid.NAMESPACE_OID, name))
+        dev = qdevices.Dimm(params=dimm_params.copy_from_keys(attrs),
                             dimm_type=dimm_type)
         dev.set_param("id", "%s-%s" % ("dimm", name))
-        if dimm_type == "nvdimm" and params.get("nvdimm_uuid"):
-            try:
-                dev.set_param("uuid", uuid.UUID(params["nvdimm_uuid"]))
-            except ValueError:
-                nvdimm_uuid = params["nvdimm_uuid"]
-                if nvdimm_uuid == "<auto>":
-                    nvdimm_uuid = uuid.uuid5(uuid.NAMESPACE_OID, name)
-                dev.set_param("uuid", nvdimm_uuid)
         for ext_k, ext_v in params.get_dict("dimm_extra_params").items():
             dev.set_param(ext_k, ext_v)
         return dev

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1511,8 +1511,9 @@ class Dimm(QDevice):
     and 'memory-backend-file'
     """
 
-    __attributes__ = ["memdev", "slot", "addr", "node", "unarmed", "size",
-                      "label-size", "uuid"]
+    __attributes__ = {"pc-dimm": ["memdev", "slot", "addr", "node", "size"],
+                      "nvdimm": ["memdev", "slot", "addr", "node", "unarmed",
+                                 "size", "label-size", "uuid"]}
 
     def __init__(self, params=None, dimm_type='pc-dimm'):
         kwargs = {'driver': dimm_type,

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -919,12 +919,12 @@ qemu_stop = on
 # Do not add --preconfig to qemu by default, set it on if needed.
 qemu_preconfig = off
 
-# Set uuid property of nvdimm device (Since QEMU-5.0), it supports the string
+# Set uuid property of dimm device (Since QEMU-5.0), it supports the string
 # representation of a UUID as a URN. // RFC 4122
 # If you use a wrong format, will generate a random UUID base on uuid5 and
 # device name.
-# nvdimm_uuid = urn:uuid:ea0ec480-6066-40bc-9709-65d0467ad024
-nvdimm_uuid = ""
+# uuid_dimm = urn:uuid:ea0ec480-6066-40bc-9709-65d0467ad024
+uuid_dimm = ""
 
 
 # Set below params to attach TPM device to

--- a/virttest/shared/cfg/machines.cfg
+++ b/virttest/shared/cfg/machines.cfg
@@ -38,7 +38,7 @@ variants:
         del rtc_drift
         del soundcards
         serial_type = 'spapr-vty'
-        nvdimm_uuid = <auto>
+        uuid_dimm = <auto>
     - arm64-mmio:
         only aarch64
         auto_cpu_model = "no"

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -590,7 +590,8 @@ class MemoryHotplugTest(MemoryBaseTest):
                                                           "memory-backend-ram")
             attrs = dev.__attributes__[backend][:]
         else:
-            attrs = dev.__attributes__[:]
+            dimm_type = dev.get_param('driver')
+            attrs = dev.__attributes__[dimm_type][:]
         params = self.params.copy_from_keys(attrs)
         for attr in attrs:
             val = dev.get_param(attr)


### PR DESCRIPTION
1. Ensure get accurate params for dimm device, avoid inrelevant params
   be used by mistake
2. Distinguish attributes for different dimm_type

id: 2106656
Signed-off-by: Yanan Fu <yfu@redhat.com>