### PR TITLE
libvirt_virtio: Require ioapic for x86

### DIFF
--- a/virttest/utils_libvirt/libvirt_virtio.py
+++ b/virttest/utils_libvirt/libvirt_virtio.py
@@ -6,6 +6,7 @@ Libvirt virtio related utilities.
 
 import logging
 
+from virttest import arch
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import iommu
 from virttest.utils_test import libvirt
@@ -37,7 +38,7 @@ def add_iommu_dev(vm, iommu_dict):
     libvirt_vmxml.remove_vm_devices_by_type(vm, 'iommu')
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
     features = vmxml.features
-    if not features.has_feature('ioapic'):
+    if not features.has_feature('ioapic') and arch.ARCH == "x86_64":
         features.add_feature('ioapic', 'driver', 'qemu')
         vmxml.features = features
 


### PR DESCRIPTION
IOAPIC is x86 only. Add this filter to avoid adding virtio-iommu failure
on aarch64.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>