### PR TITLE
qemu_vm: Amend the issue of "no attribute monitor"

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4840,7 +4840,7 @@ class VM(virt_vm.BaseVM):
             "Waiting for save to %s to complete" % path)
         # Restore the speed and downtime to default values
         qemu_migration.set_speed(self, str(32 << 20))
-        qemu_migration.monitor.set_downtime(self, 0.03)
+        qemu_migration.set_downtime(self, 0.03)
         # Base class defines VM must be off after a save
         self.monitor.cmd("system_reset")
         self.verify_status('paused')  # Throws exception if not


### PR DESCRIPTION
Amend the issue that "AttributeError: module 'qemu_migration'
has no attribute 'monitor'".

Signed-off-by: Yongxue Hong <yhong@redhat.com>