### PR TITLE
Fix a bug about order of importing config files

### DIFF
--- a/virttest/backends/qemu/cfg/tests-shared.cfg
+++ b/virttest/backends/qemu/cfg/tests-shared.cfg
@@ -12,12 +12,12 @@ connect_uri = default
 # Include the base config files.
 include base.cfg
 include machines.cfg
-include subtests.cfg
 include host.cfg
 include guest-os.cfg
 include guest-hw.cfg
 include cdkeys.cfg
 include virtio-win.cfg
+include subtests.cfg
 
 # Additional directory for find virt type tests. Relative to client/tests
 other_tests_dirs = ""


### PR DESCRIPTION
As we support override of parameters defined in different config fils,
the parameters in config files imported later should override those
imported previously. But the parameters in subtests.cfg should take
effect anyway finally since they are the definite ones that we want
to test.

This patch fixes the bug that config of smp and memory defined in
subtests.cfg are overridden by guest-os.cfg by mistake.

Signed-off-by: Yingfu Zhou <yolkfull@hotmail.com>