### PR TITLE
utils_sriov: Correct 'session' in add_connection()

### DIFF
--- a/virttest/utils_sriov.py
+++ b/virttest/utils_sriov.py
@@ -308,7 +308,7 @@ def add_connection(pf_name, bridge_name, session=None):
     :param bridge_name: bridge's name
     :param session: The session object to the host
     """
-    del_connection(pf_name, bridge_name, session=None, ignore_status=True)
+    del_connection(pf_name, bridge_name, session=session, ignore_status=True)
     cmd = 'tmux -c "ip link add name {1} type bridge; ip link set {0} up; ' \
           'ip link set {0} master {1}; ip link set {1} up; dhclient -r;' \
           'sleep 5; dhclient"'.format(pf_name, bridge_name)


### PR DESCRIPTION
The value of 'session' was set to 'None' incorrectly, so update
it in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Test result:
` (1/1) type_specific.io-github-autotest-libvirt.sriov.failover.abort_migration.hostdev_interface.with_precopy: PASS (298.92 s)
`