### PR TITLE
Add romfile option for NIC device

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -2053,3 +2053,4 @@ zfile
 zgrep
 zgrepi
 zzz
+romfile

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -63,6 +63,12 @@ nics = nic1
 nettype = user
 netdst = virbr0
 
+# Assign romfile, or specify per-nic values
+# qemu has a "romfile" option that allows specifying a binary file to present
+# as the ROM BIOS of any emulated or passthrough PCI device
+# nic_romfile = 'EMPTY_STRING'      # To disable rom loading for all nics
+# nic_romfile_nic1 = 'EMPTY_STRING' # To disable rom loading for nic1
+
 # For private bridge created by framework please set the following
 # parameters:
 # netdst = private

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -2918,7 +2918,15 @@ class ParamsNet(VMNet):
                     existing_value = None
                 except IndexError:
                     existing_value = None
-                nic_dict[propertea] = nic_params.get(propertea, existing_value)
+
+                # FIXME: We need a mapping handler to map cartesian params
+                # to nic attributes, here is just a workaround to map
+                # param nic_romfile to romfile attribute only
+                if propertea == 'romfile':
+                    nic_dict['romfile'] = nic_params.get('nic_romfile', existing_value)
+                else:
+                    nic_dict[propertea] = nic_params.get(propertea, existing_value)
+
                 if propertea == "netdst" and "shell:" in nic_dict[propertea]:
                     nic_dict[propertea] = process.getoutput(
                         nic_dict[propertea].split(':', 1)[1])
@@ -2938,7 +2946,7 @@ class ParamsNet(VMNet):
         default_params = {}
         default_params['queues'] = 1
         default_params['tftp'] = None
-        default_params['romfile'] = None
+        default_params['nic_romfile'] = None
         default_params['nic_extra_params'] = ''
         default_params['netdev_extra_params'] = ''
         nic_name_list = self.params.objects('nics')


### PR DESCRIPTION
Introduced a new VT param 'nic_romfile',
  To disable rom loading for all nics:
  nic_romfile = 'EMPTY_STRING'
  To disable rom loading for nic1
  nic_romfile_nic1 = 'EMPTY_STRING'

Signed-off-by: Zhenchao Liu <zhencliu@redhat.com>

ID: 2119345