### PR TITLE
Fix the migration downtime parameter type and default value

### DIFF
--- a/virttest/qemu_migration.py
+++ b/virttest/qemu_migration.py
@@ -18,7 +18,7 @@ def set_downtime(vm, value):
     """
     if (vm.check_capability(Flags.MIGRATION_PARAMS) and
             vm.check_migration_parameter(MigrationParams.DOWNTIME_LIMIT)):
-        return vm.monitor.set_migrate_parameter('downtime-limit', value * 1000)
+        return vm.monitor.set_migrate_parameter('downtime-limit', int(value * 1000))
     return vm.monitor.migrate_set_downtime(value)
 
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4842,7 +4842,7 @@ class VM(virt_vm.BaseVM):
             "Waiting for save to %s to complete" % path)
         # Restore the speed and downtime to default values
         qemu_migration.set_speed(self, str(32 << 20))
-        qemu_migration.set_downtime(self, 0.03)
+        qemu_migration.set_downtime(self, 0.3)
         # Base class defines VM must be off after a save
         self.monitor.cmd("system_reset")
         self.verify_status('paused')  # Throws exception if not


### PR DESCRIPTION
Providing a python float even when converted to string will result
in a float number (with a decimal zero) to be passed to the qemu
monitor which will complain with

Error: Parameter 'downtime-limit' expects int64

and break the migration thus leading to incorrect system states
that were paused but cannot be continued and other harder to debug
issues down the line. It is better to convert to integer explicitly
here even if we multiply by a 1000.

Also use the correct default float downtime value which should be
300 ms (downtime-limit: 300 ms) when multiplied by 1000 and not
30 ms which is what the float would imply.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>