### PR TITLE
Add read permission to a bit of log files

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1015,10 +1015,12 @@ def preprocess(test, params, env):
             log_level = params.get("libvirtd_debug_level", "2")
             log_file = params.get("libvirtd_debug_file", "")
             log_filters = params.get("libvirtd_debug_filters", "%s:*" % log_level)
+            log_permission = params.get("libvirtd_log_permission")
             libvirtd_debug_log = test_setup.LibvirtdDebugLog(test,
                                                              log_level,
                                                              log_file,
-                                                             log_filters)
+                                                             log_filters,
+                                                             log_permission)
             libvirtd_debug_log.enable()
 
     setup_pb = False

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -12,6 +12,7 @@ import time
 import re
 import traceback
 from collections import OrderedDict
+from pathlib import Path
 
 import aexpect
 
@@ -1990,7 +1991,9 @@ class QSwtpmDev(QDaemonDev):
             tpm_cmd += ' --tpm2'
 
         log_dir = utils_misc.get_log_file_dir()
-        tpm_cmd += ' --log file=%s' % os.path.join(log_dir, '%s_swtpm.log' % self.get_qid())
+        log_file = os.path.join(log_dir, '%s_swtpm.log' % self.get_qid())
+        Path(log_file).touch(mode=0o644, exist_ok=True)
+        tpm_cmd += ' --log file=%s' % log_file
 
         if self.get_param('extra_options'):
             tpm_cmd += self.get_param('extra_options')

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -789,6 +789,8 @@ libvirtd_debug_level = "2"
 libvirtd_debug_file = ""
 # Log filter is set to be aligned with log level by default.
 # libvirtd_debug_filters = "2:*"
+# Custom log file permissions until https://gitlab.com/libvirt/libvirt/-/issues/71 is supported
+# libvirtd_log_permission = "0600"
 libvirtd_log_cleanup = "yes"
 
 #Define one flexbit whether enable split daemons feature, default is disable

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -14,6 +14,7 @@ import resource
 
 from abc import ABCMeta
 from abc import abstractmethod
+from pathlib import Path
 
 from aexpect import remote
 
@@ -2462,11 +2463,13 @@ class LibvirtdDebugLog(object):
     """
     Enable libvirtd log for testcase in case
     with the use of param "enable_libvirtd_debug_log",
-    with additional params log level("libvirtd_debug_level")
-    and log file path("libvirtd_debug_file") can be controlled.
+    with additional params log level("libvirtd_debug_level"), log
+    filter("libvirtd_debug_filters") and log file
+    path("libvirtd_debug_file") can be controlled.
     """
 
-    def __init__(self, test, log_level="1", log_file="", log_filters="1:*"):
+    def __init__(self, test, log_level="1", log_file="", log_filters="1:*",
+                 log_permission=None):
         """
         initialize variables
 
@@ -2474,10 +2477,12 @@ class LibvirtdDebugLog(object):
         :param log_level: debug level for libvirtd log
         :param log_file: debug file path
         :param log_filters: log filters for libvirtd log
+        :param log_permission: debug file permission for libvirtd log
         """
         self.log_level = log_level
         self.log_file = log_file
         self.log_filters = log_filters
+        self.log_permission = log_permission
         self.test = test
         self.daemons_dict = {}
         self.daemons_dict["libvirtd"] = {
@@ -2523,6 +2528,9 @@ class LibvirtdDebugLog(object):
                                                 "libvirtd.log")
         # param used during libvirtd cleanup
         self.test.params["libvirtd_debug_file"] = self.log_file
+        if self.log_permission:
+            file_mode = int(self.log_permission, base=8)
+            Path(self.log_file).touch(mode=file_mode, exist_ok=True)
         LOG.debug("libvirtd debug log stored in: %s", self.log_file)
 
         for value in self.daemons_dict.values():


### PR DESCRIPTION
Let me take libvirtd.log as the example. There is an issue reported to
libvirt project: https://gitlab.com/libvirt/libvirt/-/issues/71, the use
case is people will use non-root user to analyze the libvirt instance
log file in another system, but by default the permission of libvirtd
log files are 0600, which reject other users to open the log for
analyzing.

For logs collection in testing, they should not contain confidential
information or not exposed to the outside, so add read permission for
all users should not a dangerous operation.

ID: 2119630
Signed-off-by: Yihuang Yu <yihyu@redhat.com>