### PR TITLE
libguestfs: get_bootable_part fails due to type mismatch

### DIFF
--- a/virttest/utils_test/libguestfs.py
+++ b/virttest/utils_test/libguestfs.py
@@ -756,7 +756,7 @@ class GuestfishTools(lgf.GuestfishPersistent):
         for partition in list(partitions.values()):
             num = partition.get("num")
             ba_result = self.part_get_bootable(device, num)
-            if ba_result.stdout.strip() == b"true":
+            if ba_result.stdout.strip() == "true":
                 return (True, "%s%s" % (device, num))
         return (False, partitions)
 


### PR DESCRIPTION
The `part_get_bootable` method returns str type object.
If it is compared with byte type object, it always return false.
It causes unexpected failures in libguestfs related tests.

We can check the behavior of get_bootable_part method with the following script:

```py
import virttest.utils_test.libguestfs
from virttest.utils_test.libguestfs import GuestfishTools
from pprint import pprint
from time import sleep

params = {
    "disk_img": "/var/lib/avocado/data/avocado-vt/images/avocado-vt-vm2",
}
g = GuestfishTools(params)
g.run()
sleep(5)
pprint(g.get_bootable_part("/dev/vda"))          # Try to find the bootable part

# We can also check each variables in python interpriter
g.part_get_bootable("/dev/vda", 1).stdout                      # 'false\n'
type(g.part_get_bootable("/dev/vda", 1).stdout)                # <class 'str'>
g.part_get_bootable("/dev/vda", 1).stdout.strip()              # 'false'
type(g.part_get_bootable("/dev/vda", 1).stdout.strip())        # <class 'str'>
g.part_get_bootable("/dev/vda", 1).stdout.strip() == b'false'  # False
g.part_get_bootable("/dev/vda", 1).stdout.strip() == 'false'   # True

g.shutdown()
```

Before the fix:
```
(False,
 {'0': {'end': 1074790399, 'num': 1, 'size': 1073741824, 'start': 1048576},
  '1': {'end': 9463398399, 'num': 2, 'size': 8388608000, 'start': 1074790400},
  '2': {'end': 10537140223, 'num': 3, 'size': 1073741824, 'start': 9463398400},
  '3': {'end': 16106127359, 'num': 4, 'size': 5568987136, 'start': 10537140224},
  '4': {'end': 11612979199,
        'num': 5,
        'size': 1073741824,
        'start': 10539237376}})
```

After the fix:
```
(True, '/dev/vda3')
```
