### PR TITLE
Update vm_xml.sync() method to correctly use nvram

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -715,7 +715,7 @@ class VMXML(VMXMLBase):
             LOG.debug("Failed to backup %s.", self.vm_name)
             backup = None
 
-        if not self.undefine(options, virsh_instance=virsh_instance):
+        if not backup.undefine(options, virsh_instance=virsh_instance):
             raise xcepts.LibvirtXMLError("Failed to undefine %s."
                                          % self.vm_name)
         result_define = virsh_instance.define(self.xml)


### PR DESCRIPTION
Previously sync method was calling undefine method based with the xml
that was given in argument. However when we were undefining a VM and the
vmxml did not have nvram in os part of xml, the option "--nvram" was not
added and the undefine failed.

This commit changes that and nvram is looked up in the xml that is
dumped from actively used xml. So if we're undefining a VM with nvram
the --nvram option will be added and a VM will be correctly undefined.