### PR TITLE
vm_xml: support new iothreadids element

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -3697,20 +3697,20 @@ class VMIothreadidsXML(base.LibvirtXMLBase):
         """
         Convert a string to iothread tag and attributes.
         """
-        del index
-        del libvirtxml
-        return ('iothread', {'id': item})
+        if not isinstance(item, dict):
+            raise xcepts.LibvirtXMLError("Expected a dictionary of iothread "
+                                         "attributes, not a %s"
+                                         % str(item))
+        return ('iothread', dict(item))
 
     @staticmethod
     def marshal_to_iothreads(tag, attr_dict, index, libvirtxml):
         """
         Convert a iothread tag and attributes to a string.
         """
-        del index
-        del libvirtxml
         if tag != 'iothread':
             return None
-        return attr_dict['id']
+        return dict(attr_dict)
 
 
 class VMFeaturesHptXML(base.LibvirtXMLBase):


### PR DESCRIPTION
In the past, there is only one attribute (id) supported in iothread, like
<iothread id="6"/>. But now thread_pool_min and thread_pool_max attributes
are added. And maybe more come in future. So old implementation can not meet
this requirement. This fix is to make this class extensible in future.

Signed-off-by: Dan Zheng <dzheng@redhat.com>