### PR TITLE
vm_xml: fix sync for transient vm

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -716,8 +716,8 @@ class VMXML(VMXMLBase):
         except IOError:
             LOG.debug("Failed to backup %s.", self.vm_name)
             backup = None
-
-        if not backup.undefine(options, virsh_instance=virsh_instance):
+        func_used = backup.undefine if backup else self.undefine
+        if not func_used(options, virsh_instance=virsh_instance):
             raise xcepts.LibvirtXMLError("Failed to undefine %s."
                                          % self.vm_name)
         result_define = virsh_instance.define(self.xml)


### PR DESCRIPTION
Generally we need to undefine using current vm xml object. But when vm is transient, it means current vm does not have a xml definition, we have to use the backed up vm xml to undefine as before.

Signed-off-by: Dan Zheng <dzheng@redhat.com>