### PR TITLE
Provide image specific parameters for each QemuImg instance

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -764,6 +764,7 @@ class QemuImg(object):
         :param root_dir: Base directory for relative filenames.
         :param tag: Image tag defined in parameter images.
         """
+        params = params.object_params(tag)
         self.params = params
         self.image_filename = get_image_filename(params, root_dir)
         self.image_format = params.get("image_format", "qcow2")


### PR DESCRIPTION
These are necessary for vms with multiple images and other cases where we would like to manipulate specific image and/or its snapshot.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>