### PR TITLE
Wait for proper monitor status before sending cont to monitor

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -1533,6 +1533,7 @@ prebuild
 preconfig
 precopy
 Predefine
+prelaunch
 prepend
 preprocess
 preprocessing


### PR DESCRIPTION
It seems that if the vm is still in "paused (inmigrate)" status and similar, its monitor will completely ignore the "cont" monitor command and thus the vm will remain paused indefinitely, leading to later monitor validation no longer passing and breaking tests as a result.