### PR TITLE
Do not resume but verify paused status

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4857,7 +4857,7 @@ class VM(virt_vm.BaseVM):
         self.create(name=self.name, params=self.params, root_dir=self.root_dir,
                     timeout=self.MIGRATE_TIMEOUT, migration_mode="exec",
                     migration_exec_cmd="cat " + path, mac_source=self)
-        self.resume()
+        self.verify_status('paused')  # Throws exception if not
 
     def savevm(self, tag_name):
         """


### PR DESCRIPTION
This is more compatible behavior with the implementation of the inverse method save_to_file() and with it both methods will now only verify paused status before and after they execute.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>