### PR TITLE
Make background errors nonfatal as they often register unrelated events

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3189,7 +3189,7 @@ class VM(virt_vm.BaseVM):
                          qemu_command.replace(" -", " \\\n    -"))
                 self.qemu_command = qemu_command
                 monitor_exit_status = \
-                    params.get("vm_monitor_exit_status", "yes") == "yes"
+                    params.get_boolean("vm_monitor_exit_status", False)
                 self.process = aexpect.run_tail(
                     qemu_command,
                     partial(qemu_proc_term_handler, self,

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -903,7 +903,7 @@ gluster_managed_by_test = "yes"
 #
 # vcpu_cputune = "0-2 N 1,3"
 
-# temporarily disable monitor QEMU vm exit status
+# Default behavior for treating monitor QEMU vm exit status as an error
 vm_monitor_exit_status = no
 
 # Bug `reboot` param from the kickstart is not actually restarts


### PR DESCRIPTION
Related to issue 3048:

https://github.com/avocado-framework/avocado-vt/issues/3048

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>