### PR TITLE
env_process: Fixup OSError

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1570,7 +1570,7 @@ def postprocess(test, params, env):
     global _screendump_thread, _screendump_thread_termination_event
     if _screendump_thread is not None:
         _screendump_thread_termination_event.set()
-        _screendump_thread.join(10)
+        _screendump_thread.join(30)
         _screendump_thread = None
 
     # Encode an HTML 5 compatible video from the screenshots produced

--- a/virttest/test_setup.py
+++ b/virttest/test_setup.py
@@ -2486,38 +2486,30 @@ class LibvirtdDebugLog(object):
         self.test = test
         self.daemons_dict = {}
         self.daemons_dict["libvirtd"] = {
-            "daemon": utils_libvirtd.Libvirtd("virtqemud"),
             "conf": utils_config.LibvirtdConfig(),
             "backupfile": "%s.backup" % utils_config.LibvirtdConfig().conf_path}
         if utils_split_daemons.is_modular_daemon():
             self.daemons_dict["libvirtd"]["conf"] = utils_config.VirtQemudConfig()
             self.daemons_dict["libvirtd"]["backupfile"] = "%s.backup" % utils_config.VirtQemudConfig().conf_path
             self.daemons_dict["virtnetworkd"] = {
-                "daemon": utils_libvirtd.Libvirtd("virtnetworkd"),
                 "conf": utils_config.VirtNetworkdConfig(),
                 "backupfile": "%s.backup" % utils_config.VirtNetworkdConfig().conf_path}
             self.daemons_dict["virtproxyd"] = {
-                "daemon": utils_libvirtd.Libvirtd("virtproxyd"),
                 "conf": utils_config.VirtProxydConfig(),
                 "backupfile": "%s.backup" % utils_config.VirtProxydConfig().conf_path}
             self.daemons_dict["virtstoraged"] = {
-                "daemon": utils_libvirtd.Libvirtd("virtstoraged"),
                 "conf": utils_config.VirtStoragedConfig(),
                 "backupfile": "%s.backup" % utils_config.VirtStoragedConfig().conf_path}
             self.daemons_dict["virtinterfaced"] = {
-                "daemon": utils_libvirtd.Libvirtd("virtinterfaced"),
                 "conf": utils_config.VirtInterfacedConfig(),
                 "backupfile": "%s.backup" % utils_config.VirtInterfacedConfig().conf_path}
             self.daemons_dict["virtnodedevd"] = {
-                "daemon": utils_libvirtd.Libvirtd("virtnodedevd"),
                 "conf": utils_config.VirtNodedevdConfig(),
                 "backupfile": "%s.backup" % utils_config.VirtNodedevdConfig().conf_path}
             self.daemons_dict["virtnwfilterd"] = {
-                "daemon": utils_libvirtd.Libvirtd("virtnwfilterd"),
                 "conf": utils_config.VirtNwfilterdConfig(),
                 "backupfile": "%s.backup" % utils_config.VirtNwfilterdConfig().conf_path}
             self.daemons_dict["virtsecretd"] = {
-                "daemon": utils_libvirtd.Libvirtd("virtsecretd"),
                 "conf": utils_config.VirtSecretdConfig(),
                 "backupfile": "%s.backup" % utils_config.VirtSecretdConfig().conf_path}
 
@@ -2548,13 +2540,13 @@ class LibvirtdDebugLog(object):
             value.get("conf")["log_outputs"] = '"%s:file:%s"' % (self.log_level,
                                                                  self.log_file)
             value.get("conf")["log_filters"] = '"%s"' % self.log_filters
-            value.get("daemon").restart()
+        utils_libvirtd.Libvirtd(all_daemons=True).restart()
 
     def disable(self):
         """ Disable libvirtd debug log """
         for value in self.daemons_dict.values():
             os.rename(value.get("backupfile"), value.get("conf").conf_path)
-            value.get("daemon").restart()
+        utils_libvirtd.Libvirtd(all_daemons=True).restart()
 
 
 class UlimitConfig(Setuper):


### PR DESCRIPTION
When the threads are terminated or the libvirt version is checked
frequently after the configuration files are restored, it will
report "OSError: [Errno 22] Invalid argument".

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Before the fix:**
RHEL-9.x-runtest-x86_64-function-sriov_migration/18
Test Name | Duration | Age
-- | -- | --
rhel.sriov.failover.abort_migration.hostdev_device.with_precopy | 4 min 21 sec | 5
rhel.sriov.failover.migration.hostdev_device.with_precopy | 6 min 0 sec | 5
rhel.sriov.failover.migration.hostdev_device.with_postcopy | 5 min 37 sec | 5



**After the fix:** 
RHEL-9.x-runtest-x86_64-function-sriov_migration/22
Test name | Duration | Status
-- | -- | --
failover.abort_migration.hostdev_device.with_precopy | 4 min 35 sec | Passed
failover.abort_migration.hostdev_interface.with_precopy | 20 min | Failed 
failover.migration.hostdev_device.with_postcopy | 7 min 19 sec | Passed
failover.migration.hostdev_device.with_precopy | 7 min 55 sec | Passed
failover.migration.hostdev_interface.with_postcopy | 8 min 2 sec | Passed
failover.migration.hostdev_interface.with_precopy | 8 min 20 sec | Fixed

 (1/1) type_specific.io-github-autotest-libvirt.sriov.failover.abort_migration.hostdev_interface.with_precopy:PASS (305.83 s)

