### PR TITLE
setup_attrs:Skip Getters if they are customized

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -1114,6 +1114,7 @@ getspeed
 getss
 getstate
 getsz
+Getters
 getty
 getvalue
 gic

--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -296,6 +296,10 @@ class LibvirtXMLBase(propcan.PropCanBase):
                                      % (key, self.__class__))
             get_func = eval('self.get_%s' % key)
 
+            # Skip Getters if they are customized
+            if not isinstance(get_func, propcan.PropCanBase):
+                continue
+
             # Is XMLElementNest or not
             subclass = get_func.get('subclass')
             if subclass is None:


### PR DESCRIPTION
To remove influence of old implementations.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>