### PR TITLE
utils_test: deletes unused imports

### DIFF
--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -24,8 +24,6 @@ import logging
 from functools import reduce
 
 from avocado.core import exceptions
-from avocado.utils import path as utils_path
-from avocado.utils import process
 from avocado.utils import cpu as cpuutil
 
 from virttest import error_context


### PR DESCRIPTION
utils_test: deletes unused imports
Deletes not used imports in order to avoid a CI failure in the future.

Signed-off-by: mcasquer <mcasquer@redhat.com>