### PR TITLE
libvirt.check_result:Replace mutable default args with Nones

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1221,10 +1221,10 @@ def check_status_output(status, output='',
 
 
 def check_result(result,
-                 expected_fails=[],
-                 skip_if=[],
+                 expected_fails=None,
+                 skip_if=None,
                  any_error=False,
-                 expected_match=[],
+                 expected_match=None,
                  check_both_on_error=False):
     """
     Check the result of a command and check command error message against


### PR DESCRIPTION
Some of the original default args are []s which are mutable.This patch replaces them with Nones.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>