### PR TITLE
Allow destroying vms via monitor upon recreation

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -294,6 +294,8 @@ def preprocess_vm(test, params, env, name):
                 vm.update_vm_id()
                 vm.virtnet = utils_net.VirtNet(params, name, vm.instance)
             # Start the VM (or restart it if it's already up)
+            if vm.is_alive():
+                vm.destroy(free_mac_addresses=False)
             if params.get("reuse_previous_config", "no") == "no":
                 vm.create(name, params, test.bindir,
                           timeout=int(params.get("vm_create_timeout", 90)),

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -2943,7 +2943,6 @@ class VM(virt_vm.BaseVM):
         :raise PrivateBridgeError: If fail to bring the private bridge
         """
         error_context.context("creating '%s'" % self.name)
-        self.destroy(free_mac_addresses=False)
 
         if name is not None:
             self.name = name
@@ -4934,6 +4933,7 @@ class VM(virt_vm.BaseVM):
         """
         if self.is_alive():
             self.verify_status('paused')  # Throws exception if not
+            self.destroy(gracefully=False, free_mac_addresses=False)
         LOG.debug("Restoring VM %s from %s" % (self.name, path))
         # Rely on create() in incoming migration mode to do the 'right thing'
         self.create(name=self.name, params=self.params, root_dir=self.root_dir,


### PR DESCRIPTION
In some cases the vm's memory and its images are known to be clean of corruption and we can save up to 2 minutes per test (for thousands of tests) if we destroy the vm faster before recreating it anew.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>