### PR TITLE
Drop fully migrated functions from the leftover virttest remote module

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1652,11 +1652,11 @@ def v2v_setup_ssh_key(
             cmd = r"sed -i '/%s/d' %s" % (hostname, user_known_hosts_file)
             process.run(cmd, verbose=True, ignore_status=True)
 
-        session = remote_old.ssh_login_to_migrate(
+        session = remote.remote_login(
             client='ssh',
             host=hostname,
-            username=username,
             port=port,
+            username=username,
             password=password,
             prompt=r"[\#\$\[\]%]",
             verbose=True,


### PR DESCRIPTION
Any remote logging functionality that was added during the initial migration was not also fully migrated so we can move to using the aexpect remote methods instead.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>