### PR TITLE
Update reference of Channel xml class

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2166,7 +2166,7 @@ def create_channel_xml(params, alias=False, address=False):
         channel_target['name'] = target_name
 
     channel_params = {'type_name': channel_type_name,
-                      'sources': [channel_source],
+                      'sources': [{'attrs': channel_source}],
                       'target': channel_target}
     if alias:
         if isinstance(alias, str):


### PR DESCRIPTION
Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Before fix:
```
 (1/1) type_specific.io-github-autotest-libvirt.channel.functional.positive_tests.auto_gen_port.pty_type: ERROR: Cannot set attribute "path" to <class 'virttest.libvirt_xml.devices.character.CharacterBase.Source'> object.There is no such attribute. (5.74 s)
```
After:
```
 (1/1) type_specific.io-github-autotest-libvirt.channel.functional.positive_tests.auto_gen_port.pty_type: PASS (7.05 s)
```