### PR TITLE
utils_misc: Assert test entry point is in fact callable

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2936,7 +2936,7 @@ def get_test_entrypoint_func(name, module):
     :rtype: func
     '''
     run = getattr(module, "run", None)
-    if run is not None:
+    if run is not None and callable(run):
         return run
     else:
         raise ValueError("Missing test entry point")


### PR DESCRIPTION
Introducing another check in `utils_misc.get_test_entrypoint_func` to make sure the `run` attribute of the test module is callable. The input module could have an attribute called run that is not callable (e.g. is holding a numerical value), so it looks like we should guard against that case.

This issue was elucidated during #3350 discussions and pylint check fixes. The pylint-disable comments introduced in the latter rely on the checks introduced on this PR, which has been split into this one since it didn't really match the scope of #3350.