### PR TITLE
graphics:Fix KeyError of method add_channel

### DIFF
--- a/virttest/libvirt_xml/devices/graphics.py
+++ b/virttest/libvirt_xml/devices/graphics.py
@@ -77,7 +77,9 @@ class Graphics(base.TypedDeviceBase):
         """
         Convenience method for appending channel from dictionary of attributes
         """
-        self._add_item('channel', **attributes)
+        channels = self.channels
+        channels.append(attributes)
+        self.channels = channels
 
     @staticmethod
     def change_graphic_type_passwd(vm_name, graphic, passwd=None):


### PR DESCRIPTION
Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Test result:
Before fix:
```
 (1/1) type_specific.local.virsh.domdisplay.have_passwd.no_options.readwrite.spice_t.with_ssl: ERROR: 'channel' (3.97 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-10-18T13.36-378f77f/results.html
JOB TIME   : 4.33 s
```
After fix:
```
 (1/1) type_specific.local.virsh.domdisplay.have_passwd.no_options.readwrite.spice_t.with_ssl: PASS (5.48 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-10-18T13.36-c454aa5/results.html
JOB TIME   : 5.84 s
```