### PR TITLE
hotfix for _wrappers.import_module not reaching vt_init.loader

### DIFF
--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -1,3 +1,5 @@
+import importlib
+
 from avocado.core import plugin_interfaces
 from avocado.core.loader import loader
 from avocado.core.settings import settings
@@ -12,7 +14,6 @@ from virttest.standalone_test import (SUPPORTED_DISK_BUSES,
                                       SUPPORTED_NIC_MODELS,
                                       SUPPORTED_TEST_TYPES,
                                       find_default_qemu_paths)
-from virttest._wrappers import import_module
 
 if hasattr(plugin_interfaces, 'Init'):
     class VtInit(plugin_interfaces.Init):
@@ -272,6 +273,6 @@ if hasattr(plugin_interfaces, 'Init'):
 
             settings.merge_with_configs()
 
-            virt_loader = getattr(import_module('avocado_vt.loader'),
+            virt_loader = getattr(importlib.import_module('avocado_vt.loader'),
                                   'VirtTestLoader')
             loader.register_plugin(virt_loader)


### PR DESCRIPTION
The vt_init.loader couldn't be reached by using the _wrappers.import_module method.

This commit rolls back the refactoring changes included in the vt_init.py file so avocado_vt can get back to work as supposed to while we find a more general fix to the issue.

ID: 2136437