### PR TITLE
libvirt_virtio: update to add features for intel iommu only

### DIFF
--- a/virttest/utils_libvirt/libvirt_virtio.py
+++ b/virttest/utils_libvirt/libvirt_virtio.py
@@ -6,7 +6,6 @@ Libvirt virtio related utilities.
 
 import logging
 
-from virttest import arch
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import iommu
 from virttest.utils_test import libvirt
@@ -38,7 +37,7 @@ def add_iommu_dev(vm, iommu_dict):
     libvirt_vmxml.remove_vm_devices_by_type(vm, 'iommu')
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
     features = vmxml.features
-    if not features.has_feature('ioapic') and arch.ARCH == "x86_64":
+    if not features.has_feature('ioapic') and iommu_dict.get('model') == "intel":
         features.add_feature('ioapic', 'driver', 'qemu')
         vmxml.features = features
 


### PR DESCRIPTION
No need to add additional features for virtio iommu, so udpate to only update features for intel iommu device.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
 ```
(1/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.auto_gen.virtio: PASS (19.06 s)
 (2/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.auto_gen.intel: PASS (19.31 s)
 (3/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.customized.virtio: PASS (19.22 s)
 (4/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.customized.intel: PASS (19.15 s)
```

