### PR TITLE
iscsi.py: add authentication=1 to set_chap_auth_target function

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -674,10 +674,11 @@ class IscsiLIO(_IscsiComm):
         for all Endpoints in a TPG
         """
         auth_cmd = "targetcli /iscsi/%s/tpg1/ " % self.target
-        attr_cmd = ("set attribute %s %s %s" %
+        attr_cmd = ("set attribute %s %s %s %s" %
                     ("demo_mode_write_protect=0",
                      "generate_node_acls=1",
-                     "cache_dynamic_acls=1"))
+                     "cache_dynamic_acls=1",
+                     "authentication=1"))
         process.system(auth_cmd + attr_cmd)
 
         # Set userid


### PR DESCRIPTION
If the set_chap_auth_target function doesn't include authentication=1 attribute, this means it doesn't actually use chap function. This part has been more rigorously checked In new qemu version, so update it to fix some authentication failure.

Signed-off-by: Meina Li <meili@redhat.com>