### PR TITLE
Allow the option of creating a vm firstly after loading from file

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4932,7 +4932,8 @@ class VM(virt_vm.BaseVM):
         """
         Override BaseVM restore_from_file method
         """
-        self.verify_status('paused')  # Throws exception if not
+        if self.is_alive():
+            self.verify_status('paused')  # Throws exception if not
         LOG.debug("Restoring VM %s from %s" % (self.name, path))
         # Rely on create() in incoming migration mode to do the 'right thing'
         self.create(name=self.name, params=self.params, root_dir=self.root_dir,


### PR DESCRIPTION
Loading a running vm's memory from file would require it to be paused first but would also work just fine without any prior vm. In some cases the user has to create a vm and pause it just to be able to satisfy the requirements of previously running and paused vm thus leading to overhead and circumventing more direct use of this functionality.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>