### PR TITLE
unattended_install: allow pkgs installation and locking

### DIFF
--- a/virttest/shared/unattended/RHEL-8-devel.ks
+++ b/virttest/shared/unattended/RHEL-8-devel.ks
@@ -33,6 +33,7 @@ KVM_TEST_REPOS
 python3-pillow
 python3-six
 python3-pyparsing
+python3-dnf-plugin-versionlock
 net-tools
 NetworkManager
 dconf
@@ -107,5 +108,22 @@ EOF
 cat >> '/home/test/.bashrc' << EOF
 alias shutdown='sudo shutdown'
 EOF
+# Install and lock packages specified via 'kickstart_instlock_pkgs' parameter
+install_and_lock()
+{
+    for PKG in KVM_TEST_PKGS; do
+        ECHO "dnf install $PKG -y --nogpgcheck"
+        dnf install $PKG -y --nogpgcheck
+        if [ $? -ne 0 ]; then
+            ECHO "$PKG installation failed."
+        fi
+        ECHO "dnf versionlock add $PKG"
+        dnf versionlock add $PKG
+        if [ $? -ne 0 ]; then
+            ECHO "$PKG version lock failed."
+        fi
+    done
+}
+install_and_lock
 ECHO 'Post set up finished'
 %end

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -433,6 +433,13 @@ class UnattendedInstallConfig(object):
             content = "\n".join(lines)
             contents = re.sub(dummy_repos_re, content, contents)
 
+        dummy_pkgs_re = r'\bKVM_TEST_PKGS\b'
+        if re.search(dummy_pkgs_re, contents):
+            # Extra packages to be installed and locked
+            # Use space as a separator for multiple pkgs
+            pkgs = self.params.get("kickstart_instlock_pkgs", "")
+            contents = re.sub(dummy_pkgs_re, pkgs, contents)
+
         dummy_logging_re = r'\bKVM_TEST_LOGGING\b'
         if re.search(dummy_logging_re, contents):
             if self.syslog_server_enabled == 'yes':


### PR DESCRIPTION
Install one or more packages separated by spaces using `kickstart_instlock_pkgs` parameter and lock version of these packages using `python3-dnf-plugin-versionlock`. Expected usage is part of `RHEL-8-devel.ks` file.

ID: 2135647

Signed-off-by: Lukas Kotek <lkotek@redhat.com>