### PR TITLE
utils_sriov: Fix get_pf_info to get ifaces correctly

### DIFF
--- a/virttest/utils_sriov.py
+++ b/virttest/utils_sriov.py
@@ -65,7 +65,7 @@ def get_pf_info(session=None):
     """
     pf_info = {}
     status, output = utils_misc.cmd_status_output(
-        "lspci |awk '/Ethernet/ {print $1}'", shell=True, session=session)
+        "lspci -D |awk '/Ethernet/ {print $1}'", shell=True, session=session)
     if status or not output:
         raise exceptions.TestError("Unable to get Ethernet controllers. status: %s,"
                                    "stdout: %s." % (status, output))
@@ -75,9 +75,9 @@ def get_pf_info(session=None):
                                                  session=session)
         if re.search("SR-IOV", output):
             pf_driver = re.search('driver in use: (.*)', output)[1]
-            tmp_info = {'driver': pf_driver, 'pci_id': '0000:%s' % pci}
+            tmp_info = {'driver': pf_driver, 'pci_id': pci}
 
-            iface_name = get_iface_name('0000:%s' % pci, session=session)
+            iface_name = get_iface_name(pci, session=session)
             runner = None if not session else session.cmd
             tmp_info.update({'iface': iface_name.strip(),
                              'status': utils_net.get_net_if_operstate(


### PR DESCRIPTION
Remove '0000' to get more interfaces.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

 (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.no_option.running_domain: PASS (29.64 s)

