### PR TITLE
remote: Extend timeout for handle_prompts

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -538,7 +538,7 @@ class VMManager(object):
         ssh_copy_id = f"ssh-copy-id {ssh_opts} -i {pub_key} {username}@{ip}"
         session.sendline(ssh_copy_id)
 
-        handle_prompts(session, username, password, r"[\#\$]\s*$", debug=True)
+        handle_prompts(session, username, password, r"[\#\$]\s*$", timeout=30, debug=True)
 
     def setup_ssh_auth(self):
         """


### PR DESCRIPTION
Extent the handle_prompts timeout to 30s, as sometimes it can not match the patterns within the default timeout 10s.

Before fix:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-pci virsh.migrate_options_shared.positive_test.pty_channel.with_postcopy --vt-connect-uri qemu:///system
JOB ID     : 33ca938781fff773e4867d1e1a9dd07deb06e7be
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-07T01.54-33ca938/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.pty_channel.with_postcopy: ERROR: Login timeout expired    (output: '') (156.61 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-07T01.54-33ca938/results.html
JOB TIME   : 157.00 s
```

After fix:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-pci virsh.migrate_options_shared.positive_test.pty_channel.with_postcopy --vt-connect-uri qemu:///system
JOB ID     : f898d5e161a68c612a78ccf3e4a755a3b5a537a5
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-07T01.57-f898d5e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.pty_channel.with_postcopy: PASS (232.24 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-07T01.57-f898d5e/results.html
JOB TIME   : 232.62 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>