### PR TITLE
Update vt runner config after avocado runner config update

### DIFF
--- a/avocado_vt/conf.d/vt.conf
+++ b/avocado_vt/conf.d/vt.conf
@@ -1,3 +1,9 @@
+[run]
+# The avocado-vt cannot be run in parallel,
+# when this value will be >1 the vt tests won't be resolved.
+max_parallel_tasks = 1
+
+# The following section is for avocado <= 99.0
 [nrunner]
 # The avocado-vt cannot be run in parallel,
 # when this value will be >1 the vt tests won't be resolved.

--- a/avocado_vt/plugins/vt_resolver.py
+++ b/avocado_vt/plugins/vt_resolver.py
@@ -41,9 +41,11 @@ class VTResolverUtils(DiscoveryMixIn):
         runnables = [self._parameters_to_runnable(d) for d in
                      cartesian_parser.get_dicts()]
         if runnables:
-            if self.config.get("nrunner.max_parallel_tasks", 1) != 1:
-                warnings.warn("The VT NextRunner can be run only with "
-                              "nrunner-max-parallel-tasks set to 1")
+            if self.config.get(
+                "run.max_parallel_tasks", self.config.get(
+                    "nrunner.max_parallel_tasks", 1)) != 1:
+                warnings.warn("The VT NextRunner can be run only "
+                              "with max-parallel-tasks set to 1")
             return ReferenceResolution(reference,
                                        ReferenceResolutionResult.SUCCESS,
                                        runnables)

--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -116,7 +116,9 @@ class VTTestRunner(BaseRunner):
             self.runnable = runnable
 
         yield messages.StartedMessage.get()
-        if self.runnable.config.get("nrunner.max_parallel_tasks", 1) != 1:
+        if self.runnable.config.get(
+            "run.max_parallel_tasks", self.runnable.config.get(
+                "nrunner.max_parallel_tasks", 1)) != 1:
             yield messages.FinishedMessage.get('cancel',
                                                fail_reason="parallel run is not"
                                                " allowed for vt tests")

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -111,7 +111,7 @@ If there are missing requirements, please install them and re-run `vt-bootstrap`
 .. warning:: When you bootstrap avocado-vt the parallel run of avocado nrunner
              will be disabled by default, because the avocado-vt doesn't support
              parallel tests. If you run test suite without vt tests,  you can
-             enable parallel run by `nrunner.max_parallel_tasks` config variable.
+             enable parallel run by `run.max_parallel_tasks` config variable.
 
 First steps with Avocado-VT
 ===========================


### PR DESCRIPTION
This commit update vt runner config to be compatible with the changes applied to the mainstream and the lts version as well.

Reference: https://github.com/avocado-framework/avocado/pull/5494

Signed-off-by: Xu Han <xuhan@redhat.com>