### PR TITLE
Revert "iscsi.py: add authentication=1 to set_chap_auth_target function"

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -674,11 +674,10 @@ class IscsiLIO(_IscsiComm):
         for all Endpoints in a TPG
         """
         auth_cmd = "targetcli /iscsi/%s/tpg1/ " % self.target
-        attr_cmd = ("set attribute %s %s %s %s" %
+        attr_cmd = ("set attribute %s %s %s" %
                     ("demo_mode_write_protect=0",
                      "generate_node_acls=1",
-                     "cache_dynamic_acls=1",
-                     "authentication=1"))
+                     "cache_dynamic_acls=1"))
         process.system(auth_cmd + attr_cmd)
 
         # Set userid


### PR DESCRIPTION
Reverts avocado-framework/avocado-vt#3561

There is some confused result after this PR is merged.
Moreover, even if we need authentication=1, we may not hard code the attribute, instead set this attribute under some condition, e.g. if enable_chap_authentication = 'yes', attr_cmd += "authentication=1
