### PR TITLE
virttest/migration: fix attribute access for single action during

### DIFF
--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -455,18 +455,16 @@ class MigrationTest(object):
             """
 
             for one_func in funcs_to_run:
-                need_sleep_time = one_func.get('need_sleep_time')
+                need_sleep_time = None
                 if isinstance(one_func, (types.FunctionType, types.MethodType)):
                     if not before_pause:
-                        if need_sleep_time:
-                            LOG.debug("Sleep %s.", need_sleep_time)
-                            time.sleep(int(need_sleep_time))
                         _run_simple_func(vm, one_func)
                     else:
                         LOG.error("Only support to run the function "
                                   "after guest is paused")
                 elif isinstance(one_func, dict):
                     before_vm_pause = 'yes' == one_func.get('before_pause', 'no')
+                    need_sleep_time = one_func.get('need_sleep_time')
                     if before_vm_pause == before_pause:
                         if need_sleep_time:
                             LOG.debug("Sleep %s.", need_sleep_time)


### PR DESCRIPTION
0703a97c8163d8a57a649f15931321184f9a1e22 introduced a sleep time value when actions during migration is described by dictionary entries, e.g. for new tests in tp-libvirt dc1aa8aa95ecfdcb097109969a994a290146def0

However, this can't work for functions and any test fails with

"FAIL: 'function' object has no attribute 'get'"

Instead, only query that sleep value for cases where the actions are described by dictionary entries, not by a single function or method.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>