### PR TITLE
Allow enable authentication in iscsi setup

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -225,6 +225,7 @@ class _IscsiComm(object):
         self.chap_flag = False
         self.chap_user = params.get("chap_user")
         self.chap_passwd = params.get("chap_passwd")
+        self.enable_authentication = params.get("enable_authentication")
         if self.chap_user and self.chap_passwd:
             self.chap_flag = True
 
@@ -678,6 +679,8 @@ class IscsiLIO(_IscsiComm):
                     ("demo_mode_write_protect=0",
                      "generate_node_acls=1",
                      "cache_dynamic_acls=1"))
+        if self.enable_authentication:
+            attr_cmd += " authentication=1"
         process.system(auth_cmd + attr_cmd)
 
         # Set userid

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -527,7 +527,7 @@ def setup_or_cleanup_nfs(is_setup, mount_dir="nfs-mount", is_mount=False,
 def setup_or_cleanup_iscsi(is_setup, is_login=True,
                            emulated_image="emulated-iscsi", image_size="1G",
                            chap_user="", chap_passwd="", restart_tgtd="no",
-                           portal_ip="127.0.0.1"):
+                           portal_ip="127.0.0.1", enable_authentication=False):
     """
     Set up(and login iscsi target) or clean up iscsi service on localhost.
 
@@ -546,7 +546,8 @@ def setup_or_cleanup_iscsi(is_setup, is_login=True,
     iscsi_params = {"emulated_image": emulated_path, "target": emulated_target,
                     "image_size": image_size, "iscsi_thread_id": "virt",
                     "chap_user": chap_user, "chap_passwd": chap_passwd,
-                    "restart_tgtd": restart_tgtd, "portal_ip": portal_ip}
+                    "restart_tgtd": restart_tgtd, "portal_ip": portal_ip,
+                    "enable_authentication": enable_authentication}
     _iscsi = iscsi.Iscsi.create_iSCSI(iscsi_params)
     if is_setup:
         if is_login:


### PR DESCRIPTION
Allow enable authentication in iscsi setup

As per https://github.com/avocado-framework/avocado-vt/pull/3561, sometimes authentication = 1 attribute need be enabled

Signed-off-by: chunfuwen <chwen@redhat.com>