### PR TITLE
data_dir: fix returning None unexpectedly

### DIFF
--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -202,7 +202,7 @@ def get_tmp_dir(public=True):
     """
     persistent_dir = get_settings_value('vt.common', 'tmp_dir',
                                         default="")
-    if persistent_dir != "":
+    if persistent_dir and persistent_dir != "":
         return persistent_dir
     tmp_dir = None
     # apparmor deny /tmp/* /var/tmp/* and cause failure across tests


### PR DESCRIPTION
Because get_settings_value() return None instead of '' now, so get_tmp_dir() returns None incorrectly which cause avocado crash with below messages when bootstraping:
Avocado crashed unexpectedly: expected str, bytes or os.PathLike object, not NoneType

Signed-off-by: Dan Zheng <dzheng@redhat.com>