### PR TITLE
Add conditional support for loader based plugins

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -18,7 +18,6 @@ Avocado VT plugin
 
 import os
 
-from avocado.core.loader import loader
 from avocado.core.plugin_interfaces import CLI
 from avocado.utils import path as utils_path
 
@@ -27,7 +26,13 @@ from virttest.compat import get_settings_value, add_option
 from virttest.standalone_test import (SUPPORTED_LIBVIRT_URIS,
                                       SUPPORTED_TEST_TYPES)
 
-from ..loader import VirtTestLoader
+
+try:
+    from avocado.core.loader import loader
+    from ..loader import VirtTestLoader
+    AVOCADO_LOADER_AVAILABLE = True
+except ImportError:
+    AVOCADO_LOADER_AVAILABLE = False
 
 
 _PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_test_providers_dir(),
@@ -226,4 +231,5 @@ class VTRun(CLI):
         Run test modules or simple tests.
         :param config: Command line args received from the run subparser.
         """
-        loader.register_plugin(VirtTestLoader)
+        if AVOCADO_LOADER_AVAILABLE:
+            loader.register_plugin(VirtTestLoader)

--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -1,7 +1,6 @@
 import importlib
 
 from avocado.core import plugin_interfaces
-from avocado.core.loader import loader
 from avocado.core.settings import settings
 from avocado.utils import path as utils_path
 
@@ -14,6 +13,13 @@ from virttest.standalone_test import (SUPPORTED_DISK_BUSES,
                                       SUPPORTED_NIC_MODELS,
                                       SUPPORTED_TEST_TYPES,
                                       find_default_qemu_paths)
+
+try:
+    from avocado.core.loader import loader
+    AVOCADO_LOADER_AVAILABLE = True
+except ImportError:
+    AVOCADO_LOADER_AVAILABLE = False
+
 
 if hasattr(plugin_interfaces, 'Init'):
     class VtInit(plugin_interfaces.Init):
@@ -273,6 +279,7 @@ if hasattr(plugin_interfaces, 'Init'):
 
             settings.merge_with_configs()
 
-            virt_loader = getattr(importlib.import_module('avocado_vt.loader'),
-                                  'VirtTestLoader')
-            loader.register_plugin(virt_loader)
+            if AVOCADO_LOADER_AVAILABLE:
+                virt_loader = getattr(importlib.import_module('avocado_vt.loader'),
+                                      'VirtTestLoader')
+                loader.register_plugin(virt_loader)

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -19,13 +19,18 @@ Avocado plugin that augments 'avocado list' with avocado-virt related options.
 import os
 import sys
 
-from avocado.core.loader import loader
 from avocado.core.plugin_interfaces import CLI
 
 from virttest.compat import get_settings_value, add_option
 from .vt import add_basic_vt_options, add_qemu_bin_vt_option
-from ..loader import VirtTestLoader
 from virttest._wrappers import load_source
+
+try:
+    from avocado.core.loader import loader
+    from ..loader import VirtTestLoader
+    AVOCADO_LOADER_AVAILABLE = True
+except ImportError:
+    AVOCADO_LOADER_AVAILABLE = False
 
 
 # The original virt-test runner supports using autotest from a git checkout,
@@ -120,4 +125,5 @@ class VTLister(CLI):
         add_qemu_bin_vt_option(vt_compat_group_lister)
 
     def run(self, config):
-        loader.register_plugin(VirtTestLoader)
+        if AVOCADO_LOADER_AVAILABLE:
+            loader.register_plugin(VirtTestLoader)


### PR DESCRIPTION
The "loader" architecture has been removed in the latest Avocado commits (and will be reflected on Avocado version 100.0 and later).

This adds a conditional support for the loader based plugins, so that the latest Avocado-VT can still be used (hopefully for a short time) with Avocado versions having loader support.

Fixes: https://github.com/avocado-framework/avocado-vt/issues/3591
Signed-off-by: Cleber Rosa <crosa@redhat.com>