### PR TITLE
Add force support for blockdev-change-media

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -2805,7 +2805,8 @@ class QMPMonitor(Monitor):
         args = {"id": dev_id, "node-name": node_name}
         return self.cmd(cmd, args)
 
-    def blockdev_change_medium(self, dev_id, filename, fmt=None, mode=None):
+    def blockdev_change_medium(self, dev_id, filename, fmt=None, mode=None,
+                               force=None):
         """
         Changes the medium inserted into a block device by ejecting the current
         medium and loading a new image file which is inserted as the new medium
@@ -2820,6 +2821,8 @@ class QMPMonitor(Monitor):
         :type fmt: str
         :param mode: Change the read-only mode of the device.
         :type mode: str
+        :param force: Change the media force.
+        :type force: bool
         :return: The response of command.
         """
         cmd = "blockdev-change-medium"
@@ -2829,6 +2832,8 @@ class QMPMonitor(Monitor):
             args["format"] = fmt
         if mode is not None:
             args["read-only-mode"] = mode
+        if force is not None:
+            args["force"] = force
         return self.cmd(cmd, args)
 
     def blockdev_create(self, job_id, options):

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -5360,16 +5360,18 @@ class VM(virt_vm.BaseVM):
         else:
             return self.monitor.eject_cdrom(device, force)
 
-    def change_media(self, device, target):
+    def change_media(self, device, target, force=None):
         """
         Change media of cdrom;
 
         :param device: Device ID;
         :param target: new media file;
+        :param force: force flag for change media operation;
         """
         if self.check_capability(Flags.BLOCKDEV):
             qdev = self.devices.get_qdev_by_drive(device)
-            return self.monitor.blockdev_change_medium(qdev, target)
+            return self.monitor.blockdev_change_medium(qdev, target,
+                                                       force=force)
         else:
             return self.monitor.change_media(device, target)
 


### PR DESCRIPTION
The force parameter is support since qemu7.1.
It needs to change relevant API to support it.

ID:2158370
Signed-off-by: qingwangrh <qinwang@redhat.com>