### PR TITLE
network_xml:Remove netmask of IPXML instance if it's ipv6

### DIFF
--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -663,6 +663,10 @@ class NetworkXMLBase(base.LibvirtXMLBase):
         elif isinstance(item, dict):
             ip = IPXML()
             ip.setup_attrs(**item)
+            # To deal with ipv6, which should not have netmask attribute which
+            # is configured by default when being init()
+            if item.get('family') == 'ipv6':
+                ip.del_netmask()
             return 'ip', ip
         else:
             raise xcepts.LibvirtXMLError("Expected a list of IPXML "

--- a/virttest/utils_libvirt/libvirt_network.py
+++ b/virttest/utils_libvirt/libvirt_network.py
@@ -39,6 +39,8 @@ def create_or_del_network(net_dict, is_del=False, remote_args=None):
     if not is_del:
         net_dev = libvirt.network_xml.NetworkXML(net_dict.get("name"))
         net_dev.setup_attrs(**net_dict)
+        LOG.debug(f'Creating network with xml:\n'
+                  f'{net_dev}')
 
         if not remote_virsh_session:
             if net_dev.get_active():


### PR DESCRIPTION
IPV6 does now allow the existance of netmask attribute in network xml of libvirt. Therefore remove netmask when setting ip of network.
Add log to libvirt_network.create_or_del_network function to log network xml before create it.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Test result:
Package | 花的时间 | 失败 | (区别) | 跳过 | (区别) | Pass | (区别) | 总数
-- | -- | -- | -- | -- | -- | -- | -- | --
rhel | 6 hr 21 min | 29 | 29 | 15 |   | 369 | -29 | 413
rhel.virsh | 5 hr 9 min | 0 |   | 18 | 5 | 731 | -5 | 749

Rerun failed cases 
```
 (01/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_unprivileged.precreated.host_tap: PASS (58.50 s)
 (02/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_unprivileged.precreated.host_macvtap: PASS (47.00 s)
 (03/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.default.shared_physical_network: PASS (116.54 s)
 (04/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.hotplug_iface.shared_physical_network: PASS (84.26 s)
 (05/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.hotplug_device.shared_physical_network: PASS (83.53 s)
 (06/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.update_with_diff_type.shared_physical_network: PASS (88.12 s)
 (07/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.multiqueues.hotplug_device.shared_physical_network: PASS (87.52 s)
 (08/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.test_qos.hotplug_iface.shared_physical_network: PASS (85.43 s)
 (09/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: PASS (68.45 s)
 (10/29) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.set_iface.with_net.set_all: PASS (146.01 s)
 (11/29) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.set_iface.with_net.set_one: PASS (236.94 s)
 (12/29) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.set_iface.with_br.set_all: PASS (245.52 s)
 (13/29) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.network.set_yes: PASS (246.42 s)
 (14/29) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.network.set_no: PASS (239.59 s)
 (15/29) type_specific.io-github-autotest-libvirt.virtual_network.multivms.macTableManager.linux_br.set_libvirt: PASS (238.29 s)
 (16/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_macvtap.net_bridge.default_test: PASS (38.69 s)
 (17/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_macvtap.net_bridge.multi_guests: PASS (86.14 s)
 (18/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_macvtap.net_bridge.exist_macvtap: PASS (40.05 s)
 (19/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_macvtap.net_passthrough: PASS (37.39 s)
 (20/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_macvtap.net_private: PASS (41.62 s)
 (21/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.default.driver_vhost.mode_bridge: PASS (335.69 s)
 (22/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.default.driver_vhost.mode_vepa: PASS (183.37 s)
 (23/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.default.driver_vhost.mode_private: PASS (183.10 s)
 (24/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.default.driver_qemu.mode_bridge: PASS (333.55 s)
 (25/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.default.driver_qemu.mode_vepa:PASS (187.01 s)
 (26/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.default.driver_qemu.mode_private: PASS (186.08 s)
 (27/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.multiqueue.driver_vhost.mode_bridge: PASS (331.79 s)
 (28/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.multiqueue.driver_vhost.mode_vepa: PASS (184.75 s)
 (29/29) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_macvtap.multiqueue.driver_vhost.mode_private: PASS (182.61 s)
```