### PR TITLE
numa_hmat: updates initiator option

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1977,7 +1977,7 @@ class VM(virt_vm.BaseVM):
                 if not numa_params.get('numa_hmat_lb'):
                     continue
                 nodeid = numa_params['numa_nodeid']
-                initiator = numa_params.get('numa_initiator', nodeid)
+                initiator = numa_params.get('numa_hmat_lb_initiator', nodeid)
                 for hmat_lb in numa_params.objects('numa_hmat_lb'):
                     devices.insert(
                         devices.numa_hmat_lb_define_by_params(

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -249,6 +249,8 @@ smp = 1
 # Define initiator for numa node, it has to be a node with cpu, and if current
 # numa node has cpus the initiator has to be itself.
 # numa_initiator_node0 = 0
+# From qemu 7.2 version onwards the initiator value is not required anymore
+# in the numa node option, only for numa hmat-lb, so this one can be avoided
 
 # Memory for each VM
 mem = 1024
@@ -293,12 +295,14 @@ mem_chk_re_str = ([0-9]+)
 # numa_dist_node0 = [[1, 30], [2, 40]]
 
 # Define '-numa hmat-lb' for the given initiator and target node,
-# It can be defined with different hierarchies and data-types to certain node:
+# It can be defined with an initiator and different hierarchies and data-types
+# to certain node:
 # initiator=node,target=node,
 # hierarchy=memory|first-level|second-level|third-level,
 # data-type=access-latency|read-latency|write-latency
 # [,latency=lat][,bandwidth=bw]
 # numa_hmat_lb_node0 = 'hmat_lb0 hmat_lb1'
+# numa_hmat_lb_initiator = 0
 # numa_hmat_lb_hierarchy_hmat_lb0 = 'first-level'
 # numa_hmat_lb_data_type_hmat_lb0 = 'read-latency'
 # numa_hmat_lb_latency_hmat_lb0 = 5


### PR DESCRIPTION
numa_hmat: updates initiator option

According to qemu-7.2 the initiator value
is not required anymore in -numa node option.
It is still mandatory to provide it for -numa hmat-lb, so this updated the script in order to take a new
configuration value from the auto case.

ID: 2158423
Signed-off-by: mcasquer <mcasquer@redhat.com>