### PR TITLE
CI: reinstate the waiver of failures with latest Avocado

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,6 +72,7 @@ avocado_devel_task:
   container:
     image: quay.io/avocado-framework/avocado-vt-ci-fedora-35
     kvm: true
+  allow_failures: $AVOCADO_SRC == 'git+https://github.com/avocado-framework/avocado#egg=avocado_framework'
   env:
     matrix:
       # Latest Avocado


### PR DESCRIPTION
This marks the point where the latest development (HEAD of master branches) of Avocado-VT and Avocado are not guaranteed to be compatible (to he extent that is being tested here).

The goal here is to allow for Avocado core changes that will affect plugins without breaking Avocado-VT development.  The following is the proposed development cycles for Avocado:

1) Avocado 101.0 - bug fixes, improvements and core changes (possibly
   affecting plugins)
2) Avocado 102.0 - bug fixes, improvements and core changes (possibly
   affecting plugins)
3) Avocado 103.0 (LTS) - bug fixes, compatibility and usability
   improvements only.

The compatibility check will be restored at the beginning of the Avocado 103.0 development cycle, resulting in a Avocado-VT and Avocado release that are compatible.

This reverts commit 53e8f1ea5ad60a830dea4b961e87fb276aeae9fb.

Signed-off-by: Cleber Rosa <crosa@redhat.com>