### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.7, 3.8, 3.9, 3.10.1]
       fail-fast: false
 
     steps:
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.7, 3.8, 3.9, 3.10.1]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Python 3.6 has been EOL'd for over a year. But some projects such as QEMU still have it as the mininum required Python versions, and this has kept us from deprecating it and dropping support for it.

Now Avocado itself has dropped support for Python 3.6, in light of a new effort going on to bump the minimum required version in QEMU.

Reference: https://lists.gnu.org/archive/html/qemu-devel/2023-01/msg04398.html
Reference: https://github.com/avocado-framework/avocado/pull/5591
Signed-off-by: Cleber Rosa <crosa@redhat.com>