### PR TITLE
Raise VMCreateError if QEMU VM is dead when connecting to monitor

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3454,7 +3454,11 @@ class VM(virt_vm.BaseVM):
                                                                    timeout)
                 except qemu_monitor.MonitorConnectError as detail:
                     LOG.error(detail)
+                    status = self.process.get_status()
+                    output = self.process.get_output().strip()
                     self.destroy()
+                    if not self.process.is_alive():
+                        raise virt_vm.VMCreateError(qemu_command, status, output)
                     raise
 
                 # Add this monitor to the list


### PR DESCRIPTION
Method `create` from `qemu_vm.py` tries to connect to QMP monitor right after initial cheking of QEMU process to be alive. This can bring timing issue as sometimes QEMU process can die right after this initial check when connections to QMP monitors are being established.

This PR adds check for status of process when `MonitorConnectError` exception is raised. If the QEMU VM is dead, then `VMCreateError` exception is raised instead, so the true reason of failure is not hidden.

**Context**

The problem described above directly affects correct function of `qemu_img_lock_reject_boot` test case. In case test is executed with `luks` as a image format it took longer time for QEMU process to die. As a result false alarm is created.

ID: 2156320

Signed-off-by: Lukas Kotek <lkotek@redhat.com>