### PR TITLE
guest_agent.py: Add new command 'guest-get-cpustats'

### DIFF
--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -999,3 +999,14 @@ class QemuAgent(Monitor):
         cmd = "guest-get-devices"
         self.check_has_command(cmd)
         return self.cmd(cmd=cmd)
+
+    def get_cpustats(self):
+        """
+        Get the cpu status info of guest OS.
+
+        :return: a list of cpu status such as 'user' and 'idle'
+        'nice' and 'steal'...
+        """
+        cmd = "guest-get-cpustats"
+        self.check_has_command(cmd)
+        return self.cmd(cmd)


### PR DESCRIPTION
Add a new guest agent command 'guest-get-cpustats' to get guest CPU statistics

ID: 2166558
Signed-off-by: demeng <demeng@redhat.com>