### PR TITLE
Fix acceptable negative value range for cfs_quota params

### DIFF
--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -420,8 +420,11 @@ class CgroupTest(object):
                     # no need to check scheduler type, it's fixed for qemu
                     continue
                 if "quota" in schedinfo_item:
-                    if schedinfo_value in ["-1", "18446744073709551",
-                                           "17592186044415"]:
+                    if (schedinfo_value in ["18446744073709551", "17592186044415"]
+                            or int(schedinfo_value) < 0):
+                        # When set cfs_quota values with negative values or
+                        # maximum acceptable values, it's means 'max' or
+                        # 'unlimited', so match these values to 'max'.
                         standardized_virsh_output_info[schedinfo_item] = "max"
                         continue
                 standardized_virsh_output_info[schedinfo_item] = schedinfo_value


### PR DESCRIPTION
For both cgroup v1 and v2, all negative int are acceptable for the cfs_quota params, such as vcpu_quota, emulator_quota, global_quota and iothread_quota. And a negative value means the param is set as 'max' (or 'unlimited'). So we should not only match '-1' to 'max', but match negative int to 'max'.

Signed-off-by: Yi Sun <yisun@redhat.com>