### PR TITLE
fetch_attrs:Do not return invalid values 'None'

### DIFF
--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -386,7 +386,7 @@ class LibvirtXMLBase(propcan.PropCanBase):
                         value = [v.fetch_attrs() for v in value]
                 # If the element is bool type, only return value when
                 # it's True
-                if value is not False:
+                if value is not False and value is not None:
                     attrs[key] = value
 
         return attrs


### PR DESCRIPTION
When the value we get with a certain key turns out to be None, we just ignore it and not return the data pair.