### PR TITLE
verify_kernel_crash:Expand the scope of regularity checking

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -992,7 +992,7 @@ class BaseVM(object):
                 found.
         """
         panic_re = [r"BUG:.*---\[ end trace .* \]---"]
-        panic_re.append(r"----------\[ cut here.* BUG .*\[ end trace .* \]---")
+        panic_re.append(r"----------\[ cut here.*\[ end trace .* \]---")
         panic_re.append(r"general protection fault:.* RSP.*>")
         panic_re = "|".join(panic_re)
         if self.serial_console:


### PR DESCRIPTION
According to the comment left by Linus Torvalds in the development 
community "We're trying to get rid of BUG_ON() because it kills the 
machine. Not replace it with another bogus thing that kills a machine."

Therefore, in future kernel development, developers will not 
use BUG_ON() unless necessary.
On the other hand, the expansion of the detection range is a 
double-edged sword. 
I don't want to classify all end traces as kernel crashes.
So only widen the search if console has a complete "cut here" 
"end trace", remove the "BUG:" keyword.

ID: 2174339
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)