### PR TITLE
utils_stress: Don't compile app if available

### DIFF
--- a/virttest/utils_stress.py
+++ b/virttest/utils_stress.py
@@ -210,6 +210,10 @@ def install_stressapptest(vm):
     :param vm: the vm to be installed with stressapptest
     """
     session = vm.wait_for_login(timeout=360)
+    if utils_package.package_install("stressapptest", session, timeout=300):
+        session.close()
+        return
+
     name = ["git", "gcc", "gcc-c++", "make"]
     if not utils_package.package_install(name, session, timeout=300):
         raise exceptions.TestError("Installation of packages %s in guest "


### PR DESCRIPTION
Test code should not download and compile code.

Assume that the program is available on the guest
or that it has been made available via a package
manager.

Skip compilation if the assumption is met.