### PR TITLE
[incremental_backup] skip image check if qemu killed

### DIFF
--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -119,12 +119,12 @@ variants:
         image_format = qcow2
         image_extra_params = "compat=1.1"
         check_image = yes
-        qemu_io_blkdebug, rh_qemu_iotests:
+        qemu_io_blkdebug, rh_qemu_iotests, incremental_backup..kill_qemu:
             check_image = no
     - qcow2:
         image_format = qcow2
         check_image = yes
-        qemu_io_blkdebug, rh_qemu_iotests:
+        qemu_io_blkdebug, rh_qemu_iotests, incremental_backup..kill_qemu:
             check_image = no
     - vmdk:
         no ioquit


### PR DESCRIPTION
When vm's qemu process killed in some negative cases, the 'check_image' will pop a 'Leaked clusters' warning. This warning will be captured in postprocess of our cases and reported as a failure. But such check and warning is useless in these negative tests.