### PR TITLE
HugePageConfig:Modify hugepages release operation

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -613,10 +613,11 @@ class HugePageConfig(object):
     def cleanup(self):
         if self.deallocate:
             error_context.context("trying to deallocate hugepage memory")
-            try:
-                process.system("umount %s" % self.hugepage_path)
-            except process.CmdError:
-                return
+            if os.path.ismount(self.hugepage_path):
+                try:
+                    process.system("umount %s" % self.hugepage_path)
+                except process.CmdError:
+                    return
             process.system("echo 0 > %s" % self.kernel_hp_file, shell=True)
             self.over_commit.proc_fs_value = 0
             self.ext_hugepages_surp = utils_memory.get_num_huge_pages_surp()


### PR DESCRIPTION
When the current framework is in setup(self), it first allocates
hugepages and then mounts it.
There will be a scene here, when the continuous memory is insufficient,
set_hugepages() will fail, so the mount operation will not be performed.
But the allocated huge pages are not released, like this:

echo 4 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
2

So add the hugepages release operation in this scenario.

ID: 2181945
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)