### PR TITLE
ks: Support install specific packages in the "%packages" step

### DIFF
--- a/virttest/shared/unattended/RHEL-8-devel.ks
+++ b/virttest/shared/unattended/RHEL-8-devel.ks
@@ -57,6 +57,7 @@ dmidecode
 alsa-utils
 sg3_utils
 -gnome-initial-setup
+KVM_TEST_PACKAGES_PKGS
 %end
 
 %post
@@ -108,15 +109,20 @@ EOF
 cat >> '/home/test/.bashrc' << EOF
 alias shutdown='sudo shutdown'
 EOF
-# Install and lock packages specified via 'kickstart_instlock_pkgs' parameter
-install_and_lock()
+# Install packages specified via 'kickstart_post_pkgs' parameter
+install_pkgs()
 {
-    for PKG in KVM_TEST_PKGS; do
+    for PKG in KVM_TEST_POST_PKGS; do
         ECHO "dnf install $PKG -y --nogpgcheck"
         dnf install $PKG -y --nogpgcheck
         if [ $? -ne 0 ]; then
             ECHO "$PKG installation failed."
         fi
+}
+# Lock packages specified via 'kickstart_lock_pkgs' parameter
+lock_pkgs()
+{
+    for PKG in KVM_TEST_LOCK_PKGS; do
         ECHO "dnf versionlock add $PKG"
         dnf versionlock add $PKG
         if [ $? -ne 0 ]; then
@@ -124,6 +130,7 @@ install_and_lock()
         fi
     done
 }
-install_and_lock
+install_pkgs
+lock_pkgs
 ECHO 'Post set up finished'
 %end

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -433,12 +433,30 @@ class UnattendedInstallConfig(object):
             content = "\n".join(lines)
             contents = re.sub(dummy_repos_re, content, contents)
 
-        dummy_pkgs_re = r'\bKVM_TEST_PKGS\b'
-        if re.search(dummy_pkgs_re, contents):
-            # Extra packages to be installed and locked
+        # NOTE: This is an experimental feature to install extra packages
+        # during %packages step, even it supports kickstart syntax rules, we
+        # should only use it for add packages.
+        dummy_packages_pkgs_re = r'\bKVM_TEST_PACKAGES_PKGS\b'
+        if re.search(dummy_packages_pkgs_re, contents):
+            # Extra packages to be installed at "%packages" step
             # Use space as a separator for multiple pkgs
-            pkgs = self.params.get("kickstart_instlock_pkgs", "")
-            contents = re.sub(dummy_pkgs_re, pkgs, contents)
+            pkgs = self.params.get("kickstart_packages_pkgs", "").split()
+            content = "\n".join(pkgs)
+            contents = re.sub(dummy_packages_pkgs_re, content, contents)
+
+        dummy_post_pkgs_re = r'\bKVM_TEST_POST_PKGS\b'
+        if re.search(dummy_post_pkgs_re, contents):
+            # Extra packages to be installed at "%post" step
+            # Use space as a separator for multiple pkgs
+            pkgs = self.params.get("kickstart_post_pkgs", "")
+            contents = re.sub(dummy_post_pkgs_re, pkgs, contents)
+
+        dummy_lock_pkgs_re = r'\bKVM_TEST_LOCK_PKGS\b'
+        if re.search(dummy_lock_pkgs_re, contents):
+            # Packages to be locked
+            # Use space as a separator for multiple pkgs
+            pkgs = self.params.get("kickstart_lock_pkgs", "")
+            contents = re.sub(dummy_lock_pkgs_re, pkgs, contents)
 
         dummy_logging_re = r'\bKVM_TEST_LOGGING\b'
         if re.search(dummy_logging_re, contents):


### PR DESCRIPTION
1. Add a new parameter to install pkgs in "%packages" phase
2. Split instlock to 2 functions
    1. Install pkgs in "%post" phase, supports specific nvr, url install
    2. Lock pkgs you want

ID: 2182236
Signed-off-by: Yihuang Yu <yihyu@redhat.com>