### PR TITLE
Update virtio driver attributes in some devices

### DIFF
--- a/virttest/libvirt_xml/devices/input.py
+++ b/virttest/libvirt_xml/devices/input.py
@@ -9,7 +9,7 @@ from virttest.libvirt_xml.devices import base, librarian
 
 
 class Input(base.TypedDeviceBase):
-    __slots__ = ('input_bus', 'model', 'address', 'source_evdev', 'driver_packed', 'alias')
+    __slots__ = ('input_bus', 'model', 'address', 'source_evdev', 'driver', 'alias')
 
     def __init__(self, type_name, virsh_instance=base.base.virsh):
         super(Input, self).__init__(device_tag='input',
@@ -32,8 +32,8 @@ class Input(base.TypedDeviceBase):
                                                  'virsh_instance': virsh_instance})
         accessors.XMLAttribute('source_evdev', self, parent_xpath='/',
                                tag_name='source', attribute='evdev')
-        accessors.XMLAttribute('driver_packed', self, parent_xpath='/',
-                               tag_name='driver', attribute='packed')
+        accessors.XMLElementDict('driver', self, parent_xpath='/',
+                                 tag_name='driver')
         accessors.XMLElementDict('alias', self, parent_xpath='/',
                                  tag_name='alias')
     # For convenience

--- a/virttest/libvirt_xml/devices/memballoon.py
+++ b/virttest/libvirt_xml/devices/memballoon.py
@@ -11,7 +11,7 @@ from virttest.libvirt_xml.devices import base
 class Memballoon(base.UntypedDeviceBase):
 
     __slots__ = ('model', 'stats_period', 'address', 'alias_name',
-                 'driver_packed')
+                 'driver')
 
     def __init__(self, virsh_instance=base.base.virsh):
         accessors.XMLAttribute('model', self, parent_xpath='/',
@@ -22,7 +22,7 @@ class Memballoon(base.UntypedDeviceBase):
                                  tag_name='address')
         accessors.XMLAttribute('alias_name', self, parent_xpath='/',
                                tag_name='alias', attribute='name')
-        accessors.XMLAttribute('driver_packed', self, parent_xpath='/',
-                               tag_name='driver', attribute='packed')
+        accessors.XMLElementDict('driver', self, parent_xpath='/',
+                                 tag_name='driver')
         super(Memballoon, self).__init__(device_tag='memballoon',
                                          virsh_instance=virsh_instance)

--- a/virttest/libvirt_xml/devices/video.py
+++ b/virttest/libvirt_xml/devices/video.py
@@ -12,7 +12,7 @@ class Video(base.UntypedDeviceBase):
 
     __slots__ = ('model_type', 'model_ram', 'model_vram', 'model_heads',
                  'model_vgamem', 'model_vram64',
-                 'primary', 'acceleration', 'address', 'driver_packed')
+                 'primary', 'acceleration', 'address', 'driver')
 
     def __init__(self, virsh_instance=base.base.virsh):
         accessors.XMLAttribute('model_type', self,
@@ -49,9 +49,8 @@ class Video(base.UntypedDeviceBase):
         accessors.XMLElementDict('address', self,
                                  parent_xpath='/',
                                  tag_name='address')
-        accessors.XMLAttribute('driver_packed', self,
-                               parent_xpath='/',
-                               tag_name='driver',
-                               attribute='packed')
+        accessors.XMLElementDict('driver', self,
+                                 parent_xpath='/',
+                                 tag_name='driver')
         super(Video, self).__init__(device_tag='video',
                                     virsh_instance=virsh_instance)

--- a/virttest/libvirt_xml/devices/vsock.py
+++ b/virttest/libvirt_xml/devices/vsock.py
@@ -10,7 +10,7 @@ from virttest.libvirt_xml.devices import base, librarian
 
 class Vsock(base.UntypedDeviceBase):
 
-    __slots__ = ('model_type', 'cid', 'address', 'alias')
+    __slots__ = ('model_type', 'cid', 'address', 'alias', 'driver')
 
     def __init__(self, virsh_instance=base.base.virsh):
         accessors.XMLAttribute('model_type', self,
@@ -28,6 +28,8 @@ class Vsock(base.UntypedDeviceBase):
         accessors.XMLElementDict('alias', self,
                                  parent_xpath='/',
                                  tag_name='alias')
+        accessors.XMLElementDict('driver', self, parent_xpath='/',
+                                 tag_name='driver')
         super(Vsock, self).__init__(device_tag='vsock',
                                     virsh_instance=virsh_instance)
         self.xml = '<vsock/>'


### PR DESCRIPTION
For example:
```
>>> from virttest.libvirt_xml.devices import input
>>> input_dev = input.Input("tablet")
>>> input_dev.xml = """
...    <input type='tablet' bus='virtio'>
...       <driver iommu='on' ats='on' packed='on' page_per_vq='on'/>
...       <address type='pci' domain='0x0000' bus='0x09' slot='0x00' function='0x0'/>
...     </input>
... """
>>> input_dev.fetch_attrs()
{'driver_packed': 'on', 'type_name': 'tablet', 'address': {'attrs': {'type': 'pci', 'domain': '0x0000', 'bus': '0x09', 'slot': '0x00', 'function': '0x0'}, 'type_name': 'pci'}, 'input_bus': 'virtio'}
```
Can't get other driver attributes except the driver_packed. So update some related attributes in different devices.