### PR TITLE
qemu_vm: Let target VM remove tmp files after a local migration

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4860,6 +4860,12 @@ class VM(virt_vm.BaseVM):
                         if os.path.isfile(save2):
                             os.remove(save2)
 
+            # FIXME: Never remove the source VM's files when doing a local
+            # migration because these files are still being used by the
+            # target VM, let the target VM do the cleanup work
+            if local and self.devices.temporary_image_snapshots:
+                self.devices.temporary_image_snapshots.clear()
+
             # Switch self <-> clone
             temp = self.clone(copy_state=True)
             self.destroy(gracefully=False)      # self is the source dead vm


### PR DESCRIPTION
When we perform a live migration on a single node, never remove the related resources of the source VM, because the target VM is still using these resources after migration, so let the target VM do it.


ID: 2184877