### PR TITLE
libvirt_bios: add to check firmware feature in os

### DIFF
--- a/virttest/utils_libvirt/libvirt_bios.py
+++ b/virttest/utils_libvirt/libvirt_bios.py
@@ -27,4 +27,6 @@ def remove_bootconfig_items_from_vmos(osxml):
         osxml.del_nvram()
     if os_attrs.get('loader'):
         osxml.del_loader()
+    if os_attrs.get('firmware'):
+        osxml.del_firmware()
     return osxml


### PR DESCRIPTION
The guest will automatically add firmware type/features information to os xml when defining a guest. So for some test cases which need to remove uefi related os info, we also need to check and remove this firmware feature.