### PR TITLE
Lint check: bump pylint version to match Avocado

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ requirements: pip
 	- $(PYTHON) -m pip install -r requirements.txt
 
 check:
-	inspekt checkall --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E1003,W605 --disable-style W605,W606,E501,E265,W601,E402,E722,E741 --exclude avocado-libs,scripts/github --no-license-check
+	inspekt checkall --disable-lint W,R,C,E0203,E0601,E1002,E1101,E1102,E1103,E1120,F0401,I0011,E1003,W605 --disable-style W605,W606,E501,E265,W601,E402,E722,E741 --exclude avocado-libs,scripts/github --no-license-check
 	pylint --errors-only --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
 
 clean:

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,6 +1,6 @@
 Sphinx==1.3b1
 # inspektor (static and style checks)
-pylint==2.12.2
+pylint==2.15.10
 inspektor==0.5.3
 aexpect>=1.6.4
 simplejson==3.8.0


### PR DESCRIPTION
There's an effort to share more code between the "avocado-framework" projects, including the "autils" initiative.  Having common baselines of linters, code style, etc is very helpful.

This bumps the pylint version to match the one being used in Avocado. This change being only a version bump, it disables the checks E1102, E0203 and E0601, enabled/introduced on the newer pylint version.