### PR TITLE
Add new parameter to support changing backend mem path

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1092,6 +1092,11 @@ class VM(virt_vm.BaseVM):
                 backend_options["size_mem"] = "%sM" % params["mem"]
                 if params.get("vm_mem_backend"):
                     backend_options["backend_mem"] = params.get("vm_mem_backend")
+                if params.get("vm_mem_backend") == "memory-backend-file":
+                    if not params.get("vm_mem_backend_path"):
+                        raise virt_vm.VMConfigMissingError(self.name,
+                                                           'vm_mem_backend_path')
+                    backend_options["mem-path_mem"] = params["vm_mem_backend_path"]
                 if params.get("hugepage_path"):
                     backend_options["backend_mem"] = "memory-backend-file"
                     backend_options["mem-path_mem"] = params["hugepage_path"]

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -260,6 +260,9 @@ mem = 1024
 # Pattern for check memory size inside guest
 mem_chk_re_str = ([0-9]+)
 
+# To configure the 'mem-path' for the 'memory-backend' of machine
+# vm_mem_backend_path = /dev/shm
+
 # To configure guest backed by hugepages, set it to "yes"
 # hugepage = "no"
 


### PR DESCRIPTION
 Memory: Add a new parameter "vm_mem_backend_path", this will controls
    the "mem-path" in memory object

ID: 2187577

Signed-off-by: Boqiao Fu <bfu@redhat.com>
