### PR TITLE
HugePageConfig:Update method for calculating huge pages

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -401,7 +401,7 @@ class HugePageConfig(object):
         # memory of all VMs plus qemu overhead of 128MB per guest
         # (this value can be overridden in your cartesian config)
         vmsm = self.vms * (self.mem + self.qemu_overhead)
-        target_hugepages = int(vmsm * 1024 // self.hugepage_size)
+        target_hugepages = math.ceil(vmsm * 1024 / self.hugepage_size)
 
         # FIXME Now the buddyinfo can not get chunk info which is bigger
         # than 4M. So this will only fit for 2M size hugepages. Can not work
@@ -433,8 +433,8 @@ class HugePageConfig(object):
                          " biggest number the system can support.")
                 target_hugepages = available_hugepages
                 available_mem = available_hugepages * self.hugepage_size
-                self.suggest_mem = int(available_mem // self.vms // 1024 -
-                                       self.qemu_overhead)
+                self.suggest_mem = math.ceil(available_mem / self.vms /
+                                             1024 - self.qemu_overhead)
                 if self.suggest_mem < self.lowest_mem_per_vm:
                     raise MemoryError("This host doesn't have enough free "
                                       "large memory pages for this test to "


### PR DESCRIPTION
The current calculation formula is to take the remainder. 
But the calculation of the page should be rounded up, to make sure the memory is enough.

Please refer to the following example:
21102592 // 16777216
1
math.ceil(21102592 / 16777216)
2

ID: 1425
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)
