### PR TITLE
hotfix: syntax in the RHEL-8-devel.ks file

### DIFF
--- a/virttest/shared/unattended/RHEL-8-devel.ks
+++ b/virttest/shared/unattended/RHEL-8-devel.ks
@@ -118,6 +118,7 @@ install_pkgs()
         if [ $? -ne 0 ]; then
             ECHO "$PKG installation failed."
         fi
+    done
 }
 # Lock packages specified via 'kickstart_lock_pkgs' parameter
 lock_pkgs()


### PR DESCRIPTION
In the install_pkgs function on RHEL-8-devel.ks, missing "done" in the "for" loop, this will block the guest installation, fix it.