### PR TITLE
KSMConfig.cleanup: Ensure ksm to be disabled at the end of the case

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -638,7 +638,7 @@ class KSMConfig(object):
         if self.run == "yes":
             self.run = "1"
         elif self.run == "no":
-            self.run == "0"
+            self.run = "0"
 
         # Get KSM module status if there is one
         self.ksmctler = utils_misc.KSMController()
@@ -695,6 +695,12 @@ class KSMConfig(object):
             # ksmtuned used to run in host. Start the process
             # and don't need set up the configures.
             self.ksmctler.start_ksmtuned()
+            # Ensure ksm it not enabled before return
+            if not wait.wait_for(lambda: not self.ksmctler.is_ksm_running(),
+                                 timeout=120, step=5,
+                                 text="Waiting for ksm to be disabled"):
+                LOG.warning("KSM is still running, subsequent test may not "
+                            "work as expected")
             return
 
         if default_status == self.default_status:

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3084,7 +3084,8 @@ class KSMController(object):
         Verify whether ksm is running.
         """
         if self.interface == "sysfs":
-            running = process.run("cat %s" % self.ksm_params["run"]).stdout_text
+            running = process.run(
+                "cat %s" % self.ksm_params["run"]).stdout_text.strip()
         else:
             output = process.run("ksmctl info").stdout_text
             try:


### PR DESCRIPTION
In the `cleanup` function, "start_ksmtuned" will start the 
ksmtuned.service, it controls and tunes the ksm service, but depends on 
the KSM_MONITOR_INTERVAL. So ksm is not closed immediately, but at some 
time in KSM_MONITOR_INTERVAL loop. Without this fix, the next test case 
may launch the guest with ksm enabled, which is not expected.

ID: 2215183
Signed-off-by: Yihuang Yu <yihyu@redhat.com>