### PR TITLE
Windows: remove md5sum value of win10-32

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -4,8 +4,6 @@
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         unattended_file = unattended/win10-32-autounattend.xml
         cdrom_cd1 = isos/windows/en_windows_10_enterprise_x86_dvd_6851156.iso
-        md5sum_cd1 = 68162933e551e55779504dacdfb0c5ae
-        md5sum_1m_cd1 = b44af2fdb8c39bc972f416bd3616566f
         floppies = "fl"
         floppy_name = images/win10-32/answer.vfd
         extra_cdrom_ks:


### PR DESCRIPTION
ID: 2215515
Don't need md5sum value for win10-32 os installation.