### PR TITLE
hugepage_setup: Cleanup hugepage when setup process fails

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -556,6 +556,8 @@ class HugePageConfig(object):
                 msg = "Can't read/write from kernel hugepage file"
                 raise exceptions.TestSetupFail(msg)
             if loop_hp == hp:
+                if loop_hp > 0:
+                    self.cleanup()
                 raise ValueError("Cannot set the kernel hugepage setting "
                                  "to the target value of %d hugepages." %
                                  self.target_hugepages)


### PR DESCRIPTION
If the setup process fails, func will raise an error and return. Meanwhile, if the system has created some other hugepages, they will remain on the host to consume memory.

Therefore, do the cleanup process after failing.

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_hugepage.2M: ERROR: Cannot set the kernel hugepage setting to the target value of 500 hugepages. (10.47 s)

# cat /proc/sys/vm/nr_hugepages
30
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_hugepage.2M: ERROR: Cannot set the kernel hugepage setting to the target value of 500 hugepages. (9.74 s)

# cat /proc/sys/vm/nr_hugepages
0
```