### PR TITLE
Reduce the libvirt logging verbosity (not needed for qemu vms)

### DIFF
--- a/virttest/_wrappers.py
+++ b/virttest/_wrappers.py
@@ -6,6 +6,7 @@
 
 import sys
 import importlib
+import importlib.util
 from importlib.machinery import (SourceFileLoader, SOURCE_SUFFIXES,
                                  SourcelessFileLoader, BYTECODE_SUFFIXES,
                                  ExtensionFileLoader, EXTENSION_SUFFIXES)
@@ -70,3 +71,20 @@ def load_source(name, path):
     """
     spec = importlib.util.spec_from_file_location(name, path)
     return _load_from_spec(spec)
+
+
+def lazy_import(name):
+    """ Allows for an early import that is initialized upon use (lazy import).
+
+    :param name: Name of the module that is going to be imported
+    :type name: String
+    """
+    spec = importlib.util.find_spec(name)
+    if spec is None:
+        raise ImportError(f"Could not import module {name}")
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -34,12 +34,10 @@ from virttest import cpu
 from virttest import storage
 from virttest import utils_libguestfs
 from virttest import qemu_storage
-from virttest import utils_libvirtd
 from virttest import data_dir
 from virttest import utils_net
 from virttest import nfs
 from virttest import libvirt_vm
-from virttest import virsh
 from virttest import utils_test
 from virttest import utils_iptables
 from virttest import utils_package
@@ -53,6 +51,12 @@ from virttest.staging import service
 from virttest.test_setup.core import SetupManager
 from virttest.test_setup.os_posix import UlimitConfig
 from virttest.test_setup.networking import NetworkProxies
+
+
+# lazy imports for dependencies that are not needed in all modes of use
+from virttest._wrappers import lazy_import
+utils_libvirtd = lazy_import("virttest.utils_libvirtd")
+virsh = lazy_import("virttest.virsh")
 
 
 try:

--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -56,6 +56,7 @@ class Libvirtd(object):
         self.daemons = []
         self.service_list = []
 
+        # we only import this module conditionally to make this warning always applicable
         if LIBVIRTD is None:
             LOG.warning("Libvirtd service is not available in host, "
                         "utils_libvirtd module will not function normally")

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -71,6 +71,7 @@ VIRSH_COMMAND_GROUP_CACHE_NO_DETAIL = False
 try:
     VIRSH_EXEC = path.find_command("virsh")
 except path.CmdNotFoundError:
+    # we only import this module conditionally to make this warning always applicable
     logging.getLogger('avocado.app').warning(
         "Virsh executable not set or found on path, virsh module will not "
         "function normally")


### PR DESCRIPTION
We do this by importing these modules conditionally within the modules of shared qemu and livbirt vm usage.