### PR TITLE
thread-context: support new object thread-context

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2896,6 +2896,20 @@ class DevContainer(object):
         props = json.loads(group_params.get("throttle_group_parameters", "{}"))
         return QThrottleGroup(name, props)
 
+    def thread_context_define_by_params(self, params, name):
+        """
+        Create thread-context object from params.
+        """
+        tc_params = Params()
+        prefix = 'vm_thread_context_'
+        for key in params:
+            if key.startswith(prefix):
+                new_key = key.rsplit(prefix)[1]
+                tc_params[new_key] = params[key]
+        dev = qdevices.QObject("thread-context", params=tc_params)
+        dev.set_param("id", "%s-%s" % ("thread_context", name))
+        return dev
+
     def memory_object_define_by_params(self, params, name):
         """
         Create memory object from params, default backend type is

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1252,6 +1252,15 @@ class VM(virt_vm.BaseVM):
 
             return secret_cmdline + " -spice %s" % (",".join(spice_opts))
 
+        def add_thread_context(devices, params):
+            for thread_context in params.objects("vm_thread_contexts"):
+                thread_context_params = params.object_params(thread_context)
+                dev = devices.thread_context_define_by_params(thread_context_params, thread_context)
+                set_cmdline_format_by_cfg(dev, self._get_cmdline_format_cfg(),
+                                          "thread_contexts")
+                devices.insert(dev)
+            return devices
+
         def add_qxl(qxl_nr, base_addr=29):
             """
             adds extra qxl devices
@@ -1765,6 +1774,9 @@ class VM(virt_vm.BaseVM):
         # Add Memory devices
         add_memorys(devices, params)
         mem = int(params.get("mem", 0))
+
+        # Add thread context object
+        add_thread_context(devices, params)
 
         # Get cpu model, before add smp, to determine cpu topology
         cpu_model = params.get("cpu_model", "")


### PR DESCRIPTION
thread-context: support new object thread-context

Includes support in avocado-vt for a new object:
thread-context. The intention of this new object
is to be used to make NUMA aware of the memory
preallocation threads.

ID: 2224513
Signed-off-by: mcasquer <mcasquer@redhat.com>