### PR TITLE
Update func set_graphics_attr

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1614,7 +1614,11 @@ class VMXML(VMXMLBase):
         """
         vmxml = VMXML.new_from_inactive_dumpxml(
             vm_name, virsh_instance=virsh_instance)
-        graphic = vmxml.xmltreefile.find('devices').findall('graphics')
+        devices = vmxml.xmltreefile.find('devices')
+        graphic = devices.findall('graphics')
+        if not graphic:
+            graphic = [xml_utils.ElementTree.SubElement(devices, 'graphics')]
+            graphic[0].set('type', 'vnc')
         for key in attr:
             LOG.debug("Set %s='%s'" % (key, attr[key]))
             graphic[index].set(key, attr[key])


### PR DESCRIPTION
The current set_graphics_attr() can only handle the situation where the graphics device itself exists in the original xmltree.

Update the func so that it can also handle the situation where the graphics does not exist in the original xmltree.

Before:
```
 (1/2) type_specific.io-github-autotest-libvirt.save_and_restore.save_image_dumpxml.readonly.no_opt: ERROR: list index out of range (4.37 s)
 (2/2) type_specific.io-github-autotest-libvirt.save_and_restore.save_image_dumpxml.readonly.security_info_opt: ERROR: list index out of range (4.40 s)
```

After:
```
 (1/2) type_specific.io-github-autotest-libvirt.save_and_restore.save_image_dumpxml.readonly.no_opt: PASS (26.23 s)
 (2/2) type_specific.io-github-autotest-libvirt.save_and_restore.save_image_dumpxml.readonly.security_info_opt: PASS (26.81 s)
```