### PR TITLE
base.cfg: disable libvirtd_log_cleanup

### DIFF
--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -804,7 +804,7 @@ libvirtd_debug_file = ""
 # libvirtd_debug_filters = "2:*"
 # Custom log file permissions until https://gitlab.com/libvirt/libvirt/-/issues/71 is supported
 # libvirtd_log_permission = "0600"
-libvirtd_log_cleanup = "yes"
+libvirtd_log_cleanup = "no"
 
 #Define one flexbit whether enable split daemons feature, default is disable
 enable_split_libvirtd_feature = "no"


### PR DESCRIPTION
Do not cleanup libvirtd log, since ci needs to grep error/warning msg for feature owners' debugging.