### PR TITLE
test_setup: rename parameter for hugepage path

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -279,7 +279,7 @@ class HugePageConfig(object):
         self.max_vms = int(params.get("max_vms", 0))
         self.qemu_overhead = int(params.get("hugepages_qemu_overhead", 128))
         self.deallocate = params.get("hugepages_deallocate", "yes") == "yes"
-        self.hugepage_path = params.get("hugepage_path", "/mnt/kvm_hugepage")
+        self.hugepage_path = params.get("vm_hugepage_mountpoint", "/mnt/kvm_hugepage")
         self.kernel_hp_file = params.get("kernel_hp_file", "/proc/sys/vm/nr_hugepages")
         if not os.path.exists(self.kernel_hp_file):
             raise exceptions.TestSkipError("Hugepage config file is not found: "


### PR DESCRIPTION
The old  parameter name is userd by tp-qemu for other purpose and conflicted with below avocado-vt usage. https://github.com/autotest/tp-qemu/blob/master/qemu/tests/cfg/hugepage_mem_stress.cfg#L19C13-L19C26 https://github.com/avocado-framework/avocado-vt/blob/master/virttest/qemu_vm.py#L1107C49-L1107C49


Signed-off-by: Dan Zheng <dzheng@redhat.com>

