### PR TITLE
vt_runner: Add missing whiteboard to the test status

### DIFF
--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -90,6 +90,7 @@ class VirtTest(test.VirtTest):
                                "in `debug.log` for details.")
             self.queue.put(messages.StderrMessage.get(traceback_log))
         finally:
+            self.queue.put(messages.WhiteboardMessage.get(self.whiteboard))
             if 'avocado_test_' in self.logdir:
                 self._save_log_dir()
             try:


### PR DESCRIPTION
After switched to nrunner, whiteboard is missing from the result, so it is always empty to show. This commit add `WhiteboardMessage` to catch it.

ID: 2232529