### PR TITLE
Fix an issue of ppm_utils

### DIFF
--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -424,7 +424,10 @@ def add_timestamp(image, timestamp, margin=2):
     font = ImageFont.load_default()
     watermark = time.strftime('%c', time.localtime(timestamp))
     # bar height = text height + top margin + bottom margin
-    bar_height = font.getsize(watermark)[1] + 2 * margin
+    if hasattr(font, 'getbbox'):
+        bar_height = font.getbbox(watermark)[3] + 2 * margin
+    else:
+        bar_height = font.getsize(watermark)[1] + 2 * margin
 
     # place bar at the bottom
     new_image = ImageOps.expand(image, border=(0, 0, 0, bar_height),


### PR DESCRIPTION
We could see the following error popped up when enabling screendumps

> 'ImageFont' object has no attribute 'getsize'

so let's fix it.

Issue: https://github.com/avocado-framework/avocado-vt/issues/3748