### PR TITLE
qemu_vm: Support assigning host devices to the guest

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -3977,3 +3977,30 @@ class DevContainer(object):
             raise ValueError("Unsupported secure guest: %s" % sectype)
 
         return qdevices.QObject(backend, properties)
+
+    def hostdev_define_by_params(self, name, params, bus=None):
+        """
+        Create a host device based on the provided parameters.
+
+        :param name: The name or identifier for the host device
+        :param params: A dict containing parameters to configure the device
+        :param bus: Bus name where the device should be attached
+
+        :return: The defined host device object
+        """
+        driver = params.get('vm_hostdev_driver')
+        if not self.has_device(driver):
+            raise virt_vm.VMDeviceNotSupportedError(self.vmname, driver)
+        dev_params = Params(
+            {'driver': driver,
+             'id': name,
+             'host': params['vm_hostdev_host'],
+             'failover_pair_id': params.get("vm_hostdev_failover_pair_id")
+             }
+        )
+        # TODO: Support vfio-ap and vfio-ccw, currently only for pci devices
+        dev_bus = bus or {'aobject': params.get('pci_bus', 'pci.0')}
+        dev = qdevices.QDevice(driver, dev_params, parent_bus=dev_bus)
+        for ext_k, ext_v in params.get_dict("vm_hostdev_extra_params").items():
+            dev.set_param(ext_k, ext_v)
+        return dev

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -3988,18 +3988,19 @@ class DevContainer(object):
 
         :return: The defined host device object
         """
-        driver = params.get('vm_hostdev_driver')
+        driver = params.get("vm_hostdev_driver")
         if not self.has_device(driver):
             raise virt_vm.VMDeviceNotSupportedError(self.vmname, driver)
         dev_params = Params(
-            {'driver': driver,
-             'id': name,
-             'host': params['vm_hostdev_host'],
-             'failover_pair_id': params.get("vm_hostdev_failover_pair_id")
-             }
+            {
+                "driver": driver,
+                "id": name,
+                "host": params["vm_hostdev_host"],
+                "failover_pair_id": params.get("vm_hostdev_failover_pair_id"),
+            }
         )
         # TODO: Support vfio-ap and vfio-ccw, currently only for pci devices
-        dev_bus = bus or {'aobject': params.get('pci_bus', 'pci.0')}
+        dev_bus = bus or {"aobject": params.get("pci_bus", "pci.0")}
         dev = qdevices.QDevice(driver, dev_params, parent_bus=dev_bus)
         for ext_k, ext_v in params.get_dict("vm_hostdev_extra_params").items():
             dev.set_param(ext_k, ext_v)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3035,6 +3035,16 @@ class VM(virt_vm.BaseVM):
                 set_cmdline_format_by_cfg(dev, self._get_cmdline_format_cfg(), "tpm")
             devices.insert(devs)
 
+        # Add host devices
+        # XXX: This is a temporary solution for adding host devices, it may be
+        # implemented in a better way in the future after qemu_vm splits create
+        # to define and start.
+        for hostdev in params.objects("vm_hostdevs"):
+            hostdev_params = params.object_params(hostdev)
+            dev = devices.hostdev_define_by_params(hostdev, hostdev_params)
+            set_cmdline_format_by_cfg(dev, self._get_cmdline_format_cfg(), "hostdev")
+            devices.insert(dev)
+
         disable_kvm_option = ""
         if devices.has_option("no-kvm"):
             disable_kvm_option = "-no-kvm"


### PR DESCRIPTION
1. qcontainer: Introduce hostdev_define_by_params method to define a host device, it's
used for qemu. Currently, it only supports pci devices, something like
s390x's vfio-ap and vfio-ccw are not yet supported.
2. qemu_vm: Introduces the capability to assign host devices for guest.
The loop in the code iterates through the 'vm_hostdevs' parameter,
creating host devices based on the specified parameters.

ID: 1403
Signed-off-by: Yihuang Yu <yihyu@redhat.com>