### PR TITLE
utils_misc: support die_id in topology

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1767,7 +1767,8 @@ class NumaNode(object):
         core_id_path = topology_path + "core_id"
         siblings_path = topology_path + "thread_siblings_list"
         socket_id_path = topology_path + "physical_package_id"
-        key_list = ["core_id", "siblings", "socket_id"]
+        die_id_path = topology_path + "die_id"
+        key_list = ["core_id", "siblings", "socket_id", "die_id"]
         for key in key_list:
             try:
                 key_path = eval(key + '_path')


### PR DESCRIPTION
'die_id' is newly introduced in <cpu> in virsh capabilities output, like below

```
<cpus num='2'>
            <cpu id='2' socket_id='2' die_id='0' core_id='0' siblings='2'/>
            <cpu id='3' socket_id='3' die_id='0' core_id='0' siblings='3'/>
</cpus>

```

Signed-off-by: Dan Zheng <dzheng@redhat.com>