### PR TITLE
Fix partition number error

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -26,6 +26,7 @@ from avocado.utils.service import SpecificServiceManager
 
 from virttest import error_context
 from virttest import utils_numeric
+from virttest import utils_misc
 from virttest import remote
 
 PARTITION_TABLE_TYPE_MBR = "msdos"
@@ -545,6 +546,10 @@ def clean_partition_linux(session, did, timeout=360):
     else:
         partition_numbers = partition_numbers.splitlines()
         for number in partition_numbers:
+            # Sometimes we may get wrong partition number, for example,
+            # "[ 122.778138] vdc: vdc1". So we need to ignore it.
+            if number.startswith('['):
+                continue
             LOG.info("remove partition %s on %s" % (number, did))
             session.cmd(rm_cmd % (did, number))
         session.cmd("partprobe /dev/%s" % did, timeout=timeout)


### PR DESCRIPTION
Sometimes we may get wrong partition number, for example, "[  122.778138]  vdc: vdc1". So we need to ignore it.

To fix:
  ShellCmdError: Shell command failed: 'parted -s &quot;/dev/vdc&quot; rm [  122.778138]  vdc: vdc1'    (status: 1,    output: &quot;Error: Partition doesn't exist.\n&quot;)