### PR TITLE
add more flexible for consume_mem and check_qemu func

### DIFF
--- a/virttest/utils_libvirt/libvirt_memory.py
+++ b/virttest/utils_libvirt/libvirt_memory.py
@@ -58,14 +58,15 @@ def normalize_mem_size(mem_size, mem_unit):
     return int(mem_size * 1024 ** mem_unit_idx)
 
 
-def consume_vm_freememory(vm_session):
+def consume_vm_freememory(vm_session, consume_value=100000):
     """
     Verify the free memory of the vm can be consumed normally
 
     :param vm_session: vm session
+    :param consume_value: consume value , default 100000
     """
     vm_session.cmd_status('swapoff -a')
     free_mem = utils_memory.freememtotal(vm_session)
-    cmd = 'memhog %dk' % (free_mem - 100000)
+    cmd = 'memhog %dk' % (free_mem - consume_value)
     status, stdout = vm_session.cmd_status_output(cmd, timeout=60)
     return (status, stdout)

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -3883,7 +3883,7 @@ def check_qemu_cmd_line(content,
                         expect_exist=True):
     """
     Check the specified content in the qemu command line
-    :param content: the desired string to search
+    :param content: the desired string to search, string or list type
     :param err_ignore: True to return False when fail
                        False to raise exception when fail
     :param remote_params: The params for remote executing
@@ -3898,19 +3898,23 @@ def check_qemu_cmd_line(content,
     else:
         cmd_result = remote_old.run_remote_cmd(cmd, remote_params, runner_on_target)
         qemu_line = cmd_result.stdout
-    search_result = True if re.search(r'%s' % content, qemu_line) else False
-    if search_result ^ expect_exist:
-        if err_ignore:
-            return False
+    if isinstance(content, str):
+        content = [content]
+    for con in content:
+        search_result = True if re.search(r'%s' % con, qemu_line) else False
+
+        if search_result ^ expect_exist:
+            if err_ignore:
+                return False
+            else:
+                raise exceptions.TestFail("Expecting '%s' does%s "
+                                          "exist in qemu command line, "
+                                          "but %sfound" % (con,
+                                                           '' if expect_exist else ' not',
+                                                           ' not' if expect_exist else ''))
         else:
-            raise exceptions.TestFail("Expecting '%s' does%s "
-                                      "exist in qemu command line, "
-                                      "but %sfound" % (content,
-                                                       '' if expect_exist else ' not',
-                                                       ' not' if expect_exist else ''))
-    else:
-        LOG.info("Qemu command line check for '%s': PASS", content)
-        return True
+            LOG.info("Qemu command line check for '%s': PASS", con)
+    return True
 
 
 def check_cmd_output(cmd, content, err_ignore=False, session=None):


### PR DESCRIPTION
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.backing.mount_path

 (1/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.default: PASS (61.76 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.disabled: PASS (25.95 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.customized: PASS (29.31 s)
```