### PR TITLE
qdevices: Fix the missing of the detect-zeroes

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2324,7 +2324,7 @@ class DevContainer(object):
                 if Flags.BLOCKDEV in self.caps:
                     if key == 'discard':
                         value = re.sub('on', 'unmap', re.sub('off', 'ignore', value))
-                    if key == 'cache-size':
+                    if key in ('cache-size', 'detect-zeroes', ):
                         protocol_node.set_param(key, None)
                     else:
                         protocol_node.set_param(key, value)

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -758,12 +758,11 @@ class QBlockdevNode(QCustomDevice):
         new_args = dict()
         keep_original_type = ("detect-zeroes", )
         for key, value in six.iteritems(args):
-            if key in keep_original_type:
-                continue
-            if value in ('on', 'yes'):
-                value = True
-            elif value in ('off', 'no'):
-                value = False
+            if key not in keep_original_type:
+                if value in ('on', 'yes'):
+                    value = True
+                elif value in ('off', 'no'):
+                    value = False
 
             parts = key.split(".")
             d = new_args


### PR DESCRIPTION
There has been a regression issue since the patch https://github.com/avocado-framework/avocado-vt/pull/3710
This path's aim is to keep the original type of value for the `detect-zeroes`, not drop it from the blockdev options.

ID: 1320
