### PR TITLE
Fix usb address being treated as octal

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1495,8 +1495,8 @@ def create_hostdev_xml(pci_id, boot_order=None,
                      'bus': device_bus, 'function': device_function}
             hostdev_xml.source = hostdev_xml.new_source(**attrs)
         if dev_type == "usb":
-            addr_bus = pci_id.split(':')[2]
-            addr_device = pci_id.split(':')[3]
+            addr_bus = hex(int(pci_id.split(':')[2]))
+            addr_device = hex(int(pci_id.split(':')[3]))
             hostdev_xml.source = hostdev_xml.new_source(
                 **(dict(vendor_id=device_domain, product_id=device_bus,
                         address_bus=addr_bus, address_device=addr_device)))


### PR DESCRIPTION
For the address_bus and address_device of usb pci_id, if three digits are used directly when attaching the device, they may be treated as octal numbers.

Take "1d6b:0003:008:001" as an example, address_bus "008" will be regarded as octal and will be regarded as an invalid value.

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev.usb -> CmdError: Command '/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_pue41l4m.xml --live' failed.
stdout: b'\n'
stderr: b"error: Failed to attach device from /tmp/xml_utils_temp_pue41l4m.xml\nerror: XML error: Invalid value for attribute 'bus' in element 'address': '008'. Expected integer value\n"
additional_info: None
```
After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev.usb
```