### PR TITLE
Unify all logfile handling into utils_logfile

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -31,6 +31,7 @@ from virttest import env_process
 from virttest import funcatexit
 from virttest import utils_env
 from virttest import utils_params
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest import version
 from virttest._wrappers import load_source
@@ -111,7 +112,7 @@ class VirtTest(test.Test, utils.TestUtils):
         self.__vt_params = vt_params
         self.debugdir = self.logdir
         self.resultsdir = self.logdir
-        utils_misc.set_log_file_dir(self.logdir)
+        utils_logfile.set_log_file_dir(self.logdir)
         self.__status = None
         self.__exc_info = None
 

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -45,6 +45,7 @@ from virttest import utils_qemu
 from virttest import migration
 from virttest import utils_kernel_module
 from virttest import arch
+from virttest import utils_logfile
 from virttest.utils_conn import SSHConnection
 from virttest.utils_version import VersionInterval
 from virttest.staging import service
@@ -629,6 +630,8 @@ def postprocess_vm(test, params, env, name):
             vm.remote_sessions.remove(s)
         except Exception:
             pass
+
+    utils_logfile.close_log_file()
 
     if params.get("vm_extra_dump_paths") is not None:
         vm_extra_dumps = os.path.join(test.outputdir, "vm_extra_dumps")

--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -18,7 +18,7 @@ from avocado.utils import process
 
 import six
 
-from virttest.utils_misc import log_line
+from virttest.utils_logfile import log_line
 from virttest.utils_version import VersionInterval
 
 LOG = logging.getLogger('avocado.' + __name__)

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -1472,8 +1472,7 @@ class VM(virt_vm.BaseVM):
             self.serial_console_log = os.path.join(utils_logfile.get_log_file_dir(),
                                                    output_filename)
             # Cause serial_console.close() to close open log file
-            self.serial_console.set_log_file(self.serial_console_log)
-            self.serial_console.close_hooks += [utils_logfile.close_own_log_file]
+            self.serial_console.close_hooks += [utils_logfile.close_own_log_file(self.serial_console_log)]
 
     def set_root_serial_console(self, device, remove=False):
         """

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -23,6 +23,7 @@ from avocado.utils import crypto
 from avocado.core import exceptions
 
 from virttest import error_context
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest import cpu
 from virttest import virt_vm
@@ -1455,9 +1456,10 @@ class VM(virt_vm.BaseVM):
                 cmd += (" console %s %s" % (self.name, self.serial_ports[0]))
             except IndexError:
                 raise virt_vm.VMConfigMissingError(self.name, "serial")
-            output_func = utils_misc.log_line  # Because qemu-kvm uses this
+            output_func = utils_logfile.log_line  # Because qemu-kvm uses this
+            port = self.serial_ports[0]
             # Because qemu-kvm hard-codes this
-            output_filename = self.get_serial_console_filename(self.serial_ports[0])
+            output_filename = self.get_serial_console_filename(port)
             output_params = (output_filename,)
             prompt = self.params.get("shell_prompt", "[\#\$]")
             LOG.debug("Command used to create serial console: %s", cmd)
@@ -1467,10 +1469,11 @@ class VM(virt_vm.BaseVM):
                                                        prompt=prompt)
             if not self.serial_console.is_alive():
                 LOG.error("Failed to create serial_console")
-            # Cause serial_console.close() to close open log file
-            self.serial_console.set_log_file(output_filename)
-            self.serial_console_log = os.path.join(utils_misc.get_log_file_dir(),
+            self.serial_console_log = os.path.join(utils_logfile.get_log_file_dir(),
                                                    output_filename)
+            # Cause serial_console.close() to close open log file
+            self.serial_console.set_log_file(self.serial_console_log)
+            self.serial_console.close_hooks += [utils_logfile.close_own_log_file]
 
     def set_root_serial_console(self, device, remove=False):
         """

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -34,6 +34,7 @@ except ImportError:
 # Internal imports
 from virttest import vt_iothread
 from virttest import utils_qemu
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest import arch, storage, data_dir, virt_vm
 from virttest import qemu_storage
@@ -3174,7 +3175,7 @@ class DevContainer(object):
 
         def _handle_log(line):
             try:
-                utils_misc.log_line('%s_swtpm_setup.log' % name, line)
+                utils_logfile.log_line('%s_swtpm_setup.log' % name, line)
             except Exception as e:
                 LOG.warn("Can't log %s_swtpm_setup output: %s.", name, e)
 

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import aexpect
 
 from virttest import qemu_monitor, utils_numeric
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest.qemu_devices.utils import DeviceError
 from virttest.qemu_devices.utils import none_or_int
@@ -2082,7 +2083,7 @@ class QVirtioFSDev(QDaemonDev):
         """Handle the log of virtiofs daemon."""
         name = self.get_param('name')
         try:
-            utils_misc.log_line('%s-%s.log' % (self.get_qid(), name), line)
+            utils_logfile.log_line('%s-%s.log' % (self.get_qid(), name), line)
         except Exception as e:
             LOG.warn("Can't log %s-%s, output: '%s'.", self.get_qid(), name, e)
 
@@ -2155,7 +2156,7 @@ class QSwtpmDev(QDaemonDev):
         if self.get_param('version') in ('2.0', ):
             tpm_cmd += ' --tpm2'
 
-        log_dir = utils_misc.get_log_file_dir()
+        log_dir = utils_logfile.get_log_file_dir()
         log_file = os.path.join(log_dir, '%s_swtpm.log' % self.get_qid())
         Path(log_file).touch(mode=0o644, exist_ok=True)
         tpm_cmd += ' --log file=%s' % log_file

--- a/virttest/qemu_io.py
+++ b/virttest/qemu_io.py
@@ -3,6 +3,7 @@ import re
 import aexpect
 from avocado.utils import process
 
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest import error_context
 
@@ -27,7 +28,7 @@ class QemuIO(object):
         self.type = ""
         if log_filename:
             log_filename += "-" + utils_misc.generate_random_string(4)
-            self.output_func = utils_misc.log_line
+            self.output_func = utils_logfile.log_line
             self.output_params = (log_filename,)
         else:
             self.output_func = None

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -18,6 +18,7 @@ import time
 
 import six
 
+from . import utils_logfile
 from . import utils_misc
 from . import cartesian_config
 from . import data_dir
@@ -449,8 +450,7 @@ class Monitor(object):
             raise MonitorLockError("Could not acquire exclusive lock to access"
                                    " %s" % self.open_log_files)
         try:
-            log_file_dir = utils_misc.get_log_file_dir()
-            log = utils_misc.get_path(log_file_dir, self.log_file)
+            log = utils_logfile.get_log_filename(self.log_file)
             timestr = time.strftime("%Y-%m-%d %H:%M:%S")
             try:
                 if log not in self.open_log_files:

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -33,6 +33,7 @@ from avocado.utils.astring import to_text
 import six
 from six.moves import xrange
 
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest import utils_qemu
 from virttest import cpu
@@ -2929,7 +2930,7 @@ class VM(virt_vm.BaseVM):
         self.serial_console = aexpect.ShellSession(
             "nc -U %s" % file_name,
             auto_close=False,
-            output_func=utils_misc.log_line,
+            output_func=utils_logfile.log_line,
             output_params=(log_name,),
             prompt=self.params.get("shell_prompt", "[\#\$]"),
             status_test_command=self.params.get("status_test_command",
@@ -3526,13 +3527,15 @@ class VM(virt_vm.BaseVM):
             self.create_serial_console()
 
             for key, value in list(self.logs.items()):
-                outfile = "%s-%s.log" % (key, name)
+                outfile = os.path.join(utils_logfile.get_log_file_dir(),
+                                       "%s-%s.log" % (key, name))
                 self.logsessions[key] = aexpect.Tail(
                     "nc -U %s" % value,
                     auto_close=False,
-                    output_func=utils_misc.log_line,
+                    output_func=utils_logfile.log_line,
                     output_params=(outfile,))
                 self.logsessions[key].set_log_file(outfile)
+                self.logsessions[key].close_hooks += [utils_logfile.close_own_log_file]
 
             # Wait for IO channels setting up completely,
             # such as serial console.

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3534,8 +3534,7 @@ class VM(virt_vm.BaseVM):
                     auto_close=False,
                     output_func=utils_logfile.log_line,
                     output_params=(outfile,))
-                self.logsessions[key].set_log_file(outfile)
-                self.logsessions[key].close_hooks += [utils_logfile.close_own_log_file]
+                self.logsessions[key].close_hooks += [utils_logfile.close_own_log_file(outfile)]
 
             # Wait for IO channels setting up completely,
             # such as serial console.

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -86,7 +86,8 @@ def remote_commander(client, host, port, username, password, prompt,
         log_file = utils_logfile.get_log_filename(log_filename)
         session.set_output_func(utils_logfile.log_line)
         session.set_output_params((log_file,))
-        session.set_log_file(os.path.basename(log_file))
+        session.set_log_file(log_file)
+        session.close_hooks += [utils_logfile.close_own_log_file]
 
     session.send_ctrl("raw")
     # Wrap io interfaces.

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -86,8 +86,7 @@ def remote_commander(client, host, port, username, password, prompt,
         log_file = utils_logfile.get_log_filename(log_filename)
         session.set_output_func(utils_logfile.log_line)
         session.set_output_params((log_file,))
-        session.set_log_file(log_file)
-        session.close_hooks += [utils_logfile.close_own_log_file]
+        session.close_hooks += [utils_logfile.close_own_log_file(log_file)]
 
     session.send_ctrl("raw")
     # Wrap io interfaces.

--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -27,6 +27,7 @@ from avocado.core import exceptions
 from virttest import data_dir
 from virttest import error_context
 from virttest import cpu
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest import versionable_class
 from virttest import openvswitch
@@ -1646,7 +1647,7 @@ class PciAssignable(object):
             file_name = "host_dmesg_after_load_%s.txt" % self.driver
             LOG.info("Log dmesg after loading '%s' to '%s'.", self.driver,
                      file_name)
-            utils_misc.log_line(file_name, dmesg)
+            utils_logfile.log_line(file_name, dmesg)
             self.setup = None
             return True
 

--- a/virttest/utils_logfile.py
+++ b/virttest/utils_logfile.py
@@ -167,6 +167,10 @@ def close_log_file(filename):
         _log_lock.release()
 
 
-def close_own_log_file(self):
-    """Closing hook for sessions whose log_file attribute should be passed along."""
-    close_log_file(self.log_file)
+def close_own_log_file(log_file):
+    """Closing hook for sessions with log_file managed locally."""
+
+    def hook(self):
+        close_log_file(log_file)
+
+    return hook

--- a/virttest/utils_logfile.py
+++ b/virttest/utils_logfile.py
@@ -142,9 +142,9 @@ def get_log_filename(filename):
             os.path.abspath(utils_path.get_path(_log_file_dir, filename)))
 
 
-def close_log_file(filename):
+def close_log_file(filename="*"):
     """
-    Close all files that use the same base name as filename.
+    Close log files with the same base name as filename or all by default.
 
     :param filename: Log file name
     :raise: LogLockError if the lock is unavailable
@@ -156,7 +156,8 @@ def close_log_file(filename):
                            " _open_log_files")
     try:
         for log_file, log_fd in _open_log_files.items():
-            if os.path.basename(log_file) == os.path.basename(filename):
+            if (filename == '*' or
+                    os.path.basename(log_file) == os.path.basename(filename)):
                 log_fd.close()
                 remove.append(log_file)
         if remove:

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -439,7 +439,7 @@ def get_log_filename(filename):
 def close_log_file(filename):
     logging.warning("Calling log functions from `utils_misc` is deprecated, "
                     "please use `utils_logfile` for the purpose")
-    return utils_logfile.close_log_file()
+    return utils_logfile.close_log_file(filename)
 
 
 # The following are miscellaneous utility functions.

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -17,6 +17,7 @@ from avocado.core import exceptions
 import six
 from six.moves import xrange
 
+from virttest import utils_logfile
 from virttest import utils_misc
 from virttest import utils_net
 from virttest import remote as remote_old
@@ -1108,12 +1109,13 @@ class BaseVM(object):
         log_filename = ("session-%s-%s-%s.log" %
                         (self.name, time.strftime("%m-%d-%H-%M-%S"),
                          utils_misc.generate_random_string(4)))
-        log_filename = utils_misc.get_log_filename(log_filename)
-        log_function = utils_misc.log_line
+        log_filename = utils_logfile.get_log_filename(log_filename)
+        log_function = utils_logfile.log_line
         session = remote.remote_login(client, address, port, username,
                                       password, prompt, linesep,
                                       log_filename, log_function,
                                       timeout, interface=neigh_attach_if)
+        session.close_hooks += [utils_logfile.close_own_log_file]
         session.set_status_test_command(self.params.get("status_test_command",
                                                         ""))
         self.remote_sessions.append(session)
@@ -1276,7 +1278,7 @@ class BaseVM(object):
         log_filename = ("transfer-%s-to-%s-%s.log" %
                         (self.name, address,
                          utils_misc.generate_random_string(4)))
-        log_function = utils_misc.log_line
+        log_function = utils_logfile.log_line
         remote.copy_files_to(address,
                              client,
                              username,
@@ -1291,7 +1293,7 @@ class BaseVM(object):
                              timeout=timeout,
                              interface=neigh_attach_if,
                              filesize=filesize)
-        utils_misc.close_log_file(log_filename)
+        utils_logfile.close_log_file(log_filename)
 
     @error_context.context_aware
     def copy_files_from(self, guest_path, host_path, nic_index=0, limit="",
@@ -1323,7 +1325,7 @@ class BaseVM(object):
         log_filename = ("transfer-%s-from-%s-%s.log" %
                         (self.name, address,
                          utils_misc.generate_random_string(4)))
-        log_function = utils_misc.log_line
+        log_function = utils_logfile.log_line
         remote.copy_files_from(address,
                                client,
                                username,
@@ -1338,7 +1340,7 @@ class BaseVM(object):
                                timeout=timeout,
                                interface=neigh_attach_if,
                                filesize=filesize)
-        utils_misc.close_log_file(log_filename)
+        utils_logfile.close_log_file(log_filename)
 
     def _create_serial_console(self):
         """

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1114,8 +1114,8 @@ class BaseVM(object):
         session = remote.remote_login(client, address, port, username,
                                       password, prompt, linesep,
                                       log_filename, log_function,
-                                      timeout, interface=neigh_attach_if)
-        session.close_hooks += [utils_logfile.close_own_log_file]
+                                      timeout, neigh_attach_if)
+        session.close_hooks += [utils_logfile.close_own_log_file(log_filename)]
         session.set_status_test_command(self.params.get("status_test_command",
                                                         ""))
         self.remote_sessions.append(session)


### PR DESCRIPTION
Most importantly, for better decoupling with aexpect we provide sessions with close hooks that should have the same effect of closing the open log file descriptors but in a more decoupled fashion.

The logging functionality in utils_misc has been fully deprecated for the sake of the same functionality in a fully devoted module.