### PR TITLE
Complete the libvirt verbosity fix

### DIFF
--- a/virttest/_wrappers.py
+++ b/virttest/_wrappers.py
@@ -79,6 +79,8 @@ def lazy_import(name):
     :param name: Name of the module that is going to be imported
     :type name: String
     """
+    if name in sys.modules:
+        return sys.modules[name]
     spec = importlib.util.find_spec(name)
     if spec is None:
         raise ImportError(f"Could not import module {name}")

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -37,7 +37,6 @@ from virttest import qemu_storage
 from virttest import data_dir
 from virttest import utils_net
 from virttest import nfs
-from virttest import libvirt_vm
 from virttest import utils_test
 from virttest import utils_iptables
 from virttest import utils_package
@@ -57,6 +56,7 @@ from virttest.test_setup.networking import NetworkProxies
 from virttest._wrappers import lazy_import
 utils_libvirtd = lazy_import("virttest.utils_libvirtd")
 virsh = lazy_import("virttest.virsh")
+libvirt_vm = lazy_import("virttest.libvirt_vm")
 
 
 try:

--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -2,9 +2,14 @@ import logging
 
 from avocado.utils import process
 
-from .. import propcan, xml_utils, virsh
+from .. import propcan, xml_utils
 from ..libvirt_xml import xcepts
 from .._wrappers import import_module
+
+
+# lazy imports for dependencies that are not needed in all modes of use
+from virttest._wrappers import lazy_import
+virsh = lazy_import("virttest.virsh")
 
 
 class LibvirtXMLBase(propcan.PropCanBase):

--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -12,7 +12,6 @@ from avocado.core import exceptions
 
 from virttest import libvirt_version
 from virttest import remote
-from virttest import virsh
 from virttest import utils_disk
 from virttest import utils_misc
 from virttest import test_setup
@@ -20,6 +19,11 @@ from virttest import utils_net
 from virttest import utils_iptables
 from virttest import utils_test
 from virttest.utils_test import libvirt
+
+
+# lazy imports for dependencies that are not needed in all modes of use
+from virttest._wrappers import lazy_import
+virsh = lazy_import("virttest.virsh")
 
 
 LOG = logging.getLogger('avocado.' + __name__)

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -70,8 +70,12 @@ from virttest._wrappers import import_module
 #
 # pylint: disable=unused-import
 from virttest.utils_test import qemu
-from virttest.utils_test import libvirt
-from virttest.utils_test import libguestfs
+
+# lazy imports for dependencies that are not needed in all modes of use
+from virttest._wrappers import lazy_import
+libvirt = lazy_import("virttest.utils_test.libvirt")
+libguestfs = lazy_import("virttest.utils_test.libguestfs")
+
 
 # This is so that other tests won't break when importing the names
 # 'ping' and 'raw_ping' from this namespace


### PR DESCRIPTION
This performs additional lazy imports necessary to avoid libvirt related messages for qemu-only usage and fixes the way it is done for some of the cases.