### PR TITLE
Fix typo of parameter ignore_status comments for func check_guest_xml_by_xpaths

### DIFF
--- a/virttest/utils_libvirt/libvirt_vmxml.py
+++ b/virttest/utils_libvirt/libvirt_vmxml.py
@@ -66,8 +66,8 @@ def check_guest_xml_by_xpaths(vmxml, xpaths_text, ignore_status=False):
                         {'element_attrs': [".//memory[@unit='KiB']", ..., valuenn], 'text': 'aaa'}
                         {'element_attrs': ["./os/bootmenu[@enable='yes']", ..., valuenn]}
                         ]
-    :param ignore_status: boolean, True to raise an exception when not matched
-                                   False to not raise an exception when not matched
+    :param ignore_status: boolean, True to not raise an exception when not matched
+                                   False to raise an exception when not matched
     :return: boolean, True when matched, False when not matched
     """
     for xpath_text in xpaths_text:


### PR DESCRIPTION
Comments of available parameters for ignore_status are mismatched, so correct it.