### PR TITLE
test_setup: fix TypeError in error message

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -532,9 +532,9 @@ class HugePageConfig(object):
         obj.sys_fs_value = num
         # If node has some used hugepage, result will be larger than expected.
         if obj.sys_fs_value < int(num):
-            msg = "%s (expecting %s) hugepages is set on node %s, "
-            "please check if the node "
-            "has enough memory" % (obj.sys_fs_value, num, node)
+            msg = ("%s (expecting %s) hugepages is set on node %s, "
+                   "please check if the node "
+                   "has enough memory") % (obj.sys_fs_value, num, node)
             if not ignore_error:
                 raise ValueError(msg)
             else:


### PR DESCRIPTION
test_setup: fix TypeError in error message

Fixes the TypeError produced by the bad string formatting.

ID: 1488
Signed-off-by: mcasquer <mcasquer@redhat.com>
