### PR TITLE
fix: Add missing conversion for "sndbuf" and other options for QNetdev

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -2232,6 +2232,11 @@ class QNetdev(QCustomDevice):
                 if (key in ['dnssearch', 'hostfwd', 'guestfwd'] and
                         isinstance(value, list)):
                     value = [{'str': v} for v in value]
+                # https://gitlab.com/qemu-project/qemu/-/blob/master/qapi/net.json#L242
+                elif key in ('sndbuf', ):
+                    value = int(utils_numeric.normalize_data_size(value, 'B'))
+                elif isinstance(value, str) and value.isdigit():
+                    value = int(value)
                 elif value in ('on', 'yes', 'true'):
                     value = True
                 elif value in ('off', 'no', 'false'):


### PR DESCRIPTION
The "sndbuf" option of `-netdev`, it requires size type, so if we assign a size like "1M", QNetdev should able to convert it to "1048576". On the other hand, in the first version, converting string to numeric was missing, so adding it as well this time.

ID: 1527