### PR TITLE
Machines: update default indirect_image_blacklist for s390x

### DIFF
--- a/virttest/shared/cfg/machines.cfg
+++ b/virttest/shared/cfg/machines.cfg
@@ -127,6 +127,7 @@ variants:
         # Currently no USB support
         usbs =
         usb_devices =
-        # The main disc is usually /dev/dasda device
-        indirect_image_blacklist = "/dev/dasda[\d]*"
+        # The main disc is usually /dev/dasda device before z15 and
+        # and /dev/sda start from z15
+        indirect_image_blacklist = "/dev/dasda[\d]* /dev/sda[\d]*"
         serial_type = 'sclpconsole'


### PR DESCRIPTION
General: update default indirect_image_blacklist for s390x, we could use
FCP SCSI as the system disk start from z15 as well.

ID: 1540

Signed-off-by: Boqiao Fu <bfu@redhat.com>