### PR TITLE
Change vm.destroy gracefulness for performance when discarding vms

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1156,6 +1156,7 @@ def preprocess(test, params, env):
     # leave them untouched if they have to be disregarded only for this test
     requested_vms = params.objects("vms")
     keep_unrequested_vms = params.get_boolean("keep_unrequested_vms", False)
+    kill_unrequested_vms_gracefully = params.get_boolean("kill_unrequested_vms_gracefully", True)
     for key in list(env.keys()):
         vm = env[key]
         if not isinstance(vm, virt_vm.BaseVM):
@@ -1165,7 +1166,7 @@ def preprocess(test, params, env):
                 LOG.debug("The vm %s is registered in the env and disregarded "
                           "in the current test", vm.name)
             else:
-                vm.destroy()
+                vm.destroy(gracefully=kill_unrequested_vms_gracefully)
                 del env[key]
 
     global KVM_MODULE_HANDLERS


### PR DESCRIPTION
During environment setup we discard vms that are not going to participate in a test but doing so gracefully results in a large timeout (60 seconds by default) for each one and slows down the test and overall test run significantly. As the discarded vm will either be fully reconstructed or restored from a clean state when it is needed again by a test, graceful shutdown is not needed and ridding ourselves of it will improve performance for free.