### PR TITLE
Support new nic driver igb on the framework

### DIFF
--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -23,6 +23,10 @@ variants:
         only q35
         required_qemu = [2.6.0, )
         nic_model = e1000e
+    - igb:
+        only q35
+        required_qemu = [8.0.0, )
+        nic_model = igb
     - virtio_net:
         nic_model = virtio
         # Assign the queue number of nic device


### PR DESCRIPTION
Upstream add an new nic model igb since qemu-8.0.0 which allow testing applications' SR-IOV features on a machine without a specific hardware.In order to cover more nic model,so QE sent a new patch to support this driver.

ID: 1543
Signed-off-by: Lei Yang leiyang@redhat.com