### PR TITLE
libvirt_numa: Fix parsing of continuous numa nodes

### DIFF
--- a/virttest/utils_libvirt/libvirt_numa.py
+++ b/virttest/utils_libvirt/libvirt_numa.py
@@ -83,6 +83,43 @@ def create_hmat_xml(vmxml, params):
     return vmxml
 
 
+def convert_all_nodes_to_string(node_list):
+    """
+    Convert the node list to a string representation.
+    For example:
+    If node list is [0, 1, 2, 3, 4], return "0-4"
+    If node list is [0, 1, 3, 4, 6], return "0-1,3-4,6"
+
+    :param node_list: list, the host numa node list
+    :return: str, the string representation of the node list
+    """
+
+    LOG.debug("node_list=%s" % node_list)
+    node_ranges = []
+    start_node = node_list[0]
+    end_node = node_list[0]
+
+    for node in node_list[1:]:
+        if node == end_node + 1:
+            end_node = node
+        else:
+            if start_node == end_node:
+                node_ranges.append(f"{start_node}")
+            else:
+                node_ranges.append(f"{start_node}-{end_node}")
+            start_node = node
+            end_node = node
+
+    if start_node == end_node:
+        node_ranges.append(f"{start_node}")
+    else:
+        node_ranges.append(f"{start_node}-{end_node}")
+
+    converted_numa_nodes = ",".join(node_ranges)
+    LOG.debug("Convert output for all online numa nodes: '%s'", converted_numa_nodes)
+    return converted_numa_nodes
+
+
 def parse_numa_nodeset_to_str(numa_nodeset, node_list, ignore_error=False):
     """
     Parse numa nodeset to a string


### PR DESCRIPTION
Fix parsing of continuous numa nodes.

Parsing result without the patch:
```
21:35:15 DEBUG| numa_nodeset='x-y', node_list=[0, 1, 2, 3]
21:35:15 DEBUG| Parse output for numa nodeset: '0-1'
```
Testing result without the patch:
```
FAIL 1-type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto -> TestFail: Expect cpuset.mems=0-1, but found 0-3
```

Parsing result with the patch:
```
22:48:25 DEBUG| numa_nodeset='x-y', node_list=[0, 1, 2, 3]
22:48:25 DEBUG| Parse output for numa nodeset: '0-3'
```
Testing result with the patch:
```
PASS 1-type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto
```