### PR TITLE
Support to specify virtio-win's version range

### DIFF
--- a/virttest/shared/cfg/virtio-win.cfg
+++ b/virttest/shared/cfg/virtio-win.cfg
@@ -34,6 +34,10 @@
 #
 # So you have to map the paths of your cd containing the drivers on the config
 # variables. More details below.
+#
+# The parameter required_virtio_win is used to specify a range of virtio-win iso.
+# required_virtio_win_prewhql = [0.1.180, 0.1.280]
+# required_virtio_win = [1.9.22.3, 1.9.36.0)
 
 unattended_install.cdrom, whql.support_vm_install:
     Windows..virtio_blk, Windows..virtio_scsi, Windows..virtio_net:


### PR DESCRIPTION
Add a checkpoint here to check the virtio-win version, if the version is in the specified range, test will continue, if not, cancel the test.

ID:1594