### PR TITLE
Fix the get_default_gateway

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3916,7 +3916,7 @@ def get_default_gateway(iface_name=False, session=None, ip_ver='ipv4',
     else:
         cmd = "%s | awk '/default/ { print $3 }'" % ip_cmd
     try:
-        _, output = utils_misc.cmd_status_output(cmd, shell=True)
+        _, output = utils_misc.cmd_status_output(cmd, shell=True, session=session)
         if session:
             LOG.debug("Guest default gateway is %s", output)
         else:


### PR DESCRIPTION
Without the session parameter, utils_misc.cmd_status_output() will always get default gateway from the host. Fix the issue by adding the parameter.