### PR TITLE
refactor(qemu_vm): Use QNetdev to hot plug/unplug netdev devices

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -2299,12 +2299,12 @@ class QNetdev(QCustomDevice):
 
     def verify_unplug(self, out, monitor):
         out = monitor.info("network", debug=False)
-        return self.get_qid() not in out
+        return f"{self.get_qid()}:" not in out
 
     # pylint: disable=E0202
     def verify_hotplug(self, out, monitor):
         out = monitor.info("network", debug=False)
-        return self.get_qid() in out
+        return f"{self.get_qid()}:" in out
 
 
 #

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -1484,15 +1484,14 @@ class HumanMonitor(Monitor):
         """
         return self.cmd("getfd %s" % name, fd=fd)
 
-    def closefd(self, fd, name):
+    def closefd(self, name):
         """
         Close a file descriptor
 
-        :param fd: File descriptor to pass to QEMU
         :param name: File descriptor name (internal to QEMU)
         :return: The command's output
         """
-        return self.cmd("closefd %s" % name, fd=fd)
+        return self.cmd("closefd %s" % name)
 
     def system_wakeup(self):
         """
@@ -2699,17 +2698,16 @@ class QMPMonitor(Monitor):
         args = {"fdname": name}
         return self.cmd("getfd", args, fd=fd)
 
-    def closefd(self, fd, name):
+    def closefd(self, name):
         """
         Close a file descriptor
 
-        :param fd: File descriptor to pass to QEMU
         :param name: File descriptor name (internal to QEMU)
 
         :return: The response to the command
         """
         args = {"fdname": name}
-        return self.cmd("closefd", args, fd=fd)
+        return self.cmd("closefd", args)
 
     def system_wakeup(self):
         """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4253,7 +4253,7 @@ class VM(virt_vm.BaseVM):
                               (self.name, nic))
         msg_sfx = ("nic %s on vm %s" % (nic_index_or_name, self.name))
 
-        netdev_args = {}
+        netdev_params = {"id": netdev_id}
         if nic.nettype in ['bridge', 'macvtap']:
             net_backend = "tap"
             error_context.context("Opening tap device node for %s " % nic.ifname,
@@ -4273,10 +4273,17 @@ class VM(virt_vm.BaseVM):
             qemu_fds = "/proc/%s/fd" % self.get_pid()
             openfd_list = os.listdir(qemu_fds)
             for i in range(int(nic.queues)):
+                fd = int(python_tapfds.split(':')[i])
+                fd_id = nic.tapfd_ids[i]
                 error_context.context("Assigning tap %s to qemu by fd" %
-                                      nic.tapfd_ids[i], LOG.info)
-                self.monitor.getfd(int(python_tapfds.split(':')[i]),
-                                   nic.tapfd_ids[i])
+                                      fd_id, LOG.info)
+                self.monitor.getfd(fd, fd_id)
+                # getfd will reserve fds to qemu process, and we can close
+                # original fds after that, to avoid fd leak.
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
             n_openfd_list = os.listdir(qemu_fds)
             new_fds = list(set(n_openfd_list) - set(openfd_list))
 
@@ -4295,9 +4302,9 @@ class VM(virt_vm.BaseVM):
                 raise virt_vm.VMAddNetDevError(err_msg)
             if ((int(nic.queues)) > 1 and
                     ',fds=' in self.devices.get_help_text()):
-                netdev_args["fds"] = nic.tapfds
+                netdev_params["fds"] = nic.tapfds
             else:
-                netdev_args["fd"] = nic.tapfds
+                netdev_params["fd"] = nic.tapfds
             error_context.context("Raising interface for " + msg_sfx,
                                   LOG.debug)
             utils_net.bring_up_ifname(nic.ifname)
@@ -4310,29 +4317,37 @@ class VM(virt_vm.BaseVM):
             net_backend = "user"
         elif nic.nettype == 'vdpa':
             net_backend = 'vhost-vdpa'
-            netdev_args["vhostdev"] = utils_vdpa.get_vdpa_dev_file_by_name(nic.netdst)
+            netdev_params["vhostdev"] = utils_vdpa.get_vdpa_dev_file_by_name(nic.netdst)
         else:  # unsupported nettype
             raise virt_vm.VMUnknownNetTypeError(self.name, nic_index_or_name,
                                                 nic.nettype)
+        netdev_dev = qdevices.QNetdev(net_backend, netdev_params)
         if 'netdev_extra_params' in nic and nic.netdev_extra_params:
             for netdev_param in nic.netdev_extra_params.strip(',').split(','):
                 arg_k, arg_v = netdev_param.split('=', 1)
-                if arg_k in ["vnet_hdr", "vhost", "vhostforce", "restrict",
-                             "ipv4", "ipv6"]:
-                    arg_v = arg_v in ["on", "yes", "y"]
-                elif arg_k in ["sndbuf", "queues", "poll-us", "ipv6-prefixlen"]:
-                    arg_v = int(arg_v)
-                netdev_args.update({arg_k: arg_v})
-        error_context.context("Hotplugging " + msg_sfx, LOG.debug)
-        self.monitor.netdev_add(net_backend, netdev_id, **netdev_args)
+                if arg_k in ['dnssearch', 'hostfwd', 'guestfwd']:
+                    if arg_k not in netdev_dev.params:
+                        netdev_dev.set_param(arg_k, [])
+                    netdev_dev.params[arg_k].append(arg_v)
+                else:
+                    netdev_dev.set_param(arg_k, arg_v)
 
-        network_info = self.monitor.info("network", debug=False)
-        if not re.search(r'{}:'.format(netdev_id), network_info):
-            LOG.error(network_info)
+        error_context.context("Hotplugging " + msg_sfx, LOG.debug)
+        _, verify = self.devices.simple_hotplug(netdev_dev, self.monitor)
+        if not verify:
+            LOG.error(self.monitor.info("network", debug=False))
             # Don't leave resources dangling
             self.deactivate_netdev(nic_index_or_name)
             raise virt_vm.VMAddNetDevError(("Failed to add netdev: %s for " %
                                             netdev_id) + msg_sfx)
+        # qemu process retains access via open file fd numbers are not always
+        # predictable and vm instance must support cloning.
+        if 'tapfds' in nic:
+            for fd in nic.tapfds.split(':'):
+                try:
+                    os.close(int(fd))
+                except OSError:
+                    pass
 
     @error_context.context_aware
     def activate_nic(self, nic_index_or_name):
@@ -4410,21 +4425,26 @@ class VM(virt_vm.BaseVM):
 
         :param: nic_index_or_name: name or index number for existing NIC
         """
-        # FIXME: Need to down interface & remove from bridge????
         nic = self.virtnet[nic_index_or_name]
         netdev_id = nic.netdev_id
         error_context.context("removing netdev id %s from vm %s" %
                               (netdev_id, self.name))
-        self.monitor.netdev_del(netdev_id)
+        netdev_dev = self.devices.get(netdev_id)
+        _, verify = self.devices.simple_unplug(netdev_dev, self.monitor)
 
-        network_info = self.monitor.info("network", debug=False)
-        if re.search(r'{}:'.format(netdev_id), network_info):
-            LOG.error(network_info)
+        if not verify:
+            LOG.error(self.monitor.info("network", debug=False))
             raise virt_vm.VMDelNetDevError("Fail to remove netdev %s" %
                                            netdev_id)
+        if 'tapfd_ids' in nic:
+            for fd_id in nic.tapfd_ids:
+                self.monitor.closefd(fd_id)
         if nic.nettype == 'macvtap':
             tap = utils_net.Macvtap(nic.ifname)
             tap.delete()
+        elif nic.nettype == 'bridge':
+            self._del_port_from_bridge(nic)
+        self.del_netdev(nic_index_or_name)
 
     @error_context.context_aware
     def del_nic(self, nic_index_or_name):


### PR DESCRIPTION
1. Use QNetdev to create a netdev device, and then hot-plug/unplug it
via simple_hotplug/unplug, this method will also verify if the plug
operation is completed.
2. Close origin file descriptors after getfd and close tap file
descriptors after netdev_add because qemu process retains access via
open fd, so we don't need to keep fds always open, otherwise, this will
cause fd to leak, and the qemu process takes a lot of fds.
3. Delete the tap device after netdev_del.

ID: 1400
Signed-off-by: Yihuang Yu <yihyu@redhat.com>
