### PR TITLE
Reduce logging verbosity of ovs initialization

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1197,7 +1197,7 @@ def __init_openvswitch():
             if (not __ovs.check()):
                 raise Exception("Check of OpenVSwitch failed.")
         except Exception as e:
-            LOG.error("Host does not support OpenVSwitch: %s", e)
+            LOG.debug("Host does not support OpenVSwitch: %s", e)
             __ovs = None
     return __ovs
 


### PR DESCRIPTION
When ovs management tool was not installed on the system, an error message would be emitted in some certain contexts due to there always be a corresponding check been executed no matter whether the tool was exactly required upon the users scenarios.

We had better to refactor this, but at the moment let us firstly workaround the issue by reducing the logging verbosity as such an error message did not make too much sense for the users.