### PR TITLE
fix(utils_logfile.log_line): Open file with 'a' mode for safer writing

### DIFF
--- a/virttest/utils_logfile.py
+++ b/virttest/utils_logfile.py
@@ -76,7 +76,7 @@ def log_line(filename, line):
                 os.makedirs(os.path.dirname(log_file))
             except OSError:
                 pass
-            _open_log_files[base_file] = open(log_file, "w")
+            _open_log_files[base_file] = open(log_file, "a")
         timestr = time.strftime("%Y-%m-%d %H:%M:%S")
         try:
             line = string_safe_encode(line)


### PR DESCRIPTION
utils_logfile.log_line currently uses 'w' mode to open log files, this causes some log contents missed when closing the log file. For example, when we close the log file, there are some contents in the cache and waiting for writing to the log, so need to reopen it, if use 'w' mode, old contents will be truncated.

ID: 1858
Suggested-by: Lukáš Doktor <ldoktor@redhat.com>
Signed-off-by: Yihuang Yu <yihyu@redhat.com>