### PR TITLE
env_process: Rewrite Libvirtd debug log setup/cleanup steps as a Setuper

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -51,7 +51,7 @@ from virttest.staging import service
 from virttest.test_setup.core import SetupManager
 from virttest.test_setup.os_posix import UlimitConfig
 from virttest.test_setup.networking import NetworkProxies, BridgeConfig
-
+from virttest.test_setup.libvirt_setup import LibvirtdDebugLogConfig
 
 # lazy imports for dependencies that are not needed in all modes of use
 from virttest._wrappers import lazy_import
@@ -1096,22 +1096,11 @@ def preprocess(test, params, env):
     _setup_manager.initialize(test, params, env)
     _setup_manager.register(UlimitConfig)
     _setup_manager.register(NetworkProxies)
+    _setup_manager.register(LibvirtdDebugLogConfig)
     _setup_manager.register(BridgeConfig)
     _setup_manager.do_setup()
 
     vm_type = params.get("vm_type")
-
-    if vm_type == "libvirt":
-        if params.get("enable_libvirtd_debug_log", "yes") == "yes":
-            # By default log the info level
-            log_level = params.get("libvirtd_debug_level", "2")
-            log_file = params.get("libvirtd_debug_file", "")
-            log_filters = params.get("libvirtd_debug_filters", "%s:*" % log_level)
-            log_permission = params.get("libvirtd_log_permission")
-            libvirtd_debug_log = test_setup.LibvirtdDebugLog(
-                test, log_level, log_file, log_filters, log_permission
-            )
-            libvirtd_debug_log.enable()
 
     base_dir = data_dir.get_data_dir()
     if params.get("storage_type") == "iscsi":
@@ -1993,9 +1982,6 @@ def postprocess(test, params, env):
             except Exception as details:
                 err += "\nPolkit cleanup: %s" % str(details).replace("\\n", "\n  ")
                 LOG.error("Unexpected error: %s" % details)
-        if params.get("enable_libvirtd_debug_log", "yes") == "yes":
-            libvirtd_debug_log = test_setup.LibvirtdDebugLog(test)
-            libvirtd_debug_log.disable()
 
     # Execute any post_commands
     if params.get("post_command"):

--- a/virttest/test_setup/libvirt_setup.py
+++ b/virttest/test_setup/libvirt_setup.py
@@ -1,0 +1,27 @@
+from virttest.test_setup.core import Setuper
+from virttest import test_setup
+
+
+class LibvirtdDebugLogConfig(Setuper):
+    def setup(self):
+        if (
+            self.params.get("vm_type") == "libvirt"
+            and self.params.get("enable_libvirtd_debug_log", "yes") == "yes"
+        ):
+            # By default log the info level
+            log_level = self.params.get("libvirtd_debug_level", "2")
+            log_file = self.params.get("libvirtd_debug_file", "")
+            log_filters = self.params.get("libvirtd_debug_filters", f"{log_level}:*")
+            log_permission = self.params.get("libvirtd_log_permission")
+            libvirtd_debug_log = test_setup.LibvirtdDebugLog(
+                self.test, log_level, log_file, log_filters, log_permission
+            )
+            libvirtd_debug_log.enable()
+
+    def cleanup(self):
+        if (
+            self.params.get("vm_type") == "libvirt"
+            and self.params.get("enable_libvirtd_debug_log", "yes") == "yes"
+        ):
+            libvirtd_debug_log = test_setup.LibvirtdDebugLog(self.test)
+            libvirtd_debug_log.disable()


### PR DESCRIPTION
As one of the steps of the planned `env_process.py:{pre,post}process` refactoring, this patch rewrites the setup/cleanup steps of the libvirtd debug log into an appropriate `Setuper` subclass. Then, it registers such class into the `setup_manager` in the relative order that was sitting on before refactoring the bridge setup/cleanup steps.

ID: 1469