### PR TITLE
Add 2 cpu flags and limit the mem for 32bit windows VM

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -45,6 +45,10 @@
     Win8..1, Win2012..r2:
         windows_verifier_flags = "0x008209bb"
 
+    # lm: Long Mode (x86-64: amd64, also known as Intel 64, i.e. 64-bit capable)
+    # The flag tells you that the CPU is 64-bit. it's absences tells you that it's 32-bit. (lm=off)
+    i386:
+        cpu_model_flags += "lm=off,pae=on"
     # these config are used in virt_test_utils.get_readable_cdroms()
     cdrom_get_cdrom_cmd = "echo list volume > check_cdrom &&"
     cdrom_get_cdrom_cmd += " echo exit >> check_cdrom &&"

--- a/virttest/shared/cfg/guest-os/Windows/Win10/i386.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win10/i386.cfg
@@ -1,6 +1,7 @@
 - i386:
     vm_arch_name = i686
     image_name += -32
+    vm_mem_limit = 4G
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         unattended_file = unattended/win10-32-autounattend.xml
         cdrom_cd1 = isos/windows/en_windows_10_enterprise_x86_dvd_6851156.iso

--- a/virttest/shared/cfg/guest-os/Windows/Win7/i386.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win7/i386.cfg
@@ -1,6 +1,7 @@
 - i386:
     vm_arch_name = i686
     image_name += -32
+    vm_mem_limit = 4G
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
         cdrom_cd1 = isos/windows/en_windows_7_ultimate_x86_dvd_x15-65921.iso
         md5sum_cd1 = d0b8b407e8a3d4b75ee9c10147266b89

--- a/virttest/shared/cfg/guest-os/Windows/Win8/i386.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win8/i386.cfg
@@ -1,6 +1,7 @@
 - i386:
     vm_arch_name = i686
     image_name += -32
+    vm_mem_limit = 4G
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         cdrom_cd1 = isos/windows/en_windows_8_enterprise_x86_dvd_917587.iso
         md5sum_cd1 = ad055cae50cef987586c51cc6cc3c62e


### PR DESCRIPTION
1.Based on the lm and pae flag's usage, we need add it to 32bits Windows VM.
2.'q35' maps up to 2G RAM below 4G, 'pc' maps up to 3G RAM below 4G. So 32-bit windows just ignores the memory above 4G.

ID:1875