### PR TITLE
Flush pin dict once per cpupin request

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1745,7 +1745,7 @@ class NumaNode(object):
         else:
             self.dict[i].remove(thread)
 
-    def _flush_pin(self):
+    def flush_pin(self):
         """
         Flush pin dict, remove the record of exited process.
         """
@@ -1766,7 +1766,6 @@ class NumaNode(object):
         :param pid: Process ID.
         :param cpu: CPU ID, pin thread to free CPU if cpu ID isn't set
         """
-        self._flush_pin()
         if cpu:
             error_context.context(
                 "Pinning process %s to the CPU(%s)" % (pid, cpu))

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -83,6 +83,7 @@ def pin_vm_threads(vm, node):
     :param vm: VM object
     :param node: NumaNode object
     """
+    node.flush_pin()
     if len(vm.vcpu_threads) + len(vm.vhost_threads) < len(node.cpus):
         for i in vm.vcpu_threads:
             LOG.info("pin vcpu thread(%s) to cpu(%s)" %


### PR DESCRIPTION
Currently cpu pin dict flushing in every single
cpu pin operation cause overhead and pinning operation take long time to finish when we have more vcpus.

Instead of flushing cpu pin mapping for every cpu
pin operations this commit make it once per cpu
pin request.