### PR TITLE
v2v: fix the failed func TC "default_vsphere"

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1363,7 +1363,7 @@ def v2v_cmd(params, auto_clean=True, cmd_only=False, interaction=False, shell=Fa
     hostname = params.get('hostname')
     vpx_dc = params.get('vpx_dc')
     esxi_host = params.get('esxi_host', params.get('esx_ip'))
-    vpx_no_username = params.get('vpx_no_username')
+    vpx_no_username = params_get(params, 'vpx_no_username')
     opts_extra = params.get('v2v_opts')
     # Set v2v_cmd_timeout to 5 hours, the value can give v2v enough time to execute,
     # and avoid v2v process be killed by mistake.


### PR DESCRIPTION
Fix the failed case on not-getting value.

 (1/1) type_specific.io-github-autotest-libvirt.function_test_esx.positive_test.default_vsphere.esx_80.rhev.rhv_upload.it_vddk.vpx_uri: PASS (429.57 s)
