### PR TITLE
CI: Update Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.8, 3.9, 3.10.1, 3.11]
       fail-fast: false
 
     steps:
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.8, 3.9, 3.10.1, 3.11]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Avocado has recently dropped Python 3.7, among other reasons because it has been EOL'ed.

Now, Avocado-VT's CI is broken because it tries to install the latest Avocado from source and fails.  There are a number of possibilies here, including limiting the Avocado version for the Python 3.7 checks, but, given that Python 3.7 has been EOL'ed, the most logical action is to also remove it from Avocado-VT's CI checks.

While at it, let's also expand the coverage to the other currently supported Python versions.

Reference: https://devguide.python.org/versions/