### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.8, 3.9, 3.10.1]
       fail-fast: false
 
     steps:
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.8, 3.9, 3.10.1]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Since Python 3.7 has been EOL'd and recently the support has also been dropped by the latest Avocado.

Reference: https://github.com/avocado-framework/avocado/pull/5855