### PR TITLE
Update default config for Windows guest which use seabios

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -56,6 +56,12 @@
     cdrom_check_cdrom_pattern = "\d\s+(\w).*CD-ROM"
     cdrom_test_cmd = "dir %s:\"
     cdrom_info_cmd = "wmic cdrom list full"
+
+    # Set SMBIOS to 2.x for windows guest when using seabios
+    # To avoid Windows OS bug, add this workaround.
+    # https://gitlab.com/qemu-project/qemu/-/issues/2008
+    default_bios:
+        machine_type_extra_params += "smbios-entry-point-type=32"
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         timeout = 7200
         finish_program = deps/finish/finish.bat


### PR DESCRIPTION
Currently, Windows VM will run into some failure, it is due to Windows OS bug, adjust our configuration to workaround it

ID:1933