### PR TITLE
Update guest_agent functions for unprivileged vm

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1335,10 +1335,11 @@ class VMXML(VMXMLBase):
             LOG.debug("Guest agent channel already exists")
             return
 
-        if not src_path:
-            src_path = '/var/lib/libvirt/qemu/%s-guest.agent' % self.vm_name
         channel = self.get_device_class('channel')(type_name='unix')
-        channel.add_source(mode='bind', path=src_path)
+        sources = {"mode": 'bind'}
+        if src_path:
+            sources.update({'path': src_path})
+        channel.add_source(**sources)
         channel.add_target(type='virtio', name=tgt_name)
         self.devices = self.devices.append(channel)
 


### PR DESCRIPTION
1. Add virsh instance in prepare_guest_agent
2. Update to be able to use serial vm login
3. Remove mandatory src_path assignment when no value is set

**Test results:**
`(1/1) type_specific.io-github-autotest-libvirt.agent.auto_generated.unix_source_path.session_mode: PASS (86.10 s)
`