### PR TITLE
vm_xml: set cpu mode

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -857,7 +857,8 @@ class VMXML(VMXMLBase):
                 except xcepts.LibvirtXMLNotFoundError:
                     LOG.debug("Can not find any cpu tag, now create one.")
                     vmcpu_xml = VMCPUXML()
-
+                    if 'aarch64' in platform.platform():
+                        vmcpu_xml.mode = 'host-passthrough'
                 if topology_correction and ((int(sockets) * int(cores) * int(threads)) != vcpus):
                     cores = vcpus
                     sockets = 1


### PR DESCRIPTION
On x86_64, if we set <cpu>xxx</cpu> in vm xml and save, then libvirt could automatically
fill in the cpu mode. But on arm now, libvirt can not make it which cause vm fails to
boot with below error. Libvirt dev is working on cpu model, so it is not good time to
support this auto filling now. So we need a workaround here to set it explicitly.

Signed-off-by: Dan Zheng <dzheng@redhat.com>