### PR TITLE
refactor: Move UEFI detection to utils_misc

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -4378,3 +4378,34 @@ def compare_md5(file_a, file_b):
         if _md5(fd_a) == _md5(fd_b):
             return True
     return False
+
+
+def is_linux_uefi_guest(runner=cmd_status_output):
+    """
+    Check whether guest is uefi guest
+    """
+    cmd = "ls /sys/firmware/efi"
+    status, output = runner(cmd)
+    if status != 0:
+        return False
+    return True
+
+
+def is_windows_uefi_guest(runner=cmd_status_output):
+    """
+    Check whether windows guest is uefi guest
+
+    More info:
+    https://www.tenforums.com/tutorials/85195-check-if-windows-10-using-uefi-legacy-bios.html
+    """
+    search_str = "Detected boot environment"
+    target_file = r"c:\Windows\Panther\setupact.log"
+    cmd = 'findstr /c:"%s" %s' % (search_str, target_file)
+    status, output = runner(cmd)
+    if 'BIOS' in output:
+        return False
+
+    if 'EFI' in output:
+        return True
+
+    return False

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -38,6 +38,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_version import VersionInterval
 from virttest.utils_misc import asterisk_passwd
 from virttest.utils_misc import compare_md5
+from virttest.utils_misc import is_linux_uefi_guest
+from virttest.utils_misc import is_windows_uefi_guest
 
 try:
     V2V_EXEC = path.find_command('virt-v2v')
@@ -972,11 +974,7 @@ class LinuxVMCheck(VMCheck):
         """
         Check whether guest is uefi guest
         """
-        cmd = "ls /sys/firmware/efi"
-        status, output = self.run_cmd(cmd)
-        if status != 0:
-            return False
-        return True
+        is_linux_uefi_guest(self.run_cmd)
 
     def get_grub_device(self, dev_map="/boot/grub*/device.map"):
         """
@@ -1247,23 +1245,7 @@ class WindowsVMCheck(VMCheck):
         return self.run_cmd(cmd)[0]
 
     def is_uefi_guest(self):
-        """
-        Check whether windows guest is uefi guest
-
-        More info:
-        https://www.tenforums.com/tutorials/85195-check-if-windows-10-using-uefi-legacy-bios.html
-        """
-        search_str = "Detected boot environment"
-        target_file = r"c:\Windows\Panther\setupact.log"
-        cmd = 'findstr /c:"%s" %s' % (search_str, target_file)
-        status, output = self.run_cmd(cmd)
-        if 'BIOS' in output:
-            return False
-
-        if 'EFI' in output:
-            return True
-
-        return False
+        is_windows_uefi_guest(self.run_cmd)
 
 
 def v2v_cmd(params, auto_clean=True, cmd_only=False, interaction=False, shell=False):


### PR DESCRIPTION
Previously, the UEFI guest detection functions were part of the specific VMCheck classes (`LinuxVMCheck` and `WindowsVMCheck`) in the `virttest/utils_v2v.py` file. This commit refactors and relocates these functions to the more generic `virttest/utils_misc.py` file.

Motivation:
- The `is_uefi_guest` function, previously defined in the `VMCheck` classes, had dependencies that were not universally available across different architectures (e.g., ovrit on s390x).
- To enhance code reusability the UEFI guest detection functions are moved to the utils_misc module.

Updated Functions:
- `is_linux_uefi_guest(runner)`: Check if a Linux guest is a UEFI guest.
- `is_windows_uefi_guest(runner)`: Check if a Windows guest is a UEFI guest.

These changes improve the code reusability in the codebase and make the UEFI guest detection functionality more accessible for various scenarios.