### PR TITLE
Fix dmesg log issue

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -3258,7 +3258,7 @@ def __get_kernel_messages(level_check=3, session=None):
             output: multi-line string containing all read messages
             status: exit code of read command
     """
-    cmd = "dmesg -T -l %s|grep ." % ",".join(
+    cmd = "dmesg -T -l %s|grep . --color never" % ",".join(
         map(str, xrange(0, int(level_check))))
     if session:
         environ = "guest"


### PR DESCRIPTION
In some test environments, we will get the following dmesg log:
  dmesg log:[01;31m[K[[m[K[01;31m[KS[m[K[01;31m[Ku[m[K[01;31m
  [Kn[m[K[01;31m[K [m[K[01;31m[KF[m[K[01;31m[Ke[m[K[01;31m[Kb
  [m[K[01;31m[K [m[K[01; ...

So update code to avoid this issue.