### PR TITLE
qdevices: Add support for igb device to plug into pcie-root-port

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -357,7 +357,7 @@ class QBaseDevice(object):
         """Check is it a pcie device"""
         driver = self.get_param("driver", "")
         pcie_drivers = ["e1000e", "vhost-vsock-pci", "qemu-xhci", "vfio-pci",
-                        "vhost-user-fs-pci"]
+                        "vhost-user-fs-pci", "igb"]
         return (driver in pcie_drivers or driver.startswith("virtio-"))
 
 


### PR DESCRIPTION
Based on the current code the igb device is plugged into pcie.0. But this is not meet QE's testing requirement, so add support for igb device to plug into pcie-root-port.

ID:2011
Signed-off-by: Lei Yang leiyang@redhat.com