### PR TITLE
qcontainer: support for multiple thread contexts

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -3414,12 +3414,7 @@ class DevContainer(object):
         """
         Create thread-context object from params.
         """
-        tc_params = Params()
-        prefix = "vm_thread_context_"
-        for key in params:
-            if key.startswith(prefix):
-                new_key = key.rsplit(prefix)[1]
-                tc_params[new_key] = params[key]
+        tc_params = params.get_dict("vm_thread_context_options")
         dev = qdevices.QObject("thread-context", params=tc_params)
         dev.set_param("id", "%s-%s" % ("thread_context", name))
         return dev


### PR DESCRIPTION
qcontainer: support for multiple thread contexts

Includes support for multiple thread_context
object inside the framework.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID : 2009
