### PR TITLE
Add CPU drawers and books option support for s390x

### DIFF
--- a/virttest/qemu_capabilities.py
+++ b/virttest/qemu_capabilities.py
@@ -21,6 +21,8 @@ class Flags(object):
     BLOCKDEV = _auto_value()
     SMP_DIES = _auto_value()
     SMP_CLUSTERS = _auto_value()
+    SMP_DRAWERS = _auto_value()
+    SMP_BOOKS = _auto_value()
     INCOMING_DEFER = _auto_value()
     MACHINE_MEMORY_BACKEND = _auto_value()
     MIGRATION_PARAMS = _auto_value()

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -92,6 +92,8 @@ class DevContainer(object):
     BLOCKDEV_VERSION_SCOPE = "[2.12.0, )"
     SMP_DIES_VERSION_SCOPE = "[4.1.0, )"
     SMP_CLUSTERS_VERSION_SCOPE = "[7.0.0, )"
+    SMP_BOOKS_VERSION_SCOPE = "[8.2.0, )"
+    SMP_DRAWERS_VERSION_SCOPE = "[8.2.0, )"
     FLOPPY_DEVICE_VERSION_SCOPE = "[5.1.0, )"
 
     MIGRATION_DOWNTIME_LIMTT_VERSION_SCOPE = "[5.1.0, )"
@@ -323,6 +325,12 @@ class DevContainer(object):
         # -smp clusters=?
         if self.__qemu_ver in VersionInterval(self.SMP_CLUSTERS_VERSION_SCOPE):
             self.caps.set_flag(Flags.SMP_CLUSTERS)
+        # -smp drawers=?
+        if self.__qemu_ver in VersionInterval(self.SMP_DRAWERS_VERSION_SCOPE):
+            self.caps.set_flag(Flags.SMP_DRAWERS)
+        # -smp book=?
+        if self.__qemu_ver in VersionInterval(self.SMP_BOOKS_VERSION_SCOPE):
+            self.caps.set_flag(Flags.SMP_BOOKS)
         # -incoming defer
         if self.has_option("incoming defer"):
             self.caps.set_flag(Flags.INCOMING_DEFER)

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -217,10 +217,15 @@ smp = 1
 #vcpu_sockets = 1
 #vcpu_dies = 1
 #vcpu_clusters = 1
+#vcpu_drawers = 1
+#vcpu_books = 1
 ! x86_64, i386:
     vcpu_dies = INVALID
 ! aarch64:
     vcpu_clusters = INVALID
+! s390x:
+    vcpu_drawers = INVALID
+    vcpu_books = INVALID
 
 # Configure cpu mode and model
 # possible values: host-model, host-passthrough, custom, default:''
@@ -287,9 +292,11 @@ mem_chk_re_str = ([0-9]+)
 # target_num_node2 = 1024
 
 # Define '-numa cpu' device, for every cpu 'numa_cpu_nodeid_cpu*' is mandatory,
-# optional options are socketid, dieid, clusterid, coreid and threadid.
+# optional options are drawerid, bookid, socketid, dieid, clusterid, coreid and threadid.
 # guest_numa_cpus = "cpu0 cpu1"
 # numa_cpu_nodeid_cpu0 = **
+# numa_cpu_drawerid_cpu0 = **
+# numa_cpu_bookid_cpu0 = **
 # numa_cpu_socketid_cpu0 = **
 # numa_cpu_dieid_cpu0 = **
 # numa_cpu_clusterid_cpu0 = **

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -497,6 +497,8 @@ class CpuInfo(object):
         dies=0,
         clusters=0,
         sockets=0,
+        drawers=0,
+        books=0,
     ):
         """
         :param model: CPU Model of VM (use 'qemu -cpu ?' for list)
@@ -512,6 +514,8 @@ class CpuInfo(object):
         :param dies: number of CPU dies on one socket (for PC only)
         :param clusters: number of CPU clusters on one socket (for ARM only)
         :param sockets: number of discrete sockets in the system
+        :param drawers: number of discrete drawers in the system (for s390x only)
+        :param books: number of discrete books in the system (for s390x only)
         """
         self.model = model
         self.vendor = vendor
@@ -525,6 +529,8 @@ class CpuInfo(object):
         self.dies = dies
         self.clusters = clusters
         self.sockets = sockets
+        self.drawers = drawers
+        self.books = books
 
 
 def session_handler(func):


### PR DESCRIPTION
After this patch, we can define a 5-level CPU hierarchy on s390x like:
cpus=,drawers=,books=,sockets=,cores=,maxcpus=

ID: 2036

Signed-off-by: Boqiao Fu <bfu@redhat.com>