### PR TITLE
Add import order/style check with isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ requirements: pip
 
 check:
 	./selftests/style.sh
+	./selftests/isort.sh
 	inspekt lint --disable W,R,C,E0203,E0601,E1002,E1101,E1102,E1103,E1120,F0401,I0011,E1003,W605,I1101 --exclude avocado-libs,scripts/github
 	pylint --errors-only --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
 

--- a/avocado_vt/discovery.py
+++ b/avocado_vt/discovery.py
@@ -18,6 +18,7 @@ Avocado VT plugin
 """
 
 from virttest.compat import get_opt
+
 from .options import VirtTestOptionsProcess
 
 

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -22,10 +22,7 @@ import os
 
 from avocado.core import output
 
-from virttest import cartesian_config
-from virttest import data_dir
-from virttest import standalone_test
-from virttest import storage
+from virttest import cartesian_config, data_dir, standalone_test, storage
 from virttest.compat import get_opt, set_opt
 
 from .discovery import DiscoveryMixIn

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -21,18 +21,16 @@ import os
 
 from avocado.utils import path as utils_path
 
-from virttest import cartesian_config
-from virttest import data_dir
-from virttest import defaults
-from virttest import standalone_test
+from virttest import cartesian_config, data_dir, defaults, standalone_test
 from virttest.compat import get_opt, set_opt, set_opt_from_settings
-from virttest.standalone_test import SUPPORTED_DISK_BUSES
-from virttest.standalone_test import SUPPORTED_IMAGE_TYPES
-from virttest.standalone_test import SUPPORTED_LIBVIRT_DRIVERS
-from virttest.standalone_test import SUPPORTED_NET_TYPES
-from virttest.standalone_test import SUPPORTED_NIC_MODELS
-from virttest.standalone_test import SUPPORTED_TEST_TYPES
-
+from virttest.standalone_test import (
+    SUPPORTED_DISK_BUSES,
+    SUPPORTED_IMAGE_TYPES,
+    SUPPORTED_LIBVIRT_DRIVERS,
+    SUPPORTED_NET_TYPES,
+    SUPPORTED_NIC_MODELS,
+    SUPPORTED_TEST_TYPES,
+)
 
 LOG = logging.getLogger("avocado.vt.options")
 

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -22,12 +22,12 @@ from avocado.core.plugin_interfaces import CLI
 from avocado.utils import path as utils_path
 
 from virttest import data_dir, defaults, standalone_test
-from virttest.compat import get_settings_value, add_option
+from virttest.compat import add_option, get_settings_value
 from virttest.standalone_test import SUPPORTED_LIBVIRT_URIS, SUPPORTED_TEST_TYPES
-
 
 try:
     from avocado.core.loader import loader
+
     from ..loader import VirtTestLoader
 
     AVOCADO_LOADER_AVAILABLE = True

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -12,14 +12,13 @@
 # Copyright: Red Hat Inc. 2015
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-import sys
 import logging
+import sys
 
-from avocado.utils import process
 from avocado.core.plugin_interfaces import CLICmd
+from avocado.utils import process
 
-from virttest import bootstrap
-from virttest import defaults
+from virttest import bootstrap, defaults
 from virttest.standalone_test import SUPPORTED_TEST_TYPES
 
 LOG = logging.getLogger("avocado.app")

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -1,23 +1,21 @@
 import errno
 import logging
 import os
-import re
 import random
+import re
 import string
 import sys
 
 from avocado.core import exit_codes
+from avocado.core.plugin_interfaces import JobPostTests as Post
+from avocado.core.plugin_interfaces import JobPreTests as Pre
 from avocado.utils.process import pid_exists
 from avocado.utils.stacktrace import log_exc_info
-
-from avocado.core.plugin_interfaces import JobPreTests as Pre
-from avocado.core.plugin_interfaces import JobPostTests as Post
-
-from ..test import VirtTest
+from six.moves import xrange
 
 from virttest.compat import get_settings_value
 
-from six.moves import xrange
+from ..test import VirtTest
 
 
 class LockCreationError(Exception):

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -21,12 +21,14 @@ import sys
 
 from avocado.core.plugin_interfaces import CLI
 
-from virttest.compat import get_settings_value, add_option
-from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 from virttest._wrappers import load_source
+from virttest.compat import add_option, get_settings_value
+
+from .vt import add_basic_vt_options, add_qemu_bin_vt_option
 
 try:
     from avocado.core.loader import loader
+
     from ..loader import VirtTestLoader
 
     AVOCADO_LOADER_AVAILABLE = True
@@ -69,7 +71,6 @@ if VIRT_TEST_PATH is not None:
     sys.path.append(os.path.expanduser(VIRT_TEST_PATH))
 
 from virttest import data_dir  # pylint: disable=C0413
-
 
 _PROVIDERS_DOWNLOAD_DIR = os.path.join(data_dir.get_test_providers_dir(), "downloads")
 

--- a/avocado_vt/plugins/vt_list_archs.py
+++ b/avocado_vt/plugins/vt_list_archs.py
@@ -1,4 +1,5 @@
 from avocado.core.plugin_interfaces import CLICmd
+
 from virttest.compat import add_option
 from virttest.standalone_test import get_guest_name_parser
 

--- a/avocado_vt/plugins/vt_list_guests.py
+++ b/avocado_vt/plugins/vt_list_guests.py
@@ -1,5 +1,6 @@
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.settings import settings
+
 from virttest.compat import add_option, is_registering_settings_required
 from virttest.standalone_test import get_guest_name_parser
 

--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -13,9 +13,9 @@ from avocado_vt import test
 # the 92.0 support will be dropped.
 try:
     from avocado.core.nrunner import (
+        RUNNER_RUN_CHECK_INTERVAL,
         BaseRunner,
         BaseRunnerApp,
-        RUNNER_RUN_CHECK_INTERVAL,
     )
     from avocado.core.nrunner import main as nrunner_main
     from avocado.core.runners.utils import messages
@@ -23,7 +23,7 @@ try:
     LTS = True
 except ImportError:
     from avocado.core.nrunner.app import BaseRunnerApp
-    from avocado.core.nrunner.runner import BaseRunner, RUNNER_RUN_CHECK_INTERVAL
+    from avocado.core.nrunner.runner import RUNNER_RUN_CHECK_INTERVAL, BaseRunner
     from avocado.core.utils import messages
 
     LTS = False

--- a/avocado_vt/plugins/vt_settings.py
+++ b/avocado_vt/plugins/vt_settings.py
@@ -17,10 +17,9 @@ Avocado plugin that extends the settings path of our config paths
 """
 
 import os
-from pkg_resources import resource_filename
-from pkg_resources import resource_listdir
 
 from avocado.core.plugin_interfaces import Settings
+from pkg_resources import resource_filename, resource_listdir
 
 
 class VTSettings(Settings):

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -17,27 +17,25 @@ Avocado VT plugin
 """
 
 import os
-import sys
 import shlex
+import sys
 
-from avocado.core import exceptions
-from avocado.core import test
-from avocado.utils import stacktrace
-from avocado.utils import process
-
-from virttest import error_event
-from virttest import data_dir
-from virttest import env_process
-from virttest import funcatexit
-from virttest import utils_env
-from virttest import utils_params
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest import version
-from virttest._wrappers import load_source
+from avocado.core import exceptions, test
+from avocado.utils import process, stacktrace
 
 from avocado_vt import utils
-
+from virttest import (
+    data_dir,
+    env_process,
+    error_event,
+    funcatexit,
+    utils_env,
+    utils_logfile,
+    utils_misc,
+    utils_params,
+    version,
+)
+from virttest._wrappers import load_source
 
 # avocado-vt no longer needs autotest for the majority of its functionality,
 # except by:

--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -21,8 +21,7 @@ import traceback
 from avocado.core import exceptions
 from avocado.utils import genio, stacktrace
 
-from virttest import asset, bootstrap
-from virttest import data_dir
+from virttest import asset, bootstrap, data_dir
 from virttest._wrappers import import_module
 
 BG_ERR_FILE = "background-error.log"

--- a/examples/tests/guest_hostname.py
+++ b/examples/tests/guest_hostname.py
@@ -6,7 +6,6 @@ Simple hostname test (on guest)
 """
 import logging
 
-
 LOG = logging.getLogger("avocado.vt.examples.guest_hostname")
 
 

--- a/examples/tests/hostname.py
+++ b/examples/tests/hostname.py
@@ -10,7 +10,6 @@ import logging
 
 from avocado.utils import process
 
-
 LOG = logging.getLogger("avocado.vt.examples.hostname")
 
 

--- a/examples/tests/ls_disk.py
+++ b/examples/tests/ls_disk.py
@@ -14,7 +14,6 @@ bigger differences.
 """
 import logging
 
-
 LOG = logging.getLogger("avocado.vt.examples.lsdisk")
 
 

--- a/examples/tests/service.py
+++ b/examples/tests/service.py
@@ -9,13 +9,11 @@ Please put the configuration file service.cfg into $tests/cfg/ directory.
 import logging
 import time
 
-from avocado.utils import process
 from avocado.core import exceptions
+from avocado.utils import process
 from avocado.utils.service import SpecificServiceManager
 
-from virttest import remote
-from virttest import error_context
-
+from virttest import error_context, remote
 
 LOG = logging.getLogger("avocado.vt.examples.service")
 

--- a/examples/tests/template.py
+++ b/examples/tests/template.py
@@ -3,7 +3,6 @@
 # $ avocado run template --vt-type qemu to execute it.
 import logging
 
-
 LOG = logging.getLogger("avocado.test")
 
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -6,3 +6,4 @@ aexpect>=1.6.4
 netifaces==0.11.0
 pyenchant==3.2.2
 black==22.3.0
+isort==5.10.1

--- a/scripts/cd_hash.py
+++ b/scripts/cd_hash.py
@@ -5,15 +5,13 @@ Program that calculates several hashes for a given CD image.
 :copyright: Red Hat 2008-2009
 """
 
-import os
-import sys
 import logging
 import optparse
+import os
+import sys
 
 from avocado.utils import crypto
-
 from logging_config import LoggingConfig
-
 
 if __name__ == "__main__":
     log_cfg = LoggingConfig(set_fmt=False)

--- a/scripts/download_manager.py
+++ b/scripts/download_manager.py
@@ -18,24 +18,20 @@ Downloads blobs defined in assets. Assets are .ini files that contain the
 
 :copyright: Red Hat 2012
 """
-import sys
-import os
 import logging
+import os
+import sys
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest import asset
-
 from avocado.core.output import TERM_SUPPORT
-
 from logging_config import LoggingConfig
+from six.moves import input, urllib
 
-
-from six.moves import input
-from six.moves import urllib
+from virttest import asset
 
 
 def download_assets():

--- a/scripts/github/cache_populate.py
+++ b/scripts/github/cache_populate.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import sys
+
 import getpass
+import sys
 
 from github import Github
 from github_issues import GithubIssues
-
 from six.moves import input
-
 
 gh = Github(
     login_or_token=input("Enter github username: "),

--- a/scripts/github/example.py
+++ b/scripts/github/example.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import sys
-import getpass
+
 import datetime
+import getpass
+import sys
 
 # PyGithub >= 1.13 is required https://pypi.python.org/pypi/PyGithub
 from github import Github
-from github_issues import GithubIssuesBase, GithubIssues
+from github_issues import GithubIssues, GithubIssuesBase
 
 # You could use OAuth here too for unattended access
 # see http://developer.github.com/v3/oauth/#create-a-new-authorization

--- a/scripts/github/github_issues.py
+++ b/scripts/github/github_issues.py
@@ -2,14 +2,13 @@
 Classes to cache and read specific items from github issues in a uniform way
 """
 
-from functools import partial as Partial
 import datetime
-import time
 import shelve
+import time
+from functools import partial as Partial
 
 # Requires PyGithub version >= 1.13 for access to raw_data attribute
 import github
-
 from six.moves import xrange
 
 

--- a/scripts/github/label_issues.py
+++ b/scripts/github/label_issues.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+
 import getpass
 
 from github import Github
 from github_issues import GithubIssues, MutableIssue
-
-
 from six.moves import input
 
 

--- a/scripts/github/pulls_applied.py
+++ b/scripts/github/pulls_applied.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import getpass
+
 import datetime
+import getpass
 
 from github import Github
 from github_issues import GithubIssues
-
 from six.moves import input
-
 
 gh = Github(
     login_or_token=input("Enter github username: "),

--- a/scripts/github/stale_pulls.py
+++ b/scripts/github/stale_pulls.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, division
-import getpass
+from __future__ import division, print_function
+
 import datetime
+import getpass
 
 from github import Github
 from github_issues import GithubIssues
-
 from six.moves import input
-
 
 gh = Github(
     login_or_token=input("Enter github username: "),

--- a/scripts/github/unassigned_issues.py
+++ b/scripts/github/unassigned_issues.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+
 import getpass
 
 from github import Github
 from github_issues import GithubIssues
-
 from six.moves import input
-
 
 gh = Github(
     login_or_token=input("Enter github username: "),

--- a/scripts/koji_pkgspec.py
+++ b/scripts/koji_pkgspec.py
@@ -8,9 +8,9 @@ The main use case is making sure the packages specified in a KojiInstaller
 will match the packages you intended to install.
 """
 
-import sys
 import optparse
 import os
+import sys
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/scripts/package_jeos.py
+++ b/scripts/package_jeos.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python
 
-import os
-import sys
 import logging
+import os
 import shutil
+import sys
 
 from avocado.utils import process
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -7,9 +7,10 @@ compute and check regression bug.
 :author: Amos Kong <akong@redhat.com>
 """
 from __future__ import division
+
 import os
-import sys
 import re
+import sys
 import warnings
 
 try:
@@ -243,8 +244,8 @@ Please check sysinfo directory in autotest result to get more details.
         t-test: http://en.wikipedia.org/wiki/Student's_t-test
         """
         try:
-            from scipy import stats
             import numpy as np
+            from scipy import stats
         except ImportError:
             print("No python scipy/numpy library installed!")
             return None

--- a/scripts/scan_results.py
+++ b/scripts/scan_results.py
@@ -5,15 +5,15 @@ script, avocado We must be launch with '--journal' option.
 """
 
 from __future__ import division
-import os
-import sys
-import sqlite3
-import argparse
 
-from avocado.core import data_dir
-from dateutil import parser as dateparser
+import argparse
+import os
+import sqlite3
+import sys
 
 import six
+from avocado.core import data_dir
+from dateutil import parser as dateparser
 from six.moves import xrange
 
 

--- a/scripts/tapfd_helper.py
+++ b/scripts/tapfd_helper.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
-import sys
 import os
 import re
+import sys
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/scripts/virt_disk.py
+++ b/scripts/virt_disk.py
@@ -8,9 +8,9 @@ The main use case for this tool is debugging guest installations with an
 disks just like they're created by the virt unattended test installation.
 """
 
-import sys
 import optparse
 import os
+import sys
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -8,7 +8,6 @@ import unittest
 
 from avocado.utils import process
 
-
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
 basedir = os.path.abspath(basedir)
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -4,10 +4,9 @@ import shutil
 import tempfile
 import unittest
 
-from avocado.utils import process
-from avocado.utils import script
-from virttest import data_dir
+from avocado.utils import process, script
 
+from virttest import data_dir
 
 BASE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
 BASE_DIR = os.path.abspath(BASE_DIR)

--- a/selftests/isort.sh
+++ b/selftests/isort.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+isort --check-only --profile black .

--- a/selftests/run
+++ b/selftests/run
@@ -3,10 +3,9 @@
 
 __author__ = 'Lucas Meneghel Rodrigues <lmr@redhat.com>'
 
+import logging
 import os
 import sys
-import logging
-
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest

--- a/selftests/unit/test_cartesian_config.py
+++ b/selftests/unit/test_cartesian_config.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 
-import unittest
-import os
 import gzip
+import os
 import sys
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -11,7 +11,6 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
 from virttest import cartesian_config
-
 
 mydir = os.path.dirname(__file__)
 testdatadir = os.path.join(mydir, "unittest_data")

--- a/selftests/unit/test_cartesian_config_lint.py
+++ b/selftests/unit/test_cartesian_config_lint.py
@@ -10,7 +10,6 @@ else:
 
 from virttest import cartesian_config
 
-
 BASEDIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 RHELDIR = os.path.join(BASEDIR, "shared", "cfg", "guest-os", "Linux", "RHEL")
 UNATTENDEDDIR = os.path.join(BASEDIR, "shared", "unattended")

--- a/selftests/unit/test_installer.py
+++ b/selftests/unit/test_installer.py
@@ -1,16 +1,15 @@
 #!/usr/bin/python
 
-import unittest
 import os
 import sys
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest import installer
-from virttest import cartesian_config
+from virttest import cartesian_config, installer
 
 
 class installer_test(unittest.TestCase):

--- a/selftests/unit/test_iscsi.py
+++ b/selftests/unit/test_iscsi.py
@@ -1,20 +1,17 @@
 #!/usr/bin/python
-import unittest
 import os
 import sys
+import unittest
 
-from avocado.utils import path
-from avocado.utils import process
-
+from avocado.utils import path, process
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from virttest import iscsi, utils_selinux
 from virttest.unittest_utils import mock
-from virttest import iscsi
-from virttest import utils_selinux
 
 
 class iscsi_test(unittest.TestCase):

--- a/selftests/unit/test_libvirt_network.py
+++ b/selftests/unit/test_libvirt_network.py
@@ -2,13 +2,12 @@
 """
 Unit tests for Manipulator classes in libvirt_xml module.
 """
-import unittest
+import itertools
 import os
 import sys
-import itertools
+import unittest
 
 from avocado.utils.process import CmdResult
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -16,6 +15,7 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
 from test_virsh import FakeVirshFactory
+
 from virttest.libvirt_xml.network_xml import NetworkXML
 
 # The output of virsh.net_list with only default net

--- a/selftests/unit/test_libvirt_storage.py
+++ b/selftests/unit/test_libvirt_storage.py
@@ -1,18 +1,18 @@
 #!/usr/bin/python
-import unittest
 import os
 import sys
+import unittest
 
 from avocado.utils.process import CmdResult
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest import libvirt_storage
 from test_virsh import FakeVirshFactory
+
+from virttest import libvirt_storage
 
 # The output of virsh.pool_list with only default pool
 _DEFAULT_POOL = (

--- a/selftests/unit/test_libvirt_xml.py
+++ b/selftests/unit/test_libvirt_xml.py
@@ -1,15 +1,13 @@
 #!/usr/bin/python
 
-import unittest
+import logging
 import os
 import shutil
-import logging
 import sys
+import unittest
 
 import six
-
 from avocado.utils import process
-
 
 try:
     unicode
@@ -22,13 +20,20 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest import xml_utils, utils_misc, data_dir
-from virttest.libvirt_xml import accessors, vm_xml, xcepts, network_xml, base
-from virttest.libvirt_xml import nodedev_xml
-from virttest.libvirt_xml.devices import librarian
-from virttest.libvirt_xml.devices import base as devices_base
-from virttest.libvirt_xml import capability_xml
 from test_virsh import FakeVirshFactory
+
+from virttest import data_dir, utils_misc, xml_utils
+from virttest.libvirt_xml import (
+    accessors,
+    base,
+    capability_xml,
+    network_xml,
+    nodedev_xml,
+    vm_xml,
+    xcepts,
+)
+from virttest.libvirt_xml.devices import base as devices_base
+from virttest.libvirt_xml.devices import librarian
 
 # save a copy
 ORIGINAL_DEVICE_TYPES = list(librarian.DEVICE_TYPES)

--- a/selftests/unit/test_nfs.py
+++ b/selftests/unit/test_nfs.py
@@ -1,21 +1,18 @@
 #!/usr/bin/python
-import unittest
 import os
 import sys
+import unittest
 
-from avocado.utils import path
-from avocado.utils import process
-
+from avocado.utils import path, process
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest.unittest_utils import mock
-from virttest import nfs
-from virttest import utils_misc
+from virttest import nfs, utils_misc
 from virttest.staging import service
+from virttest.unittest_utils import mock
 
 
 class FakeService(object):

--- a/selftests/unit/test_propcan.py
+++ b/selftests/unit/test_propcan.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-import unittest
 import logging
 import os
 import sys
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -7,23 +7,22 @@ This is a unittest for qemu_devices library.
 """
 __author__ = """Lukas Doktor (ldoktor@redhat.com)"""
 
-import re
-import unittest
 import os
+import re
 import sys
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest.unittest_utils import mock
-from virttest.qemu_devices import qdevices, qcontainer
-from virttest import qemu_monitor
-
 import six
 from six.moves import xrange
 
+from virttest import qemu_monitor
+from virttest.qemu_devices import qcontainer, qdevices
+from virttest.unittest_utils import mock
 
 UNITTEST_DATA_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "unittest_data"

--- a/selftests/unit/test_qemu_monitor.py
+++ b/selftests/unit/test_qemu_monitor.py
@@ -1,17 +1,17 @@
 #!/usr/bin/python
 
-import unittest
 import os
 import sys
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest import qemu_monitor
-
 import six
+
+from virttest import qemu_monitor
 
 
 class MockMonitor(qemu_monitor.Monitor):

--- a/selftests/unit/test_qemu_qtree.py
+++ b/selftests/unit/test_qemu_qtree.py
@@ -7,21 +7,20 @@ This is a unittest for qemu_qtree library.
 """
 __author__ = """Lukas Doktor (ldoktor@redhat.com)"""
 
-import unittest
 import os
 import sys
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest.unittest_utils import mock
-from virttest import qemu_qtree
-
 import six
 from six.moves import xrange
 
+from virttest import qemu_qtree
+from virttest.unittest_utils import mock
 
 OFFSET_PER_LEVEL = qemu_qtree.OFFSET_PER_LEVEL
 

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -1,16 +1,15 @@
 #!/usr/bin/python
 
-import unittest
 import os
 import sys
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest import remote
-from virttest import data_dir
+from virttest import data_dir, remote
 
 
 class RemoteFileTest(unittest.TestCase):

--- a/selftests/unit/test_setup_networking.py
+++ b/selftests/unit/test_setup_networking.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from virttest.test_setup.networking import BridgeConfig, NetworkProxies
 from virttest.utils_params import Params
-from virttest.test_setup.networking import NetworkProxies, BridgeConfig
 
 
 class TestProxySetuper(unittest.TestCase):

--- a/selftests/unit/test_utils_cgroup.py
+++ b/selftests/unit/test_utils_cgroup.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
 import os
-import unittest
-import tempfile
 import sys
+import tempfile
+import unittest
 
 from avocado.core import exceptions
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/selftests/unit/test_utils_config.py
+++ b/selftests/unit/test_utils_config.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 import os
-import tempfile
 import sys
+import tempfile
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest

--- a/selftests/unit/test_utils_env.py
+++ b/selftests/unit/test_utils_env.py
@@ -1,19 +1,17 @@
 #!/usr/bin/python
-import unittest
-import time
 import logging
 import os
-import threading
 import sys
+import threading
+import time
+import unittest
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
-from virttest import utils_env
-from virttest import utils_params
-from virttest import utils_misc
+from virttest import utils_env, utils_misc, utils_params
 
 
 class FakeVm(object):

--- a/selftests/unit/test_utils_libguestfs.py
+++ b/selftests/unit/test_utils_libguestfs.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python
-import unittest
 import logging
 import os
 import sys
+import unittest
 
 from avocado.utils import path
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/selftests/unit/test_utils_misc.py
+++ b/selftests/unit/test_utils_misc.py
@@ -1,22 +1,19 @@
 #!/usr/bin/python
 
 import os
+import sys
 import tempfile
 import unittest
-import sys
 
 from avocado.utils import process
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from virttest import build_helper, cartesian_config, utils_misc
 from virttest.unittest_utils import mock
-from virttest import utils_misc
-from virttest import cartesian_config
-from virttest import build_helper
 
 
 class TestUtilsMisc(unittest.TestCase):

--- a/selftests/unit/test_utils_net.py
+++ b/selftests/unit/test_utils_net.py
@@ -1,31 +1,25 @@
 #!/usr/bin/python
 
 from __future__ import division
-import unittest
-import time
+
 import logging
-import sys
-import random
 import os
+import random
 import shelve
+import sys
+import time
+import unittest
 
 from avocado.utils import process
-
 from six.moves import xrange
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from virttest import cartesian_config, propcan, utils_misc, utils_net, utils_params
 from virttest.unittest_utils import mock
-from virttest import utils_net
-from virttest import utils_misc
-from virttest import cartesian_config
-from virttest import utils_params
-from virttest import propcan
-
 
 # Disable some pylint checks for selftests
 # pylint: disable=E1133,E1136

--- a/selftests/unit/test_utils_params.py
+++ b/selftests/unit/test_utils_params.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
-import unittest
 import os
 import sys
+import unittest
 from collections import OrderedDict
 
 # simple magic for using scripts within a source tree

--- a/selftests/unit/test_versionable_class.py
+++ b/selftests/unit/test_versionable_class.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
-import unittest
 import os
 import sys
+import unittest
 
 try:
     import pickle as cPickle
@@ -15,7 +15,7 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
 from virttest.unittest_utils import mock
-from virttest.versionable_class import Manager, factory, VersionableClass
+from virttest.versionable_class import Manager, VersionableClass, factory
 
 man = Manager(__name__)
 

--- a/selftests/unit/test_virsh.py
+++ b/selftests/unit/test_virsh.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python
 
-import unittest
 import logging
 import os
 import sys
+import unittest
 
 from avocado.utils import process
-
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/selftests/unit/test_wrappers.py
+++ b/selftests/unit/test_wrappers.py
@@ -1,13 +1,12 @@
 import os
+import random
 import sys
 import unittest
-import random
-from string import ascii_lowercase as ascii_lc
-
-from time import sleep
-from copy import deepcopy
 from abc import ABC
 from concurrent.futures import ThreadPoolExecutor, wait
+from copy import deepcopy
+from string import ascii_lowercase as ascii_lc
+from time import sleep
 
 from virttest import _wrappers
 

--- a/selftests/unit/test_xml_utils.py
+++ b/selftests/unit/test_xml_utils.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 
-import unittest
-import tempfile
-import os
 import glob
 import logging
+import os
 import sys
+import tempfile
+import unittest
 from xml.etree import ElementTree
 
 # simple magic for using scripts within a source tree

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ import os
 import shutil
 from distutils.command.clean import clean
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
 

--- a/virttest/_wrappers.py
+++ b/virttest/_wrappers.py
@@ -4,18 +4,17 @@
     Please, use this module ONLY from other virttest/avocado-vt modules.
 """
 
-import sys
 import importlib
 import importlib.util
+import sys
 from importlib.machinery import (
-    SourceFileLoader,
-    SOURCE_SUFFIXES,
-    SourcelessFileLoader,
     BYTECODE_SUFFIXES,
-    ExtensionFileLoader,
     EXTENSION_SUFFIXES,
+    SOURCE_SUFFIXES,
+    ExtensionFileLoader,
+    SourceFileLoader,
+    SourcelessFileLoader,
 )
-
 
 _LOADERS = (
     (SourceFileLoader, SOURCE_SUFFIXES),

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -1,8 +1,9 @@
+import glob
 import logging
 import os
 import re
-import glob
 import shutil
+
 from six import StringIO
 
 try:
@@ -10,15 +11,9 @@ try:
 except ImportError:
     import ConfigParser
 
-from avocado.utils import astring
-from avocado.utils import process
-from avocado.utils import genio
-from avocado.utils import crypto
-from avocado.utils import download
-from avocado.utils import git
-
-from six.moves import urllib
+from avocado.utils import astring, crypto, download, genio, git, process
 from six import string_types
+from six.moves import urllib
 
 from virttest import data_dir
 

--- a/virttest/base_installer.py
+++ b/virttest/base_installer.py
@@ -6,18 +6,13 @@ These classes can be, and usually are, inherited by subclasses that implement
 custom logic for each virtualization hypervisor/software.
 """
 
-import os
 import logging
+import os
 
 from avocado.core import exceptions
-from avocado.utils import process
-from avocado.utils import path
-from avocado.utils import linux_modules
+from avocado.utils import linux_modules, path, process
 
-from . import build_helper
-from . import utils_misc
-from . import yumrepo
-from . import arch
+from . import arch, build_helper, utils_misc, yumrepo
 from .staging import utils_koji
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -1,26 +1,17 @@
-from distutils import dir_util  # virtualenv problem pylint: disable=E0611
+import glob
 import logging
 import os
-import glob
+import re
 import shutil
 import sys
-import re
+from distutils import dir_util  # virtualenv problem pylint: disable=E0611
 
-from avocado.utils import cpu
-from avocado.utils import distro
-from avocado.utils import genio
-from avocado.utils import linux_modules
+from avocado.utils import cpu, distro, genio, linux_modules
 from avocado.utils import path as utils_path
 from avocado.utils import process
 
-from . import data_dir
-from . import asset
-from . import cartesian_config
-from . import utils_selinux
-from . import defaults
-from . import arch
+from . import arch, asset, cartesian_config, data_dir, defaults, utils_selinux
 from .compat import get_opt
-
 
 LOG = logging.getLogger("avocado.app")
 

--- a/virttest/build_helper.py
+++ b/virttest/build_helper.py
@@ -5,13 +5,9 @@ import shutil
 import tarfile
 
 from avocado.core import exceptions
-from avocado.utils import download
-from avocado.utils import git
-from avocado.utils import path
-from avocado.utils import process
+from avocado.utils import download, git, path, process
 
 from virttest import data_dir
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -132,10 +132,10 @@ The base of the definitions come verbatim as follows:
 :copyright: Red Hat 2008-2013
 """
 
-import os
 import collections
-import optparse
 import logging
+import optparse
+import os
 import re
 import sys
 

--- a/virttest/ceph.py
+++ b/virttest/ceph.py
@@ -14,9 +14,7 @@ import re
 
 from avocado.utils import process
 
-from virttest import utils_numeric
-from virttest import error_context
-from virttest import utils_misc
+from virttest import error_context, utils_misc, utils_numeric
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -15,25 +15,21 @@
 # Author: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
 
 
-import re
 import json
 import logging
-import platform
-import time
 import os
+import platform
+import re
+import time
 import uuid
 import xml.etree.ElementTree as ET
 
-
-from avocado.utils import cpu as utils
-from avocado.utils.software_manager import manager
-from avocado.utils import process
-from avocado.utils import path
 from avocado.core import exceptions
-from virttest import utils_misc
-from virttest import libvirt_version
-from virttest import data_dir
+from avocado.utils import cpu as utils
+from avocado.utils import path, process
+from avocado.utils.software_manager import manager
 
+from virttest import data_dir, libvirt_version, utils_misc
 
 # lazy imports for dependencies that are not needed in all modes of use
 # (as the cpu module is generic to qemu vm use only, libvirt is optional)

--- a/virttest/curl.py
+++ b/virttest/curl.py
@@ -1,6 +1,6 @@
-from virttest import error_context
-
 from avocado.utils import process
+
+from virttest import error_context
 
 
 @error_context.context_aware

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -2,22 +2,20 @@
 """
 Library used to provide the appropriate data dir for virt test.
 """
+import glob
 import inspect
 import logging
 import os
-import glob
 import shutil
 import stat
 
 import pkg_resources
-
 from avocado.core import data_dir
 from avocado.utils import distro
 from avocado.utils import path as utils_path
+from six.moves import xrange
 
 from virttest.compat import get_settings_value
-
-from six.moves import xrange
 
 BASE_BACKEND_DIR = pkg_resources.resource_filename("virttest", "backends")
 TEST_PROVIDERS_DIR = pkg_resources.resource_filename("virttest", "test-providers.d")

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1,60 +1,59 @@
 from __future__ import division
-import os
-import time
-import re
-import logging
+
+import copy
 import glob
-import threading
+import logging
+import multiprocessing
+import os
+import re
 import shutil
 import sys
-import copy
-import multiprocessing
+import threading
+import time
 
 import aexpect
+import six
 from aexpect import remote
-
-from avocado.utils import process as a_process
-from avocado.utils import crypto
-from avocado.utils import path
-from avocado.utils import distro
-from avocado.utils import cpu as cpu_utils
 from avocado.core import exceptions
 from avocado.utils import archive
-
-import six
+from avocado.utils import cpu as cpu_utils
+from avocado.utils import crypto, distro, path
+from avocado.utils import process as a_process
 from six.moves import xrange
 
-from virttest import error_context
-from virttest import qemu_monitor
-from virttest import ppm_utils
-from virttest import test_setup
-from virttest import virt_vm
-from virttest import utils_misc
-from virttest import cpu
-from virttest import storage
-from virttest import utils_libguestfs
-from virttest import qemu_storage
-from virttest import data_dir
-from virttest import utils_net
-from virttest import nfs
-from virttest import utils_test
-from virttest import utils_iptables
-from virttest import utils_package
-from virttest import utils_qemu
-from virttest import migration
-from virttest import utils_kernel_module
-from virttest import arch
-from virttest import utils_logfile
-from virttest.utils_conn import SSHConnection
-from virttest.utils_version import VersionInterval
-from virttest.staging import service
-from virttest.test_setup.core import SetupManager
-from virttest.test_setup.os_posix import UlimitConfig
-from virttest.test_setup.networking import NetworkProxies, BridgeConfig
-from virttest.test_setup.libvirt_setup import LibvirtdDebugLogConfig
+from virttest import (
+    arch,
+    cpu,
+    data_dir,
+    error_context,
+    migration,
+    nfs,
+    ppm_utils,
+    qemu_monitor,
+    qemu_storage,
+    storage,
+    test_setup,
+    utils_iptables,
+    utils_kernel_module,
+    utils_libguestfs,
+    utils_logfile,
+    utils_misc,
+    utils_net,
+    utils_package,
+    utils_qemu,
+    utils_test,
+    virt_vm,
+)
 
 # lazy imports for dependencies that are not needed in all modes of use
 from virttest._wrappers import lazy_import
+from virttest.staging import service
+from virttest.test_setup.core import SetupManager
+from virttest.test_setup.libvirt_setup import LibvirtdDebugLogConfig
+from virttest.test_setup.networking import BridgeConfig, NetworkProxies
+from virttest.test_setup.os_posix import UlimitConfig
+from virttest.utils_conn import SSHConnection
+from virttest.utils_version import VersionInterval
 
 utils_libvirtd = lazy_import("virttest.utils_libvirtd")
 virsh = lazy_import("virttest.virsh")

--- a/virttest/funcatexit.py
+++ b/virttest/funcatexit.py
@@ -8,9 +8,8 @@ __all__ = ["register", "run_exitfuncs", "unregister"]
 
 import traceback
 
-from avocado.core import exceptions
-
 import six
+from avocado.core import exceptions
 
 
 def run_exitfuncs(env, test_type):

--- a/virttest/gluster.py
+++ b/virttest/gluster.py
@@ -12,16 +12,11 @@ import os
 import re
 import socket
 
-from avocado.utils import process
-from avocado.utils import path as utils_path
 from avocado.core import exceptions
+from avocado.utils import path as utils_path
+from avocado.utils import process
 
-from virttest import data_dir
-from virttest import utils_disk
-from virttest import remote
-from virttest import utils_misc
-from virttest import utils_net
-from virttest import error_context
+from virttest import data_dir, error_context, remote, utils_disk, utils_misc, utils_net
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/graphical_console.py
+++ b/virttest/graphical_console.py
@@ -3,14 +3,13 @@ Graphical Console
 """
 
 from __future__ import division
-import time
-import os
+
 import csv
 import math
+import os
+import time
 
-from virttest import data_dir
-from virttest import ppm_utils
-
+from virttest import data_dir, ppm_utils
 
 _STR_DASH = "-"
 

--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -4,20 +4,18 @@ Interfaces to the virt agent.
 :copyright: 2008-2012 Red Hat Inc.
 """
 
-import socket
-import time
-import logging
-import random
 import base64
 import json
+import logging
+import random
+import socket
+import time
 
+import six
 from avocado.utils import process
 
 from virttest import error_context
 from virttest.qemu_monitor import Monitor, MonitorError
-
-
-import six
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/http_server.py
+++ b/virttest/http_server.py
@@ -1,11 +1,12 @@
+import logging
 import os
 import posixpath
-import logging
 
 try:
     from urllib.parse import unquote, urlparse
 except ImportError:
     from urllib import unquote
+
     from urlparse import urlparse
 try:
     from http.server import HTTPServer, SimpleHTTPRequestHandler
@@ -14,7 +15,6 @@ except ImportError:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
 
 from avocado.utils.astring import to_text
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/installer.py
+++ b/virttest/installer.py
@@ -8,9 +8,7 @@ The most common use case is to simply call make_installer() inside your tests.
 
 from avocado.core import exceptions
 
-from . import base_installer
-from . import qemu_installer
-from . import libvirt_installer
+from . import base_installer, libvirt_installer, qemu_installer
 
 __all__ = [
     "InstallerRegistry",

--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -2,9 +2,9 @@
 IP sniffing facilities
 """
 
-import threading
 import logging
 import re
+import threading
 
 try:
     from collections import Iterable
@@ -12,11 +12,10 @@ except ImportError:
     from collections.abc import Iterable
 
 import aexpect
+import six
 from aexpect.remote import handle_prompts
 from avocado.utils import path as utils_path
 from avocado.utils import process
-
-import six
 
 from virttest.utils_logfile import log_line
 from virttest.utils_version import VersionInterval

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -8,20 +8,15 @@ iscsi in localhost then access it.
 """
 
 from __future__ import division
-import re
-import os
+
 import logging
+import os
+import re
 
 from avocado.core import exceptions
-from avocado.utils import data_factory
-from avocado.utils import process
-from avocado.utils import path
-from avocado.utils import distro
+from avocado.utils import data_factory, distro, path, process
 
-from virttest import utils_selinux
-from virttest import utils_net
-from virttest import data_dir
-from virttest import utils_package
+from virttest import data_dir, utils_net, utils_package, utils_selinux
 from virttest.staging import service
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/kernel_interface.py
+++ b/virttest/kernel_interface.py
@@ -1,9 +1,8 @@
+import logging
 import os
 import re
-import logging
 
 from avocado.utils import process
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -3,14 +3,13 @@ Virtualization test - cgroup related utility functions for libvirt
 
 :copyright: 2019 Red Hat Inc.
 """
-import os
 import logging
+import os
 import re
 
 from avocado.utils import process
 
-from virttest import utils_disk
-from virttest import virsh
+from virttest import utils_disk, virsh
 from virttest.staging import utils_cgroup
 
 VIRSH_BLKIOTUNE_OUTPUT_MAPPING = {

--- a/virttest/libvirt_installer.py
+++ b/virttest/libvirt_installer.py
@@ -4,13 +4,13 @@ Installer code that implement KVM specific bits.
 See BaseInstaller class in base_installer.py for interface details.
 """
 
+import logging
 import os
 import platform
-import logging
 
 from avocado.utils import process
-from virttest import base_installer
 
+from virttest import base_installer
 
 __all__ = [
     "GitRepoInstaller",

--- a/virttest/libvirt_remote.py
+++ b/virttest/libvirt_remote.py
@@ -7,9 +7,7 @@ import logging
 from avocado.core import exceptions
 
 from virttest import remote
-
 from virttest.utils_test import libvirt
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -7,13 +7,12 @@ This exports:
   - class for storage pool operations
 """
 
-import re
 import logging
+import re
 
 from avocado.utils import process
 
-from virttest import storage
-from virttest import virsh
+from virttest import storage, virsh
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/libvirt_version.py
+++ b/virttest/libvirt_version.py
@@ -2,14 +2,12 @@
 Shared code for tests that need to get the libvirt version
 """
 
-import re
 import logging
+import re
 
 from avocado.core import exceptions
-from avocado.utils import path
-from avocado.utils import process
+from avocado.utils import path, process
 from avocado.utils.astring import to_text
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -5,37 +5,37 @@ Utility classes and functions to handle Virtual Machine creation using libvirt.
 """
 
 from __future__ import division
-import time
-import string
-import os
-import logging
+
 import fcntl
+import logging
+import os
+import platform
 import re
 import shutil
+import string
 import tempfile
-import platform
+import time
 
 import aexpect
 from aexpect import remote
-
-from avocado.utils import process
-from avocado.utils import crypto
 from avocado.core import exceptions
+from avocado.utils import crypto, process
 
-from virttest import error_context
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest import cpu
-from virttest import virt_vm
-from virttest import storage
-from virttest import virsh
-from virttest import libvirt_xml
-from virttest import data_dir
-from virttest import xml_utils
-from virttest import utils_selinux
-from virttest import test_setup
-from virttest import utils_package
-
+from virttest import (
+    cpu,
+    data_dir,
+    error_context,
+    libvirt_xml,
+    storage,
+    test_setup,
+    utils_logfile,
+    utils_misc,
+    utils_package,
+    utils_selinux,
+    virsh,
+    virt_vm,
+    xml_utils,
+)
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.

--- a/virttest/libvirt_xml/__init__.py
+++ b/virttest/libvirt_xml/__init__.py
@@ -35,21 +35,14 @@ within this module should raise LibvirtXMLError or a subclass.
 
 # These are the objects considered for common use:
 
-# all exceptions are siblings of LibvirtXMLError
-from virttest.libvirt_xml.xcepts import LibvirtXMLError
-
 from virttest.libvirt_xml.capability_xml import CapabilityXML
-
-from virttest.libvirt_xml.network_xml import RangeList, IPXML, NetworkXML
-
+from virttest.libvirt_xml.network_xml import IPXML, NetworkXML, RangeList
+from virttest.libvirt_xml.nwfilter_xml import NwfilterXML
+from virttest.libvirt_xml.pool_xml import PoolXML, SourceXML
+from virttest.libvirt_xml.snapshot_xml import SnapshotXML
+from virttest.libvirt_xml.sysinfo_xml import SysinfoXML
 from virttest.libvirt_xml.vm_xml import VMXML
-
-from virttest.libvirt_xml.pool_xml import SourceXML, PoolXML
-
 from virttest.libvirt_xml.vol_xml import VolXML
 
-from virttest.libvirt_xml.nwfilter_xml import NwfilterXML
-
-from virttest.libvirt_xml.sysinfo_xml import SysinfoXML
-
-from virttest.libvirt_xml.snapshot_xml import SnapshotXML
+# all exceptions are siblings of LibvirtXMLError
+from virttest.libvirt_xml.xcepts import LibvirtXMLError

--- a/virttest/libvirt_xml/accessors.py
+++ b/virttest/libvirt_xml/accessors.py
@@ -3,12 +3,11 @@ Specializations of base.AccessorBase for particular XML manipulation types
 """
 
 import logging
-
 from xml.etree.ElementTree import tostring
 
 from virttest import xml_utils
+from virttest.libvirt_xml import base, xcepts
 from virttest.propcan import PropCanBase
-from virttest.libvirt_xml import xcepts, base
 
 
 def type_check(name, thing, expected):

--- a/virttest/libvirt_xml/backup_xml.py
+++ b/virttest/libvirt_xml/backup_xml.py
@@ -2,7 +2,7 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatbackup.html
 """
-from virttest.libvirt_xml import base, accessors, xcepts
+from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class BackupXML(base.LibvirtXMLBase):

--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -2,13 +2,12 @@ import logging
 
 from avocado.utils import process
 
-from .. import propcan, xml_utils
-from ..libvirt_xml import xcepts
-from .._wrappers import import_module
-
-
 # lazy imports for dependencies that are not needed in all modes of use
 from virttest._wrappers import lazy_import
+
+from .. import propcan, xml_utils
+from .._wrappers import import_module
+from ..libvirt_xml import xcepts
 
 virsh = lazy_import("virttest.virsh")
 

--- a/virttest/libvirt_xml/capability_xml.py
+++ b/virttest/libvirt_xml/capability_xml.py
@@ -4,7 +4,7 @@ http://libvirt.org/formatcaps.html
 """
 
 from virttest import xml_utils
-from virttest.libvirt_xml import base, accessors, xcepts
+from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class CapabilityXML(base.LibvirtXMLBase):

--- a/virttest/libvirt_xml/checkpoint_xml.py
+++ b/virttest/libvirt_xml/checkpoint_xml.py
@@ -2,7 +2,7 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatdomaincheckpoint.html
 """
-from virttest.libvirt_xml import base, accessors
+from virttest.libvirt_xml import accessors, base
 
 
 class CheckpointXML(base.LibvirtXMLBase):

--- a/virttest/libvirt_xml/devices/base.py
+++ b/virttest/libvirt_xml/devices/base.py
@@ -3,10 +3,11 @@ Common base classes for devices
 """
 
 import logging
+
 from six import StringIO
 
 from virttest import xml_utils
-from virttest.libvirt_xml import base, xcepts, accessors
+from virttest.libvirt_xml import accessors, base, xcepts
 from virttest.xml_utils import ElementTree
 
 

--- a/virttest/libvirt_xml/devices/channel.py
+++ b/virttest/libvirt_xml/devices/channel.py
@@ -4,8 +4,7 @@ Classes to support XML for channel devices
 http://libvirt.org/formatdomain.html#elementCharSerial
 """
 
-from virttest.libvirt_xml import base
-from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml import accessors, base
 from virttest.libvirt_xml.devices.character import CharacterBase
 
 

--- a/virttest/libvirt_xml/devices/character.py
+++ b/virttest/libvirt_xml/devices/character.py
@@ -4,7 +4,7 @@ Generic character device support for serial, parallel, channel, and console
 http://libvirt.org/formatdomain.html#elementCharSerial
 """
 
-from virttest.libvirt_xml import base, accessors, xcepts
+from virttest.libvirt_xml import accessors, base, xcepts
 from virttest.libvirt_xml.devices import base
 from virttest.libvirt_xml.devices.seclabel import Seclabel
 

--- a/virttest/libvirt_xml/devices/console.py
+++ b/virttest/libvirt_xml/devices/console.py
@@ -4,7 +4,7 @@ Console device support class(es)
 http://libvirt.org/formatdomain.html#elementCharSerial
 """
 
-from virttest.libvirt_xml import base, accessors
+from virttest.libvirt_xml import accessors, base
 from virttest.libvirt_xml.devices.character import CharacterBase
 
 

--- a/virttest/libvirt_xml/devices/filesystem.py
+++ b/virttest/libvirt_xml/devices/filesystem.py
@@ -4,8 +4,8 @@ filesystem device support class(es)
 https://libvirt.org/formatdomain.html#elementsFilesystem
 """
 
-from virttest.libvirt_xml.devices import base
 from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml.devices import base
 
 
 class Filesystem(base.TypedDeviceBase):

--- a/virttest/libvirt_xml/devices/graphics.py
+++ b/virttest/libvirt_xml/devices/graphics.py
@@ -4,9 +4,7 @@ graphics framebuffer device support class(es)
 http://libvirt.org/formatdomain.html#elementsGraphics
 """
 
-from virttest.libvirt_xml import accessors
-from virttest.libvirt_xml import vm_xml
-from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml import accessors, vm_xml, xcepts
 from virttest.libvirt_xml.devices import base
 
 

--- a/virttest/libvirt_xml/devices/hostdev.py
+++ b/virttest/libvirt_xml/devices/hostdev.py
@@ -4,8 +4,7 @@ hostdev device support class(es)
 http://libvirt.org/formatdomain.html#elementsHostDev
 """
 from virttest.libvirt_xml import accessors
-from virttest.libvirt_xml.devices import base
-from virttest.libvirt_xml.devices import librarian
+from virttest.libvirt_xml.devices import base, librarian
 
 
 class Hostdev(base.TypedDeviceBase):

--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -5,8 +5,7 @@ http://libvirt.org/formatdomain.html#elementsNICS
 http://libvirt.org/formatnwfilter.html#nwfconceptsvars
 """
 
-from virttest.libvirt_xml import accessors
-from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml import accessors, xcepts
 from virttest.libvirt_xml.devices import base, librarian
 
 

--- a/virttest/libvirt_xml/devices/lease.py
+++ b/virttest/libvirt_xml/devices/lease.py
@@ -4,8 +4,8 @@ lease device support class(es)
 http://libvirt.org/formatdomain.html#elementsLease
 """
 
-from virttest.libvirt_xml.devices import base
 from virttest.libvirt_xml import accessors
+from virttest.libvirt_xml.devices import base
 
 
 class Lease(base.UntypedDeviceBase):

--- a/virttest/libvirt_xml/devices/librarian.py
+++ b/virttest/libvirt_xml/devices/librarian.py
@@ -6,7 +6,6 @@ import os
 
 from virttest.libvirt_xml import base
 
-
 # Avoid accidental names like __init__, librarian, and/or other support modules
 DEVICE_TYPES = [
     "disk",

--- a/virttest/libvirt_xml/devices/memory.py
+++ b/virttest/libvirt_xml/devices/memory.py
@@ -4,8 +4,7 @@ memory device support class(es)
 """
 
 from virttest.libvirt_xml import accessors
-from virttest.libvirt_xml.devices import base
-from virttest.libvirt_xml.devices import librarian
+from virttest.libvirt_xml.devices import base, librarian
 
 
 class Memory(base.UntypedDeviceBase):

--- a/virttest/libvirt_xml/devices/serial.py
+++ b/virttest/libvirt_xml/devices/serial.py
@@ -4,7 +4,7 @@ Classes to support XML for serial devices
 http://libvirt.org/formatdomain.html#elementCharSerial
 """
 
-from virttest.libvirt_xml import base, accessors
+from virttest.libvirt_xml import accessors, base
 from virttest.libvirt_xml.devices.character import CharacterBase
 
 

--- a/virttest/libvirt_xml/devices/tpm.py
+++ b/virttest/libvirt_xml/devices/tpm.py
@@ -6,9 +6,9 @@ http://libvirt.org/formatdomain.html#elementsTpm
 
 import logging
 
+from virttest import xml_utils
 from virttest.libvirt_xml import accessors
 from virttest.libvirt_xml.devices import base
-from virttest import xml_utils
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/libvirt_xml/devices/watchdog.py
+++ b/virttest/libvirt_xml/devices/watchdog.py
@@ -4,8 +4,9 @@ watchdog device support class(es)
 http://libvirt.org/formatdomain.html#elementsWatchdog
 """
 
-import aexpect
 import logging
+
+import aexpect
 
 from virttest.libvirt_xml import accessors
 from virttest.libvirt_xml.devices import base

--- a/virttest/libvirt_xml/domcapability_xml.py
+++ b/virttest/libvirt_xml/domcapability_xml.py
@@ -5,7 +5,7 @@ http://libvirt.org/formatdomaincaps.html
 import logging
 
 from virttest import xml_utils
-from virttest.libvirt_xml import base, accessors, xcepts
+from virttest.libvirt_xml import accessors, base, xcepts
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -6,7 +6,7 @@ http://libvirt.org/formatnetwork.html
 import logging
 
 from virttest import xml_utils
-from virttest.libvirt_xml import base, xcepts, accessors
+from virttest.libvirt_xml import accessors, base, xcepts
 from virttest.libvirt_xml.devices import librarian
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/libvirt_xml/nodedev_xml.py
+++ b/virttest/libvirt_xml/nodedev_xml.py
@@ -5,7 +5,7 @@ http://libvirt.org/formatnode.html
 
 import os
 
-from virttest.libvirt_xml import base, xcepts, accessors
+from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class CAPXML(base.LibvirtXMLBase):

--- a/virttest/libvirt_xml/nwfilter_binding.py
+++ b/virttest/libvirt_xml/nwfilter_binding.py
@@ -3,7 +3,7 @@ Module simplifying manipulation of XML described at
 http://libvirt.org/formatnwfilter.html
 """
 
-from virttest.libvirt_xml import base, accessors
+from virttest.libvirt_xml import accessors, base
 from virttest.libvirt_xml.devices.filterref import Filterref
 
 

--- a/virttest/libvirt_xml/nwfilter_protocols/base.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/base.py
@@ -5,7 +5,7 @@ Common base classes for filter rule protocols
 from six import StringIO
 
 from virttest import xml_utils
-from virttest.libvirt_xml import base, xcepts, accessors
+from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class UntypedDeviceBase(base.LibvirtXMLBase):

--- a/virttest/libvirt_xml/nwfilter_protocols/librarian.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/librarian.py
@@ -6,7 +6,6 @@ import os
 
 from virttest.libvirt_xml import base
 
-
 # Avoid accidental names like __init__, librarian, and/or other support modules
 FILTER_TYPES = [
     "mac",

--- a/virttest/libvirt_xml/nwfilter_xml.py
+++ b/virttest/libvirt_xml/nwfilter_xml.py
@@ -3,7 +3,7 @@ Module simplifying manipulation of XML described at
 http://libvirt.org/formatnwfilter.html
 """
 
-from virttest.libvirt_xml import base, xcepts, accessors
+from virttest.libvirt_xml import accessors, base, xcepts
 from virttest.libvirt_xml.nwfilter_protocols import librarian
 
 

--- a/virttest/libvirt_xml/pool_xml.py
+++ b/virttest/libvirt_xml/pool_xml.py
@@ -2,17 +2,15 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatstorage.html#StoragePool
 """
-import os
 import logging
+import os
 import tempfile
-
 from xml.etree import ElementTree as ET
 
 from avocado.utils import process
 
-from .. import data_dir
-from .. import libvirt_storage
-from ..libvirt_xml import base, xcepts, accessors
+from .. import data_dir, libvirt_storage
+from ..libvirt_xml import accessors, base, xcepts
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/libvirt_xml/secret_xml.py
+++ b/virttest/libvirt_xml/secret_xml.py
@@ -3,8 +3,7 @@ Module simplifying manipulation of XML described at
 http://libvirt.org/formatsecret.html
 """
 
-from virttest.libvirt_xml import base, accessors
-from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class SecretXMLBase(base.LibvirtXMLBase):

--- a/virttest/libvirt_xml/snapshot_xml.py
+++ b/virttest/libvirt_xml/snapshot_xml.py
@@ -4,9 +4,8 @@ http://libvirt.org/formatsnapshot.html
 """
 
 from virttest import xml_utils
-from virttest.libvirt_xml import base, accessors
+from virttest.libvirt_xml import accessors, base, xcepts
 from virttest.libvirt_xml.devices.disk import Disk
-from virttest.libvirt_xml import xcepts
 
 
 class SnapshotXMLBase(base.LibvirtXMLBase):

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -7,9 +7,8 @@ import logging
 import platform
 import re
 
-from .. import xml_utils
-from .. import utils_misc
-from ..libvirt_xml import base, accessors, xcepts
+from .. import utils_misc, xml_utils
+from ..libvirt_xml import accessors, base, xcepts
 from ..libvirt_xml.base import LibvirtXMLBase
 from ..libvirt_xml.devices import librarian
 

--- a/virttest/libvirt_xml/vol_xml.py
+++ b/virttest/libvirt_xml/vol_xml.py
@@ -3,7 +3,7 @@ Module simplifying manipulation of XML described at
 http://libvirt.org/formatstorage.html#StorageVol
 """
 
-from virttest.libvirt_xml import base, accessors
+from virttest.libvirt_xml import accessors, base
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
 
 

--- a/virttest/libvirtd_decorator.py
+++ b/virttest/libvirtd_decorator.py
@@ -6,12 +6,10 @@ Copyright: Red Hat Inc. 2020
 import logging
 import os
 import re
+
+from avocado.utils import astring, path, process
+
 from virttest import data_dir
-
-from avocado.utils import process
-from avocado.utils import path
-from avocado.utils import astring
-
 
 try:
     path.find_command("libvirtd")

--- a/virttest/logging_manager.py
+++ b/virttest/logging_manager.py
@@ -1,6 +1,5 @@
 import logging
 
-
 # implementation follows
 
 logger = logging.getLogger("avocado.vt")

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -22,18 +22,17 @@ Required params:
         PhysicalVolume name eg, /dev/sdb or /dev/sdb1;
 """
 from __future__ import division
-import os
-import time
-import re
-import math
+
 import logging
+import math
+import os
+import re
+import time
 
 from avocado.core import exceptions
-from avocado.utils import path
-from avocado.utils import process
+from avocado.utils import path, process
 
-from virttest import utils_misc
-from virttest import data_dir
+from virttest import data_dir, utils_misc
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/lvsb.py
+++ b/virttest/lvsb.py
@@ -5,11 +5,10 @@ Higher order classes and functions for Libvirt Sandbox (lxc) container testing
 """
 
 import datetime
-import time
 import logging
+import time
 
 from virttest import lvsb_base
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/lvsb_base.py
+++ b/virttest/lvsb_base.py
@@ -8,9 +8,7 @@ import logging
 import signal
 
 import aexpect
-
 from six.moves import xrange
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/lvsbs.py
+++ b/virttest/lvsbs.py
@@ -2,11 +2,9 @@
 Higher order classes for Libvirt Sandbox Service (lxc) service container testing
 """
 
-from avocado.utils import process
-from avocado.utils import service
+from avocado.utils import process, service
 
-from . import lvsb_base
-from . import virsh
+from . import lvsb_base, virsh
 
 
 class SandboxService(object):

--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -1,28 +1,29 @@
-import time
-import threading
-import types
 import logging
 import re
 import signal
+import threading
+import time
+import types
 
-from avocado.utils import process
-from avocado.utils import path as utils_path
-from avocado.utils import distro
 from avocado.core import exceptions
+from avocado.utils import distro
+from avocado.utils import path as utils_path
+from avocado.utils import process
 
-from virttest import libvirt_version
-from virttest import remote
-from virttest import utils_disk
-from virttest import utils_misc
-from virttest import test_setup
-from virttest import utils_net
-from virttest import utils_iptables
-from virttest import utils_test
-from virttest.utils_test import libvirt
-
+from virttest import (
+    libvirt_version,
+    remote,
+    test_setup,
+    utils_disk,
+    utils_iptables,
+    utils_misc,
+    utils_net,
+    utils_test,
+)
 
 # lazy imports for dependencies that are not needed in all modes of use
 from virttest._wrappers import lazy_import
+from virttest.utils_test import libvirt
 
 virsh = lazy_import("virttest.virsh")
 

--- a/virttest/migration_template.py
+++ b/virttest/migration_template.py
@@ -1,30 +1,27 @@
-import logging
 import functools
+import logging
 import os
-
 from enum import Enum
-
-from six import itervalues, iteritems, string_types
 
 from avocado.utils import distro
 from avocado.utils import path as utils_path
+from six import iteritems, itervalues, string_types
 
-from virttest import virsh, migration, remote
-from virttest import libvirt_version
-from virttest import utils_iptables, utils_selinux, utils_misc
-
-from virttest.libvirt_xml import vm_xml
-
+from virttest import (
+    libvirt_version,
+    migration,
+    remote,
+    utils_iptables,
+    utils_misc,
+    utils_selinux,
+    virsh,
+)
 from virttest.libvirt_vm import get_uri_with_transport as get_uri
-
-from virttest.utils_conn import TLSConnection, TCPConnection, SSHConnection
-
-from virttest.utils_test import libvirt
-
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_conn import SSHConnection, TCPConnection, TLSConnection
 from virttest.utils_libvirt import libvirt_disk
-
 from virttest.utils_libvirt.libvirt_config import remove_key_for_modular_daemon
-
+from virttest.utils_test import libvirt
 
 # Migration flags
 VIR_MIGRATE_LIVE = 1 << 0

--- a/virttest/nbd.py
+++ b/virttest/nbd.py
@@ -1,10 +1,9 @@
 import os
 import string
 
-from virttest import error_context
-from virttest import utils_misc
-
 from avocado.utils import process
+
+from virttest import error_context, utils_misc
 
 
 @error_context.context_aware

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -2,21 +2,18 @@
 Basic nfs support for Linux host. It can support the remote
 nfs mount and the local nfs set up and mount.
 """
-import re
-import aexpect
 import logging
+import re
 
-from avocado.utils import path
-from avocado.utils import process
-from avocado.utils import distro
-from avocado.utils.astring import to_text
+import aexpect
 from avocado.core import exceptions
+from avocado.utils import distro, path, process
+from avocado.utils.astring import to_text
 
-from virttest import utils_misc
-from virttest import test_setup
-from virttest.utils_iptables import Iptables
-from virttest.utils_conn import SSHConnection
+from virttest import test_setup, utils_misc
 from virttest.staging import service
+from virttest.utils_conn import SSHConnection
+from virttest.utils_iptables import Iptables
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -1,14 +1,12 @@
 import logging
-import re
 import os
+import re
 import signal
 
-from avocado.utils import path
-from avocado.utils import process
-from avocado.utils import linux_modules
+from avocado.utils import linux_modules, path, process
 
-from .versionable_class import VersionableClass, Manager, factory
 from . import utils_misc
+from .versionable_class import Manager, VersionableClass, factory
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -5,15 +5,14 @@ oVirt SDK wrapper module.
 """
 
 
-import time
 import logging
+import time
 
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
 
 from virttest import virt_vm
 from virttest.utils_net import ping
-
 
 _api = None
 _connected = False

--- a/virttest/ovs_utils.py
+++ b/virttest/ovs_utils.py
@@ -8,7 +8,6 @@ from avocado.utils import process
 
 from . import utils_net
 
-
 LOG = logging.getLogger("avocado." + __name__)
 
 

--- a/virttest/postprocess_iozone.py
+++ b/virttest/postprocess_iozone.py
@@ -10,15 +10,15 @@ is not present, functionality degrates gracefully.
 """
 
 from __future__ import division
-import os
-import sys
-import optparse
+
 import logging
 import math
+import optparse
+import os
+import sys
 import time
 
-from avocado.utils import process
-from avocado.utils import path
+from avocado.utils import path, process
 
 from . import utils_misc
 

--- a/virttest/ppm_utils.py
+++ b/virttest/ppm_utils.py
@@ -5,21 +5,17 @@ Utility functions to deal with ppm (qemu screendump format) files.
 """
 
 from __future__ import division
-import os
-import struct
-import time
-import re
+
 import glob
 import logging
-
+import os
+import re
+import struct
+import time
 from functools import reduce
 
-
 try:
-    from PIL import Image
-    from PIL import ImageOps
-    from PIL import ImageDraw
-    from PIL import ImageFont
+    from PIL import Image, ImageDraw, ImageFont, ImageOps
 except ImportError:
     Image = None
     logging.getLogger("avocado.app").warning(

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -9,21 +9,21 @@ interact and verify the qemu qdev structure.
 
 # Python imports
 from __future__ import division
+
+import json
 import logging
-import re
 import os
+import re
 import shutil
 import stat
-import json
 import uuid
+
+import aexpect
+import six
 
 # Avocado imports
 from avocado.core import exceptions
 from avocado.utils import process
-
-import aexpect
-
-import six
 from six.moves import xrange
 
 try:
@@ -32,14 +32,20 @@ except ImportError:
     from collections import Sequence
 
 # Internal imports
-from virttest import vt_iothread
-from virttest import utils_qemu
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest import arch, storage, data_dir, virt_vm
-from virttest import qemu_storage
-from virttest.qemu_devices.qdevices import QThrottleGroup
+from virttest import (
+    arch,
+    data_dir,
+    qemu_storage,
+    storage,
+    utils_logfile,
+    utils_misc,
+    utils_qemu,
+    virt_vm,
+    vt_iothread,
+)
+from virttest.qemu_capabilities import Capabilities, Flags, MigrationParams
 from virttest.qemu_devices import qdevices
+from virttest.qemu_devices.qdevices import QThrottleGroup
 from virttest.qemu_devices.utils import (
     DeviceError,
     DeviceHotplugError,
@@ -47,10 +53,9 @@ from virttest.qemu_devices.utils import (
     DeviceRemoveError,
     DeviceUnplugError,
     none_or_int,
+    set_cmdline_format_by_cfg,
 )
-from virttest.qemu_devices.utils import set_cmdline_format_by_cfg
 from virttest.utils_params import Params
-from virttest.qemu_capabilities import Flags, Capabilities, MigrationParams
 from virttest.utils_version import VersionInterval
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -9,23 +9,19 @@ interact with qemu qdev structure.
 import json
 import logging
 import os
-import time
 import re
+import time
 import traceback
 from collections import OrderedDict
 from pathlib import Path
 
 import aexpect
-
-from virttest import qemu_monitor, utils_numeric
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest.qemu_devices.utils import DeviceError
-from virttest.qemu_devices.utils import none_or_int
-from virttest.utils_version import VersionInterval
-
 import six
 from six.moves import xrange
+
+from virttest import qemu_monitor, utils_logfile, utils_misc, utils_numeric
+from virttest.qemu_devices.utils import DeviceError, none_or_int
+from virttest.utils_version import VersionInterval
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/qemu_installer.py
+++ b/virttest/qemu_installer.py
@@ -4,8 +4,8 @@ Installer code that implement KVM specific bits.
 See BaseInstaller class in base_installer.py for interface details.
 """
 
-import os
 import logging
+import os
 
 from avocado.core import exceptions
 from avocado.utils import process

--- a/virttest/qemu_io.py
+++ b/virttest/qemu_io.py
@@ -3,9 +3,7 @@ import re
 import aexpect
 from avocado.utils import process
 
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest import error_context
+from virttest import error_context, utils_logfile, utils_misc
 
 
 class QemuIOParamError(Exception):

--- a/virttest/qemu_migration.py
+++ b/virttest/qemu_migration.py
@@ -2,9 +2,7 @@
 Interface for QEMU migration.
 """
 
-from virttest.qemu_capabilities import MigrationParams
-from virttest.qemu_capabilities import Flags
-
+from virttest.qemu_capabilities import Flags, MigrationParams
 from virttest.utils_numeric import normalize_data_size
 
 

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -18,13 +18,9 @@ import time
 
 import six
 
-from . import utils_logfile
-from . import utils_misc
-from . import cartesian_config
-from . import data_dir
-
 from virttest.qemu_capabilities import Flags
 
+from . import cartesian_config, data_dir, utils_logfile, utils_misc
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -9,14 +9,10 @@ import logging
 import os
 import re
 
+import six
 from six.moves import xrange
 
-from . import storage
-from . import data_dir
-from . import utils_misc
-from . import arch
-
-import six
+from . import arch, data_dir, storage, utils_misc
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -10,18 +10,13 @@ import json
 import logging
 import os
 import re
-import six
 import string
 
+import six
 from avocado.core import exceptions
 from avocado.utils import process
 
-from virttest import utils_misc
-from virttest import virt_vm
-from virttest import storage
-from virttest import nvme
-from virttest import data_dir
-from virttest import error_context
+from virttest import data_dir, error_context, nvme, storage, utils_misc, virt_vm
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -4,21 +4,20 @@ Interfaces and helpers for the virtio_serial ports.
 :copyright: 2012 Red Hat Inc.
 """
 from __future__ import division
-from threading import Thread
-from collections import deque
+
 import logging
 import os
 import random
 import select
 import socket
-import time
 import struct
+import time
+from collections import deque
+from threading import Thread
 
 import aexpect
-
 from avocado.core import exceptions
 from avocado.utils import process
-
 from six.moves import xrange
 
 from virttest import data_dir

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -6,56 +6,52 @@ Utility classes and functions to handle Virtual Machine creation using qemu.
 
 from __future__ import division
 
-import shutil
-import time
-import os
-import logging
-import fcntl
-import re
-import random
-import sys
-import math
-import json
 import ast
-
+import fcntl
+import json
+import logging
+import math
+import os
+import random
+import re
+import shutil
+import sys
+import time
 from functools import partial, reduce
 from operator import mul
 
 import aexpect
-from aexpect import remote
-
-from avocado.core import exceptions
-from avocado.utils import process
-from avocado.utils import crypto
-from avocado.utils import linux_modules
-from avocado.utils.astring import to_text
-
 import six
+from aexpect import remote
+from avocado.core import exceptions
+from avocado.utils import crypto, linux_modules, process
+from avocado.utils.astring import to_text
 from six.moves import xrange
 
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest import utils_qemu
-from virttest import cpu
-from virttest import virt_vm
-from virttest import test_setup
-from virttest import qemu_migration
-from virttest import qemu_monitor
-from virttest import qemu_virtio_port
-from virttest import data_dir
-from virttest import utils_net
-from virttest import arch
-from virttest import storage
-from virttest import error_context
-from virttest import utils_vsock
-from virttest import utils_vdpa
-from virttest import error_event
-from virttest.qemu_devices import qdevices, qcontainer
-from virttest.qemu_devices.utils import DeviceError, set_cmdline_format_by_cfg
+from virttest import (
+    arch,
+    cpu,
+    data_dir,
+    error_context,
+    error_event,
+    qemu_migration,
+    qemu_monitor,
+    qemu_virtio_port,
+    storage,
+    test_setup,
+    utils_logfile,
+    utils_misc,
+    utils_net,
+    utils_qemu,
+    utils_vdpa,
+    utils_vsock,
+    virt_vm,
+)
 from virttest.qemu_capabilities import Flags
+from virttest.qemu_devices import qcontainer, qdevices
+from virttest.qemu_devices.utils import DeviceError, set_cmdline_format_by_cfg
 from virttest.utils_params import Params
 from virttest.utils_version import VersionInterval
-
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -2,23 +2,21 @@
 Functions and classes used for logging into guests and transferring files.
 """
 from __future__ import division
+
 import logging
-import time
-import re
 import os
+import re
 import shutil
 import tempfile
+import time
 
 import aexpect
 from aexpect.remote import *
-
 from avocado.core import exceptions
 from avocado.utils import process
 
-from virttest import data_dir
-from virttest import utils_logfile
-from virttest.remote_commander import remote_master
-from virttest.remote_commander import messenger
+from virttest import data_dir, utils_logfile
+from virttest.remote_commander import messenger, remote_master
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/remote_build.py
+++ b/virttest/remote_build.py
@@ -1,12 +1,11 @@
-import os
-import re
 import hashlib
 import logging
+import os
+import re
 
 from aexpect import remote
 
 from virttest import data_dir
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/remote_commander/messenger.py
+++ b/virttest/remote_commander/messenger.py
@@ -7,12 +7,12 @@ Created on Dec 6, 2013
 :contact: Andrei Stepanov <astepano@redhat.com>
 """
 
-import os
-import logging
-import select
-import time
 import base64
 import importlib
+import logging
+import os
+import select
+import time
 
 try:
     from cStringIO import StringIO

--- a/virttest/remote_commander/remote_master.py
+++ b/virttest/remote_commander/remote_master.py
@@ -8,12 +8,12 @@ Created on Dec 6, 2013
 """
 
 from __future__ import division
+
+import inspect
 import sys
 import time
-import inspect
 
-from virttest.remote_commander import remote_interface
-from virttest.remote_commander import messenger
+from virttest.remote_commander import messenger, remote_interface
 
 
 def getsource(obj):

--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -7,21 +7,21 @@ Created on Dec 6, 2013
 :contact: Andrei Stepanov <astepano@redhat.com>
 """
 
-import os
-import sys
-import importlib
-import select
-import time
-import stat
 import gc
+import importlib
 import logging
-import traceback
-import subprocess
-import string
+import os
 import random
+import select
 import shutil
 import signal
+import stat
+import string
+import subprocess
+import sys
 import tempfile
+import time
+import traceback
 
 if __name__ == "__main__":
     remote_interface = importlib.import_module("remote_interface")
@@ -30,9 +30,7 @@ else:
     from virttest.remote_commander import remote_interface
     from virttest.remote_commander import messenger as ms
 
-
 from six.moves import input
-
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/virttest/scan_autotest_results.py
+++ b/virttest/scan_autotest_results.py
@@ -100,9 +100,9 @@ def main(resfiles):
 
 
 if __name__ == "__main__":
-    import sys
     import glob
     import os
+    import sys
 
     dirname = os.path.dirname(sys.modules[__name__].__file__)
     CLIENT_DIR = os.path.abspath(os.path.join(dirname, ".."))

--- a/virttest/scheduler.py
+++ b/virttest/scheduler.py
@@ -3,8 +3,7 @@ import select
 
 import aexpect
 
-from virttest import utils_env
-from virttest import virt_vm
+from virttest import utils_env, virt_vm
 
 
 class scheduler:

--- a/virttest/shared/deps/run_autotest/boottool.py
+++ b/virttest/shared/deps/run_autotest/boottool.py
@@ -6,20 +6,19 @@ A boottool clone, but written in python and relying mostly on grubby[1].
 [1] - http://git.fedorahosted.org/git/?p=grubby.git
 """
 
+import logging
+import optparse
 import os
 import re
-import sys
-import optparse
-import logging
-import subprocess
-import tarfile
-import tempfile
 import shutil
 import struct
+import subprocess
+import sys
+import tarfile
+import tempfile
 
 import six
 from six.moves import urllib
-
 
 #
 # Get rid of DeprecationWarning messages on newer Python version while still

--- a/virttest/shared/deps/run_autotest/kernel_install/kernelinstall.py
+++ b/virttest/shared/deps/run_autotest/kernel_install/kernelinstall.py
@@ -1,10 +1,9 @@
-import os
 import logging
+import os
 import sys
 
-from autotest.client import test
-from autotest.client import utils
-from autotest.client.shared import git, error, software_manager
+from autotest.client import test, utils
+from autotest.client.shared import error, git, software_manager
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/shared/deps/serial/VirtIoChannel_guest_send_receive.py
+++ b/virttest/shared/deps/serial/VirtIoChannel_guest_send_receive.py
@@ -8,10 +8,10 @@
 # LICENSE_GPL_v2 which accompany this distribution.
 #
 
-import os
-import struct
-import platform
 import optparse
+import os
+import platform
+import struct
 
 try:
     import hashlib

--- a/virttest/shared/deps/serial/serial_host_send_receive.py
+++ b/virttest/shared/deps/serial/serial_host_send_receive.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 
+import optparse
 import os
 import socket
 import struct
-import optparse
 
 try:
     import hashlib

--- a/virttest/shared/deps/serial/windows_support.py
+++ b/virttest/shared/deps/serial/windows_support.py
@@ -1,9 +1,9 @@
-import win32security
-import win32file
-import win32event
-import win32con
-import win32api
 import pywintypes
+import win32api
+import win32con
+import win32event
+import win32file
+import win32security
 
 
 class WinBufferedReadFile(object):

--- a/virttest/shared/scripts/cb.py
+++ b/virttest/shared/scripts/cb.py
@@ -1,11 +1,11 @@
 import pygtk
 
 pygtk.require("2.0")
-import gtk
-import sys
 import os
+import sys
 from optparse import OptionParser
 
+import gtk
 from six.moves import xrange
 
 

--- a/virttest/shared/scripts/cmd_runner.py
+++ b/virttest/shared/scripts/cmd_runner.py
@@ -3,13 +3,13 @@ This script is used to execute a program and collect the monitor
 information in background, redirect the outputs to log files.
 """
 
-import threading
-import shelve
-import re
 import os
-import sys
 import random
+import re
+import shelve
 import string
+import sys
+import threading
 
 
 def getstatusoutput(cmd):

--- a/virttest/shared/scripts/dd.py
+++ b/virttest/shared/scripts/dd.py
@@ -1,6 +1,5 @@
-import sys
 import os
-
+import sys
 
 if len(sys.argv) != 3:
     print("Useage: %s path size")

--- a/virttest/shared/scripts/duplicate_pages.py
+++ b/virttest/shared/scripts/duplicate_pages.py
@@ -2,7 +2,6 @@
 
 import os
 
-
 mem_fd = open("/proc/meminfo", "r")
 contents = mem_fd.readlines()
 mem_fd.close()

--- a/virttest/shared/scripts/ksm_overcommit_guest.py
+++ b/virttest/shared/scripts/ksm_overcommit_guest.py
@@ -8,17 +8,17 @@ Auxiliary script used to allocate memory on guests.
 """
 
 from __future__ import division
-import os
+
 import array
-import sys
-import random
 import copy
-import tempfile
 import datetime
 import math
+import os
+import random
+import sys
+import tempfile
 
 from six.moves import input
-
 
 PAGE_SIZE = 4096  # machine page size
 

--- a/virttest/shared/scripts/multicast_guest.py
+++ b/virttest/shared/scripts/multicast_guest.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-import socket
-import struct
 import os
 import signal
+import socket
+import struct
 import sys
 
 # -*- coding: utf-8 -*-

--- a/virttest/shared/scripts/telnet.py
+++ b/virttest/shared/scripts/telnet.py
@@ -1,6 +1,6 @@
-import telnetlib
-import sys
 import os
+import sys
+import telnetlib
 
 if len(sys.argv) != 5:
     print("Usage: %s host_ip user password prompt" % sys.argv[0])

--- a/virttest/shared/scripts/virtio_console_guest.py
+++ b/virttest/shared/scripts/virtio_console_guest.py
@@ -8,20 +8,21 @@ Auxiliary script used to send data between ports on guests.
 :author: Lukas Doktor (ldoktor@redhat.com)
 """
 from __future__ import division
-import threading
-from threading import Thread
-import os
-import select
-import re
-import random
-import sys
+
 import array
-import stat
-import traceback
-import signal
-import time
+import os
 import platform
+import random
+import re
+import select
+import signal
+import stat
+import sys
+import threading
+import time
+import traceback
 from distutils.version import LooseVersion  # pylint: disable=W0611,E0611
+from threading import Thread
 
 # For Python 2 and 3 compatibility
 # xrange

--- a/virttest/ssh_key.py
+++ b/virttest/ssh_key.py
@@ -1,11 +1,9 @@
-import os
 import logging
+import os
 
 import aexpect
 from aexpect import remote
-
-from avocado.utils import process
-from avocado.utils import path
+from avocado.utils import path, process
 
 from virttest import remote as remote_old
 

--- a/virttest/staging/__init__.py
+++ b/virttest/staging/__init__.py
@@ -1,5 +1,2 @@
 __all__ = ["service", "utils_cgroup", "utils_koji", "utils_memory"]
-from virttest.staging import service
-from virttest.staging import utils_cgroup
-from virttest.staging import utils_koji
-from virttest.staging import utils_memory
+from virttest.staging import service, utils_cgroup, utils_koji, utils_memory

--- a/virttest/staging/lv_utils.py
+++ b/virttest/staging/lv_utils.py
@@ -39,8 +39,8 @@ The ramdisk volume group size is in MB.
 """
 
 import logging
-import re
 import os
+import re
 import shutil
 import time
 

--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -16,13 +16,12 @@
 #  The full GNU General Public License is included in this distribution in
 #  the file called "COPYING".
 
+import logging
 import os
 import re
-import logging
 from tempfile import mktemp
 
 from avocado.utils import process
-
 
 _COMMAND_TABLE_DOC = """
 

--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -8,17 +8,17 @@ Helpers for cgroup testing.
 """
 import logging
 import os
+import random
+import re
 import shutil
 import subprocess
 import time
-import re
-import random
-import six
 from tempfile import mkdtemp
 
+import six
 from avocado.core import exceptions
-from avocado.utils.software_manager import manager
 from avocado.utils import process
+from avocado.utils.software_manager import manager
 
 from . import service
 

--- a/virttest/staging/utils_koji.py
+++ b/virttest/staging/utils_koji.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import time
-import logging
 
 try:
     from html.parser import HTMLParser
@@ -11,12 +11,8 @@ try:
 except ImportError:
     import ConfigParser
 
-from avocado.utils import astring
-from avocado.utils import path
-from avocado.utils import download
-
+from avocado.utils import astring, download, path
 from six.moves import urllib
-
 
 try:
     import koji

--- a/virttest/staging/utils_memory.py
+++ b/virttest/staging/utils_memory.py
@@ -1,8 +1,9 @@
 from __future__ import division
-import re
-import math
+
 import logging
+import math
 import os
+import re
 
 from avocado.core import exceptions
 from avocado.utils import process

--- a/virttest/standalone_test.py
+++ b/virttest/standalone_test.py
@@ -2,8 +2,7 @@ import os
 
 from avocado.utils import path as utils_path
 
-from . import data_dir
-from . import cartesian_config
+from . import cartesian_config, data_dir
 from .compat import get_opt
 
 GUEST_NAME_LIST = None

--- a/virttest/step_editor.py
+++ b/virttest/step_editor.py
@@ -6,11 +6,11 @@ Step file creator/editor.
 :author: mgoldish@redhat.com (Michael Goldish)
 """
 
-import os
 import glob
+import logging
+import os
 import shutil
 import sys
-import logging
 
 try:
     from gi import pygtkcompat as pygtk
@@ -22,7 +22,6 @@ if pygtk is not None:
 import gtk
 
 from virttest import ppm_utils
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -6,32 +6,35 @@ This exports:
   - class for image operates and basic parameters
 """
 from __future__ import division
+
+import collections
 import errno
+import functools
+import json
 import logging
 import os
-import shutil
 import re
-import functools
-import collections
-import json
+import shutil
 
 from avocado.core import exceptions
 from avocado.utils import process
 
-from virttest import storage_ssh
-from virttest import nbd
-from virttest import curl
-from virttest import iscsi
-from virttest import utils_misc
-from virttest import utils_numeric
-from virttest import utils_params
-from virttest import virt_vm
-from virttest import gluster
-from virttest import lvm
-from virttest import ceph
-from virttest import nvme
-from virttest import data_dir
-from virttest import vdpa_blk
+from virttest import (
+    ceph,
+    curl,
+    data_dir,
+    gluster,
+    iscsi,
+    lvm,
+    nbd,
+    nvme,
+    storage_ssh,
+    utils_misc,
+    utils_numeric,
+    utils_params,
+    vdpa_blk,
+    virt_vm,
+)
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/storage_ssh.py
+++ b/virttest/storage_ssh.py
@@ -1,6 +1,6 @@
-from virttest import error_context
-
 from avocado.utils import process
+
+from virttest import error_context
 
 
 @error_context.context_aware

--- a/virttest/syslog_server.py
+++ b/virttest/syslog_server.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 
 try:
     import SocketServer as socketserver

--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -1,46 +1,39 @@
 """Library to perform pre/post test setup for virt test."""
 from __future__ import division
-import os
-import logging
-import time
-import re
-import random
-import math
-import shutil
-import platform
-import ipaddress
-import six
 
+import ipaddress
+import logging
+import math
+import os
+import platform
+import random
+import re
+import shutil
+import time
 from pathlib import Path
 
+import six
 from aexpect import remote
-
-from avocado.utils import process
-from avocado.utils import archive
-from avocado.utils import wait
-from avocado.utils import genio
-from avocado.utils import path
-from avocado.utils import distro
-from avocado.utils import linux_modules
 from avocado.core import exceptions
+from avocado.utils import archive, distro, genio, linux_modules, path, process, wait
 
-from virttest import data_dir
-from virttest import error_context
-from virttest import cpu
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest import versionable_class
-from virttest import openvswitch
-from virttest import utils_libvirtd
-from virttest import utils_net
-from virttest import utils_config
-from virttest import utils_package
-from virttest import kernel_interface
-from virttest import libvirt_version
-from virttest import utils_split_daemons
-from virttest.staging import service
-from virttest.staging import utils_memory
-
+from virttest import (
+    cpu,
+    data_dir,
+    error_context,
+    kernel_interface,
+    libvirt_version,
+    openvswitch,
+    utils_config,
+    utils_libvirtd,
+    utils_logfile,
+    utils_misc,
+    utils_net,
+    utils_package,
+    utils_split_daemons,
+    versionable_class,
+)
+from virttest.staging import service, utils_memory
 
 ARCH = platform.machine()
 

--- a/virttest/test_setup/core.py
+++ b/virttest/test_setup/core.py
@@ -1,8 +1,7 @@
 import logging
-import six
+from abc import ABCMeta, abstractmethod
 
-from abc import ABCMeta
-from abc import abstractmethod
+import six
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/test_setup/libvirt_setup.py
+++ b/virttest/test_setup/libvirt_setup.py
@@ -1,5 +1,5 @@
-from virttest.test_setup.core import Setuper
 from virttest import test_setup
+from virttest.test_setup.core import Setuper
 
 
 class LibvirtdDebugLogConfig(Setuper):

--- a/virttest/test_setup/networking.py
+++ b/virttest/test_setup/networking.py
@@ -3,8 +3,8 @@
 import re
 import urllib.request
 
-from virttest.test_setup.core import Setuper
 from virttest.test_setup import PrivateBridgeConfig, PrivateOvsBridgeConfig
+from virttest.test_setup.core import Setuper
 
 
 class NetworkProxies(Setuper):

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1,12 +1,13 @@
 from __future__ import division
+
 import logging
-import time
-import re
 import os
-import tempfile
-import threading
+import re
 import shutil
 import stat
+import tempfile
+import threading
+import time
 import xml.dom.minidom
 
 try:
@@ -15,29 +16,25 @@ except ImportError:
     import ConfigParser
 
 from aexpect import remote
-
 from avocado.core import exceptions
-from avocado.utils import astring
-from avocado.utils import iso9660
-from avocado.utils import process
-from avocado.utils import crypto
-from avocado.utils import download
+from avocado.utils import astring, crypto, download, iso9660, process
 
-from virttest import virt_vm
-from virttest import asset
-from virttest import utils_disk
-from virttest import qemu_monitor
-from virttest import syslog_server
-from virttest import http_server
-from virttest import data_dir
-from virttest import utils_net
-from virttest import utils_test
-from virttest import utils_misc
-from virttest import funcatexit
-from virttest import storage
-from virttest import error_context
-from virttest import qemu_storage
-
+from virttest import (
+    asset,
+    data_dir,
+    error_context,
+    funcatexit,
+    http_server,
+    qemu_monitor,
+    qemu_storage,
+    storage,
+    syslog_server,
+    utils_disk,
+    utils_misc,
+    utils_net,
+    utils_test,
+    virt_vm,
+)
 
 # Whether to print all shell commands called
 DEBUG = False

--- a/virttest/unittest_utils/mock.py
+++ b/virttest/unittest_utils/mock.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 import collections
 import re
 import sys
@@ -6,7 +7,6 @@ import sys
 import six
 from six import StringIO
 from six import string_types as basestring
-
 
 __author__ = "raphtee@google.com (Travis Miller)"
 

--- a/virttest/unittests/libvirt_xml/device_xml/test_controller_xml.py
+++ b/virttest/unittests/libvirt_xml/device_xml/test_controller_xml.py
@@ -2,7 +2,6 @@ import unittest
 
 from virttest.libvirt_xml.devices import controller
 
-
 XM_PCI = """
     <controller type='pci' index='1' model='pcie-root-port'>
       <model name='pcie-root-port'/>

--- a/virttest/unittests/libvirt_xml/device_xml/test_interface_xml.py
+++ b/virttest/unittests/libvirt_xml/device_xml/test_interface_xml.py
@@ -2,7 +2,6 @@ import unittest
 
 from virttest.libvirt_xml.devices import interface
 
-
 XML = """
   <interface type='network'>
     <source network='default' portgroup='engineering'/>

--- a/virttest/unittests/test_utils_misc.py
+++ b/virttest/unittests/test_utils_misc.py
@@ -1,8 +1,7 @@
-import unittest
 import logging
+import unittest
 
 from virttest import utils_misc
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/unittests/test_utils_test__init__.py
+++ b/virttest/unittests/test_utils_test__init__.py
@@ -1,14 +1,15 @@
-import unittest
 import logging
+import unittest
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-from virttest.utils_test import update_boot_option
-from virttest import utils_test
 from avocado.core import exceptions
+
+from virttest import utils_test
+from virttest.utils_test import update_boot_option
 
 check_kernel_cmdline_mock = mock.MagicMock(return_value=["3", None])
 

--- a/virttest/utils_backup.py
+++ b/virttest/utils_backup.py
@@ -1,21 +1,16 @@
+import filecmp
+import json
 import logging
 import os
-import json
-import filecmp
-
 import xml.etree.ElementTree as ET
 
-from avocado.utils import process
 from avocado.core import exceptions
+from avocado.utils import process
 
-from virttest import utils_misc
-from virttest import virsh
-from virttest import libvirt_version
-from virttest import data_dir
+from virttest import data_dir, libvirt_version, utils_misc, virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.backup_xml import BackupXML
 from virttest.libvirt_xml.checkpoint_xml import CheckpointXML
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -1,6 +1,7 @@
 import ast
 import logging
 import os.path
+
 from six import StringIO
 
 try:

--- a/virttest/utils_conn.py
+++ b/virttest/utils_conn.py
@@ -9,19 +9,18 @@ import tempfile
 
 import aexpect
 from aexpect import remote
-
 from avocado.core import exceptions
-from avocado.utils import path
-from avocado.utils import process
+from avocado.utils import path, process
 
-from virttest import propcan, utils_libvirtd
+from virttest import data_dir, libvirt_version, propcan
 from virttest import remote as remote_old
-from virttest import data_dir
-from virttest import utils_misc
-from virttest import utils_package
-from virttest import libvirt_version
-from virttest import utils_split_daemons
-from virttest import utils_iptables
+from virttest import (
+    utils_iptables,
+    utils_libvirtd,
+    utils_misc,
+    utils_package,
+    utils_split_daemons,
+)
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -3,32 +3,29 @@ Virtualization test - Virtual disk related utility functions
 
 :copyright: Red Hat Inc.
 """
-import os
 import glob
-import shutil
-import stat
+import logging
+import os
 import platform
 import random
+import re
+import shutil
+import stat
 import string
 import tempfile
-import logging
-import re
 
 try:
     import configparser as ConfigParser
 except ImportError:
     import ConfigParser
+
 from functools import cmp_to_key
 
 from avocado.core import exceptions
-from avocado.utils import process
-from avocado.utils import wait
+from avocado.utils import process, wait
 from avocado.utils.service import SpecificServiceManager
 
-from virttest import error_context
-from virttest import utils_numeric
-from virttest import utils_misc
-from virttest import remote
+from virttest import error_context, remote, utils_misc, utils_numeric
 
 PARTITION_TABLE_TYPE_MBR = "msdos"
 PARTITION_TABLE_TYPE_GPT = "gpt"

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -1,7 +1,7 @@
-import os
-import logging
-import threading
 import functools
+import logging
+import os
+import threading
 
 try:
     from collections import UserDict as IterableUserDict
@@ -13,11 +13,9 @@ except ImportError:
     import cPickle
 
 from aexpect import remote
-
 from avocado.core import exceptions
 
-from virttest import virt_vm
-from virttest import ip_sniffing
+from virttest import ip_sniffing, virt_vm
 
 ENV_VERSION = 1
 

--- a/virttest/utils_gdb.py
+++ b/virttest/utils_gdb.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 import signal
 import threading
 
@@ -8,9 +8,10 @@ try:
 except ImportError:
     import Queue
 
+from enum import Enum
+
 import aexpect
 
-from enum import Enum
 from virttest import utils_misc
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/utils_hotplug.py
+++ b/virttest/utils_hotplug.py
@@ -18,8 +18,8 @@
 
 
 import logging
-from virttest.libvirt_xml.devices import memory
 
+from virttest.libvirt_xml.devices import memory
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_iptables.py
+++ b/virttest/utils_iptables.py
@@ -4,9 +4,8 @@ Library to perform iptables configuration for virt test.
 import logging
 
 from aexpect import remote
-
-from avocado.utils import process
 from avocado.core import exceptions
+from avocado.utils import process
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_kernel_module.py
+++ b/virttest/utils_kernel_module.py
@@ -16,8 +16,8 @@
 Handle Linux kernel modules
 """
 
-import os
 import logging
+import os
 
 from avocado.utils import process
 

--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -3,13 +3,12 @@ libguestfs tools test utility functions.
 """
 
 import logging
-import signal
 import os
 import re
+import signal
 
 import aexpect
-from avocado.utils import path
-from avocado.utils import process
+from avocado.utils import path, process
 
 from . import propcan
 

--- a/virttest/utils_libvirt/libvirt_bios.py
+++ b/virttest/utils_libvirt/libvirt_bios.py
@@ -6,7 +6,6 @@ Libvirt BIOS related utilities.
 
 import logging
 
-
 LOG = logging.getLogger("avocado." + __name__)
 
 

--- a/virttest/utils_libvirt/libvirt_ceph_utils.py
+++ b/virttest/utils_libvirt/libvirt_ceph_utils.py
@@ -12,15 +12,10 @@ import os
 from avocado.core import exceptions
 from avocado.utils import process
 
-from virttest import ceph
-from virttest import data_dir
-from virttest import utils_package
-from virttest import virsh
-
-from virttest.utils_test import libvirt
-from virttest.utils_libvirt import libvirt_disk
-
+from virttest import ceph, data_dir, utils_package, virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_config.py
+++ b/virttest/utils_libvirt/libvirt_config.py
@@ -7,10 +7,7 @@ import re
 
 from avocado.core import exceptions
 
-from virttest import utils_config
-from virttest import utils_libvirtd
-from virttest import utils_split_daemons
-from virttest import remote
+from virttest import remote, utils_config, utils_libvirtd, utils_split_daemons
 from virttest.utils_test import libvirt
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/utils_libvirt/libvirt_disk.py
+++ b/virttest/utils_libvirt/libvirt_disk.py
@@ -11,15 +11,10 @@ from avocado.utils import process
 
 from virttest import libvirt_storage
 from virttest import remote as remote_old
-from virttest import utils_misc
-from virttest import utils_disk
-from virttest import virsh
-from virttest import utils_package
-
+from virttest import utils_disk, utils_misc, utils_package, virsh
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_test import libvirt
-
 from virttest.libvirt_xml.devices.disk import Disk
+from virttest.utils_test import libvirt
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_embedded_qemu.py
+++ b/virttest/utils_libvirt/libvirt_embedded_qemu.py
@@ -1,16 +1,14 @@
 """
 Classes and functions for embedded qemu driver.
 """
-import re
 import logging
+import re
 
 import aexpect
 from avocado.core import exceptions
-from avocado.utils import path
-from avocado.utils import process
+from avocado.utils import path, process
 
-from virttest import utils_split_daemons
-from virttest import utils_misc
+from virttest import utils_misc, utils_split_daemons
 
 try:
     path.find_command("virt-qemu-run")

--- a/virttest/utils_libvirt/libvirt_misc.py
+++ b/virttest/utils_libvirt/libvirt_misc.py
@@ -4,8 +4,8 @@ Virtualization test - utility functions for libvirt
 :copyright: 2021 Red Hat Inc.
 """
 
-import re
 import logging
+import re
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_monitor.py
+++ b/virttest/utils_libvirt/libvirt_monitor.py
@@ -4,8 +4,7 @@ import math
 
 from avocado.core import exceptions
 
-from virttest import libvirt_version
-from virttest import virsh
+from virttest import libvirt_version, virsh
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_nested.py
+++ b/virttest/utils_libvirt/libvirt_nested.py
@@ -3,9 +3,7 @@ import logging
 from avocado.core import exceptions
 from avocado.utils import process
 
-from virttest import cpu
-from virttest import utils_package
-
+from virttest import cpu, utils_package
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_network.py
+++ b/virttest/utils_libvirt/libvirt_network.py
@@ -1,18 +1,14 @@
 """
 Virsh net* command related utility functions
 """
-import re
-import logging
 import ast
+import logging
+import re
 
 from avocado.core import exceptions
 from avocado.utils import process
 
-from virttest import virsh
-from virttest import remote
-from virttest import utils_misc
-from virttest import utils_iptables
-
+from virttest import remote, utils_iptables, utils_misc, virsh
 from virttest.libvirt_xml import NetworkXML
 from virttest.utils_test import libvirt
 

--- a/virttest/utils_libvirt/libvirt_numa.py
+++ b/virttest/utils_libvirt/libvirt_numa.py
@@ -4,8 +4,8 @@ http://libvirt.org/formatdomain.html
 """
 
 
-import logging
 import ast
+import logging
 
 from avocado.core import exceptions
 

--- a/virttest/utils_libvirt/libvirt_pcicontr.py
+++ b/virttest/utils_libvirt/libvirt_pcicontr.py
@@ -6,8 +6,8 @@ Accommodate libvirt pci controller utility functions.
 
 import logging
 
-from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_secret.py
+++ b/virttest/utils_libvirt/libvirt_secret.py
@@ -6,12 +6,11 @@ import logging
 import re
 
 from aexpect import remote
-
 from avocado.core import exceptions
 
 from virttest import virsh
-from virttest.utils_test import libvirt
 from virttest.libvirt_xml import secret_xml
+from virttest.utils_test import libvirt
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_service.py
+++ b/virttest/utils_libvirt/libvirt_service.py
@@ -2,9 +2,7 @@ import logging
 
 from avocado.utils import process
 
-from virttest import utils_libvirtd
-from virttest import remote
-
+from virttest import remote, utils_libvirtd
 from virttest.staging import service
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/utils_libvirt/libvirt_unprivileged.py
+++ b/virttest/utils_libvirt/libvirt_unprivileged.py
@@ -1,9 +1,8 @@
 import logging
 
 import aexpect
-from virttest import libvirt_vm
-from virttest import remote
-from virttest import utils_params
+
+from virttest import libvirt_vm, remote, utils_params
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirt/libvirt_virtio.py
+++ b/virttest/utils_libvirt/libvirt_virtio.py
@@ -8,8 +8,8 @@ import logging
 
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import iommu
-from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -1,16 +1,13 @@
 """
 Module to control libvirtd service.
 """
-import re
 import logging
+import re
 
 import aexpect
-from avocado.utils import path
-from avocado.utils import process
-from avocado.utils import wait
+from avocado.utils import path, process, wait
 
-from virttest import libvirt_version
-from virttest import utils_split_daemons
+from virttest import libvirt_version, utils_split_daemons
 
 from . import remote as remote_old
 from . import utils_misc

--- a/virttest/utils_logfile.py
+++ b/virttest/utils_logfile.py
@@ -10,8 +10,8 @@ Naive module that keeps tacks of some opened files and somehow manages them.
 import logging
 import os
 import re
-import time
 import threading
+import time
 
 from avocado.core import exceptions
 from avocado.utils import aurl

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -5,31 +5,32 @@ Virtualization test utility functions.
 """
 
 from __future__ import division
-import time
-import string
-import random
-import socket
-import os
-import stat
-import signal
-import re
-import logging
-import subprocess
-import fcntl
-import sys
-import inspect
-import tarfile
-import shutil
-import getpass
-import ctypes
-import threading
-import platform
-import traceback
-import math
-import select
-import aexpect
 
+import ctypes
+import fcntl
+import getpass
+import inspect
+import logging
+import math
+import os
+import platform
+import random
+import re
+import select
+import shutil
+import signal
+import socket
+import stat
+import string
+import subprocess
+import sys
+import tarfile
+import threading
+import time
+import traceback
 from hashlib import md5
+
+import aexpect
 
 try:
     from io import BytesIO
@@ -42,25 +43,18 @@ except NameError:
     basestring = (str, bytes)
 
 from avocado.core import exceptions
-from avocado.utils import distro
-from avocado.utils import git
+from avocado.utils import aurl, distro, download, genio, git, linux_modules, memory
 from avocado.utils import path as utils_path
 from avocado.utils import process
-from avocado.utils import genio
-from avocado.utils import aurl
-from avocado.utils import download
-from avocado.utils import linux_modules
-from avocado.utils import memory
 from avocado.utils.astring import to_text
 
+# pylint: disable=W0611
 # Symlink avocado implementation of process functions
-from avocado.utils.process import CmdResult
+from avocado.utils.process import kill_process_by_pattern  # pylint: disable=W0611
 from avocado.utils.process import pid_exists  # pylint: disable=W0611
 from avocado.utils.process import safe_kill  # pylint: disable=W0611
+from avocado.utils.process import CmdResult
 from avocado.utils.process import kill_process_tree as _kill_process_tree
-from avocado.utils.process import kill_process_by_pattern  # pylint: disable=W0611
-
-# pylint: disable=W0611
 from avocado.utils.process import (
     process_in_ptree_is_defunct as process_or_children_is_defunct,
 )
@@ -68,29 +62,28 @@ from avocado.utils.process import (
 # Symlink avocado implementation of port-related functions
 
 try:
-    from avocado.utils.network.ports import is_port_free  # pylint: disable=W0611
     from avocado.utils.network.ports import find_free_port  # pylint: disable=W0611
     from avocado.utils.network.ports import find_free_ports  # pylint: disable=W0611
+    from avocado.utils.network.ports import is_port_free  # pylint: disable=W0611
 except ImportError:
     from avocado.utils.network import is_port_free  # pylint: disable=W0611
     from avocado.utils.network import find_free_port  # pylint: disable=W0611
     from avocado.utils.network import find_free_ports  # pylint: disable=W0611
 
-from virttest import data_dir
-from virttest import error_context
-from virttest import utils_selinux
-from virttest import utils_disk
-from virttest import utils_logfile
-from virttest import logging_manager
-from virttest import kernel_interface
-
-from virttest.staging import utils_koji
-from virttest.staging import service
-from virttest.xml_utils import XMLTreeFile
-
-
 import six
 from six.moves import xrange
+
+from virttest import (
+    data_dir,
+    error_context,
+    kernel_interface,
+    logging_manager,
+    utils_disk,
+    utils_logfile,
+    utils_selinux,
+)
+from virttest.staging import service, utils_koji
+from virttest.xml_utils import XMLTreeFile
 
 LOG = logging.getLogger("avocado." + __name__)
 
@@ -4481,6 +4474,7 @@ def get_sosreport(
     """
     from aexpect import remote
     from avocado.core import data_dir
+
     from virttest import utils_package
 
     if "ubuntu" in get_distro(session=session).lower():

--- a/virttest/utils_nbd.py
+++ b/virttest/utils_nbd.py
@@ -16,11 +16,8 @@ import shutil
 
 from avocado.utils import process
 
-from virttest import utils_config
-from virttest import utils_libvirtd
-from virttest import utils_net
-
-from virttest.utils_conn import build_server_key, build_CA, build_client_key
+from virttest import utils_config, utils_libvirtd, utils_net
+from virttest.utils_conn import build_CA, build_client_key, build_server_key
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1,50 +1,45 @@
-import re
-import os
-import socket
-import fcntl
 import errno
-import struct
-import logging
-import random
-import math
-import time
-import shelve
-import signal
-import sys
-import netifaces
-import platform
-import uuid
+import fcntl
 import hashlib
-import shutil
-import json
 import ipaddress as pyipaddr
+import json
+import logging
+import math
+import os
+import platform
+import random
+import re
+import shelve
+import shutil
+import signal
+import socket
+import struct
+import sys
+import time
+import uuid
 
 import aexpect
+import netifaces
+import six
 from aexpect import remote
-
 from avocado.core import exceptions
 from avocado.utils import path as utils_path
-from avocado.utils import process
-from avocado.utils import stacktrace
-
-import six
+from avocado.utils import process, stacktrace
 from six.moves import xrange
 
-from virttest import openvswitch
-from virttest import data_dir
-from virttest import propcan
-from virttest import utils_misc
-from virttest import arch
-from virttest import utils_selinux
-from virttest import utils_package
-
+from virttest import (
+    arch,
+    data_dir,
+    openvswitch,
+    propcan,
+    utils_misc,
+    utils_package,
+    utils_selinux,
+)
 from virttest.remote import RemoteRunner
-from virttest.staging import utils_memory
-from virttest.staging import service
+from virttest.staging import service, utils_memory
+from virttest.utils_windows import system, virtio_win
 from virttest.versionable_class import factory
-from virttest.utils_windows import virtio_win
-from virttest.utils_windows import system
-
 
 try:
     unicode

--- a/virttest/utils_netperf.py
+++ b/virttest/utils_netperf.py
@@ -1,15 +1,11 @@
+import logging
 import ntpath
 import os
-import logging
 import re
 
 import aexpect
 from aexpect import remote
-
-from avocado.utils import download
-from avocado.utils import aurl
-from avocado.utils import wait
-
+from avocado.utils import aurl, download, wait
 from six.moves import xrange
 
 from . import data_dir

--- a/virttest/utils_npiv.py
+++ b/virttest/utils_npiv.py
@@ -2,14 +2,12 @@ import logging
 import os
 import re
 import time
+from tempfile import mktemp
 
 from avocado.core import exceptions
 from avocado.utils import process
 
-from tempfile import mktemp
-
-from virttest import utils_misc
-from virttest import virsh
+from virttest import utils_misc, virsh
 from virttest.libvirt_xml.devices import hostdev
 from virttest.libvirt_xml.nodedev_xml import NodedevXML
 from virttest.utils_test import libvirt

--- a/virttest/utils_numeric.py
+++ b/virttest/utils_numeric.py
@@ -1,8 +1,8 @@
 from __future__ import division
-import re
+
 import math
-from decimal import Decimal
-from decimal import getcontext
+import re
+from decimal import Decimal, getcontext
 
 
 def align_value(value, factor=1024):

--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -2,14 +2,13 @@
 Package utility for manage package operation on host
 """
 import logging
-import aexpect
 
+import aexpect
 from avocado.core import exceptions
 from avocado.utils.software_manager import manager
 from six import string_types
 
-from virttest import utils_misc
-from virttest import vt_console
+from virttest import utils_misc, vt_console
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -4,10 +4,10 @@ try:
     from collections import UserDict as IterableUserDict
 except ImportError:
     from UserDict import IterableUserDict
+
 from collections import OrderedDict
 
 from avocado.core import exceptions
-
 from six.moves import xrange
 
 

--- a/virttest/utils_pyvmomi.py
+++ b/virttest/utils_pyvmomi.py
@@ -6,10 +6,9 @@ https://github.com/vmware/pyvmomi-community-samples
 """
 import datetime
 import logging
-
 from functools import wraps
 
-from pyVim.connect import SmartConnect, SmartConnectNoSSL, Disconnect
+from pyVim.connect import Disconnect, SmartConnect, SmartConnectNoSSL
 from pyVim.task import WaitForTask
 from pyVmomi import vim
 

--- a/virttest/utils_qemu.py
+++ b/virttest/utils_qemu.py
@@ -1,8 +1,8 @@
 """
 QEMU related utility functions.
 """
-import re
 import json
+import re
 
 from avocado.utils import process
 

--- a/virttest/utils_sasl.py
+++ b/virttest/utils_sasl.py
@@ -6,13 +6,10 @@ import logging
 
 import aexpect
 from aexpect import remote
-
 from avocado.core import exceptions
-from avocado.utils import path
-from avocado.utils import process
+from avocado.utils import path, process
 
-from virttest import propcan
-from virttest import virsh
+from virttest import propcan, virsh
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_scheduling.py
+++ b/virttest/utils_scheduling.py
@@ -3,8 +3,8 @@ Virtualization test utility functions.
 
 :copyright: 2008-2009 Red Hat Inc.
 """
-import multiprocessing.pool
 import functools
+import multiprocessing.pool
 
 
 def timeout(timeout):

--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -3,12 +3,10 @@ selinux test utility functions.
 """
 
 import logging
-import re
 import os
+import re
 
-from avocado.utils import process
-from avocado.utils import distro
-
+from avocado.utils import distro, process
 
 ubuntu = distro.detect().name == "Ubuntu"
 

--- a/virttest/utils_spice.py
+++ b/virttest/utils_spice.py
@@ -2,15 +2,15 @@
 Common spice test utility functions.
 
 """
-import os
 import logging
-import time
+import os
 import sys
+import time
 
 from aexpect import ShellCmdError, ShellStatusError
 from avocado.core import exceptions
 
-from . import utils_net, utils_misc
+from . import utils_misc, utils_net
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_split_daemons.py
+++ b/virttest/utils_split_daemons.py
@@ -1,18 +1,16 @@
 """
 Module to control split daemon service.
 """
-# pylint: disable=E0611
-import re
 import logging
 
-import aexpect
-from avocado.utils import process
-from avocado.utils import wait
-from avocado.core import exceptions
+# pylint: disable=E0611
+import re
 
-from virttest import libvirtd_decorator
-from virttest import remote
-from virttest import utils_misc
+import aexpect
+from avocado.core import exceptions
+from avocado.utils import process, wait
+
+from virttest import libvirtd_decorator, remote, utils_misc
 from virttest.staging import service
 from virttest.utils_gdb import GDB
 

--- a/virttest/utils_sriov.py
+++ b/virttest/utils_sriov.py
@@ -3,14 +3,12 @@ SRIOV related utility functions
 """
 
 import logging
-import re
 import os
+import re
 
 from avocado.core import exceptions
 
-from virttest import utils_misc
-from virttest import utils_net
-from virttest import utils_package
+from virttest import utils_misc, utils_net, utils_package
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_stress.py
+++ b/virttest/utils_stress.py
@@ -1,18 +1,16 @@
+import logging
 import os
 import random
-import time
 import threading
-import logging
+import time
 
-from avocado.utils import cpu
 from avocado.core import exceptions
+from avocado.utils import cpu
 
-from virttest import virsh
 from virttest import cpu as cpuutil
-from virttest import utils_net
-from virttest import utils_package
-from virttest.utils_test import libvirt
+from virttest import utils_net, utils_package, virsh
 from virttest.libvirt_xml.devices.disk import Disk
+from virttest.utils_test import libvirt
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_switchdev.py
+++ b/virttest/utils_switchdev.py
@@ -3,13 +3,12 @@ Virtualization test - SwitchDev related utilities
 
 :copyright: Red Hat Inc.
 """
-import os
 import logging
+import os
 
 from avocado.utils import process
 
 from virttest import utils_sriov
-
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -17,50 +17,43 @@ More specifically:
 """
 
 from __future__ import division
+
+import ast
+import functools
 import glob
 import locale
 import logging
 import os
 import re
+import shutil
 import signal
+import subprocess
 import tempfile
 import threading
 import time
-import subprocess
-import shutil
-import ast
-import functools
 
 import aexpect
 from aexpect import remote
-
 from avocado.core import exceptions
-from avocado.utils import process
-from avocado.utils import aurl
-from avocado.utils import download
-from avocado.utils import crypto
-from avocado.utils import path
-from avocado.utils import archive
-
+from avocado.utils import archive, aurl, crypto, download, path, process
 from six.moves import xrange
 
 # Import from the top level virttest namespace
-from virttest import asset
-from virttest import bootstrap
-from virttest import data_dir
-from virttest import error_context
-from virttest import qemu_virtio_port
+from virttest import asset, bootstrap, data_dir, error_context, qemu_virtio_port
 from virttest import remote as remote_old
-from virttest import scan_autotest_results
-from virttest import storage
-from virttest import utils_misc
-from virttest import utils_net
-from virttest import virt_vm
-from virttest import utils_package
-from virttest.utils_iptables import Iptables
-from virttest import data_dir
+from virttest import (
+    scan_autotest_results,
+    storage,
+    utils_misc,
+    utils_net,
+    utils_package,
+    virt_vm,
+)
+
+# lazy imports for dependencies that are not needed in all modes of use
+from virttest._wrappers import import_module, lazy_import
 from virttest.staging import utils_memory
-from virttest._wrappers import import_module
+from virttest.utils_iptables import Iptables
 
 # Get back to importing submodules
 # This is essential for accessing these submodules directly from
@@ -70,9 +63,6 @@ from virttest._wrappers import import_module
 #
 # pylint: disable=unused-import
 from virttest.utils_test import qemu
-
-# lazy imports for dependencies that are not needed in all modes of use
-from virttest._wrappers import lazy_import
 
 libvirt = lazy_import("virttest.utils_test.libvirt")
 libguestfs = lazy_import("virttest.utils_test.libguestfs")

--- a/virttest/utils_test/libguestfs.py
+++ b/virttest/utils_test/libguestfs.py
@@ -1,14 +1,13 @@
-import re
-import os
 import logging
+import os
+import re
 
 from avocado.core import exceptions
 from avocado.utils import process
 
-from .. import virsh, virt_vm, libvirt_vm, data_dir
-from .. import utils_net, xml_utils
+from .. import data_dir, libvirt_vm, qemu_storage
 from .. import utils_libguestfs as lgf
-from .. import qemu_storage
+from .. import utils_net, virsh, virt_vm, xml_utils
 from ..libvirt_xml import vm_xml, xcepts
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -17,70 +17,68 @@ More specifically:
 """
 
 from __future__ import division
-import re
-import os
+
 import ast
 import logging
-import shutil
-import time
-import sys
-import aexpect
+import os
 import platform
 import random
-import string
+import re
 import shutil
+import string
+import sys
+import time
 
+import aexpect
+import six
 from aexpect import remote
-
 from avocado.core import exceptions
+from avocado.utils import distro, linux_modules
 from avocado.utils import path as utils_path
-from avocado.utils import process
-from avocado.utils import stacktrace
-from avocado.utils import linux_modules
-from avocado.utils import distro
+from avocado.utils import process, stacktrace
 from avocado.utils.astring import to_text
 
-import six
-
-from virttest import virsh
-from virttest import xml_utils
-from virttest import iscsi
-from virttest import nfs
-from virttest import utils_misc
-from virttest import utils_selinux
-from virttest import libvirt_storage
-from virttest import utils_net
-from virttest import gluster
-from virttest import test_setup
-from virttest import data_dir
-from virttest import utils_libvirtd
-from virttest import utils_config
-from virttest import utils_split_daemons
+from virttest import data_dir, gluster, iscsi, libvirt_storage, nfs
 from virttest import remote as remote_old
+from virttest import (
+    test_setup,
+    utils_config,
+    utils_libvirtd,
+    utils_misc,
+    utils_net,
+    utils_selinux,
+    utils_split_daemons,
+    virsh,
+    xml_utils,
+)
+from virttest.libvirt_xml import (
+    IPXML,
+    CapabilityXML,
+    NetworkXML,
+    base,
+    network_xml,
+    nwfilter_xml,
+    pool_xml,
+    secret_xml,
+    vm_xml,
+    vol_xml,
+    xcepts,
+)
+from virttest.libvirt_xml.devices import (
+    channel,
+    controller,
+    disk,
+    hostdev,
+    interface,
+    panic,
+    redirdev,
+    rng,
+    seclabel,
+    tpm,
+    vsock,
+)
 from virttest.staging import lv_utils
 from virttest.utils_libvirtd import service_libvirtd_control
-from virttest.libvirt_xml import vm_xml
-from virttest.libvirt_xml import network_xml
-from virttest.libvirt_xml import xcepts
-from virttest.libvirt_xml import NetworkXML
-from virttest.libvirt_xml import IPXML
-from virttest.libvirt_xml import pool_xml
-from virttest.libvirt_xml import nwfilter_xml
-from virttest.libvirt_xml import vol_xml
-from virttest.libvirt_xml import secret_xml
-from virttest.libvirt_xml import CapabilityXML
-from virttest.libvirt_xml import base
-from virttest.libvirt_xml.devices import disk
-from virttest.libvirt_xml.devices import hostdev
-from virttest.libvirt_xml.devices import controller
-from virttest.libvirt_xml.devices import redirdev
-from virttest.libvirt_xml.devices import seclabel
-from virttest.libvirt_xml.devices import channel
-from virttest.libvirt_xml.devices import interface
-from virttest.libvirt_xml.devices import panic
-from virttest.libvirt_xml.devices import tpm
-from virttest.libvirt_xml.devices import vsock
-from virttest.libvirt_xml.devices import rng
 
 ping = utils_net.ping
 

--- a/virttest/utils_test/libvirt_domjobinfo.py
+++ b/virttest/utils_test/libvirt_domjobinfo.py
@@ -2,9 +2,9 @@
 Virsh domjobinfo command related utility functions
 """
 
-import re
-import math
 import logging
+import math
+import re
 
 from avocado.core import exceptions
 

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -16,19 +16,17 @@ More specifically:
 :copyright: 2008-2013 Red Hat Inc.
 """
 
+import logging
 import os
 import re
-import six
 import time
-import logging
 from functools import reduce
 
+import six
 from avocado.core import exceptions
 from avocado.utils import cpu as cpuutil
 
-from virttest import error_context
-from virttest import utils_misc
-from virttest import qemu_monitor
+from virttest import error_context, qemu_monitor, utils_misc
 from virttest.qemu_devices import qdevices
 from virttest.staging import utils_memory
 

--- a/virttest/utils_test/qemu/migration.py
+++ b/virttest/utils_test/qemu/migration.py
@@ -8,10 +8,11 @@ import errno
 import fcntl
 import logging
 import os
+import re
 import socket
 import threading
 import time
-import re
+
 import six
 
 try:
@@ -20,21 +21,15 @@ except ImportError:
     import cPickle
 
 from aexpect import remote
-
 from avocado.core import exceptions
-from avocado.utils import crypto
-from avocado.utils import data_factory
+from avocado.utils import crypto, data_factory
 from avocado.utils import path as utils_path
 from avocado.utils import process
 from avocado.utils.data_structures import DataSize
 
-from virttest import data_dir
-from virttest import storage
-from virttest import utils_test
-from virttest import utils_misc
-from virttest import env_process
+from virttest import data_dir, env_process
 from virttest import error_context as error
-from virttest import qemu_migration
+from virttest import qemu_migration, storage, utils_misc, utils_test
 
 try:
     import aexpect

--- a/virttest/utils_time.py
+++ b/virttest/utils_time.py
@@ -1,12 +1,10 @@
 import logging
 import re
 
-from avocado.utils import path
-from avocado.utils import process
 from avocado.core import exceptions
+from avocado.utils import path, process
 
-from virttest import error_context
-from virttest import utils_test
+from virttest import error_context, utils_test
 
 # command `grep --color` may have alias name `grep` in some systems,
 # so get explicit command 'grep' with path

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -11,33 +11,27 @@ import logging
 import os
 import pwd
 import random
-import uuid
 import re
 import shutil
 import tempfile
 import time
+import uuid
 
 import aexpect
-
 from aexpect import remote
-from avocado.utils import path
-from avocado.utils import process
-from avocado.utils.astring import to_text
 from avocado.core import exceptions
+from avocado.utils import path, process
+from avocado.utils.astring import to_text
 
-from virttest import libvirt_vm as lvirt
-from virttest import ovirt
-from virttest import virsh
-from virttest import ppm_utils
 from virttest import data_dir
+from virttest import libvirt_vm as lvirt
+from virttest import ovirt, ppm_utils
 from virttest import remote as remote_old
-from virttest import utils_misc
-from virttest import ssh_key
-from virttest.utils_test import libvirt
+from virttest import ssh_key, utils_misc, virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_misc import asterisk_passwd, compare_md5
+from virttest.utils_test import libvirt
 from virttest.utils_version import VersionInterval
-from virttest.utils_misc import asterisk_passwd
-from virttest.utils_misc import compare_md5
 
 try:
     V2V_EXEC = path.find_command("virt-v2v")

--- a/virttest/utils_vdpa.py
+++ b/virttest/utils_vdpa.py
@@ -11,11 +11,7 @@ import time
 from avocado.core import exceptions
 from avocado.utils import process
 
-from virttest import openvswitch
-from virttest import utils_misc
-from virttest import utils_net
-from virttest import utils_sriov
-from virttest import utils_switchdev
+from virttest import openvswitch, utils_misc, utils_net, utils_sriov, utils_switchdev
 from virttest.utils_kernel_module import KernelModuleHandler
 from virttest.versionable_class import factory
 

--- a/virttest/utils_version.py
+++ b/virttest/utils_version.py
@@ -1,8 +1,8 @@
 import operator
 import re
-from distutils.version import (
+from distutils.version import (  # pylint: disable=no-name-in-module,import-error
     LooseVersion,
-)  # pylint: disable=no-name-in-module,import-error
+)
 
 
 class VersionInterval(object):

--- a/virttest/utils_virtio_port.py
+++ b/virttest/utils_virtio_port.py
@@ -2,9 +2,7 @@ import logging
 
 from six.moves import xrange
 
-from . import env_process
-from . import error_context
-from . import qemu_virtio_port
+from . import env_process, error_context, qemu_virtio_port
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/utils_vsock.py
+++ b/virttest/utils_vsock.py
@@ -1,7 +1,7 @@
-import os
-import fcntl
-import struct
 import errno
+import fcntl
+import os
+import struct
 
 from virttest import arch
 

--- a/virttest/utils_windows/drive.py
+++ b/virttest/utils_windows/drive.py
@@ -2,8 +2,9 @@
 Windows drive utilities
 """
 
-from . import wmic
 from virttest import utils_misc
+
+from . import wmic
 
 
 def _logical_disks(session, cond=None, props=None):

--- a/virttest/utils_windows/virtio_win.py
+++ b/virttest/utils_windows/virtio_win.py
@@ -2,13 +2,12 @@
 Windows virtio-win utilities
 """
 
-import re
 import logging
+import re
 
-from . import drive
-from . import system
 from avocado.core import exceptions
 
+from . import drive, system
 
 ARCH_MAP_ISO = {"32-bit": "x86", "64-bit": "amd64"}
 ARCH_MAP_VFD = {"32-bit": "i386", "64-bit": "amd64"}

--- a/virttest/utils_windows/wmic.py
+++ b/virttest/utils_windows/wmic.py
@@ -4,7 +4,6 @@ Windows WMIC utilities
 
 import re
 
-
 _WMIC_CMD = "wmic"
 
 FMT_TYPE_LIST = "/format:list"

--- a/virttest/utils_zcrypt.py
+++ b/virttest/utils_zcrypt.py
@@ -30,10 +30,11 @@ Example:
     mask_helper.return_to_host_all()
 
 """
-from uuid import uuid1
 from os.path import join
+from uuid import uuid1
 
 from avocado.utils import process
+
 from virttest.utils_misc import cmd_status_output
 
 # timeout value in seconds for any command run

--- a/virttest/video_maker.py
+++ b/virttest/video_maker.py
@@ -8,12 +8,11 @@ and tools.
 """
 
 
-import os
-import time
 import glob
 import logging
+import os
 import re
-
+import time
 
 __all__ = ["get_video_maker_klass", "video_maker"]
 

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -21,31 +21,24 @@ for non-existant keys.
 :copyright: 2012 Red Hat Inc.
 """
 
-import signal
+import base64
+import inspect
+import locale
 import logging
 import os
 import re
-import weakref
-import time
 import select
-import locale
-import base64
-import inspect
-
+import signal
+import time
+import weakref
 from functools import wraps
 
 import aexpect
 from aexpect import remote
-
-from avocado.utils import path
-from avocado.utils import process
-
+from avocado.utils import path, process
 from six.moves import urllib
 
-from virttest import propcan
-from virttest import utils_misc
-from virttest import data_dir
-
+from virttest import data_dir, propcan, utils_misc
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -21,24 +21,18 @@ for non-existant keys.
 :copyright: 2012 Red Hat Inc.
 """
 
-import signal
 import logging
 import re
-import weakref
-import time
 import select
+import signal
+import time
+import weakref
 
 import aexpect
 from aexpect import remote
+from avocado.utils import path, process
 
-from avocado.utils import path
-from avocado.utils import process
-
-from virttest import propcan
-from virttest import utils_misc
-from virttest import utils_split_daemons
-from virttest import utils_config
-
+from virttest import propcan, utils_config, utils_misc, utils_split_daemons
 
 # list of symbol names NOT to wrap as Virtadmin class methods
 # Everything else from globals() will become a method of Virtadmin class

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1,31 +1,23 @@
 from __future__ import division
-import logging
-import time
+
+import functools
 import glob
+import logging
 import os
 import re
 import socket
+import time
 import traceback
-import functools
-
-from aexpect import remote
-from aexpect.exceptions import ShellError
-from aexpect.exceptions import ExpectError
-
-from avocado.core import exceptions
 
 import six
+from aexpect import remote
+from aexpect.exceptions import ExpectError, ShellError
+from avocado.core import exceptions
 from six.moves import xrange
 
-from virttest import utils_logfile
-from virttest import utils_misc
-from virttest import utils_net
+from virttest import data_dir, error_context, ppm_utils
 from virttest import remote as remote_old
-from virttest import ppm_utils
-from virttest import data_dir
-from virttest import error_context
-from virttest import vt_console
-
+from virttest import utils_logfile, utils_misc, utils_net, vt_console
 
 LOG = logging.getLogger("avocado." + __name__)
 

--- a/virttest/vt_console.py
+++ b/virttest/vt_console.py
@@ -1,7 +1,6 @@
 import threading
 import time
 
-
 from aexpect import remote
 
 

--- a/virttest/vt_utils/block.py
+++ b/virttest/vt_utils/block.py
@@ -16,8 +16,8 @@
 import platform
 import re
 
-from avocado.utils import process
-from avocado.utils import wait
+from avocado.utils import process, wait
+
 from virttest import utils_numeric
 from virttest.vt_utils import filesystem
 

--- a/virttest/vt_utils/filesystem.py
+++ b/virttest/vt_utils/filesystem.py
@@ -16,6 +16,7 @@
 import re
 
 from avocado.utils import process
+
 from virttest import utils_numeric
 from virttest.vt_utils import block
 

--- a/virttest/xml_utils.py
+++ b/virttest/xml_utils.py
@@ -37,14 +37,15 @@
 """
 
 import io
+import logging
 import os
 import shutil
-import tempfile
 import string
-import logging
-from six import StringIO
-from xml.parsers import expat
+import tempfile
 from xml.etree import ElementTree
+from xml.parsers import expat
+
+from six import StringIO
 
 # Also used by unittests
 TMPPFX = "xml_utils_temp_"

--- a/virttest/yumrepo.py
+++ b/virttest/yumrepo.py
@@ -6,7 +6,6 @@ YUM repositories on the system.
 
 import os
 
-
 __all__ = ["REPO_DIR", "YumRepo"]
 
 


### PR DESCRIPTION
Avocado has been using isort to enforce one import order/code style for a long time, with very good results.  Let's expand the same to Avocado-VT.  With a common code style across Avocado and Avocado-VT it'll be easier to move libraries to the common autils repo.

Reference: https://github.com/avocado-framework/autils/issues/3