### PR TITLE
libvirt_vfio: Update to support mlx5_vfio_pci

### DIFF
--- a/virttest/utils_libvirt/libvirt_vfio.py
+++ b/virttest/utils_libvirt/libvirt_vfio.py
@@ -11,13 +11,14 @@ from avocado.utils import process
 LOG = logging.getLogger("avocado." + __name__)
 
 
-def check_vfio_pci(pci_id, status_error=False, ignore_error=False):
+def check_vfio_pci(pci_id, status_error=False, ignore_error=False, exp_driver=None):
     """
     Check if the driver is vfio-pci
 
     :param pci_id: The id of pci device
     :param status_error: Whether the driver should be vfio-pci
     :param ignore_error: Whether to raise an exception
+    :param exp_driver: The expected driver
     :raise: TestFail if not match
     :return: True if got the expected driver;
         False otherwise when ignore_error is set to True
@@ -27,9 +28,16 @@ def check_vfio_pci(pci_id, status_error=False, ignore_error=False):
         "| awk -F '/' '{print $NF}'" % pci_id
     )
     output = process.run(cmd, shell=True, verbose=True).stdout_text.strip()
-    if (output == "vfio-pci") == status_error:
-        err_msg = "Get incorrect driver {}, it should{} be vfio-pci.".format(
-            output, " not" if status_error else ""
+    res = (
+        exp_driver == output
+        if exp_driver
+        else output.endswith(("vfio-pci", "vfio_pci"))
+    )
+    if res == status_error:
+        err_msg = "Get incorrect driver {}, it should{} be {}.".format(
+            output,
+            " not" if status_error else "",
+            exp_driver if exp_driver else "vfio-pci",
         )
         if ignore_error:
             LOG.error(err_msg)


### PR DESCRIPTION
Update to be able to check mlx5_vfio_pci driver.


**Test results:**
```
>>> libvirt_vfio.check_vfio_pci('0002:01:00.2')
True
>>> libvirt_vfio.check_vfio_pci('0002:01:00.2', expr_driver="vfio_pci")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/ci/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/utils_libvirt/libvirt_vfio.py", line 40, in check_vfio_pci
    raise exceptions.TestFail(err_msg)
avocado.core.exceptions.TestFail: Get incorrect driver mlx5_vfio_pci, it should be vfio_pci.
>>> libvirt_vfio.check_vfio_pci('0002:01:00.2', expr_driver="mlx5_vfio_pci")
True
>>> 
```