### PR TITLE
libvirt: support not to execute sync

### DIFF
--- a/virttest/utils_libvirt/libvirt_vmxml.py
+++ b/virttest/utils_libvirt/libvirt_vmxml.py
@@ -130,7 +130,9 @@ def create_vm_device_by_type(dev_type, dev_dict):
     return dev_obj
 
 
-def modify_vm_device(vmxml, dev_type, dev_dict=None, index=0, virsh_instance=virsh):
+def modify_vm_device(
+    vmxml, dev_type, dev_dict=None, index=0, virsh_instance=virsh, sync_vm=True
+):
     """
      Get specified device , update it with given dev_dict if the device exists,
      Create the device if it does not exist
@@ -139,6 +141,8 @@ def modify_vm_device(vmxml, dev_type, dev_dict=None, index=0, virsh_instance=vir
     :param dev_type: device type
     :param dev_dict: dict to create device
     :param index: device index
+    :param virsh_instance: virsh instance
+    :param sync_vm: boolean, True to execute sync, otherwise not
     :return: device object
     """
     dev_obj = None
@@ -148,10 +152,13 @@ def modify_vm_device(vmxml, dev_type, dev_dict=None, index=0, virsh_instance=vir
 
         vmxml.devices = xml_devices
         vmxml.xmltreefile.write()
-        vmxml.sync(virsh_instance=virsh_instance)
+        if sync_vm:
+            vmxml.sync(virsh_instance=virsh_instance)
     except IndexError:
         dev_obj = create_vm_device_by_type(dev_type, dev_dict)
-        libvirt.add_vm_device(vmxml, dev_obj, virsh_instance=virsh_instance)
+        libvirt.add_vm_device(
+            vmxml, dev_obj, virsh_instance=virsh_instance, sync_vm=sync_vm
+        )
 
     LOG.debug(f"XML of {dev_type} device is:\n{dev_obj}")
     return dev_obj

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -2494,16 +2494,19 @@ def get_vm_device(vmxml, dev_tag, index=0):
     return (dev_obj, xml_devices)
 
 
-def add_vm_device(vmxml, new_device, virsh_instance=virsh):
+def add_vm_device(vmxml, new_device, virsh_instance=virsh, sync_vm=True):
     """
     Add device in vmxml
 
     :param vmxml: domain VMXML instance
     :param new_device: device instance
+    :param virsh_instance: virsh instance
+    :param sync_vm: boolean, True to execute sync, otherwise not
     """
     vmxml.add_device(new_device)
     vmxml.xmltreefile.write()
-    vmxml.sync(virsh_instance=virsh_instance)
+    if sync_vm:
+        vmxml.sync(virsh_instance=virsh_instance)
 
 
 def set_guest_agent(vm):


### PR DESCRIPTION
Sometimes we do not need the VM is synced with the updated VM xml. So this is to add this option.

Signed-off-by: Dan Zheng <dzheng@redhat.com>