### PR TITLE
test_setup.storage: Fix indentation level of code block

### DIFF
--- a/virttest/test_setup/storage.py
+++ b/virttest/test_setup/storage.py
@@ -63,14 +63,14 @@ class StorageConfig(Setuper):
                 seLinuxBool = SELinuxBoolean(self.params)
                 seLinuxBool.setup()
 
-        image_name_only = os.path.basename(self.params["image_name"])
-        for image_name in self.params.objects("images"):
-            name_tag = "image_name_%s" % image_name
-            if self.params.get(name_tag):
-                image_name_only = os.path.basename(self.params[name_tag])
-                self.params[name_tag] = os.path.join(
-                    image_nfs.mount_dir, image_name_only
-                )
+            image_name_only = os.path.basename(self.params["image_name"])
+            for image_name in self.params.objects("images"):
+                name_tag = "image_name_%s" % image_name
+                if self.params.get(name_tag):
+                    image_name_only = os.path.basename(self.params[name_tag])
+                    self.params[name_tag] = os.path.join(
+                        image_nfs.mount_dir, image_name_only
+                    )
 
     def cleanup(self):
         base_dir = data_dir.get_data_dir()


### PR DESCRIPTION
The patch fixes the regression introduced by commit 5fd4847847fd996d37b93dd3dddff58416ac9acb. The latter tried to refactor the storage setup steps into a Setuper. However, a piece of code related to the nfs setup was left behind at a higher indentation level. That led to test cases failing during test setup as the "image_nfs variable was "referenced before assignment".

This commit just takes such piece of code back to its appropriate indentation level, fixing the issue.

ID: 2082