### PR TITLE
Add a limitation for the smbios setting

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -61,7 +61,8 @@
     # To avoid Windows OS bug, add this workaround.
     # https://gitlab.com/qemu-project/qemu/-/issues/2008
     default_bios:
-        machine_type_extra_params += "smbios-entry-point-type=32"
+        ! Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3:
+            machine_type_extra_params += "smbios-entry-point-type=32"
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         timeout = 7200
         finish_program = deps/finish/finish.bat


### PR DESCRIPTION
This issue was introduced by supporting machine type 9.4, add a limitation to not apply this workaround to all OS version

ID:2085