### PR TITLE
Revert the workaround for smbios configuration

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -61,8 +61,7 @@
     # To avoid Windows OS bug, add this workaround.
     # https://gitlab.com/qemu-project/qemu/-/issues/2008
     default_bios:
-        ! Host_RHEL.m6, Host_RHEL.m7, Host_RHEL.m8, Host_RHEL.m9.u0, Host_RHEL.m9.u1, Host_RHEL.m9.u2, Host_RHEL.m9.u3:
-            machine_type_extra_params += "smbios-entry-point-type=32"
+        machine_type_extra_params += "smbios-entry-point-type=32"
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         timeout = 7200
         finish_program = deps/finish/finish.bat

--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -56,12 +56,6 @@
     cdrom_check_cdrom_pattern = "\d\s+(\w).*CD-ROM"
     cdrom_test_cmd = "dir %s:\"
     cdrom_info_cmd = "wmic cdrom list full"
-
-    # Set SMBIOS to 2.x for windows guest when using seabios
-    # To avoid Windows OS bug, add this workaround.
-    # https://gitlab.com/qemu-project/qemu/-/issues/2008
-    default_bios:
-        machine_type_extra_params += "smbios-entry-point-type=32"
     unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
         timeout = 7200
         finish_program = deps/finish/finish.bat


### PR DESCRIPTION
The related problem no longer exists, so revert the previous temporary workaround commits.

ID:2109