### PR TITLE
USB: fix Invalid value for attribute 'bus' in element 'address'

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1541,8 +1541,8 @@ def create_hostdev_xml(
             }
             hostdev_xml.source = hostdev_xml.new_source(**attrs)
         if dev_type == "usb":
-            addr_bus = pci_id.split(":")[2]
-            addr_device = pci_id.split(":")[3]
+            addr_bus = pci_id.split(":")[2].lstrip("0")
+            addr_device = pci_id.split(":")[3].lstrip("0")
             hostdev_xml.source = hostdev_xml.new_source(
                 **(
                     dict(


### PR DESCRIPTION
From libvirt document, The values of these attributes can be given in decimal, hexadecimal (starting with 0x) or octal (starting with 0) form.

In our script, the analyze of 'lsusb' output pass bus and address literally. If the bus num is greater or equal than 8, for instance '008', libvirt will report the error.

In the lsusb output, the bus value should be decimal, so just remove the leading zeros from the string to fix it.