### PR TITLE
Update driver status check method

### DIFF
--- a/virttest/utils_windows/virtio_win.py
+++ b/virttest/utils_windows/virtio_win.py
@@ -15,6 +15,14 @@ ARCH_MAP_VFD = {"32-bit": "i386", "64-bit": "amd64"}
 LOG = logging.getLogger("avocado." + __name__)
 
 
+DRIVER_SVC_MAP = {
+    "viorng": "VirtRng",
+    "vioser": "VirtioSerial",
+    "viofs": "VirtioFsDrv",
+    "vioinput": "VirtioInput",
+}
+
+
 def arch_dirname_iso(session):
     """
     Get architecture directory's name - iso media version.


### PR DESCRIPTION
For INF isolation all win11 drivers are moved to DriverStore
    (C:\WINDOWS\system32\DriverStore\FileRepository).
    Each installation creates a new directory in
    the DriverStore folder depending on the driver hash.
    While for win10 drivers, there are no change.
    
    So that, it's better to use Win32_SystemDriver to
     check driver status, it's suitable for win10 and
    win11 vm.

ID: 2220