### PR TITLE
libvirt_numa: Fix parsing of continuous numa nodes

### DIFF
--- a/virttest/utils_libvirt/libvirt_numa.py
+++ b/virttest/utils_libvirt/libvirt_numa.py
@@ -122,67 +122,14 @@ def convert_all_nodes_to_string(node_list):
 
 def parse_numa_nodeset_to_str(numa_nodeset, node_list, ignore_error=False):
     """
-    Parse numa nodeset to a string
+    Parse numa nodeset to a string. 
+    The effect is the same as convert_all_nodes_to_string function.
 
     :param numa_nodeset: str, formats supported are 'x', 'x,y', 'x-y', 'x-y,^y'
     :param node_list: list, host numa nodes
     :param ignore_error: no exception raised if True
     :return: str, parsed numa nodeset
-    :raises exceptions.TestError if unsupported format of numa nodeset
     """
 
-    def _get_first_continuous_numa_node_index(node_list):
-        """
-        Get the first continues numa node index
-        For example:
-        If node list is [0, 1, 3, 4], return 0
-        If node list is [0, 2, 3, 5], return 1
-        If node list is [1, 4, 8], return -1
-
-        :param node_list: list, the host numa node list
-        :return: int, the first index of continuous numa node or -1 if not exists
-        """
-        for index in range(0, len(node_list) - 1):
-            if node_list[index] + 1 == node_list[index + 1]:
-                return index
-        return -1
-
-    LOG.debug("numa_nodeset='%s', node_list=%s" % (numa_nodeset, node_list))
-    if numa_nodeset == "x":
-        numa_nodeset = str(node_list[0])
-    elif numa_nodeset == "x,y":
-        numa_nodeset = ",".join(map(str, node_list))
-    elif numa_nodeset == "x-y":
-        candidate_index = _get_first_continuous_numa_node_index(node_list)
-        if candidate_index == -1:
-            LOG.debug(
-                "No continuous numa node, use 'x,y' format instead of 'x-y' format"
-            )
-            numa_nodeset = ",".join(map(str, node_list))
-        else:
-            numa_nodeset = "%s-%s" % (
-                str(node_list[candidate_index]),
-                str(node_list[candidate_index + 1]),
-            )
-    elif numa_nodeset == "x-y,^y":
-        candidate_index = _get_first_continuous_numa_node_index(node_list)
-        if candidate_index == -1:
-            LOG.debug(
-                "No continuous numa node, use 'x,y' format instead of 'x-y' format"
-            )
-            numa_nodeset = ",".join(map(str, node_list))
-        else:
-            numa_nodeset = "%s-%s,^%s" % (
-                str(node_list[candidate_index]),
-                str(node_list[candidate_index + 1]),
-                str(node_list[candidate_index + 1]),
-            )
-    elif ignore_error:
-        LOG.error("Supported formats are not found. No parsing happens.")
-    else:
-        raise exceptions.TestError(
-            "Unsupported format for numa_" "nodeset value '%s'" % numa_nodeset
-        )
-
-    LOG.debug("Parse output for numa nodeset: '%s'", numa_nodeset)
+    numa_nodeset = convert_all_nodes_to_string(node_list)
     return numa_nodeset

--- a/virttest/utils_libvirt/libvirt_numa.py
+++ b/virttest/utils_libvirt/libvirt_numa.py
@@ -120,16 +120,3 @@ def convert_all_nodes_to_string(node_list):
     return converted_numa_nodes
 
 
-def parse_numa_nodeset_to_str(numa_nodeset, node_list, ignore_error=False):
-    """
-    Parse numa nodeset to a string. 
-    The effect is the same as convert_all_nodes_to_string function.
-
-    :param numa_nodeset: str, formats supported are 'x', 'x,y', 'x-y', 'x-y,^y'
-    :param node_list: list, host numa nodes
-    :param ignore_error: no exception raised if True
-    :return: str, parsed numa nodeset
-    """
-
-    numa_nodeset = convert_all_nodes_to_string(node_list)
-    return numa_nodeset

--- a/virttest/utils_libvirt/libvirt_numa.py
+++ b/virttest/utils_libvirt/libvirt_numa.py
@@ -7,8 +7,6 @@ http://libvirt.org/formatdomain.html
 import ast
 import logging
 
-from avocado.core import exceptions
-
 from virttest.libvirt_xml import vm_xml
 
 LOG = logging.getLogger("avocado." + __name__)

--- a/virttest/utils_libvirt/libvirt_numa.py
+++ b/virttest/utils_libvirt/libvirt_numa.py
@@ -118,5 +118,3 @@ def convert_all_nodes_to_string(node_list):
     converted_numa_nodes = ",".join(node_ranges)
     LOG.debug("Convert output for all online numa nodes: '%s'", converted_numa_nodes)
     return converted_numa_nodes
-
-


### PR DESCRIPTION
In PR[#3804](https://github.com/avocado-framework/avocado-vt/pull/3804), a similar bug is fixed by replacing parse_numa_nodeset_to_str with the new convert_all_nodes_to_string function. However, parse_numa_nodeset_to_str is still called at several places. Therefore, in this PR, directly call convert_all_nodes_to_string in parse_numa_nodeset_to_str to fix the bug with minimal changes.

Signed-off-by: Qian Jianhua <qianjh@fujitsu.com>

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (56.75 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: PASS (48.46 s)
```