### PR TITLE
Fixup: check 'tc filter' output

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4716,7 +4716,7 @@ def check_filter_rules(ifname, bandwidth, expect_none=False):
     LOG.debug("Bandwidth filter output: %s", filter_output)
     if expect_none:
         return not filter_output.strip()
-    if not filter_output.count("filter protocol all pref"):
+    if not re.search(r"filter.*protocol all pref", filter_output, re.M):
         LOG.error("Can't find 'protocol all' settings in filter rules")
         return False
     filter_pattern = r".*police.*rate (\d+)(K?M?)bit burst (\d+)(K?M?)b.*"


### PR DESCRIPTION
In the output of 'tc filter' command, there is a parent object between 'filter' and 'protocol all' in some cases.

Signed-off-by: Qian Jianhua <qianjh@fujitsu.com>

for example, in ovs_qos test case. the output of 'tc filter' command as below.

> filter ingress protocol all pref 1 matchall chain 0
filter ingress protocol all pref 1 matchall chain 0 handle 0x1
  not_in_hw
        action order 1:  police 0x2 rate 40Mbit burst 1000Kb mtu 64Kb action drop/continue overhead 0b linklayer unspec
        ref 1 bind 1



Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_ovs.net_ovs.ovs_qos.start:  FAIL: Qos test fail! (7.15 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_ovs.net_ovs.ovs_qos.start:  PASS (6.90 s)
```