### PR TITLE
qcontainer: add dynamic-memslots support

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -3498,6 +3498,7 @@ class DevContainer(object):
                     supported = [
                         "any_layout",
                         "block-size",
+                        "dynamic-memslots",
                         "event_idx",
                         "indirect_desc",
                         "iommu_platform",


### PR DESCRIPTION
qcontainer: add dynamic-memslots support

Includes dynamic-memslots option for virtio-mem devices

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2253