### PR TITLE
serial/windows_support.py: Fix data type conversion issue

### DIFF
--- a/virttest/shared/deps/serial/windows_support.py
+++ b/virttest/shared/deps/serial/windows_support.py
@@ -53,7 +53,7 @@ class WinBufferedReadFile(object):
                     frags.append(self._bufs.pop(0))
                     frags_length += len(frags[-1])
                 self._n -= n
-                whole = "".join(frags)
+                whole = b"".join(frags)
                 ret = whole[:n]
                 rest = whole[n:]
                 if len(rest) > 0:


### PR DESCRIPTION
In Python 3, there is a clear distinction between string and bytes objects, so we need to convert the memoryview object to a bytes object. To fix this problem, we need to change the type of whole from a string to a bytes object.

ID: 2227
Signed-off-by: Dehan Meng <demeng@redhat.com>