### PR TITLE
Remove unused libvirt import of utils_test

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -64,7 +64,6 @@ from virttest.utils_iptables import Iptables
 # pylint: disable=unused-import
 from virttest.utils_test import qemu
 
-libvirt = lazy_import("virttest.utils_test.libvirt")
 libguestfs = lazy_import("virttest.utils_test.libguestfs")
 
 


### PR DESCRIPTION
We don't need to import `libvirt` in `__init__.py` to directly access
classes/functions of `libvirt`. The change of
https://github.com/avocado-framework/avocado-vt/commit/f6adc5d34018ca68ceaf1d98b2698a5819f30442 could be affected by older
version of python.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

---
Run a few tests which include code `utils_test.libvirt.xxxx()`
```
chardev_with_log_file.py
...
        utils_test.libvirt.virsh_console_login(
            access_session, params.get('username'), params.get('password'),
            debug=True, timeout=20)
...

 (1/2) type_specific.io-github-autotest-libvirt.chardev.log.console.pty: PASS (46.30 s)
 (2/2) type_specific.io-github-autotest-libvirt.chardev.log.console.unix: PASS (45.75 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

```
virsh_console.py
...
        force_status = utils_test.libvirt.verify_virsh_console(
            force_session, login_user, login_passwd,
            timeout=CMD_TIMEOUT, debug=True)
...
        status = utils_test.libvirt.verify_virsh_console(
            console_session, login_user, login_passwd,
            timeout=CMD_TIMEOUT, debug=True)
...
 (01/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.non_acl.valid_domname: PASS (148.18 s)
 (02/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.non_acl.valid_domid: PASS (146.21 s)
 (03/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.non_acl.valid_domuuid: PASS (267.83 s)
 (04/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domname: PASS (153.26 s)
 (05/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domid: PASS (151.14 s)
 (06/14) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domuuid: PASS (152.32 s)
 (07/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.invalid_domname: PASS (112.38 s)
 (08/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.invalid_domid: PASS (112.77 s)
 (09/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.hex_domid: PASS (111.27 s)
 (10/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.invalid_domuuid: PASS (112.68 s)
 (11/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.invalid_options.none_domname: PASS (112.27 s)
 (12/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.special_operation.vm_paused: PASS (142.44 s)
 (13/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.special_operation.vm_shut_off: PASS (113.54 s)
 (14/14) type_specific.io-github-autotest-libvirt.virsh.console.error_test.acl_test: PASS (116.17 s)
Not opening readers, lock_server_running not locked
RESULTS    : PASS 14 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
More test result on jenkins:

Package | Duration | Fail | (diff) | Skip | (diff) | Pass | (diff) | Total | (diff)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
rhel | 8 min 16 sec | 0 |   | 0 |   | 7 | +7 | 7 | +7
rhel.virsh | 15 min | 0 |   | 0 |   | 22 | +22 | 22 | +22
