### PR TITLE
env_process: Fix the issue of iterating an integer

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1036,7 +1036,7 @@ def preprocess(test, params, env):
     except Exception:
         LOG.warning("Could not get host cpu family")
     migration_setup = params.get("migration_setup", "no") == "yes"
-    if cpu_family is not None and "power" in cpu_family:
+    if cpu_family is not None and "power" in str(cpu_family):
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())
         power9_compat = "yes" == params.get("power9_compat", "no")
@@ -1849,7 +1849,7 @@ def postprocess(test, params, env):
         )
     except Exception:
         LOG.warning("Could not get host cpu family")
-    if cpu_family is not None and "power" in cpu_family:
+    if cpu_family is not None and "power" in str(cpu_family):
         pvr_cmd = "grep revision /proc/cpuinfo | awk '{print $3}' | head -n 1"
         pvr = float(a_process.system_output(pvr_cmd, shell=True).strip())
         # Restore SMT changes in the powerpc host is set


### PR DESCRIPTION
A recent avocado commit(241c9cdf62f0162e24c37913ab37053971563ee4) enhanced cpu.get_family to return an integer for a AMD cpu, which can cause error, but get_family was declared to return a *name*, instead of an integer, which is confused. Added this commit as a workaround to bypass the error.

We expect a better solution for cpu.get_family later