### PR TITLE
Fixup:marshal_from_address not found error

### DIFF
--- a/virttest/libvirt_xml/nodedev_xml.py
+++ b/virttest/libvirt_xml/nodedev_xml.py
@@ -223,6 +223,24 @@ class StorageXML(CAPXML):
         )
 
 
+class VDPAXML(CAPXML):
+    """
+    class for capability whose type is vdpa.
+    """
+
+    # Example:
+    # <capability type='vdpa'>
+    #     <chardev>/dev/vhost-vdpa-0</chardev>
+    # </capability>
+
+    __slots__ = "chardev"
+
+    def __init__(self, virsh_instance=base.virsh):
+        accessors.XMLElementText("chardev", self, parent_xpath="/", tag_name="chardev")
+        super(VDPAXML, self).__init__(virsh_instance=virsh_instance)
+        self.xml = " <capability type='vdpa'></capability>"
+
+
 class PCIXML(CAPXML):
 
     """
@@ -317,25 +335,6 @@ class PCIXML(CAPXML):
         )
         super(PCIXML, self).__init__(virsh_instance=virsh_instance)
         self.xml = " <capability type='pci'></capability>"
-
-
-class VDPAXML(CAPXML):
-
-    """
-    class for capability whose type is vdpa.
-    """
-
-    # Example:
-    # <capability type='vdpa'>
-    #     <chardev>/dev/vhost-vdpa-0</chardev>
-    # </capability>
-
-    __slots__ = "chardev"
-
-    def __init__(self, virsh_instance=base.virsh):
-        accessors.XMLElementText("chardev", self, parent_xpath="/", tag_name="chardev")
-        super(VDPAXML, self).__init__(virsh_instance=virsh_instance)
-        self.xml = " <capability type='vdpa'></capability>"
 
     class Address(base.LibvirtXMLBase):
 


### PR DESCRIPTION
VDPAXML class mistakenly moved some functions from PCIXML to itself.Move them back to fix the functions missing error.