### PR TITLE
Replace readfp with read_file

### DIFF
--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -45,7 +45,7 @@ class ConfigLoader:
         # File is already a file like object
         if hasattr(cfg, "read"):
             self.cfg = cfg
-            self.parser.readfp(self.cfg)
+            self.parser.read_file(self.cfg)
         elif isinstance(cfg, string_types):
             # Config file is a URL. Download it to a temp dir
             if cfg.startswith("http") or cfg.startswith("ftp"):
@@ -64,7 +64,7 @@ class ConfigLoader:
             # object using StringIO
             else:
                 self.cfg = StringIO(cfg)
-                self.parser.readfp(self.cfg)
+                self.parser.read_file(self.cfg)
 
     def get(self, section, option, default=None):
         """

--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -97,7 +97,7 @@ class SectionlessConfig(object):
         self.parser.optionxform = str
         self.backup_content = open(path, "r").read()
         read_fp = StringIO("[root]\n" + self.backup_content)
-        self.parser.readfp(read_fp)
+        self.parser.read_file(read_fp)
 
     def __sync_file(self):
         out_file = open(self.path, "w")


### PR DESCRIPTION
ConfigParser.readfp was removed in the latest python(3.12), so updating to use read_file().