### PR TITLE
Update virtual bus for s390 and s390x

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1689,19 +1689,16 @@ class DevContainer(object):
             bus = (
                 qdevices.QNoAddrCustomBus(
                     "bus",
-                    [["addr"], [64]],
-                    "virtio-blk-ccw",
-                    "virtio-bus",
-                    "virtio-blk-ccw",
-                ),
-                qdevices.QNoAddrCustomBus(
-                    "bus", [["addr"], [32]], "virtual-css", "virtual-css", "virtual-css"
+                    [["addr"], [32]],
+                    "virtual-css",
+                    "virtual-css",
+                    "virtual-css",
                 ),
                 qdevices.QCPUBus(params.get("cpu_model"), [[""], [0]], "vcpu"),
             )
             devices.append(
                 qdevices.QMachine(
-                    params=machine_params, child_bus=bus, aobject="virtio-blk-ccw"
+                    params=machine_params, child_bus=bus, aobject="virtual-css"
                 )
             )
             return devices
@@ -3572,7 +3569,7 @@ class DevContainer(object):
                 qbus_type = "virtio-bus"
             elif machine_type.startswith("s390"):
                 driver += "-ccw"
-                qbus_type = "virtio-bus"
+                qbus_type = "virtual-css"
             else:
                 driver += "-pci"
 
@@ -3676,7 +3673,7 @@ class DevContainer(object):
                 qbus_type = "virtio-bus"
             elif machine_type.startswith("s390"):
                 qdriver += "-ccw"
-                qbus_type = "virtio-bus"
+                qbus_type = "virtual-css"
             else:
                 qdriver += "-pci"
 

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -735,7 +735,7 @@ class VM(virt_vm.BaseVM):
                 if model == "virtio-net-device":
                     dev.parent_bus = {"type": "virtio-bus"}
                 elif model == "virtio-net-ccw":  # For s390x platform
-                    dev.parent_bus = {"type": "virtio-bus"}
+                    dev.parent_bus = {"type": "virtual-css"}
                 elif model != "spapr-vlan":
                     dev.parent_bus = pci_bus
                     dev.set_param("addr", pci_addr)
@@ -1633,7 +1633,7 @@ class VM(virt_vm.BaseVM):
             machine_type = self.params.get("machine_type")
             if "s390" in machine_type:  # For s390x platform
                 model = "virtio-balloon-ccw"
-                bus = {"type": "virtio-bus"}
+                bus = {"type": "virtual-css"}
             else:
                 model = "virtio-balloon-pci"
             dev = QDevice(model, parent_bus=bus)


### PR DESCRIPTION
s390x: Update bus on s390x from virtio-bus to virtual-css, we only use
virtual-css as the bus on s390x. virtio-bus is actually an adapter but
shown as bus in info qtree.

ID: 2383
    
Signed-off-by: Boqiao Fu <bfu@redhat.com>