### PR TITLE
libvirt_xml/other: add empty __init__.py file

### DIFF
--- a/virttest/libvirt_xml/other/__init__.py
+++ b/virttest/libvirt_xml/other/__init__.py
@@ -1,0 +1,10 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: smitterl@redhat.com
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This file needs to be added to avoid module import errors.


### PR DESCRIPTION
Fixes module setup errors with avocado 104 python 3.9.

Should fix https://github.com/avocado-framework/avocado-vt/pull/3895
Workaround confirmed by @yanan-fu 