### PR TITLE
Fix VM creation checking issue

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3863,9 +3863,15 @@ class VM(virt_vm.BaseVM):
                         self, m_name, m_params, timeout
                     )
                 except qemu_monitor.MonitorConnectError as detail:
-                    LOG.error(detail)
-                    self.destroy()
-                    raise
+                    if self.process.is_alive():
+                        LOG.error(detail)
+                        self.destroy()
+                        raise
+                    else:
+                        stat = self.process.get_status()
+                        output = self.process.get_output().strip()
+                        self.destroy()
+                        raise virt_vm.VMCreateError(qemu_command, stat, output)
 
                 # Add this monitor to the list
                 self.monitors.append(monitor)


### PR DESCRIPTION
Sometimes, the VM may not step in dead immediately, so the first check may not detect the VM is dead.
It should check the VM status over time.

ID:2384