### PR TITLE
Adding support for ubuntu 24.04 guest-os name and qcow2 image name.

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux/Ubuntu/24.04.ppc64le.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/Ubuntu/24.04.ppc64le.cfg
@@ -1,0 +1,5 @@
+- 24.04.ppc64le:
+    image_name += -24.04-ppc64le
+    shell_prompt = "^.*:~[\#\$]\s*$"
+    vm_arch_name = ppc64le
+    os_variant = ubuntu24.04


### PR DESCRIPTION
Creating a cfg file for Ubuntu 24.04, tested basic scenario as importing guest, running one test from lifecycle test bucket and removing guest using --guest-os Ubuntu.24.04.ppc64le  Please find the test results below.

root@localhost:/home/tests# python3 avocado-setup.py --run-suite guest_lifecycle_bck --guest-os Ubuntu.24.04.ppc64le --only-filter 'virtio_scsi virtio_net qcow2' --no-download
11:56:57 WARNING : Overriding user setting and enabling kvm bootstrap as guest tests are requested
11:56:57 INFO    : Check for environment
11:56:58 INFO    : Creating temporary mux dir
11:56:58 INFO    : 
11:56:58 INFO    : Running Guest Tests Suite lifecycle_bck
11:56:58 INFO    : Running: /usr/local/bin/avocado run --vt-type libvirt --vt-config /home/tests/data/avocado-vt/backends/libvirt/cfg/lifecycle_bck.cfg                 --force-job-id 6fd229eb8cfe6d4ebec70f16374230de6f26a226                 --job-results-dir /home/tests/results  --vt-only-filter                                             "virtio_scsi virtio_net qcow2 Ubuntu.24.04.ppc64le" 
JOB ID     : 6fd229eb8cfe6d4ebec70f16374230de6f26a226
JOB LOG    : /home/tests/results/job-2024-06-10T11.57-6fd229e/job.log
 (1/3) io-github-autotest-qemu.unattended_install.import.import.default_install.aio_native: STARTED
 (1/3) io-github-autotest-qemu.unattended_install.import.import.default_install.aio_native: PASS (38.51 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.destroy.error_test.hex_id_option: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virsh.destroy.error_test.hex_id_option: PASS (35.85 s)
 (3/3) io-github-autotest-libvirt.remove_guest.without_disk: STARTED
 (3/3) io-github-autotest-libvirt.remove_guest.without_disk: PASS (5.40 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/tests/results/job-2024-06-10T11.57-6fd229e/results.html
JOB TIME   : 89.18 s
11:58:30 INFO    : 
11:58:30 INFO    : Summary of test results can be found below:
TestSuite                                                                                TestRun    Summary
 
guest_lifecycle_bck                                                                      Run        Successfully executed
/home/tests/results/job-2024-06-10T11.57-6fd229e/job.log
| PASS 3 || CANCEL 0 || ERRORS 0 || FAILURES 0 || SKIP 0 || WARN 0 || INTERRUPT 0 |
11:58:30 INFO    : Removing temporary mux dir
