### PR TITLE
Added vm_secure_guest_object_options for secure guest object

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -3966,6 +3966,10 @@ class DevContainer(object):
                 raise ValueError("Unsupported tdx-guest object")
 
             backend, tdx_obj_props = "tdx-guest", {"id": obj_id}
+            tdx_opts = params.get_dict("vm_secure_guest_object_options")
+            if tdx_opts:
+                tdx_obj_props.update(tdx_opts)
+
             return backend, tdx_obj_props
 
         obj_props_handlers = {"sev": _gen_sev_obj_props, "tdx": _gen_tdx_obj_props}

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -1071,6 +1071,10 @@ uuid_dimm = ""
 # Note: The following types are supported: sev
 #       Disable secure guest: vm_secure_guest_type[_vm1] = ""
 #
+# Set the secure guest object options, use a blank to join more options (optional)
+# TODO: Currently this param is used for tdx guest object only
+#vm_secure_guest_object_options[_vm1] = "debug=on mrconfigid=xx mrowner=yy"
+#
 # AMD SEV secure guest params
 #
 # Set the cbitpos, or specify per-vm values (required)


### PR DESCRIPTION
vm_secure_guest_object_options is used to define secure guest object options.