### PR TITLE
libvirt_vm: install guest agent before start

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -3223,6 +3223,7 @@ class VM(virt_vm.BaseVM):
 
         def _start_ga():
             if not _is_ga_running():
+                self.install_package("qemu-guest-agent")
                 cmd = "service qemu-guest-agent start"
                 status, output = session.cmd_status_output(cmd)
                 # Sometimes the binary of the guest agent was corrupted on the


### PR DESCRIPTION
Fix a failure when start guest qemu-guest-agent service but no pkg installed in it before.