### PR TITLE
utils_netperf: bypass compilation failure

### DIFF
--- a/virttest/utils_netperf.py
+++ b/virttest/utils_netperf.py
@@ -168,6 +168,8 @@ class NetperfPackage(remote_old.Remote_Package):
         np_build = build_type.get(build_arch, build_arch).strip()
         setup_cmd = (
             "./autogen.sh > /dev/null 2>&1 &&"
+            # Workaround for gcc >= 14.0
+            " CFLAGS=-Wno-implicit-function-declaration"
             " ./configure --build=%s %s > /dev/null 2>&1" % (np_build, compile_option)
         )
         setup_cmd += " && make > /dev/null 2>&1"


### PR DESCRIPTION
Starting from gcc 14.0, implicit function declarations are treated as errors by default [1], which caused the following failure been observed during the compilation.

> netlib.c:2343:9: error: implicit declaration of function ...
> ...
> make[3]: *** [Makefile:454: netlib.o] Error 1

One contributor has already sent a PR [2] to fix the issue to the netperf upstream, however, it has not been merged yet since a year ago. At the moment, let's just bypass this issue, while waiting for a regular fix to be done.

References:
[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91092
[2] https://github.com/HewlettPackard/netperf/pull/74

ID: 2505