### PR TITLE
add support for dynamic memory slots

### DIFF
--- a/virttest/libvirt_xml/devices/memory.py
+++ b/virttest/libvirt_xml/devices/memory.py
@@ -91,6 +91,7 @@ class Memory(base.UntypedDeviceBase):
             "block_unit",
             "readonly",
             "address",
+            "attrs",
         )
 
         def __init__(self, virsh_instance=base.base.virsh):
@@ -156,6 +157,7 @@ class Memory(base.UntypedDeviceBase):
                 subclass=Memory.Address,
                 subclass_dargs={"type_name": "pci", "virsh_instance": virsh_instance},
             )
+            accessors.XMLElementDict("attrs", self, parent_xpath="/", tag_name="target")
             super(self.__class__, self).__init__(virsh_instance=virsh_instance)
             self.xml = "<target/>"
 


### PR DESCRIPTION
 need dynamicMemorySlots for memory target
Signed-off-by: nanli <nanli@redhat.com>

For https://github.com/autotest/tp-libvirt/pull/5703 