### PR TITLE
Obtaing the ip address of the guest and update address cache

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -35,6 +35,7 @@ from virttest import (
     utils_misc,
     utils_package,
     utils_selinux,
+    virsh,
 )
 from virttest.remote import RemoteRunner
 from virttest.staging import service, utils_memory
@@ -4867,3 +4868,21 @@ def check_class_rules(ifname, rule_id, bandwidth):
         stacktrace.log_exc_info(sys.exc_info())
         return False
     return True
+
+def obtain_guest_ip_from_dhcp_leases(mac):
+    """
+    Obtaining the guest ip address from virsh-net-dhcp-leases command
+
+    :param: Mac address of the guest
+    :return: return ip-address if found for given mac in the 
+             virsh-net-dhcp-leases default table, else return None
+    """
+    output = virsh.net_dhcp_leases("default")
+    lines = output.stdout.splitlines()
+    for line in lines:
+        if mac in line:
+            parts = line.split()
+            for part in parts:
+                if '/' in part:
+                    return part.split('/')[0]
+    return None

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -935,10 +935,11 @@ class BaseVM(object):
 
         ipaddr = utils_misc.wait_for(_get_address, timeout, step=interval)
         if not ipaddr:
-            # Read guest address via serial console and update VM address
-            # cache to avoid get out-dated address.
-            utils_net.update_mac_ip_address(self, timeout)
-            ipaddr = self.get_address(nic_index, ip_version)
+            # obatining ip address from virsh-net-dhcp-leases command
+            mac = self.get_mac_address(nic_index).lower()
+            ipaddr = utils_net.obtain_guest_ip_from_dhcp_leases(mac)
+            # updating cache with the latest ip address value
+            self.address_cache[mac] = ipaddr
         msg = "Found/Verified IP %s for VM %s NIC %s" % (ipaddr, self.name, nic_index)
         LOG.debug(msg)
         return ipaddr


### PR DESCRIPTION
Few of the times it is seen that the ip address is not being fetch and the avocado runs were failed with error "ERROR: Failures occurred while postprocess:\n\n: Guest virt-tests-vm1 dmesg verification failed: Login timeout expired    (output: 'exceeded 240 s timeout, last failure: No ipv4 DHCP lease for MAC aa:bb:cc:dd:ee:ff') "

To handle this error the patch has been sent. The patch helps in obtaining ip address of the guest using "virsh-net-dhcp-leases default" command. If the guest mac address is found in the command output, the mac ipv4 address is obatined and updated in the address.cache