### PR TITLE
libvirt.py -- Fix create_disk_xml() sometimes creates inaccessible file

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -28,6 +28,7 @@ import shutil
 import string
 import sys
 import time
+import uuid
 
 import aexpect
 import six
@@ -1881,7 +1882,6 @@ def create_disk_xml(params):
         diskxml.xmltreefile.write()
     except Exception as detail:
         LOG.error("Fail to create disk XML:\n%s", detail)
-    LOG.debug("Disk XML %s:\n%s", diskxml.xml, str(diskxml))
 
     # Wait for file completed
     def file_exists():
@@ -1892,7 +1892,13 @@ def create_disk_xml(params):
 
     # Wait for file write over with '</disk>' keyword at the file end
     wait_for_file_over("</disk>", diskxml.xml)
-    return diskxml.xml
+
+    tmp_dir = data_dir.get_tmp_dir(public=False)
+    path = tmp_dir + "/" + "disk_xml_" + str(uuid.uuid4()) + ".xml"
+    shutil.copy(src=diskxml.xml, dst=path)
+    LOG.debug("Disk XML %s:\n%s", path, str(diskxml))
+
+    return path
 
 
 def set_disk_attr(vmxml, target, tag, attr):


### PR DESCRIPTION
### The Issue
create_disk_xml() uses a disk.Disk() object to create a disk XML file. The disk.Disk() object, deletes the underlying XML when the object is garbage collected. The create_disk_xml() function only returns the XML filename, not the entire disk.Disk() object. As a result, the disk.Disk() object is garbage collected, and the underlying XML file is deleted.

This will result in any access to the XML file failing after a garbage collection cycle has been run.

### The Solution
Copy the contents of the XML file into a more permanent file.