### PR TITLE
env_process: Refactor running-as-root check into a Setuper 

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -54,7 +54,10 @@ from virttest.test_setup.networking import (
     NetworkProxies,
 )
 from virttest.test_setup.os_posix import UlimitConfig
-from virttest.test_setup.requirement_checks import CheckInstalledCMDs
+from virttest.test_setup.requirement_checks import (
+    CheckInstalledCMDs,
+    CheckRunningAsRoot,
+)
 from virttest.test_setup.storage import StorageConfig
 from virttest.utils_conn import SSHConnection
 from virttest.utils_version import VersionInterval
@@ -1087,13 +1090,9 @@ def preprocess(test, params, env):
                     pvr,
                     remote_pvr,
                 )
-    # First, let's verify if this test does require root or not. If it
-    # does and the test suite is running as a regular user, we shall just
-    # throw a TestSkipError exception, which will skip the test.
-    if params.get("requires_root", "no") == "yes":
-        utils_misc.verify_running_as_root()
 
     _setup_manager.initialize(test, params, env)
+    _setup_manager.register(CheckRunningAsRoot)
     _setup_manager.register(CheckInstalledCMDs)
     _setup_manager.register(UlimitConfig)
     _setup_manager.register(NetworkProxies)

--- a/virttest/test_setup/requirement_checks.py
+++ b/virttest/test_setup/requirement_checks.py
@@ -1,6 +1,7 @@
 from avocado.core import exceptions
 from avocado.utils import path
 
+from virttest import utils_misc
 from virttest.test_setup.core import Setuper
 
 
@@ -14,6 +15,18 @@ class CheckInstalledCMDs(Setuper):
                     path.find_command(cmd)
                 except path.CmdNotFoundError as msg:
                     raise exceptions.TestSkipError(msg)
+
+    def cleanup(self):
+        pass
+
+
+class CheckRunningAsRoot(Setuper):
+    def setup(self):
+        # Verify if this test does require root or not. If it does and the
+        # test suite is running as a regular user, we shall just throw a
+        # TestSkipError exception, which will skip the test.
+        if self.params.get("requires_root", "no") == "yes":
+            utils_misc.verify_running_as_root()
 
     def cleanup(self):
         pass


### PR DESCRIPTION
Moving the logic that checked that the process was run as root into a `Setuper`. Functional changes aren't intended with this patch.

ID: 2430