### PR TITLE
virttest/virt_admin.py: Provide better Error Msg

### DIFF
--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -209,13 +209,14 @@ class VirtadminSession(aexpect.ShellSession):
 
         # fail if libvirtd is not running
         if check_libvirtd:
-            if self.cmd_status("uri", timeout=60) != 0:
+            status, out = self.cmd_status_output("uri", timeout=60)
+            if status != 0:
                 LOG.debug(
                     "Persistent virt-admin session is not responding, "
                     "libvirtd may be dead."
                 )
                 self.auto_close = True
-                raise aexpect.ShellStatusError(virtadmin_exec, "uri")
+                raise aexpect.ShellStatusError(virtadmin_exec, out)
 
     def cmd_status_output(
         self, cmd, timeout=60, internal_timeout=None, print_func=None, safe=False


### PR DESCRIPTION
### The Issue
To ensure the virt-admin interactive shell is alive, a "uri" command is executed. However, the output of this command is ignored. This makes debugging a failure of this command hard.

### The Fix
Print the output of the error