### PR TITLE
Fix qemu simple_unplug issue

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1053,6 +1053,7 @@ class DevContainer(object):
         try:
             device.unplug_hook()
             drive = device.get_param("drive")
+            self.remove(device, True)
             if drive:
                 if Flags.BLOCKDEV in self.caps:
                     # top node
@@ -1076,7 +1077,6 @@ class DevContainer(object):
                             parent_node.del_child_node(node)
                 else:
                     self.remove(drive)
-            self.remove(device, True)
             if ver_out is True:
                 self.set_clean()
             elif out is False:

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -1113,7 +1113,6 @@ class QDevice(QCustomDevice):
         )
         if driver:
             self.set_param("driver", driver)
-        self.hook_drive_bus = None
 
     def _get_alternative_name(self):
         """:return: alternative object name"""
@@ -1159,13 +1158,6 @@ class QDevice(QCustomDevice):
         for key in self.dynamic_params:
             params[key] = "DYN"
         return "device_add", params
-
-    def get_children(self):
-        """Device bus should be removed too"""
-        devices = super(QDevice, self).get_children()
-        if self.hook_drive_bus:
-            devices.append(self.hook_drive_bus)
-        return devices
 
     def unplug_hmp(self):
         """:return: the unplug monitor command"""
@@ -1367,13 +1359,6 @@ class QObject(QCustomDevice):
         super(QObject, self).__init__(**kwargs)
         self.set_param("backend", backend)
 
-    def get_children(self):
-        """Device bus should be removed too"""
-        devices = super(QObject, self).get_children()
-        if getattr(self, "hook_drive_bus", None):
-            devices.append(self.hook_drive_bus)
-        return devices
-
     def _get_alternative_name(self):
         """:return: alternative object name"""
         if self.get_param("backend"):
@@ -1567,7 +1552,6 @@ class QThrottleGroup(QObject):
         self.throttle_group_bus = QThrottleGroupBus(group_id)
         self.add_child_bus(self.throttle_group_bus)
         self.set_aid(group_id)
-        self.hook_drive_bus = None
 
     @staticmethod
     def _map_key(params):
@@ -1688,7 +1672,6 @@ class Memory(QObject):
 
     def __init__(self, backend, params=None):
         super(Memory, self).__init__(backend, params)
-        self.hook_drive_bus = None
 
     def _refresh_hotplug_props(self, params):
         convert_size = utils_misc.normalize_data_size
@@ -1822,7 +1805,6 @@ class Dimm(QDevice):
         kwargs = {"driver": dimm_type, "params": params}
         super(Dimm, self).__init__(**kwargs)
         self.set_param("driver", dimm_type)
-        self.hook_drive_bus = None
 
     def verify_hotplug(self, out, monitor):
         out = monitor.info("memory-devices", debug=False)
@@ -3170,8 +3152,6 @@ class QDriveBus(QSparseBus):
         store this bus device into hook variable of the device.
         """
         self._set_device_props(device, addr)
-        if hasattr(device, "hook_drive_bus"):
-            device.hook_drive_bus = self.get_device()
 
 
 class QDenseBus(QSparseBus):


### PR DESCRIPTION
- qdevices: remove hook_drive_bus attribute

    The `hook_drive_bus` attribute was introduced for handling parentship
    between the `QDevice`s and theirs parent nodes. However, since that
    time, it improperly made them seeing each other as the child, which
    is senseless. This patch removes the attribute and the relevant code
    accordingly.

- qcontainer: fix simple_unplug issue

    This ensure that a device would be removed from the DevContainer
    before its parent(s) been removed.

ID: 2408