### PR TITLE
Introduce image slices

### DIFF
--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -792,12 +792,16 @@ class QBlockdevNode(QCustomDevice):
         """
         new_args = dict()
         keep_original_type = ("detect-zeroes",)
+        int_opts = ("offset", "size")
         for key, value in six.iteritems(args):
             if key not in keep_original_type:
                 if value in ("on", "yes"):
                     value = True
                 elif value in ("off", "no"):
                     value = False
+
+            if key in int_opts:
+                value = int(value)
 
             parts = key.split(".")
             d = new_args

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -390,6 +390,18 @@ image_unbootable_pattern = "Hard Disk.*not a bootable disk"
 #
 #drive_cache = none
 
+#
+# Image slices param
+#
+# Image configurations to specify slics.
+# image_slices: list of slice names
+# (currently, only support 1 slice)
+#image_slices = slice1
+# image_slice_offset: position where the content starts
+#image_slice_offset_slice1 = 4096
+# image_slice_size: the assumed size of the content
+#image_slice_size_slice1 = 10G
+
 # Iscsi support related params. Please fill them depends on your environment.
 # For both iscsi and emulated iscsi should have this option:
 # target: target name of your iscsi device

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -28,6 +28,7 @@ from virttest import (
     lvm,
     nbd,
     nvme,
+    propcan,
     storage_ssh,
     utils_misc,
     utils_numeric,
@@ -800,6 +801,49 @@ class ImageEncryption(object):
         if self.key_secret:
             return self.base_key_secrets + [self.key_secret]
         return self.base_key_secrets
+
+
+class ImageSlicesInfo:
+
+    """Slices information associated with images."""
+
+    def __init__(self, image, slices):
+        """
+        Initialize image slices information.
+
+        :param image: Image tag name.
+        :param slices: List of slice properties.
+        """
+        self.image = image
+        self.slices = slices
+
+    @classmethod
+    def slices_info_define_by_params(cls, image, params):
+        """
+        Get slices information from image parameters.
+
+        :param image: Image tag name.
+        :param params: Image parameters.
+
+        :return: ImageSlicesInfo instance to the specified image.
+        """
+        slices = []
+        slice_tags = params.objects("image_slices")
+        for tag in slice_tags:
+            slice_params = params.object_params(tag)
+            offset = slice_params.get("image_slice_offset")
+            size = slice_params.get("image_slice_size")
+            if size is not None:
+                size = utils_numeric.normalize_data_size(size, order_magnitude="B")
+            slices.append(SliceProperties(offset=offset, size=size))
+        return cls(image, slices)
+
+
+class SliceProperties(propcan.PropCan):
+
+    """Properties of a single slice associated with images."""
+
+    __slots__ = ["offset", "size"]
 
 
 def copy_nfs_image(params, root_dir, basename=False):


### PR DESCRIPTION
Introduce the image slices support to allow users assigning parts of the block devices to the VMs as storage backends.

Notes that this patch merely implements the support for qemu testing.

ID: 2644