### PR TITLE
libvirt-vm:Add support for cmdline parameter for --boot

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -986,6 +986,8 @@ class VM(virt_vm.BaseVM):
                     result += "initrd=%s," % initrd_path
                 if has_sub_option("boot", "kernel_args") and kernel_args:
                     result += 'kernel_args="%s",' % kernel_args
+                elif has_sub_option("boot", "cmdline") and kernel_args:
+                    result += 'cmdline="%s",' % kernel_args
             else:
                 result = ""
                 LOG.warning("boot option is not supported")
@@ -1449,6 +1451,8 @@ class VM(virt_vm.BaseVM):
         kernel = params.get("kernel", None)
         initrd = params.get("initrd", None)
         kernel_args = params.get("kernel_args", None)
+        if not kernel_args:
+            kernel_args = params.get("cmdline", None)
         if (kernel or initrd) and kernel_args:
             virt_install_cmd += add_kernel(
                 help_text, virt_install_cmd, kernel, initrd, kernel_args


### PR DESCRIPTION
### libvirt-vm: Add support for cmdline parameter for --boot
Currently, kernel_args is not present in the output of "virt-install --boot help" as "--boot cmdline=%s" is the recommended way of passing kernel command line parameters. As a result, the import/install test is failiing since kernel and initrd parameter is being passed without kernel_args

But --boot option supports both kernel_args and cmdline parameter for passing kernel arguments to the guest, i.e,
`--boot kernel=<vmlinuz>,initrd=<initrd>,cmdline=<kernel-cmdline>` (recommended way)
(or)
`--boot kernel=<vmlinuz>,initrd=<initrd>,kernel_args= <kernel-cmdline>`

This patch adds support of reading both cmdline and kernel_args parameter and passes whichever is available from config to the virt-install --boot option

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)