### PR TITLE
add support for PERSISTENT_ONLY in libvirt-guests

### DIFF
--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -529,6 +529,7 @@ class LibvirtGuestsConfig(LibvirtConfigCommon):
         "SHUTDOWN_TIMEOUT": "int",
         "BYPASS_CACHE": "boolean",
         "SYNC_TIME": "boolean",
+        "PERSISTENT_ONLY": "string",
     }
 
 


### PR DESCRIPTION
for https://github.com/autotest/tp-libvirt/pull/5852 