### PR TITLE
Replacing deprecated 'warn' function with 'warning'

### DIFF
--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -108,7 +108,7 @@ class VTJobLock(Pre, Post):
                     try:
                         os.unlink(path)
                     except OSError:
-                        self.log.warn("Unable to remove stale lock: %s", path)
+                        self.log.warning("Unable to remove stale lock: %s", path)
 
     @staticmethod
     def _get_klass_or_none(test_factory):

--- a/avocado_vt/utils.py
+++ b/avocado_vt/utils.py
@@ -142,12 +142,14 @@ class TestUtils:
             try:
                 pickle.dumps(env.data)
             except Exception:
-                self.log.warn(
+                self.log.warning(
                     "Unable to save environment: %s",
                     stacktrace.str_unpickable_object(env.data),
                 )
             else:
-                self.log.warn("Unable to save environment: %s (%s)", details, env.data)
+                self.log.warning(
+                    "Unable to save environment: %s (%s)", details, env.data
+                )
             return True
         return False
 

--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -924,7 +924,7 @@ def bootstrap(options, interactive=False):
         asset.download_all_test_providers(get_opt(options, "vt_update_providers"))
     else:
         if not_downloaded:
-            LOG.warn(
+            LOG.warning(
                 "The following test providers have not been downloaded: %s",
                 ", ".join(not_downloaded),
             )

--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -1509,7 +1509,7 @@ class Parser(object):
             LOG.debug(s, *args)
 
     def _warn(self, s, *args):
-        LOG.warn(s, *args)
+        LOG.warning(s, *args)
 
     def parse_file(self, filename):
         """

--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -1045,7 +1045,7 @@ def get_host_cpu_models():
                 cpu_model = cpu_type
                 cpu_support_model.append(cpu_model)
     else:
-        LOG.warn("Can not Get cpu flags from cpuinfo")
+        LOG.warning("Can not Get cpu flags from cpuinfo")
 
     return cpu_support_model
 
@@ -1200,15 +1200,15 @@ def get_model_features(model_name):
                             features.append(feature.get("name"))
                         break
     except ET.ParseError as error:
-        LOG.warn("Configuration file %s has wrong xml format" % conf)
+        LOG.warning("Configuration file %s has wrong xml format" % conf)
         raise
     except AttributeError as elem_attr:
-        LOG.warn("No attribute %s in file %s" % (str(elem_attr), conf))
+        LOG.warning("No attribute %s in file %s" % (str(elem_attr), conf))
         raise
     except Exception:
         # Other exceptions like IOError when open/read configuration file,
         # capture here
-        LOG.warn(
+        LOG.warning(
             "Some other exceptions, like configuration file is not "
             "found or not file: %s" % conf
         )

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -409,7 +409,7 @@ def preprocess_vm(test, params, env, name):
             debug_msg += "There is no serial console in VM."
         if debug_msg:
             debug_msg += " Skip the kernel command line check."
-            LOG.warn(debug_msg)
+            LOG.warning(debug_msg)
             return
         cmd_line = params.get("kernel_cmd_line_str", "Command line:")
         try:
@@ -435,7 +435,7 @@ def preprocess_vm(test, params, env, name):
 
             LOG.info("Kernel command line get from serial port is as expect")
         except Exception as err:
-            LOG.warn(
+            LOG.warning(
                 "Did not get the kernel command line from serial "
                 "port output. Skip the kernel command line check."
                 "Error is %s" % err
@@ -516,7 +516,7 @@ def check_image(test, params, image_name, vm_process_status=None):
             if params.get(
                 "skip_cluster_leak_warn"
             ) == "yes" and "Leaked clusters" in six.text_type(e):
-                LOG.warn(six.text_type(e))
+                LOG.warning(six.text_type(e))
             else:
                 raise e
 
@@ -533,7 +533,7 @@ def postprocess_image(test, params, image_name, vm_process_status=None):
                               or None for no vm exist.
     """
     if vm_process_status == "running":
-        LOG.warn(
+        LOG.warning(
             "Skipped processing image '%s' since " "the VM is running!" % image_name
         )
         return
@@ -615,7 +615,7 @@ def postprocess_fs_source(test, params, fs_name, vm_process_status=None):
                               running, dead or None for no vm exist.
     """
     if vm_process_status == "running":
-        LOG.warn(
+        LOG.warning(
             "Skipped processing filesystem '%s' since " "the VM is running!" % fs_name
         )
         return
@@ -741,7 +741,7 @@ def process_command(test, params, env, command, command_timeout, command_noncrit
         a_process.system("cd %s; %s" % (test.bindir, command), shell=True)
     except a_process.CmdError as e:
         if command_noncritical:
-            LOG.warn(e)
+            LOG.warning(e)
         else:
             raise
 
@@ -1617,7 +1617,7 @@ def postprocess(test, params, env):
     ppm_file_rex = "*_iter%s.ppm" % test.iteration
     for f in glob.glob(os.path.join(screendump_temp_dir, ppm_file_rex)):
         if not ppm_utils.image_verify_ppm_file(f):
-            LOG.warn("Found corrupt PPM file: %s", f)
+            LOG.warning("Found corrupt PPM file: %s", f)
 
     # Should we convert PPM files to PNG format?
     if params.get("convert_ppm_files_to_png", "no") == "yes":
@@ -1669,7 +1669,7 @@ def postprocess(test, params, env):
                     session = vm.wait_for_serial_login(timeout=vm.LOGIN_WAIT_TIMEOUT)
                     session.close()
             except (remote.LoginError, virt_vm.VMError, IndexError) as e:
-                LOG.warn(e)
+                LOG.warning(e)
                 vm.destroy(gracefully=False)
 
     # Kill VMs with deleted disks
@@ -1874,16 +1874,16 @@ def _take_screendumps(test, params, env):
             try:
                 vm.screendump(filename=temp_filename, debug=False)
             except qemu_monitor.MonitorError as e:
-                LOG.warn(e)
+                LOG.warning(e)
                 continue
             except AttributeError as e:
-                LOG.warn(e)
+                LOG.warning(e)
                 continue
             if not os.path.exists(temp_filename):
-                LOG.warn("VM '%s' failed to produce a screendump", vm.name)
+                LOG.warning("VM '%s' failed to produce a screendump", vm.name)
                 continue
             if not ppm_utils.image_verify_ppm_file(temp_filename):
-                LOG.warn("VM '%s' produced an invalid screendump", vm.name)
+                LOG.warning("VM '%s' produced an invalid screendump", vm.name)
                 os.unlink(temp_filename)
                 continue
             screendump_dir = "screendumps_%s_%s_iter%s" % (
@@ -1973,10 +1973,10 @@ def store_vm_info(vm, log_filename, info_cmd="registers", append=False, vmtype="
         try:
             output = vm.catch_monitor.info(info_cmd, debug=False)
         except qemu_monitor.MonitorError as err:
-            LOG.warn(err)
+            LOG.warning(err)
             return False
         except AttributeError as err:
-            LOG.warn(err)
+            LOG.warning(err)
             return False
     elif vmtype == "libvirt":
         try:
@@ -1985,7 +1985,7 @@ def store_vm_info(vm, log_filename, info_cmd="registers", append=False, vmtype="
             )
             output = result.stdout
         except Exception as details:
-            LOG.warn(details)
+            LOG.warning(details)
             return False
 
     log_filename = "%s_%s" % (log_filename, timestamp)

--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -191,7 +191,7 @@ class QemuAgent(Monitor):
         except VAgentError as e:
             self._close_sock()
             if suppress_exceptions:
-                LOG.warn(e)
+                LOG.warning(e)
             else:
                 raise
 
@@ -333,7 +333,7 @@ class QemuAgent(Monitor):
         if not self._supported_cmds:
             # If initiation fails, set supported list to a None-only list.
             self._supported_cmds = [None]
-            LOG.warn("Could not get supported guest agent cmds list")
+            LOG.warning("Could not get supported guest agent cmds list")
 
     def check_has_command(self, cmd):
         """

--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -176,7 +176,7 @@ class Sniffer(object):
         try:
             log_line(self._logfile, line)
         except Exception as e:
-            LOG.warn("Can't log ip sniffer output: '%s'", e)
+            LOG.warning("Can't log ip sniffer output: '%s'", e)
         if self._output_handler(line):
             return
         # We can check whether the process is terminated unexpectedly
@@ -349,7 +349,7 @@ class TSharkSniffer(Sniffer):
         if re.match(r"[0-9a-fA-F]{1,4}:\S+", packet[0]):
             # TODO: support DHCPv6
             if not self.__dict__.setdefault("_ip6_warned", False):
-                LOG.warn(
+                LOG.warning(
                     "IPv6 address sniffing is not supported yet by "
                     "using TShark, please fallback to use other "
                     "sniffers by uninstalling TShark when testing "

--- a/virttest/libvirt_xml/domcapability_xml.py
+++ b/virttest/libvirt_xml/domcapability_xml.py
@@ -87,7 +87,7 @@ class DomCapabilityXML(base.LibvirtXMLBase):
                             continue
                         feature_list.append(item)
         except AttributeError as elem_attr:
-            LOG.warn("Failed to find attribute %s" % elem_attr)
+            LOG.warning("Failed to find attribute %s" % elem_attr)
             feature_list = []
         finally:
             return feature_list
@@ -138,7 +138,7 @@ class DomCapabilityXML(base.LibvirtXMLBase):
                 if mode_node.get("name") == "host-model":
                     return mode_node.find("model").text
         except AttributeError as elem_attr:
-            LOG.warn("Failed to find attribute %s" % elem_attr)
+            LOG.warning("Failed to find attribute %s" % elem_attr)
             return ""
 
 

--- a/virttest/libvirtd_decorator.py
+++ b/virttest/libvirtd_decorator.py
@@ -65,15 +65,17 @@ def get_libvirt_version_compare(major, minor, update, session=None):
         func = session.cmd_output
 
     if LIBVIRTD is None:
-        LOG.warn("Can not find command to dertermin libvirt version")
+        LOG.warning("Can not find command to dertermin libvirt version")
         return False
     libvirt_ver_cmd = "%s -V" % LIBVIRTD
-    LOG.warn(libvirt_ver_cmd)
+    LOG.warning(libvirt_ver_cmd)
     try:
         regex = r"%s\s*.*[Ll]ibvirt.*\s*" % LIBVIRTD
         regex += r"(\d+)\.(\d+)\.(\d+)"
         lines = astring.to_text(func(libvirt_ver_cmd)).splitlines()
-        LOG.warn("libvirt version value by libvirtd or virtqemud command: %s" % lines)
+        LOG.warning(
+            "libvirt version value by libvirtd or virtqemud command: %s" % lines
+        )
         for line in lines:
             match = re.search(regex, line.strip())
             if match:
@@ -84,7 +86,7 @@ def get_libvirt_version_compare(major, minor, update, session=None):
                 )
                 break
     except (ValueError, TypeError, AttributeError):
-        LOG.warn("Error determining libvirt version")
+        LOG.warning("Error determining libvirt version")
         return False
 
     compare_version = major * 1000000 + minor * 1000 + update
@@ -122,13 +124,13 @@ def libvirt_version_context_aware_libvirtd_legacy(fn):
         """
         check_libvirt_version()
         if not IS_LIBVIRTD_SPLIT_VERSION or not LIBVIRTD_SPLIT_ENABLE_BIT:
-            LOG.warn(
+            LOG.warning(
                 "legacy start libvirtd daemon NORMALLY with function name: %s"
                 % fn.__name__
             )
             return fn(*args, **kwargs)
         else:
-            LOG.warn(
+            LOG.warning(
                 "legacy start libvirtd daemon IGNORED with function name: %s"
                 % fn.__name__
             )
@@ -153,13 +155,13 @@ def libvirt_version_context_aware_libvirtd_split(fn):
         """
         check_libvirt_version()
         if IS_LIBVIRTD_SPLIT_VERSION and LIBVIRTD_SPLIT_ENABLE_BIT:
-            LOG.warn(
+            LOG.warning(
                 "Split start libvirtd daemon NORMALLY with function name: %s"
                 % fn.__name__
             )
             return fn(*args, **kwargs)
         else:
-            LOG.warn(
+            LOG.warning(
                 "Split start libvirtd daemon IGNORED with function name: %s"
                 % fn.__name__
             )

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -50,7 +50,7 @@ def normalize_data_size(size):
 def cmd_output(cmd, res="[\w/]+"):
     result = process.run(cmd, ignore_status=True)
     if result.exit_status != 0:
-        LOG.warn(result)
+        LOG.warning(result)
         return None
     output = result.stdout_text
     for line in output.splitlines():
@@ -563,7 +563,9 @@ class LVM(object):
             LOG.info("LogicalVolume(%s) really exists " % lv_name + "skip to create it")
         if lv.size != lv_size:
             lv.display()
-            LOG.warn("lv size(%s) mismath," % lv.size + "required size %s;" % lv_size)
+            LOG.warning(
+                "lv size(%s) mismath," % lv.size + "required size %s;" % lv_size
+            )
             lv.resize(lv_size)
         return lv
 
@@ -670,7 +672,9 @@ class EmulatedLVM(LVM):
             self.register(pv)
             self.pvs.append(pv)
         else:
-            LOG.warn("PhysicalVolume(%s) really exists" % pv_name + "skip to create it")
+            LOG.warning(
+                "PhysicalVolume(%s) really exists" % pv_name + "skip to create it"
+            )
         pv.set_vg(vg)
         pvs.append(pv)
         return pvs

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -107,7 +107,7 @@ class Exportfs(object):
             unexport_cmd = "exportfs -u %s:%s" % (self.client, self.path)
             self.func(unexport_cmd)
         else:
-            LOG.warn(
+            LOG.warning(
                 "Target %s %s is not exported yet."
                 "Can not unexport it." % (self.client, self.path)
             )
@@ -135,7 +135,7 @@ class Exportfs(object):
                 self.unexport()
             else:
                 self.already_exported = True
-                LOG.warn("Already exported target. Don't need export it again")
+                LOG.warning("Already exported target. Don't need export it again")
                 return True
         export_cmd = "exportfs"
         if self.options:

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -1606,7 +1606,7 @@ class DevContainer(object):
             aarch64 (arm64) doesn't support PCI bus, only MMIO transports.
             Also it requires pflash for EFI boot.
             """
-            LOG.warn("Support for aarch64 is highly experimental!")
+            LOG.warning("Support for aarch64 is highly experimental!")
             devices = []
             # Add virtio-bus
             # TODO: Currently this uses QNoAddrCustomBus and does not
@@ -1633,7 +1633,7 @@ class DevContainer(object):
             """
             Experimental support for pci-based aarch64
             """
-            LOG.warn("Support for aarch64 is highly experimental!")
+            LOG.warning("Support for aarch64 is highly experimental!")
             devices = []
 
             bus = (
@@ -1694,7 +1694,7 @@ class DevContainer(object):
             # set the device's properties. This means that the qemu qtree
             # and autotest's representations are completely different and
             # can't be used.
-            LOG.warn("Support for s390x is highly experimental!")
+            LOG.warning("Support for s390x is highly experimental!")
             bus = (
                 qdevices.QNoAddrCustomBus(
                     "bus",
@@ -1716,7 +1716,7 @@ class DevContainer(object):
             """
             riscv doesn't support PCI bus, only MMIO transports.
             """
-            LOG.warn(
+            LOG.warning(
                 "Support for riscv64 is highly experimental. See "
                 "https://avocado-vt.readthedocs.io"
                 "/en/latest/Experimental.html#riscv64 for "
@@ -1747,7 +1747,7 @@ class DevContainer(object):
             isapc or unknown machine type. This type doesn't add any default
             buses or devices, only sets the cmdline.
             """
-            LOG.warn(
+            LOG.warning(
                 "Machine type isa/unknown is not supported by "
                 "avocado-vt. False errors might occur"
             )
@@ -1811,7 +1811,7 @@ class DevContainer(object):
         elif avocado_machine == "riscv64-mmio":
             devices = machine_riscv64_mmio(machine_params)
         else:
-            LOG.warn(
+            LOG.warning(
                 "Machine type '%s' is not supported "
                 "by avocado-vt, errors might occur",
                 machine_type,
@@ -2346,7 +2346,7 @@ class DevContainer(object):
 
         use_device = self.has_option("device")
         if fmt == "scsi":  # fmt=scsi force the old version of devices
-            LOG.warn(
+            LOG.warning(
                 "'scsi' drive_format is deprecated, please use the "
                 "new lsi_scsi type for disk %s",
                 name,
@@ -2382,18 +2382,18 @@ class DevContainer(object):
         port = none_or_int(port)  # Third level
         # Compatibility with old params - scsiid, lun
         if scsiid is not None:
-            LOG.warn(
+            LOG.warning(
                 "drive_scsiid param is obsolete, use drive_unit " "instead (disk %s)",
                 name,
             )
             unit = none_or_int(scsiid)
         if lun is not None:
-            LOG.warn(
+            LOG.warning(
                 "drive_lun param is obsolete, use drive_port instead " "(disk %s)", name
             )
             port = none_or_int(lun)
         if pci_addr is not None and fmt == "virtio":
-            LOG.warn(
+            LOG.warning(
                 "drive_pci_addr is obsolete, use drive_bus instead " "(disk %s)", name
             )
             bus = none_or_int(pci_addr)
@@ -2413,7 +2413,7 @@ class DevContainer(object):
                 )
             ):
                 if not (bus is None and unit is None and port is None):
-                    LOG.warn(
+                    LOG.warning(
                         "Using scsi interface without -device "
                         "support; ignoring bus/unit/port. (%s)",
                         name,
@@ -2447,7 +2447,7 @@ class DevContainer(object):
                 devices.extend(_[0])
         elif fmt == "ide":
             if bus:
-                LOG.warn(
+                LOG.warning(
                     "ide supports only 1 hba, use drive_unit to set"
                     "ide.* for disk %s",
                     name,
@@ -2492,7 +2492,7 @@ class DevContainer(object):
             devices.extend(_)
         elif fmt in ("usb1", "usb2", "usb3"):
             if bus:
-                LOG.warn(
+                LOG.warning(
                     "Manual setting of drive_bus is not yet supported"
                     " for usb disk %s",
                     name,
@@ -2604,7 +2604,7 @@ class DevContainer(object):
         if Flags.BLOCKDEV in self.caps:
             for opt, val in zip(("serial", "boot"), (serial, boot)):
                 if val is not None:
-                    LOG.warn(
+                    LOG.warning(
                         "The command line option %s is not supported "
                         "on %s by -blockdev." % (opt, name)
                     )
@@ -2656,7 +2656,7 @@ class DevContainer(object):
 
         if "aio" in self.get_help_text():
             if aio == "native" and snapshot == "yes":
-                LOG.warn("snapshot is on, fallback aio to threads.")
+                LOG.warning("snapshot is on, fallback aio to threads.")
                 aio = "threads"
             if Flags.BLOCKDEV in self.caps:
                 if isinstance(
@@ -2823,7 +2823,7 @@ class DevContainer(object):
                 devices[-1].set_param("addr", pci_addr)
                 devices[-1].parent_bus = (pci_bus,)
             if not media == "cdrom":
-                LOG.warn(
+                LOG.warning(
                     "Using -drive fmt=xxx for %s is unsupported "
                     "method, false errors might occur.",
                     name,
@@ -2883,7 +2883,7 @@ class DevContainer(object):
                     ({"busid": "drive_%s" % name}, {"type": fmt}),
                 )
         else:
-            LOG.warn("Using default device handling (disk %s)", name)
+            LOG.warning("Using default device handling (disk %s)", name)
             devices[-1].set_param("driver", fmt)
         if force_fmt:
             LOG.info("Force to use %s for the device" % force_fmt)
@@ -3334,7 +3334,7 @@ class DevContainer(object):
                 scsi_hba = "virtio-scsi-ccw"
         if cd_format in (None, "ide"):
             if not self.get_buses({"atype": "ide"}):
-                LOG.warn("cd_format IDE not available, using AHCI instead.")
+                LOG.warning("cd_format IDE not available, using AHCI instead.")
                 cd_format = "ahci"
         if scsi_hba == "virtio-scsi-pci":
             if "mmio" in image_params.get("machine_type"):
@@ -3613,7 +3613,7 @@ class DevContainer(object):
             dev.set_param("id", "input_%s" % name)
             devices.append(dev)
         else:
-            LOG.warn("'%s' is not supported by your qemu", driver)
+            LOG.warning("'%s' is not supported by your qemu", driver)
 
         return devices
 
@@ -3747,7 +3747,7 @@ class DevContainer(object):
             try:
                 utils_logfile.log_line("%s_swtpm_setup.log" % name, line)
             except Exception as e:
-                LOG.warn("Can't log %s_swtpm_setup output: %s.", name, e)
+                LOG.warning("Can't log %s_swtpm_setup output: %s.", name, e)
 
         def _emulator_setup(binary, extra_options=None):
             setup_cmd = binary

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -554,7 +554,7 @@ class QOldDrive(QDrive):
         Ignore addr parameters as they are not supported by old qemus
         """
         if option == "addr":
-            LOG.warn(
+            LOG.warning(
                 "Ignoring 'addr=%s' parameter of %s due of old qemu"
                 ", PCI addresses might be messed up.",
                 value,
@@ -2138,7 +2138,7 @@ class QDaemonDev(QBaseDevice):
         start_until_timeout = self.get_param("start_until_timeout", 1)
 
         if cmd is None:
-            LOG.warn("No provided command to start %s daemon.", name)
+            LOG.warning("No provided command to start %s daemon.", name)
             self._daemon_process = None
 
         if self.is_daemon_alive():
@@ -2255,7 +2255,7 @@ class QVirtioFSDev(QDaemonDev):
         try:
             utils_logfile.log_line("%s-%s.log" % (self.get_qid(), name), line)
         except Exception as e:
-            LOG.warn("Can't log %s-%s, output: '%s'.", self.get_qid(), name, e)
+            LOG.warning("Can't log %s-%s, output: '%s'.", self.get_qid(), name, e)
 
     def start_daemon(self):
         """Start the virtiofs daemon in background."""

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -158,7 +158,7 @@ def create_monitor(vm, monitor_name, monitor_params):
     if monitor_params.get("monitor_type") == "qmp":
         if not utils_misc.qemu_has_option("qmp", vm.qemu_binary):
             # Add a "human" monitor on non-qmp version of qemu.
-            LOG.warn(
+            LOG.warning(
                 "QMP monitor is unsupported by %s,"
                 " creating human monitor instead." % vm.qemu_version
             )
@@ -188,7 +188,7 @@ def wait_for_create_monitor(vm, monitor_name, monitor_params, timeout):
         try:
             return create_monitor(vm, monitor_name, monitor_params)
         except MonitorError as e:
-            LOG.warn(e)
+            LOG.warning(e)
             time.sleep(1)
     else:
         raise MonitorConnectError(monitor_name)
@@ -841,7 +841,7 @@ class HumanMonitor(Monitor):
         except MonitorError as e:
             self._close_sock()
             if suppress_exceptions:
-                LOG.warn(e)
+                LOG.warning(e)
             else:
                 raise
 
@@ -913,7 +913,7 @@ class HumanMonitor(Monitor):
             self._supported_cmds = [c for c in cmd_list if c]
 
         if not self._supported_cmds:
-            LOG.warn("Could not get supported monitor cmds list")
+            LOG.warning("Could not get supported monitor cmds list")
 
     def _log_response(self, cmd, resp, debug=True):
         """
@@ -1841,7 +1841,7 @@ class QMPMonitor(Monitor):
         except MonitorError as e:
             self._close_sock()
             if suppress_exceptions:
-                LOG.warn(e)
+                LOG.warning(e)
             else:
                 raise
 
@@ -1943,7 +1943,7 @@ class QMPMonitor(Monitor):
             self._supported_cmds = [n["name"] for n in cmds if "name" in n]
 
         if not self._supported_cmds:
-            LOG.warn("Could not get supported monitor cmds list")
+            LOG.warning("Could not get supported monitor cmds list")
 
     def _get_supported_hmp_cmds(self):
         """
@@ -1955,7 +1955,7 @@ class QMPMonitor(Monitor):
             self._supported_hmp_cmds = [(i + j) for i, j in cmd_list if i or j]
 
         if not self._supported_cmds:
-            LOG.warn("Could not get supported monitor cmds list")
+            LOG.warning("Could not get supported monitor cmds list")
 
     def _has_hmp_command(self, cmd):
         """

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -1506,7 +1506,7 @@ class QemuImg(storage.QemuImg):
             if "--backing-chain" in self.help_text:
                 cmd += " --backing-chain"
             else:
-                LOG.warn("'--backing-chain' option is not supported")
+                LOG.warning("'--backing-chain' option is not supported")
 
         if force_share:
             cmd += " -U"
@@ -1569,7 +1569,7 @@ class QemuImg(storage.QemuImg):
         compare_images = self.support_cmd("compare")
         force_share &= self.cap_force_share
         if not compare_images:
-            LOG.warn("sub-command compare not supported by qemu-img")
+            LOG.warning("sub-command compare not supported by qemu-img")
             return None
         else:
             LOG.info("Comparing images %s and %s", image1, image2)
@@ -1612,7 +1612,7 @@ class QemuImg(storage.QemuImg):
         :return: compare result [process.CmdResult]
         """
         if not self.support_cmd("compare"):
-            LOG.warn("qemu-img subcommand compare not supported")
+            LOG.warning("qemu-img subcommand compare not supported")
             return
         force_share &= self.cap_force_share
         LOG.info(
@@ -2118,7 +2118,7 @@ class Iscsidev(storage.Iscsidev):
         Access the iscsi target. And return the local raw device name.
         """
         if self.iscsidevice.logged_in():
-            LOG.warn("Session already present. Don't need to login again")
+            LOG.warning("Session already present. Don't need to login again")
         else:
             self.iscsidevice.login()
 

--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -79,7 +79,7 @@ class _VirtioPort(object):
         """
         # TODO: add port cleanup into qemu_vm.py
         if self.is_open():
-            LOG.warn(
+            LOG.warning(
                 "Force closing virtio_port socket, FIX the code to "
                 " close the socket prior this to avoid possible err."
             )
@@ -405,7 +405,7 @@ class GuestWorker(object):
             "virt.exit_threads()", 3, ("^PASS: All threads" " finished",)
         )
         if match is None:
-            LOG.warn("Workaround the stuck thread on guest")
+            LOG.warning("Workaround the stuck thread on guest")
             # Thread is stuck in read/write
             for send_pt in send_pts:
                 timeout = None
@@ -505,7 +505,7 @@ class GuestWorker(object):
             self.session.close()
             # On windows it dies with the connection
             if match != 0 and self.os_linux:
-                LOG.warn(
+                LOG.warning(
                     "guest_worker stuck during cleanup:\n%s\n," " killing python...",
                     tmp,
                 )

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -594,7 +594,7 @@ class VM(virt_vm.BaseVM):
 
         def add_qmp_monitor(devices, monitor_name, filename):
             if not devices.has_option("qmp"):
-                LOG.warn("Fallback to human monitor since qmp is" " unsupported")
+                LOG.warning("Fallback to human monitor since qmp is" " unsupported")
                 return add_human_monitor(devices, monitor_name, filename)
 
             if not devices.has_option("chardev"):
@@ -843,7 +843,7 @@ class VM(virt_vm.BaseVM):
                             else:
                                 txt += " qemu do not support vhostfd."
                             if txt:
-                                LOG.warn(txt)
+                                LOG.warning(txt)
                         # For negative test
                         if add_vhostfd:
                             dev.set_param("vhostfd", vhostfds.split(":")[0])
@@ -1006,7 +1006,7 @@ class VM(virt_vm.BaseVM):
                         device.set_param(key, val, vtype, False)
                 devices.insert(device)
             else:
-                LOG.warn("option '-%s' not supportted" % name)
+                LOG.warning("option '-%s' not supportted" % name)
 
         def add_pcidevice(
             devices, host, params, device_driver="pci-assign", pci_bus="pci.0"
@@ -1037,7 +1037,7 @@ class VM(virt_vm.BaseVM):
                     " It only support following parameter:\n %s"
                     % (", ".join(fail_param), pcidevice_help)
                 )
-                LOG.warn(msg)
+                LOG.warning(msg)
             devices.insert(dev)
 
         def add_virtio_rng(devices, rng_params, parent_bus="pci.0"):
@@ -1502,13 +1502,13 @@ class VM(virt_vm.BaseVM):
         def add_boot(devices, opts):
             machine_type = params.get("machine_type", "")
             if machine_type.startswith("arm") or machine_type.startswith("riscv"):
-                LOG.warn(
+                LOG.warning(
                     "-boot on %s is usually not supported, use " "bootindex instead.",
                     machine_type,
                 )
                 return ""
             if machine_type.startswith("s390"):
-                LOG.warn("-boot on s390x only support boot strict=on")
+                LOG.warning("-boot on s390x only support boot strict=on")
                 return "-boot strict=on"
             cmd = " -boot"
             options = []
@@ -2046,7 +2046,7 @@ class VM(virt_vm.BaseVM):
             ) != "yes" and not cpu_model.startswith("EPYC"):
                 vcpu_threads = 1
                 txt = "Set vcpu_threads to 1 for AMD non-EPYC cpu."
-                LOG.warn(txt)
+                LOG.warning(txt)
 
         smp_err = ""
         SMP_PREFER_CORES_VERSION_SCOPE = "[6.2.0, )"
@@ -2413,7 +2413,7 @@ class VM(virt_vm.BaseVM):
             else:
                 pvpanic = "pvpanic"
             if not devices.has_device(pvpanic):
-                LOG.warn("%s device is not supported", pvpanic)
+                LOG.warning("%s device is not supported", pvpanic)
             else:
                 if pvpanic == "pvpanic-pci":
                     pvpanic_dev = qdevices.QDevice(
@@ -2439,7 +2439,7 @@ class VM(virt_vm.BaseVM):
         # Add vmcoreinfo device
         if params.get("vmcoreinfo") == "yes":
             if not devices.has_device("vmcoreinfo"):
-                LOG.warn("vmcoreinfo device is not supported")
+                LOG.warning("vmcoreinfo device is not supported")
             else:
                 vmcoreinfo_dev = qdevices.QDevice("vmcoreinfo")
                 set_cmdline_format_by_cfg(
@@ -4192,9 +4192,9 @@ class VM(virt_vm.BaseVM):
                 try:
                     self.monitor.quit()
                 except Exception as e:
-                    LOG.warn(e)
+                    LOG.warning(e)
                     if self.is_dead():
-                        LOG.warn(
+                        LOG.warning(
                             "VM %s down during try to kill it " "by monitor", self.name
                         )
                         return
@@ -5308,7 +5308,7 @@ class VM(virt_vm.BaseVM):
                         except qemu_monitor.MonitorNotSupportedError:
                             # x-multifd-page-count was dropped without
                             # replacement, ignore this param
-                            LOG.warn(
+                            LOG.warning(
                                 "Parameter x-multifd-page-count "
                                 "not supported on src, probably "
                                 "newer qemu, not setting it."
@@ -5346,7 +5346,7 @@ class VM(virt_vm.BaseVM):
                                 parameter, value, True, False
                             )
                         except qemu_monitor.MonitorNotSupportedError:
-                            LOG.warn(
+                            LOG.warning(
                                 "Parameter x-multifd-page-count "
                                 "not supported on dst, probably "
                                 "newer qemu, not setting it."
@@ -5571,7 +5571,7 @@ class VM(virt_vm.BaseVM):
             try:
                 return bool(self.monitor.get_event("RESET"))
             except (qemu_monitor.MonitorSocketError, AttributeError):
-                LOG.warn(
+                LOG.warning(
                     "MonitorSocketError while querying for RESET QMP "
                     "event, it might get lost."
                 )
@@ -5667,7 +5667,7 @@ class VM(virt_vm.BaseVM):
             if self.catch_monitor:
                 self.catch_monitor.screendump(filename=filename, debug=debug)
         except qemu_monitor.MonitorError as e:
-            LOG.warn(e)
+            LOG.warning(e)
 
     def save_to_file(self, path):
         """

--- a/virttest/shared/deps/run_autotest/boottool.py
+++ b/virttest/shared/deps/run_autotest/boottool.py
@@ -785,13 +785,13 @@ class Grubby(object):
         """
         current_version = self.get_grubby_version()
         if current_version is None:
-            self.log.warn(
+            self.log.warning(
                 "Could not detect current grubby version. It may "
                 "be that you are running an unsupported version "
                 "of grubby"
             )
         elif current_version < GRUBBY_REQ_VERSION:
-            self.log.warn(
+            self.log.warning(
                 "version %s.%s being used is not guaranteed to "
                 "work properly. Mininum required version is %s.%s.",
                 current_version[0],
@@ -1416,7 +1416,7 @@ class Grubby(object):
         """
         output = self.get_grubby_version_raw()
         if output is None:
-            self.log.warn("Could not run grubby to fetch its version")
+            self.log.warning("Could not run grubby to fetch its version")
             return None
 
         match = re.match("(grubby version)?(\s)?(\d+)\.(\d+)(.*)", output)
@@ -1455,7 +1455,7 @@ class Grubby(object):
             try:
                 shutil.move(path, backup_path)
             except Exception:
-                self.log.warn("Failed to backup the current grubby binary")
+                self.log.warning("Failed to backup the current grubby binary")
 
     def grubby_install_fetch_tarball(self, topdir):
         """
@@ -1558,7 +1558,7 @@ class Grubby(object):
         if deps_klass is not None:
             deps = deps_klass()
             if not deps.check():
-                self.log.warn(
+                self.log.warning(
                     "Installing distro build deps for grubby. This "
                     "may take a while, depending on bandwidth and "
                     "actual number of packages to install"
@@ -2154,7 +2154,7 @@ class BoottoolApp(object):
         """
         current_version = self.grubby.get_grubby_version()
         if current_version is None:
-            self.log.warn("Could not get version numbers from grubby")
+            self.log.warning("Could not get version numbers from grubby")
             return -1
 
         required_version = self.opts.grubby_version_check.split(".", 1)

--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -196,7 +196,7 @@ class Cgroup(object):
             os.rmdir(pwd)
             self.cgroups.remove(pwd)
         except ValueError:
-            LOG.warn(
+            LOG.warning(
                 "cg.rm_cgroup(): Removed cgroup which wasn't created"
                 "using this Cgroup"
             )
@@ -406,7 +406,7 @@ class Cgroup(object):
             if value[-1] in human:
                 value = int(value[:-1]) * human[value[-1]]
         except Exception:
-            LOG.warn("cg.set_prop() fallback into cg.set_property.")
+            LOG.warning("cg.set_prop() fallback into cg.set_property.")
             value = _value
         self.set_property(prop, value, pwd, check, checkprop)
 
@@ -549,7 +549,7 @@ class CgroupModules(object):
                 try:
                     process.system("umount %s -l" % self.modules[1][i])
                 except Exception as failure_detail:
-                    LOG.warn(
+                    LOG.warning(
                         "CGM: Couldn't unmount %s directory: %s",
                         self.modules[1][i],
                         failure_detail,
@@ -559,7 +559,7 @@ class CgroupModules(object):
                 # If delete /cgroup/, this action will break cgroup service.
                 shutil.rmtree(self.mountdir)
         except Exception:
-            LOG.warn("CGM: Couldn't remove the %s directory", self.mountdir)
+            LOG.warning("CGM: Couldn't remove the %s directory", self.mountdir)
 
     def init(self, _modules):
         """

--- a/virttest/staging/utils_koji.py
+++ b/virttest/staging/utils_koji.py
@@ -255,7 +255,7 @@ class KojiClient(object):
             koji_command_ok = False
 
         if not os.access(self.command, os.X_OK):
-            LOG.warn(
+            LOG.warning(
                 'Koji command "%s" is not executable: this is '
                 "not fatal but indicates an unexpected situation",
                 self.command,

--- a/virttest/staging/utils_memory.py
+++ b/virttest/staging/utils_memory.py
@@ -367,7 +367,7 @@ def get_buddy_info(chunk_sizes, nodes="all", zones="all", session=None):
         re_buddyinfo += "(%s)" % "|".join(nodes.split())
 
     if not re.findall(re_buddyinfo, buddy_info_content):
-        LOG.warn("Can not find Nodes %s" % nodes)
+        LOG.warning("Can not find Nodes %s" % nodes)
         return None
     re_buddyinfo += ".*?zone\s+"
     if zones == "all":
@@ -375,7 +375,7 @@ def get_buddy_info(chunk_sizes, nodes="all", zones="all", session=None):
     else:
         re_buddyinfo += "(%s)" % "|".join(zones.split())
     if not re.findall(re_buddyinfo, buddy_info_content):
-        LOG.warn("Can not find zones %s" % zones)
+        LOG.warning("Can not find zones %s" % zones)
         return None
     re_buddyinfo += "\s+([\s\d]+)"
 

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -258,7 +258,7 @@ def get_image_filename(params, root_dir, basename=False):
             )
         return get_image_filename_filesytem(params, root_dir, basename=basename)
     else:
-        LOG.warn("image_name parameter not set.")
+        LOG.warning("image_name parameter not set.")
 
 
 def get_image_filename_filesytem(params, root_dir, basename=False):

--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -305,7 +305,7 @@ class HugePageConfig(object):
         try:
             self.expected_hugepage_size = int(params.get("expected_hugepage_size", 0))
         except TypeError:
-            LOG.warn(
+            LOG.warning(
                 "Invalid value 'expected_hugepage_size=%s'",
                 params.get("expected_hugepage_size"),
             )
@@ -456,7 +456,7 @@ class HugePageConfig(object):
 
             available_hugepages = available_hugepages - decreased_pages
             if target_hugepages > available_hugepages:
-                LOG.warn(
+                LOG.warning(
                     "This test requires more huge pages than we"
                     " currently have, we'll try to allocate the"
                     " biggest number the system can support."
@@ -2295,7 +2295,7 @@ class EGDConfig(object):
             # wait port released by egd.pl
             wait.wait_for(_all_killed, timeout=60)
         except OSError:
-            LOG.warn("egd.pl is running")
+            LOG.warning("egd.pl is running")
 
 
 class StraceQemu(object):

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -1393,7 +1393,7 @@ def run(test, params, env):
                 error_context.context("Quit qemu-kvm before copying guest image")
                 vm.monitor.quit()
             except Exception as e:
-                LOG.warn(e)
+                LOG.warning(e)
             from virttest import utils_test
 
             error_context.context("Copy image from NFS Server")
@@ -1437,7 +1437,7 @@ def run(test, params, env):
     for media in params.get("copy_to_local", "").split():
         media_path = params.get(media)
         if not media_path:
-            LOG.warn(
+            LOG.warning(
                 "Media '%s' is not available, will not "
                 "be copied into local directory",
                 media,
@@ -1534,7 +1534,7 @@ def run(test, params, env):
                         log_file, post_finish_str
                     )
                 except IOError:
-                    LOG.warn("Could not read final serial log file")
+                    LOG.warning("Could not read final serial log file")
                 else:
                     if install_error_str_found:
                         raise exceptions.TestFail(install_error_exception_str)
@@ -1561,7 +1561,7 @@ def run(test, params, env):
                             vm.start()
                             break
                         except:
-                            LOG.warn(
+                            LOG.warning(
                                 "Failed to start unattended install "
                                 "image workaround reboot kickstart "
                                 "parameter bug"
@@ -1594,7 +1594,7 @@ def run(test, params, env):
                 # Only make noise after several failed reads
                 serial_read_fails += 1
                 if serial_read_fails > 10:
-                    LOG.warn(
+                    LOG.warning(
                         "Cannot read from serial log file after %d tries",
                         serial_read_fails,
                     )
@@ -1623,7 +1623,7 @@ def run(test, params, env):
         else:
             time.sleep(1)
     else:
-        LOG.warn("Timeout elapsed while waiting for install to finish ")
+        LOG.warning("Timeout elapsed while waiting for install to finish ")
         attempt_to_log_useful_files(test, vm)
         copy_images()
         raise exceptions.TestFail(

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -78,21 +78,21 @@ class Env(IterableUserDict):
                     if env.get("version", 0) >= version:
                         self.data = env
                     else:
-                        LOG.warn("Incompatible env file found. Not using it.")
+                        LOG.warning("Incompatible env file found. Not using it.")
                         self.data = empty
                 else:
                     # No previous env file found, proceed...
-                    LOG.warn("Creating new, empty env file")
+                    LOG.warning("Creating new, empty env file")
                     self.data = empty
             # Almost any exception can be raised during unpickling, so let's
             # catch them all
             except Exception as e:
-                LOG.warn("Exception thrown while loading env")
-                LOG.warn(e)
-                LOG.warn("Creating new, empty env file")
+                LOG.warning("Exception thrown while loading env")
+                LOG.warning(e)
+                LOG.warning("Creating new, empty env file")
                 self.data = empty
         else:
-            LOG.warn("Creating new, empty env file")
+            LOG.warning("Creating new, empty env file")
             self.data = empty
 
     def save(self, filename=None):

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1569,7 +1569,7 @@ class NumaInfo(object):
             node_distance = re.findall("%s:.*" % node_id, node_distances)[0]
             node_distance = node_distance.split(":")[-1]
         except Exception:
-            LOG.warn("Get unexpect information from numctl")
+            LOG.warning("Get unexpect information from numctl")
             numa_sys_path = self.numa_sys_path
             distance_path = get_path(numa_sys_path, "node%s/distance" % node_id)
             if not check_isfile(distance_path, session=self.session):
@@ -1732,7 +1732,7 @@ class NumaNode(object):
                 )
                 cpus = str(numa_sys.sys_fs_value)
             except Exception as info:
-                LOG.warn(
+                LOG.warning(
                     "Can not find the cpu list information from both"
                     " numactl and sysfs. Please check your system.\n"
                     " Error: %s",
@@ -1753,7 +1753,9 @@ class NumaNode(object):
                             _ += "%s " % str(n)
                         cpus = re.sub(cstr, _, cpus)
                 except (IndexError, ValueError):
-                    LOG.warn("The format of cpu list is not the same as" " expected.")
+                    LOG.warning(
+                        "The format of cpu list is not the same as" " expected."
+                    )
                     break_flag = False
             if break_flag:
                 cpus = ""
@@ -1785,7 +1787,7 @@ class NumaNode(object):
                 key_val = str(numa_sys.sys_fs_value).rstrip("\n")
                 cpu_topo[key] = key_val
             except IOError:
-                LOG.warn(
+                LOG.warning(
                     "Can not find file %s from sysfs. Please check "
                     "your system." % key_path
                 )
@@ -4409,7 +4411,7 @@ def _wait_for_commands(bg_jobs, start_time, timeout):
         if bg_job.result.exit_status is not None:
             continue
 
-        LOG.warn("run process timeout (%s) fired on: %s", timeout, bg_job.command)
+        LOG.warning("run process timeout (%s) fired on: %s", timeout, bg_job.command)
         nuke_subprocess(bg_job.sp)
         bg_job.result.exit_status = bg_job.sp.poll()
         bg_job.result.duration = time.time() - start_time

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1015,7 +1015,7 @@ def get_macvtap_base_iface(base_interface=None):
         if base_interface:
             warn_msg = "Can not use '%s' as macvtap base interface, "
             warn_msg += "will choice automatically"
-            LOG.warn(warn_msg % base_interface)
+            LOG.warning(warn_msg % base_interface)
         for interface in dev_int:
             base_inter = Interface(interface)
             if base_inter.is_brport():
@@ -3934,11 +3934,11 @@ def update_mac_ip_address(vm, timeout=240):
         addr_map = get_guest_address_map(session)
         session.close()
         if not addr_map:
-            LOG.warn("No VM's NIC got IP address")
+            LOG.warning("No VM's NIC got IP address")
             return
         vm.address_cache.update(addr_map)
     except Exception as e:
-        LOG.warn("Error occur when update VM address cache: %s", str(e))
+        LOG.warning("Error occur when update VM address cache: %s", str(e))
 
 
 def get_windows_nic_attribute(

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -706,12 +706,12 @@ def run_file_transfer(test, params, env):
         try:
             os.remove(host_path)
         except OSError as detail:
-            LOG.warn("Could not remove temp files in host: '%s'", detail)
+            LOG.warning("Could not remove temp files in host: '%s'", detail)
         LOG.info("Cleaning temp file on guest")
         try:
             session.cmd("%s %s" % (clean_cmd, guest_path))
         except aexpect.ShellError as detail:
-            LOG.warn("Could not remove temp files in guest: '%s'", detail)
+            LOG.warning("Could not remove temp files in guest: '%s'", detail)
         finally:
             session.close()
 
@@ -762,7 +762,7 @@ def run_virtio_serial_file_transfer(
                         if md5_check:
                             raise exceptions.TestFail(err)
                         else:
-                            LOG.warn(err)
+                            LOG.warning(err)
                 else:
                     md5_re = "md5_sum = (\w{32})"
                     try:
@@ -782,7 +782,7 @@ def run_virtio_serial_file_transfer(
                             if md5_check:
                                 raise exceptions.TestFail(err)
                             else:
-                                LOG.warn(err)
+                                LOG.warning(err)
                     else:
                         md5_re = "md5_sum = (\w{32})"
                         try:
@@ -798,7 +798,7 @@ def run_virtio_serial_file_transfer(
                     if md5_check:
                         raise exceptions.TestFail(err)
                     else:
-                        LOG.warn(err)
+                        LOG.warning(err)
 
     env["serial_file_transfer_start"] = False
     vm = env.get_vm(params["main_vm"])
@@ -1828,7 +1828,7 @@ def get_loss_ratio(output):
     try:
         return float(re.findall(r"(\d*\.?\d+)%.*loss", output)[0])
     except IndexError:
-        LOG.warn("Invalid output of ping command: %s" % output)
+        LOG.warning("Invalid output of ping command: %s" % output)
     return -1
 
 

--- a/virttest/utils_test/libguestfs.py
+++ b/virttest/utils_test/libguestfs.py
@@ -866,6 +866,6 @@ class GuestfishTools(lgf.GuestfishPersistent):
             if is_need.stdout.strip() == b"false":
                 cp_result = self.cp(bak_file, ifcfg_file)
                 if cp_result.exit_status:
-                    LOG.warn("Recover ifcfg file failed:%s", cp_result)
+                    LOG.warning("Recover ifcfg file failed:%s", cp_result)
                     return False
         return True

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -260,7 +260,7 @@ def setup_runlevel(params, session):
         tmp_runlevel = session.cmd(cmd)
         tmp_runlevel = tmp_runlevel.split()[-1]
         if tmp_runlevel != expect_runlevel:
-            LOG.warn(
+            LOG.warning(
                 "Changing runlevel from %s to %s failed (%s)!",
                 ori_runlevel,
                 expect_runlevel,
@@ -350,7 +350,7 @@ class GuestSuspend(object):
             session = self._get_session()
             self._session_cmd_close(session, suspend_bg_program_kill_cmd)
         except Exception as e:
-            LOG.warn("Could not stop background program: '%s'", e)
+            LOG.warning("Could not stop background program: '%s'", e)
             pass
 
     @error_context.context_aware
@@ -712,7 +712,7 @@ class MemoryHotplugTest(MemoryBaseTest):
                 self._device_unplug(device, qid, devices, vm)
                 break
         else:
-            LOG.warn("'%s' is not used by any memory devices" % qid_mem)
+            LOG.warning("'%s' is not used by any memory devices" % qid_mem)
 
         step = "Unplug memory object '%s'" % qid_mem
         error_context.context(step, LOG.info)

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -744,7 +744,7 @@ class BaseVM(object):
         """
         log_path = None
         if not self.params["os_type"] == "linux":
-            LOG.warn("sosreport not applicable for %s", self.params["os_type"])
+            LOG.warning("sosreport not applicable for %s", self.params["os_type"])
             return None
         try:
             pkg = "sos"
@@ -997,7 +997,7 @@ class BaseVM(object):
                 continue
             elif nic.mac == mac:
                 return index
-        LOG.warn("Not find nic by '%s'", mac)
+        LOG.warning("Not find nic by '%s'", mac)
         return -1
 
     def verify_kernel_crash(self):
@@ -1014,7 +1014,7 @@ class BaseVM(object):
         if self.serial_console:
             data = self.serial_console.get_output()
             if data is None:
-                LOG.warn("Unable to read serial console")
+                LOG.warning("Unable to read serial console")
                 return
             match = re.search(panic_re, data, re.DOTALL | re.MULTILINE | re.I)
             if match:
@@ -1075,7 +1075,7 @@ class BaseVM(object):
         if self.serial_console is not None:
             data = self.serial_console.get_output()
             if data is None:
-                LOG.warn("Unable to read serial console")
+                LOG.warning("Unable to read serial console")
                 return
             match = re.findall(r".*trap invalid opcode.*\n", data, re.MULTILINE)
 


### PR DESCRIPTION
The warn() is deprecated in all the supported versions of python and is now removed in python3.13.

Hence we should be using warning() which is functionally identical to warn().

Referrence:
https://docs.python.org/3.12/library/logging.html#logging.Logger.warning https://docs.python.org/3.13/whatsnew/3.13.html#logging