### PR TITLE
Update cpu_model_flags value

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows.cfg
+++ b/virttest/shared/cfg/guest-os/Windows.cfg
@@ -48,7 +48,7 @@
     # lm: Long Mode (x86-64: amd64, also known as Intel 64, i.e. 64-bit capable)
     # The flag tells you that the CPU is 64-bit. it's absences tells you that it's 32-bit. (lm=off)
     i386:
-        cpu_model_flags += "lm=off,pae=on"
+        cpu_model_flags += ",lm=off,pae=on"
     # these config are used in virt_test_utils.get_readable_cdroms()
     cdrom_get_cdrom_cmd = "echo list volume > check_cdrom &&"
     cdrom_get_cdrom_cmd += " echo exit >> check_cdrom &&"


### PR DESCRIPTION
Currently, cpu_model_flags's value is missing ',', it may cause
the issue that cpu_model_flags's can be parsed correctly.

ID: 2819