### PR TITLE
Fix ip addresses obtaining issue

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -35,7 +35,6 @@ from virttest import (
     utils_misc,
     utils_package,
     utils_selinux,
-    virsh,
 )
 from virttest.remote import RemoteRunner
 from virttest.staging import service, utils_memory
@@ -4890,21 +4889,3 @@ def check_class_rules(ifname, rule_id, bandwidth, expect_none=False):
         stacktrace.log_exc_info(sys.exc_info())
         return False
     return True
-
-def obtain_guest_ip_from_dhcp_leases(mac):
-    """
-    Obtaining the guest ip address from virsh-net-dhcp-leases command
-
-    :param: Mac address of the guest
-    :return: return ip-address if found for given mac in the 
-             virsh-net-dhcp-leases default table, else return None
-    """
-    output = virsh.net_dhcp_leases("default")
-    lines = output.stdout.splitlines()
-    for line in lines:
-        if mac in line:
-            parts = line.split()
-            for part in parts:
-                if '/' in part:
-                    return part.split('/')[0]
-    return None

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4891,13 +4891,12 @@ def check_class_rules(ifname, rule_id, bandwidth, expect_none=False):
         return False
     return True
 
-
 def obtain_guest_ip_from_dhcp_leases(mac):
     """
     Obtaining the guest ip address from virsh-net-dhcp-leases command
 
     :param: Mac address of the guest
-    :return: return ip-address if found for given mac in the
+    :return: return ip-address if found for given mac in the 
              virsh-net-dhcp-leases default table, else return None
     """
     output = virsh.net_dhcp_leases("default")
@@ -4906,6 +4905,6 @@ def obtain_guest_ip_from_dhcp_leases(mac):
         if mac in line:
             parts = line.split()
             for part in parts:
-                if "/" in part:
-                    return part.split("/")[0]
+                if '/' in part:
+                    return part.split('/')[0]
     return None

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -935,11 +935,10 @@ class BaseVM(object):
 
         ipaddr = utils_misc.wait_for(_get_address, timeout, step=interval)
         if not ipaddr:
-            # obatining ip address from virsh-net-dhcp-leases command
-            mac = self.get_mac_address(nic_index).lower()
-            ipaddr = utils_net.obtain_guest_ip_from_dhcp_leases(mac)
-            # updating cache with the latest ip address value
-            self.address_cache[mac] = ipaddr
+            # Read guest address via serial console and update VM address
+            # cache to avoid get out-dated address.
+            utils_net.update_mac_ip_address(self, timeout)
+            ipaddr = self.get_address(nic_index, ip_version)
         msg = "Found/Verified IP %s for VM %s NIC %s" % (ipaddr, self.name, nic_index)
         LOG.debug(msg)
         return ipaddr


### PR DESCRIPTION
An issue was introduced by https://github.com/avocado-framework/avocado-vt/pull/3935/commits/95377457678130adca7ba80c7f540117855a6998 which leads the failure of obtaining guest's ip addresses since not all of test scenarios requiring libvirt to manage the ip leases.

This patch merely reverted the problematic commit.