### PR TITLE
virsh.py: add 'Location'

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -3381,6 +3381,7 @@ def snapshot_info(name, snapshot, **dargs):
         "Domain",
         "Current",
         "State",
+        "Location",
         "Parent",
         "Children",
         "Descendants",


### PR DESCRIPTION
Add 'Location' in output to serve tp-libvirt test checking.