### PR TITLE
v2v: extend timeout for win guests

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -651,7 +651,7 @@ class VMCheck(object):
         else:
             raise ValueError("Doesn't support %s target now" % self.target)
 
-    def create_session(self, timeout=480):
+    def create_session(self, timeout=900):
         if self.session:
             LOG.debug("vm session %s exists", self.session)
             return


### PR DESCRIPTION
As rhel9.4.z hotfix, windows guests need around 10min to startup. Fix the timeout issue to extend 15min.