### PR TITLE
Refactor host dmesg verification into a Setuper

### DIFF
--- a/virttest/test_setup/verify.py
+++ b/virttest/test_setup/verify.py
@@ -1,0 +1,25 @@
+from virttest import utils_misc
+from virttest.test_setup.core import Setuper
+
+
+class VerifyHostDMesg(Setuper):
+    def setup(self):
+        # Check host for any errors to start with and just report and
+        # clear it off, so that we do not get the false test failures.
+        if self.params.get("verify_host_dmesg", "yes") == "yes":
+            utils_misc.verify_dmesg(ignore_result=True)
+
+    def cleanup(self):
+        if self.params.get("verify_host_dmesg", "yes") == "yes":
+            dmesg_log_file = self.params.get("host_dmesg_logfile", "host_dmesg.log")
+            level = self.params.get("host_dmesg_level", 3)
+            expected_host_dmesg = self.params.get("expected_host_dmesg", "")
+            ignore_result = self.params.get("host_dmesg_ignore", "no") == "yes"
+            dmesg_log_file = utils_misc.get_path(self.test.debugdir, dmesg_log_file)
+            # exception will be propagated so setup_manager handles it instead
+            utils_misc.verify_dmesg(
+                dmesg_log_file=dmesg_log_file,
+                ignore_result=ignore_result,
+                level_check=level,
+                expected_dmesg=expected_host_dmesg,
+            )


### PR DESCRIPTION
The main goal of this patch is to add a new `Setuper` subclass named `VerifyHostDMesg`, then use it in the `env_process` `{pre,post}process` methods `setup_manager`.

Meanwhile, I'm renaming the `virttest.test_setup.os_posix.py` file into `virttest.test_setup.host_config`, as that would help maintaining the number of submodules under `virttest.test_setup` under a reasonable amount.

ID: 2437