### PR TITLE
Fix check_idmap_xml_filesystem_device failure

### DIFF
--- a/virttest/utils_ids.py
+++ b/virttest/utils_ids.py
@@ -57,7 +57,11 @@ def _get_subid(id_filepath, name, info):
     if result.exit_status:
         raise TestError("Couldn't read %s" % id_filepath)
 
-    entry = [l for l in result.stdout_text.split("\n") if name in l]
+    entry = [
+        l
+        for l in result.stdout_text.split("\n")
+        if name in l and name == l.split(":")[0]
+    ]
     if not entry:
         raise TestError("No entry for %s found in %s" % (name, id_filepath))
 


### PR DESCRIPTION
Previously use name in line to get user id and group id. In some cases, if there is one more name with same prefix in,it can get wrong user information