### PR TITLE
Add consume memory repeat times

### DIFF
--- a/virttest/utils_libvirt/libvirt_memory.py
+++ b/virttest/utils_libvirt/libvirt_memory.py
@@ -71,12 +71,13 @@ def normalize_mem_size(mem_size, mem_unit):
     return int(mem_size * 1024**mem_unit_idx)
 
 
-def consume_vm_freememory(vm_session, consume_value=100000):
+def consume_vm_freememory(vm_session, consume_value=100000, repeat_times=1):
     """
     Verify the free memory of the vm can be consumed normally
 
     :param vm_session: vm session
     :param consume_value: consume value , default 100000
+    :param repeat_times: consume memory times, default 1
     """
     vm_session.cmd_status("swapoff -a")
     free_mem = utils_memory.freememtotal(vm_session)
@@ -84,6 +85,6 @@ def consume_vm_freememory(vm_session, consume_value=100000):
         raise exceptions.TestError(
             "Fail to install package 'numactl' which provides command 'memhog'"
         )
-    cmd = "memhog %dk" % (free_mem - consume_value)
+    cmd = "memhog -r%d %dk" % (repeat_times, (free_mem - consume_value))
     status, stdout = vm_session.cmd_status_output(cmd, timeout=60)
     return (status, stdout)


### PR DESCRIPTION
test results of test run containing this commit:
 (1/1) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_hard_limit.4k.2048: PASS (35.33 s)
