### PR TITLE
omit_data_loss config variable

### DIFF
--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -250,6 +250,20 @@ class VTRun(CLI):
             help=help_msg,
         )
 
+        help_msg = (
+            "Omits the `OSError [Errno 9] Bad file descriptor` caused by "
+            "avocado.utils.process utility during clean up. This can be used "
+            "when this error would cause false positive failures of a test."
+        )
+        add_option(
+            vt_compat_group_common,
+            dest="vt.omit_data_loss",
+            arg="--vt-omit-data-loss",
+            action="store_true",
+            default=False,
+            help=help_msg,
+        )
+
     def run(self, config):
         """
         Run test modules or simple tests.

--- a/avocado_vt/plugins/vt_init.py
+++ b/avocado_vt/plugins/vt_init.py
@@ -125,6 +125,19 @@ if hasattr(plugin_interfaces, "Init"):
                 help_msg=help_msg,
             )
 
+            help_msg = (
+                "Omits the `OSError [Errno 9] Bad file descriptor` caused by "
+                "avocado.utils.process utility during clean up. This can be used "
+                "when this error would cause false positive failures of a test."
+            )
+            settings.register_option(
+                section,
+                key="omit_data_loss",
+                key_type=bool,
+                default=False,
+                help_msg=help_msg,
+            )
+
             # [vt.setup] section
             section = "vt.setup"
 


### PR DESCRIPTION
In tp_libvrt testing, We've seen many occurrences where "Bad file descriptor" OSError was raised during clean up phase when an external command is executed via `avocado.utils.process` utility. It happens when `SubProcess` class wants to flush the stdout and stderr of the external command after finishes. These kinds of errors might lead to stdout and stderr data loss, but during the tp_libvrt testing it leads to false positive failures, which makes test evaluation harder.

This commit introduces a new config variable `omit_data_loss` which, when is enabled, will omit these errors, and they won't affect the overall test result.

Reference: https://github.com/avocado-framework/avocado/pull/6019