### PR TITLE
Enable IOMMUFD for VM device passthrough

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -4031,9 +4031,32 @@ class DevContainer(object):
                 "failover_pair_id": params.get("vm_hostdev_failover_pair_id"),
             }
         )
+
+        devs = []
+        iommufd_id = params.get("vm_hostdev_iommufd")
+        if iommufd_id:
+            dev_params["iommufd"] = iommufd_id
+            if not self.get_by_qid(iommufd_id):
+                iommufd = self.iommufd_object_define_by_params(iommufd_id)
+                devs.append(iommufd)
+
         # TODO: Support vfio-ap and vfio-ccw, currently only for pci devices
         dev_bus = bus or {"aobject": params.get("pci_bus", "pci.0")}
         dev = qdevices.QDevice(driver, dev_params, parent_bus=dev_bus)
         for ext_k, ext_v in params.get_dict("vm_hostdev_extra_params").items():
             dev.set_param(ext_k, ext_v)
-        return dev
+        devs.append(dev)
+        return devs
+
+    def iommufd_object_define_by_params(self, obj_id):
+        """
+        Create iommufd object device by params
+
+        The iommufd objects cmdlines:
+            -object iommufd,id=iommufd0
+
+        :param obj_id: The id of the QObject device, e.g. iommufd0
+        :return: the iommufd QObject device
+        """
+        backend, properties = "iommufd", {"id": obj_id}
+        return qdevices.QObject(backend, properties)


### PR DESCRIPTION
iommufd-backed VFIO, for example:
-object iommufd,id=iommufd0 \
-device vfio-pci,host=01:00.0,iommufd=iommufd0
Multiple pcie device can use the same iommufd.