### PR TITLE
Enable compatibility testsing with latest avocado

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,7 +72,6 @@ avocado_devel_task:
   container:
     image: quay.io/avocado-framework/avocado-vt-ci-fedora-35
     kvm: true
-  allow_failures: $AVOCADO_SRC == 'git+https://github.com/avocado-framework/avocado#egg=avocado_framework'
   env:
     matrix:
       # Latest Avocado


### PR DESCRIPTION
We would like to have the latest avocado release (109) compatible with changes in latest avocado-vt. Therefore, we need to make the compatible check active in CI to avoid avocado and avocado-vt compatibility issues. This check will be waived again after the release.

Reference: https://github.com/avocado-framework/avocado/milestone/35