### PR TITLE
env_process: Refactor QEMU coverage report resetter

### DIFF
--- a/virttest/test_setup/gcov.py
+++ b/virttest/test_setup/gcov.py
@@ -1,0 +1,28 @@
+import os
+
+from avocado.utils import process as a_process
+
+from virttest.test_setup.core import Setuper
+
+
+class ResetQemuGCov(Setuper):
+    def setup(self):
+        # Check if code coverage for qemu is enabled and
+        # if coverage reset is enabled too, reset coverage report
+        gcov_qemu = self.params.get("gcov_qemu", "no") == "yes"
+        gcov_qemu_reset = self.params.get("gcov_qemu_reset", "no") == "yes"
+        if gcov_qemu and gcov_qemu_reset:
+            qemu_builddir = os.path.join(self.test.bindir, "build", "qemu")
+            qemu_bin = os.path.join(self.test.bindir, "bin", "qemu")
+            if os.path.isdir(qemu_builddir) and os.path.isfile(qemu_bin):
+                os.chdir(qemu_builddir)
+                # Looks like libvirt process does not have permissions to write to
+                # coverage files, hence give write for all files in qemu source
+                reset_cmd = "make clean-coverage;%s -version;" % qemu_bin
+                reset_cmd += (
+                    'find %s -name "*.gcda" -exec chmod a=rwx {} \;' % qemu_builddir
+                )
+                a_process.system(reset_cmd, shell=True)
+
+    def cleanup(self):
+        pass


### PR DESCRIPTION
yet another `env_process` `preprocess` and `postprocess` refactoring patch. This time it targets the step that resets gcov for qemu if it is configured so.

Another option for this piece of code would be to wait until it was time to refactor the `postprocess` step gathering gcov data and generating reports. However, both steps are not in the same level around the `_setup_manager` calls, which would could cause regressions of some sort. That's the reason why I'm treating each of them separately.

ID: 2932
