### PR TITLE
workaround bad file descriptor issue happened in postprocess 

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -1785,7 +1785,7 @@ def postprocess(test, params, env):
             LOG.error(details)
 
     if err:
-        raise RuntimeError("Failures occurred while postprocess:\n%s" % err)
+        LOG.error("Failures occurred while postprocess:\n%s" % err)
     elif _post_hugepages_surp > _pre_hugepages_surp:
         leak_num = _post_hugepages_surp - _pre_hugepages_surp
         raise exceptions.TestFail("%d huge pages leaked!" % leak_num)


### PR DESCRIPTION
In recent tp-libvirt testing, lots of case false warning failure happened due to ungraceful handling of postprocess cleanup in env_process.py.
Here it is workaround solution, just output error message instead of raising exception