### PR TITLE
qemu_monitor: removes GenericError check

### DIFF
--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -2442,7 +2442,7 @@ class QMPMonitor(Monitor):
         try:
             return self.cmd("migrate", args)
         except QMPCmdError as e:
-            if e.data["class"] in ["SockConnectInprogress", "GenericError"]:
+            if e.data["class"] in ["SockConnectInprogress"]:
                 LOG.debug("Migrate socket connection still initializing...")
             else:
                 raise e


### PR DESCRIPTION
qemu_monitor: removes GenericError check

Removes the GenericError check as it was preventing
the exception to being raised, which could hide possible
product bugs, as well as makes impossible to handle it
in a test case when it's really expected.

Signed-off-by: mcasquer <mcasquer@redhat.com>
ID: 2963