### PR TITLE
add emsr_bitmap and xmm_input attributes in VMFeaturesHypervXML class

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -4454,6 +4454,8 @@ class VMFeaturesHypervXML(base.LibvirtXMLBase):
         "ipi",
         "evmcs",
         "avic",
+        "emsr_bitmap",
+        "xmm_input",
     )
 
     def __init__(self, virsh_instance=base.virsh):
@@ -4538,7 +4540,18 @@ class VMFeaturesHypervXML(base.LibvirtXMLBase):
             subclass=VMFeaturesStimerXML,
             subclass_dargs={"virsh_instance": virsh_instance},
         )
-
+        accessors.XMLElementDict(
+            property_name="emsr_bitmap",
+            libvirtxml=self,
+            parent_xpath="/",
+            tag_name="emsr_bitmap",
+        )
+        accessors.XMLElementDict(
+            property_name="xmm_input",
+            libvirtxml=self,
+            parent_xpath="/",
+            tag_name="xmm_input",
+        )
         super(VMFeaturesHypervXML, self).__init__(virsh_instance=virsh_instance)
         self.xml = "<hyperv/>"
 


### PR DESCRIPTION
  Need to add new attribute
Signed-off-by: nanli <nanli@redhat.com>

Before fix
```
 avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 vm_features.positive_test.hyperv.features_in_domcapabilities --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.features_in_domcapabilities: ERROR: Cannot set attribute "xmm_input" to <class 'virttest.libvirt_xml.vm_xml.VMFeaturesHypervXML'> object.There is no such attribute. (7.58 s)
 (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.features_in_domcapabilities: ERROR: Cannot set attribute "xmm_input" to <class 'virttest.libvirt_xml.vm_xml.VMFeaturesHypervXML'> object.There is no such attribute. (7.63 s)
```

After fix
```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 vm_features.positive_test.hyperv.features_in_domcapabilities --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.features_in_domcapabilities: PASS (40.35 s)
```
