### PR TITLE
virt_vm: remove session log files upon login failures

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1146,6 +1146,7 @@ class BaseVM(object):
             )
         except Exception:
             utils_logfile.close_log_file(log_filename)
+            os.unlink(log_filename)
             raise
         session.close_hooks += [utils_logfile.close_own_log_file(log_filename)]
         session.set_status_test_command(self.params.get("status_test_command", ""))


### PR DESCRIPTION
Currently, session log files would be saved even though the login failed, which might dump tons of duplicated records and result in a waste of storage space while calling `wait_for_login`.

This patch removes the session log files if login failed.

ID: 2988