### PR TITLE
env_process: Refactor {pre,post}process_vm_off_hook execution

### DIFF
--- a/virttest/test_setup/vms.py
+++ b/virttest/test_setup/vms.py
@@ -1,6 +1,6 @@
 import logging
 
-from virttest import virt_vm
+from virttest import env_process, virt_vm
 from virttest.test_setup.core import Setuper
 
 LOG = logging.getLogger(__name__)
@@ -32,3 +32,24 @@ class UnrequestedVMHandler(Setuper):
 
     def cleanup(self):
         pass
+
+
+class ProcessVMOff(Setuper):
+    def setup(self):
+        # Run this hook before any network setup stage and vm creation.
+        if callable(env_process.preprocess_vm_off_hook):
+            env_process.preprocess_vm_off_hook(
+                self.test, self.params, self.env
+            )  # pylint: disable=E1102
+
+    def cleanup(self):
+        if callable(env_process.postprocess_vm_off_hook):
+            try:
+                env_process.postprocess_vm_off_hook(
+                    self.test, self.params, self.env
+                )  # pylint: disable=E1102
+            except Exception as details:
+                raise Exception(
+                    "\nPostprocessing dead vm hook: %s"
+                    % str(details).replace("\\n", "\n  ")
+                ) from None


### PR DESCRIPTION
This is part of the `env_process` `{pre,post}process` function refactoring. Now it was turn of the `{pre,post}process_vm_off_hook` execution steps.

I couldn't find any direct use-case in `avocado-vt` or [`tp-qemu`](https://github.com/autotest/tp-qemu) so I could test the patch. However, as I found in https://github.com/avocado-framework/avocado-vt/pull/2106 and https://github.com/avocado-framework/avocado-vt/issues/2134 these hooks seem to be a part of the [I2N plugin](https://github.com/intra2net/avocado-i2n).

I tried to ~~test~~ mock the way the [`i2n.cmd_parser`](https://github.com/intra2net/avocado-i2n/blob/master/avocado_i2n/cmd_parser.py) modifies the hooks through [`i2n.plugins.auto`](https://github.com/intra2net/avocado-i2n/blob/master/avocado_i2n/plugins/auto.py) and [`i2n.plugins.manu`](https://github.com/intra2net/avocado-i2n/blob/master/avocado_i2n/plugins/manu.py). I did so by adding a few lines in `avocado_vt.test` that modified the values of the hooks. However, this would feel safer if you @pevogam could have a look and maybe check that it doesn't bring any unintended regression. Would you mind it?

Also, I'd appreciate it if you could have a look too, @YongxueHong.

Thanks in advance!
