### PR TITLE
Replace WMIC with powershell cmd

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -2106,3 +2106,5 @@ subgid
 uids
 gids
 nexthops
+powershell
+CimInstance

--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -836,7 +836,7 @@ def get_disk_size_windows(session, did):
                 e.g. 0, 1
     :return: disk size.
     """
-    cmd = "wmic diskdrive get size, index"
+    cmd = 'powershell -command "Get-CimInstance Win32_DiskDrive | Select-Object Index, Size"'
     return int(re.findall(r"%s\s+(\d+)" % did, session.cmd_output(cmd))[0])
 
 

--- a/virttest/utils_netperf.py
+++ b/virttest/utils_netperf.py
@@ -290,7 +290,10 @@ class Netperf(object):
     def is_target_running(self, target):
         list_cmd = "ps -C %s" % target
         if self.client == "nc":
-            list_cmd = "wmic process where name='%s' list" % target
+            list_cmd = (
+                "powershell -command \"Get-CimInstance Win32_Process | Where-Object {$_.Name -eq '%s'}"
+                ' | Format-List *"'
+            ) % target
         try:
             output = self.session.cmd_output_safe(list_cmd, timeout=120)
             check_reg = re.compile(r"%s" % target, re.I | re.M)

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -486,7 +486,7 @@ class MemoryBaseTest(object):
         :return: physical memory report by guest OS in MB
         """
         if vm.params.get("os_type") == "windows":
-            cmd = "wmic ComputerSystem get TotalPhysicalMemory"
+            cmd = 'powershell -command "(Get-CimInstance -ClassName Win32_ComputerSystem).TotalPhysicalMemory"'
         else:
             cmd = "grep 'MemTotal:' /proc/meminfo"
         return vm.get_memory_size(cmd)

--- a/virttest/utils_windows/virtio_win.py
+++ b/virttest/utils_windows/virtio_win.py
@@ -101,7 +101,7 @@ def drive_letter_iso(session):
 
     :return: Drive letter.
     """
-    return drive.get_hard_drive_letter(session, "virtio-win%")
+    return drive.get_hard_drive_letter(session, "virtio-win*")
 
 
 def drive_letter_vfd(session):


### PR DESCRIPTION
From Win11-24H2, WMIC is an optional feature for Windows, And it will be fully removed in the future.So replace the related cmd

ID: 3268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced deprecated Windows `wmic` commands with modern PowerShell alternatives for disk, memory, network, and file operations, improving compatibility and reliability.
  * Updated logic for retrieving and parsing Windows system information, including disk size, free disk space, memory, and network attributes.
  * Improved file path detection and drive letter matching on Windows guests.
  * Enhanced handling of wildcards when identifying virtio-win drive letters.

* **Documentation**
  * Updated docstrings and comments to reflect the use of PowerShell commands instead of `wmic`.

* **Chores**
  * Added "powershell" and "CimInstance" to the list of ignored spell-check terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->