### PR TITLE
env_process: Refactor kvm module reload/restore steps

### DIFF
--- a/virttest/test_setup/kernel.py
+++ b/virttest/test_setup/kernel.py
@@ -1,0 +1,28 @@
+from virttest import arch, utils_kernel_module
+from virttest.test_setup.core import Setuper
+
+
+class ReloadKVMModules(Setuper):
+    def __init__(self, test, params, env):
+        super().__init__(test, params, env)
+        self.kvm_module_handlers = []
+
+    def setup(self):
+        kvm_modules = arch.get_kvm_module_list()
+        for module in reversed(kvm_modules):
+            param_prefix = module if module == "kvm" else "kvm_probe"
+            module_force_load = self.params.get_boolean(
+                "%s_module_force_load" % param_prefix
+            )
+            module_parameters = self.params.get(
+                "%s_module_parameters" % param_prefix, ""
+            )
+            module_handler = utils_kernel_module.reload(
+                module, module_force_load, module_parameters
+            )
+            if module_handler is not None:
+                self.kvm_module_handlers.append(module_handler)
+
+    def cleanup(self):
+        for kvm_module in self.kvm_module_handlers:
+            kvm_module.restore()


### PR DESCRIPTION
KVM modules are reloaded and restored before and after running tests. That was done directly in the preprocess and postprocess functions in virttest.env_process. Write a Setuper subclass that implements those in setup/cleanup methods and register the setuper in the env_process setup_manager.

This is a patch from a larger patch series refactoring the env_process preprocess and postprocess functions. In each of these patches, a pre/post process step is identified and replaced with a Setuper subclass so the following can finally be met:
    - Only cleanup steps of successful setup steps are run to avoid possible environment corruption or hard to read errors.
    - Running setup/cleanup steps symmetrically during env pre/post process.
    - Reduce explicit pre/post process function code length.

ID: 2934