### PR TITLE
utils_net: make function safe for serial session

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3897,7 +3897,9 @@ def get_linux_iface_info(iface="", mac=None, session=None):
     :return: dict-type info of interface, None if not get any
     """
     ip_cmd = f"ip -json addr show {iface}"
-    run_func = session.cmd_output if session else process.getoutput
+    run_func = process.getoutput
+    if session:
+        run_func = lambda x: session.cmd_output(x, safe=True)
 
     try:
         ip_output_str = run_func(ip_cmd).strip()


### PR DESCRIPTION
On serial sessions, kernel messages can clutter the output. aexpects 'safe' functions deal with this.

A test failed because of such clutter:

"""
Interface info :[   15.114033] block dm-0: the capability attribute has
been deprecated.ip -json addr
show[{"ifindex":1,"ifname":"lo","flags":["...
"""

leads to

"""
Failed to get interface info via "ip" command. Reason: Extra data: line 1 column 16 (char 15) """

The 'safe' option removes the "[   15... deprecated." so that the json
can be parsed correctly.