### PR TITLE
Use raw image format by default for block devices

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -2563,9 +2563,11 @@ class DevContainer(object):
                 format_cls = qdevices.QBlockdevFormatLuks
             elif imgfmt == "nvme":
                 format_cls = qdevices.QBlockdevFormatRaw
-            elif imgfmt is None:
-                # use RAW type as the default
+            elif imgfmt is None or imgfmt == "":
+                # use RAW type as the default (None or empty string)
                 format_cls = qdevices.QBlockdevFormatRaw
+            else:
+                raise ValueError(f"Unsupported image format: {imgfmt}")
 
             protocol_node = protocol_cls(name)
             devices.append(protocol_node)


### PR DESCRIPTION
Not providing a default behavior leads to use of variable without a value and thus cryptic errors regarding the simple fact that we have to provide an image format. It is also not recommended in any conditionals as it leads to undefined behaviors. Finally, in the case of multiple images we may have "image_format=" to use empty string which should be handled similarly to None (lack of any image_format parameter) or generally as the comment suggests to a meaningful default behavior.