### PR TITLE
Add AttributeError to exception when cpu topology file is not found

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -1786,7 +1786,7 @@ class NumaNode(object):
                 )
                 key_val = str(numa_sys.sys_fs_value).rstrip("\n")
                 cpu_topo[key] = key_val
-            except IOError:
+            except (IOError, AttributeError):
                 LOG.warning(
                     "Can not find file %s from sysfs. Please check "
                     "your system." % key_path


### PR DESCRIPTION
if cpu toplogy file in sysfs is not found, AttributeError would be thrown, so add this exception.
Test result related with this pr:
(1/1) type_specific.io-github-autotest-libvirt.numa_capabilities.default: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.numa_capabilities.default: PASS (9.83 s)