### PR TITLE
Replacing nfs.service as nfs-server.service for fedora!

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -196,7 +196,7 @@ class Nfs(object):
             params.get("setup_remote_nfs") == "yes"
             or params.get("setup_local_nfs") == "yes"
         ):
-            if "Ubuntu" in distro_details or "rhel" in distro_details or "fedora" in distro_details:
+            if distro_details.upper() in ("UBUNTU", "RHEL", "FEDORA", ):
                 self.nfs_service = service.Service("nfs-server", session=self.session)
             else:
                 self.nfs_service = service.Service("nfs", session=self.session)

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -196,7 +196,7 @@ class Nfs(object):
             params.get("setup_remote_nfs") == "yes"
             or params.get("setup_local_nfs") == "yes"
         ):
-            if "Ubuntu" in distro_details or "rhel" in distro_details:
+            if "Ubuntu" in distro_details or "rhel" in distro_details or "fedora" in distro_details:
                 self.nfs_service = service.Service("nfs-server", session=self.session)
             else:
                 self.nfs_service = service.Service("nfs", session=self.session)


### PR DESCRIPTION
NFS service is named as nfs-server.service in Fedora, so in fedora also it should be starting nfs-server.service at place of nfs.service.
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>