### PR TITLE
Removing the escape sequence from the output of get_cpu_count()!

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -12,6 +12,7 @@ import traceback
 import six
 from aexpect import remote
 from aexpect.exceptions import ExpectError, ShellError
+from aexpect.utils import astring
 from avocado.core import exceptions
 from six.moves import xrange
 
@@ -1564,7 +1565,9 @@ class BaseVM(object):
         """
         cmd = self.params.get(check_cmd)
         out = self.session.cmd_output_safe(cmd)
-        return int(re.search("\d+", out, re.M).group())
+        # Removing the escape sequence from the output
+        out_no_escape = astring.strip_console_codes(out)
+        return int(re.search("\d+", out_no_escape, re.M).group())
 
     def get_memory_size(self, cmd=None, timeout=60):
         """


### PR DESCRIPTION
The get_cpu_count function is returning the output containing the escape sequence so the checks are failing, I have removed the escape sequence from the output then returned it!
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>