### PR TITLE
env_process: Refactor huge pages setup/cleanup steps

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -92,11 +92,6 @@ _vm_info_thread_termination_event = None
 
 _setup_manager = SetupManager()
 
-# default num of surplus hugepage, order to compare the values before and after
-# the test when 'setup_hugepages = yes'
-_pre_hugepages_surp = 0
-_post_hugepages_surp = 0
-
 #: Hooks to use for own customization stages of the virtual machines with
 #: test, params. and env as supplied arguments
 preprocess_vm_off_hook = None
@@ -1576,9 +1571,6 @@ def postprocess(test, params, env):
 
     if err:
         raise RuntimeError("Failures occurred while postprocess:\n%s" % err)
-    elif _post_hugepages_surp > _pre_hugepages_surp:
-        leak_num = _post_hugepages_surp - _pre_hugepages_surp
-        raise exceptions.TestFail("%d huge pages leaked!" % leak_num)
 
 
 def postprocess_on_error(test, params, env):

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -46,6 +46,7 @@ from virttest.test_setup.core import SetupManager
 from virttest.test_setup.gcov import ResetQemuGCov
 from virttest.test_setup.kernel import ReloadKVMModules
 from virttest.test_setup.libvirt_setup import LibvirtdDebugLogConfig
+from virttest.test_setup.memory import HugePagesSetup
 from virttest.test_setup.migration import MigrationEnvSetup
 from virttest.test_setup.networking import (
     BridgeConfig,
@@ -1023,6 +1024,7 @@ def preprocess(test, params, env):
     _setup_manager.register(CheckVirtioWinVersion)
     _setup_manager.register(CheckLibvirtVersion)
     _setup_manager.register(LogVersionInfo)
+    _setup_manager.register(HugePagesSetup)
     _setup_manager.do_setup()
 
     vm_type = params.get("vm_type")
@@ -1030,24 +1032,6 @@ def preprocess(test, params, env):
     base_dir = data_dir.get_data_dir()
 
     libvirtd_inst = None
-
-    # If guest is configured to be backed by hugepages, setup hugepages in host
-    if params.get("hugepage") == "yes":
-        params["setup_hugepages"] = "yes"
-
-    if params.get("setup_hugepages") == "yes":
-        global _pre_hugepages_surp
-        h = test_setup.HugePageConfig(params)
-        _pre_hugepages_surp = h.ext_hugepages_surp
-        suggest_mem = h.setup()
-        if suggest_mem is not None:
-            params["mem"] = suggest_mem
-        if not params.get("hugepage_path"):
-            params["hugepage_path"] = h.hugepage_path
-        if vm_type == "libvirt":
-            if libvirtd_inst is None:
-                libvirtd_inst = utils_libvirtd.Libvirtd()
-            libvirtd_inst.restart()
 
     if params.get("setup_thp") == "yes":
         thp = test_setup.TransparentHugePageConfig(test, params, env)
@@ -1533,21 +1517,6 @@ def postprocess(test, params, env):
 
     libvirtd_inst = None
     vm_type = params.get("vm_type")
-
-    if params.get("setup_hugepages") == "yes":
-        global _post_hugepages_surp
-        try:
-            h = test_setup.HugePageConfig(params)
-            h.cleanup()
-            if vm_type == "libvirt":
-                if libvirtd_inst is None:
-                    libvirtd_inst = utils_libvirtd.Libvirtd()
-                libvirtd_inst.restart()
-        except Exception as details:
-            err += "\nHP cleanup: %s" % str(details).replace("\\n", "\n  ")
-            LOG.error(details)
-        else:
-            _post_hugepages_surp = h.ext_hugepages_surp
 
     if params.get("setup_thp") == "yes":
         try:

--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -76,6 +76,14 @@ class THPKhugepagedError(THPError):
     pass
 
 
+class HugePagesLeakError(Exception):
+    """
+    Thrown when huge pages are leaked after cleanup.
+    """
+
+    pass
+
+
 class PolkitConfigError(Exception):
 
     """

--- a/virttest/test_setup/memory.py
+++ b/virttest/test_setup/memory.py
@@ -1,15 +1,21 @@
-from virttest import env_process, test_setup, utils_libvirtd
+from virttest import test_setup, utils_libvirtd
 from virttest.test_setup.core import Setuper
 
 
 class HugePagesSetup(Setuper):
+    def __init__(self, test, params, env):
+        super().__init__(test, params, env)
+        # default num of surplus hugepages, in order to compare the values
+        # before and after the test when 'setup_hugepages = yes'
+        self._pre_hugepages_surp = 0
+
     def setup(self):
         # If guest is configured to be backed by hugepages, setup hugepages in host
         if self.params.get("hugepage") == "yes":
             self.params["setup_hugepages"] = "yes"
         if self.params.get("setup_hugepages") == "yes":
             h = test_setup.HugePageConfig(self.params)
-            env_process._pre_hugepages_surp = h.ext_hugepages_surp
+            self._pre_hugepages_surp = h.ext_hugepages_surp
             suggest_mem = h.setup()
             if suggest_mem is not None:
                 self.params["mem"] = suggest_mem
@@ -24,4 +30,7 @@ class HugePagesSetup(Setuper):
             h.cleanup()
             if self.params.get("vm_type") == "libvirt":
                 utils_libvirtd.Libvirtd().restart()
-            env_process._post_hugepages_surp = h.ext_hugepages_surp
+            post_hugepages_surp = h.ext_hugepages_surp
+            if post_hugepages_surp > self._pre_hugepages_surp:
+                leak_num = post_hugepages_surp - self._pre_hugepages_surp
+                raise test_setup.HugePagesLeakError("%d huge pages leaked!" % leak_num)

--- a/virttest/test_setup/memory.py
+++ b/virttest/test_setup/memory.py
@@ -1,0 +1,27 @@
+from virttest import env_process, test_setup, utils_libvirtd
+from virttest.test_setup.core import Setuper
+
+
+class HugePagesSetup(Setuper):
+    def setup(self):
+        # If guest is configured to be backed by hugepages, setup hugepages in host
+        if self.params.get("hugepage") == "yes":
+            self.params["setup_hugepages"] = "yes"
+        if self.params.get("setup_hugepages") == "yes":
+            h = test_setup.HugePageConfig(self.params)
+            env_process._pre_hugepages_surp = h.ext_hugepages_surp
+            suggest_mem = h.setup()
+            if suggest_mem is not None:
+                self.params["mem"] = suggest_mem
+            if not self.params.get("hugepage_path"):
+                self.params["hugepage_path"] = h.hugepage_path
+            if self.params.get("vm_type") == "libvirt":
+                utils_libvirtd.Libvirtd().restart()
+
+    def cleanup(self):
+        if self.params.get("setup_hugepages") == "yes":
+            h = test_setup.HugePageConfig(self.params)
+            h.cleanup()
+            if self.params.get("vm_type") == "libvirt":
+                utils_libvirtd.Libvirtd().restart()
+            env_process._post_hugepages_surp = h.ext_hugepages_surp


### PR DESCRIPTION
Creating a new Setuper subclass for setting and cleaning huge pages up. Removing the original code from virttest.env_process and replacing it instead with the new HugePagesSetup class being registered in the setup_manager.

_pre_hugepages_surp and _post_hugepages_surp were left in env_process. Their goal is to provide a mechanism in env_process to raise a TestFail in case pages were leaked during a test. If that mechanism was refactored into the setuper, the TestFail would be masked by just an Error due to the way setup_manager handles postprocess exceptions. Changing the way SetupManager handles that requires bigger discussion on how the test infrastructure should handle test status reports, which is a way broader topic that what this patch aims to be.

This is a patch from a larger patch series refactoring the env_process preprocess and postprocess functions. In each of these patches, a pre/post process step is identified and replaced with a Setuper subclass so the following can finally be met:
    - Only cleanup steps of successful setup steps are run to avoid possible environment corruption or hard to read errors.
    - Running setup/cleanup steps symmetrically during env pre/post process.
    - Reduce explicit pre/post process function code length.