### PR TITLE
 Static checks: introduce usage of "avocado-static-checks" project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: true
       - name: Check signed-off-by
         run: ./selftests/signedoff-check.sh
       - name: Install make

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "avocado-static-checks"]
+	path = avocado-static-checks
+	url = https://github.com/avocado-framework/avocado-static-checks

--- a/CODING_STYLE
+++ b/CODING_STYLE
@@ -15,7 +15,7 @@ Base coding style
 
 The coding style for all Python code is the one enforced by black (see
 https://black.readthedocs.io/en/stable/the_black_code_style/).  The
-selftests/style.sh script can be used to verify the code style matches.
+avocado-static-checks/check-style script can be used to verify the code style matches.
 
 
 Variable names and UpPeR cAsE

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ requirements: pip
 	- $(PYTHON) -m pip install -r requirements.txt
 
 check:
-	./selftests/style.sh
-	./selftests/isort.sh
+	./avocado-static-checks/check-style
+	./avocado-static-checks/check-import-order
 	inspekt lint --disable W,R,C,E0203,E0601,E1002,E1101,E1102,E1103,E1120,F0401,I0011,E1003,W605,I1101 --exclude avocado-libs,scripts/github
 	pylint --errors-only --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
 

--- a/avocado_vt/loader.py
+++ b/avocado_vt/loader.py
@@ -84,7 +84,6 @@ def arch_listing(config, guest_name_parser=None):
 
 
 class NotAvocadoVTTest(object):
-
     """
     Not an Avocado-vt test (for reporting purposes)
     """
@@ -93,7 +92,6 @@ class NotAvocadoVTTest(object):
 if AVOCADO_LOADER_AVAILABLE:
 
     class VirtTestLoader(loader.TestLoader, DiscoveryMixIn):
-
         """
         Avocado loader plugin to load avocado-vt tests
         """

--- a/avocado_vt/options.py
+++ b/avocado_vt/options.py
@@ -36,7 +36,6 @@ LOG = logging.getLogger("avocado.vt.options")
 
 
 class VirtTestOptionsProcess(object):
-
     """
     Pick virt test options and parse them to get to a cartesian parser.
     """

--- a/avocado_vt/plugins/vt.py
+++ b/avocado_vt/plugins/vt.py
@@ -196,7 +196,6 @@ def add_qemu_bin_vt_option(parser):
 
 
 class VTRun(CLI):
-
     """
     Avocado VT - legacy virt-test support
     """

--- a/avocado_vt/plugins/vt_bootstrap.py
+++ b/avocado_vt/plugins/vt_bootstrap.py
@@ -25,7 +25,6 @@ LOG = logging.getLogger("avocado.app")
 
 
 class VTBootstrap(CLICmd):
-
     """
     Avocado VT - implements the 'vt-bootstrap' subcommand
     """

--- a/avocado_vt/plugins/vt_joblock.py
+++ b/avocado_vt/plugins/vt_joblock.py
@@ -19,7 +19,6 @@ from ..test import VirtTest
 
 
 class LockCreationError(Exception):
-
     """
     Represents any error situation when attempting to create a lock file
     """
@@ -28,7 +27,6 @@ class LockCreationError(Exception):
 
 
 class OtherProcessHoldsLockError(Exception):
-
     """
     Represents a condition where other process has the lock
     """

--- a/avocado_vt/plugins/vt_list.py
+++ b/avocado_vt/plugins/vt_list.py
@@ -85,7 +85,6 @@ except (OSError, AssertionError):
 
 
 class VTLister(CLI):
-
     """
     Avocado VT - implements legacy virt-test listing
     """

--- a/avocado_vt/plugins/vt_list_archs.py
+++ b/avocado_vt/plugins/vt_list_archs.py
@@ -7,7 +7,6 @@ from ..loader import arch_listing
 
 
 class VTListArchs(CLICmd):
-
     """
     Avocado VT - implements vt-list-archs command
     """

--- a/avocado_vt/plugins/vt_list_guests.py
+++ b/avocado_vt/plugins/vt_list_guests.py
@@ -8,7 +8,6 @@ from ..loader import guest_listing
 
 
 class VTListGuests(CLICmd):
-
     """
     Avocado VT - implements vt-list-guests command
     """

--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -68,7 +68,6 @@ def cleanup_env(env_filename, env_version):
 
 
 class VirtTest(test.Test, utils.TestUtils):
-
     """
     Minimal test class used to run a virt test.
     """

--- a/docs/source/contributing/DownloadSource.rst
+++ b/docs/source/contributing/DownloadSource.rst
@@ -6,7 +6,7 @@ The main source is maintained on git and may be cloned as below:
 
 ::
 
-    git clone https://github.com/avocado-framework/avocado-vt.git
+    git clone --recurse-submodules https://github.com/avocado-framework/avocado-vt.git
 
 If you want to learn how to use git as an effective contribution tool, consider
 reading `the git workflow autotest docs <https://github.com/autotest/autotest/wiki/GitWorkflow>`_

--- a/docs/source/contributing/Guidelines.rst
+++ b/docs/source/contributing/Guidelines.rst
@@ -77,7 +77,7 @@ Rules for Maintainers
 Rules for Contributors
 ======================
 
-1. [Must] Coding style should conform to what's enforced by black (see ``selftests/style.sh``)
+1. [Must] Coding style should conform to what's enforced by black (see ``./avocado-static-checks/check-style``)
 2. [Must] PR commit message is meaningful. Refer to the link on how to write a good commit message
 3. [Must] Travis CI pass and no conflict
 4. [Must] Provide test results. If no, provide justification. Apply to any PR

--- a/examples/tests/bad_test.py
+++ b/examples/tests/bad_test.py
@@ -4,6 +4,7 @@ Simple bad test.
 :difficulty: simple
 :copyright: 2014 Red Hat Inc.
 """
+
 from avocado.utils import process
 
 

--- a/examples/tests/guest_hostname.py
+++ b/examples/tests/guest_hostname.py
@@ -4,6 +4,7 @@ Simple hostname test (on guest)
 :difficulty: simple
 :copyright: 2014 Red Hat Inc.
 """
+
 import logging
 
 LOG = logging.getLogger("avocado.vt.examples.guest_hostname")

--- a/examples/tests/hostname.py
+++ b/examples/tests/hostname.py
@@ -6,6 +6,7 @@ Before this test please set your hostname to something meaningful.
 :difficulty: simple
 :copyright: 2014 Red Hat Inc.
 """
+
 import logging
 
 from avocado.utils import process

--- a/examples/tests/ls_disk.py
+++ b/examples/tests/ls_disk.py
@@ -12,6 +12,7 @@ bigger differences.
 :difficulty: advanced
 :copyright: 2014 Red Hat Inc.
 """
+
 import logging
 
 LOG = logging.getLogger("avocado.vt.examples.lsdisk")

--- a/examples/tests/service.py
+++ b/examples/tests/service.py
@@ -6,6 +6,7 @@ Please put the configuration file service.cfg into $tests/cfg/ directory.
 :difficulty: advanced
 :copyright: 2014 Red Hat Inc.
 """
+
 import logging
 import time
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -5,5 +5,5 @@ inspektor==0.5.3
 aexpect>=1.6.4
 netifaces==0.11.0
 pyenchant==3.2.2
-black==22.3.0
+black==24.3.0
 isort==5.10.1

--- a/scripts/github/github_issues.py
+++ b/scripts/github/github_issues.py
@@ -24,7 +24,6 @@ class SearchResults(object):
 
 
 class GithubCache(object):
-
     """
     Auto-refreshing github.GithubObject.GithubObject from dict
     """
@@ -193,7 +192,6 @@ class GithubCache(object):
 
 
 class GithubIssuesBase(list):
-
     """
     Base class for cached list of github issues
     """
@@ -318,7 +316,6 @@ class GithubIssuesBase(list):
 
 
 class GithubIssues(GithubIssuesBase, object):
-
     """
     Read-only List-like interface to cached github issues in standardized format
     """
@@ -696,7 +693,6 @@ class MutateError(KeyError):
 
 
 class MutableIssue(dict):
-
     """Allow modification of some issue values"""
 
     def __init__(self, github_issues, issue_number):

--- a/scripts/koji_pkgspec.py
+++ b/scripts/koji_pkgspec.py
@@ -22,7 +22,6 @@ from virttest.staging import utils_koji
 
 
 class OptionParser(optparse.OptionParser):
-
     """
     KojiPkgSpec App option parser
     """
@@ -58,7 +57,6 @@ class OptionParser(optparse.OptionParser):
 
 
 class App(object):
-
     """
     KojiPkgSpec app
     """

--- a/scripts/logging_config.py
+++ b/scripts/logging_config.py
@@ -4,7 +4,6 @@ import sys
 
 
 class AllowBelowSeverity(logging.Filter):
-
     """
     Allows only records less severe than a given level (the opposite of what
     the normal logging level filtering does.

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -67,7 +67,6 @@ def get_test_keyval(jobid, keyname, default=""):
 
 
 class Sample(object):
-
     """Collect test results in same environment to a sample"""
 
     def __init__(self, sample_type, arg):

--- a/scripts/virt_disk.py
+++ b/scripts/virt_disk.py
@@ -21,7 +21,6 @@ from virttest import utils_disk
 
 
 class OptionParser(optparse.OptionParser):
-
     """
     App option parser
     """
@@ -82,7 +81,6 @@ class OptionParser(optparse.OptionParser):
 
 
 class App:
-
     """
     Virt Disk Creation App
     """

--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -3,6 +3,7 @@ Build documentation and report whether we had warning/error messages.
 
 This is geared towards documentation build regression testing.
 """
+
 import os
 import unittest
 
@@ -52,7 +53,7 @@ class DocBuildTest(unittest.TestCase):
                 "%s ERRORS and/or WARNINGS detected while building the html docs:\n"
                 % len(failure_lines)
             )
-            for (index, failure_line) in enumerate(failure_lines):
+            for index, failure_line in enumerate(failure_lines):
                 e_msg += "%s) %s\n" % (index + 1, failure_line)
             e_msg += "Full output: %s\n" % "\n".join(output_lines)
             e_msg += "Please check the output and fix your docstrings/.rst docs"

--- a/selftests/isort.sh
+++ b/selftests/isort.sh
@@ -1,3 +1,0 @@
-#!/bin/sh -e
-
-isort --check-only --profile black .

--- a/selftests/style.sh
+++ b/selftests/style.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -e
-echo "** Running black..."
-
-black --check --diff --color .

--- a/selftests/unit/test_libvirt_network.py
+++ b/selftests/unit/test_libvirt_network.py
@@ -31,7 +31,6 @@ _net_state = {"active": False, "autostart": False, "persistent": False}
 
 
 class NetworkTestBase(unittest.TestCase):
-
     """
     Base class for NetworkXML test providing fake virsh commands.
     """
@@ -111,7 +110,6 @@ class NetworkTestBase(unittest.TestCase):
 
 
 class NetworkXMLTest(NetworkTestBase):
-
     """
     Unit test class for manipulator methods in NetworkXML class.
     """

--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -42,7 +42,6 @@ QEMU_MACHINE = open(os.path.join(UNITTEST_DATA_DIR, "qemu-1.5.0__machine_help"))
 
 
 class ParamsDict(dict):
-
     """params like dictionary"""
 
     def objects(self, item):
@@ -51,14 +50,13 @@ class ParamsDict(dict):
 
     def object_params(self, obj):
         ret = self.copy()
-        for (param, value) in six.iteritems(self):
+        for param, value in six.iteritems(self):
             if param.endswith("_%s" % obj):
                 ret[param[: -len("_%s" % obj)]] = value
         return ret
 
 
 class MockHMPMonitor(qemu_monitor.HumanMonitor):
-
     """Dummy class inherited from qemu_monitor.HumanMonitor"""
 
     def __init__(self):  # pylint: disable=W0231
@@ -69,7 +67,6 @@ class MockHMPMonitor(qemu_monitor.HumanMonitor):
 
 
 class Devices(unittest.TestCase):
-
     """set of qemu devices tests"""
 
     def test_q_base_device(self):
@@ -151,7 +148,6 @@ class Devices(unittest.TestCase):
 
 
 class Buses(unittest.TestCase):
-
     """Set of bus-representation tests"""
 
     def test_q_sparse_bus(self):
@@ -671,7 +667,6 @@ Slots:
 
 
 class Container(unittest.TestCase):
-
     """Tests related to the abstract representation of qemu machine"""
 
     def setUp(self):

--- a/selftests/unit/test_qemu_monitor.py
+++ b/selftests/unit/test_qemu_monitor.py
@@ -15,7 +15,6 @@ from virttest import qemu_monitor
 
 
 class MockMonitor(qemu_monitor.Monitor):
-
     """Dummy class inherited from qemu_monitor.HumanMonitor"""
 
     def __init__(self):  # pylint: disable=W0231

--- a/selftests/unit/test_qemu_qtree.py
+++ b/selftests/unit/test_qemu_qtree.py
@@ -27,7 +27,6 @@ OFFSET_PER_LEVEL = qemu_qtree.OFFSET_PER_LEVEL
 
 # Dummy classes and functions
 class ParamsDict(dict):
-
     """params like dictionary"""
 
     def objects(self, item):
@@ -36,7 +35,7 @@ class ParamsDict(dict):
 
     def object_params(self, obj):
         ret = self.copy()
-        for (param, value) in six.iteritems(self):
+        for param, value in six.iteritems(self):
             if param.endswith("_%s" % obj):
                 ret[param[: -len("_%s" % obj)]] = value
         return ret
@@ -191,7 +190,6 @@ params = ParamsDict(
 
 
 class QtreeContainerTest(unittest.TestCase):
-
     """QtreeContainer tests"""
 
     def test_qtree(self):
@@ -259,7 +257,6 @@ class QtreeContainerTest(unittest.TestCase):
 
 
 class QtreeDiskContainerTest(unittest.TestCase):
-
     """QtreeDiskContainer tests"""
 
     def setUp(self):
@@ -330,7 +327,6 @@ Host: scsi1 Channel: 00 Id: 00 Lun: 00
 
 
 class KvmQtreeClassTest(unittest.TestCase):
-
     """Additional tests for qemu_qtree classes"""
 
     def test_qtree_bus_bus(self):

--- a/virttest/RFBDes.py
+++ b/virttest/RFBDes.py
@@ -2,7 +2,6 @@ from virttest import utils_misc
 
 
 class Des(object):
-
     """
     Base Data Encryption Standard class.
     For details, please refer to:

--- a/virttest/asset.py
+++ b/virttest/asset.py
@@ -15,7 +15,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class ConfigLoader:
-
     """
     Base class of the configuration parser
     """

--- a/virttest/base_installer.py
+++ b/virttest/base_installer.py
@@ -19,7 +19,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class NoModuleError(Exception):
-
     """
     Error raised when no suitable modules were found to load
     """
@@ -28,7 +27,6 @@ class NoModuleError(Exception):
 
 
 class VirtInstallException(Exception):
-
     """
     Base virtualization software components installation exception
     """
@@ -37,7 +35,6 @@ class VirtInstallException(Exception):
 
 
 class VirtInstallFailed(VirtInstallException):
-
     """
     Installation of virtualization software components failed
     """
@@ -46,7 +43,6 @@ class VirtInstallFailed(VirtInstallException):
 
 
 class VirtInstallNotInstalled(VirtInstallException):
-
     """
     Virtualization software components are not installed
     """
@@ -55,7 +51,6 @@ class VirtInstallNotInstalled(VirtInstallException):
 
 
 class BaseInstaller(object):
-
     """
     Base virtualization software installer
 
@@ -456,7 +451,6 @@ class BaseInstaller(object):
 
 
 class NoopInstaller(BaseInstaller):
-
     """
     Dummy installer that does nothing, useful when software is pre-installed
     """
@@ -481,7 +475,6 @@ class NoopInstaller(BaseInstaller):
 
 
 class YumInstaller(BaseInstaller):
-
     """
     Installs virtualization software using YUM
 
@@ -527,7 +520,6 @@ class YumInstaller(BaseInstaller):
 
 
 class KojiInstaller(BaseInstaller):
-
     """
     Handles virtualization software installation via koji/brew
 
@@ -748,7 +740,6 @@ class BaseLocalSourceInstaller(BaseInstaller):
 
 
 class LocalSourceDirInstaller(BaseLocalSourceInstaller):
-
     """
     Handles software installation by building/installing from a source dir
     """
@@ -764,7 +755,6 @@ class LocalSourceDirInstaller(BaseLocalSourceInstaller):
 
 
 class LocalSourceTarInstaller(BaseLocalSourceInstaller):
-
     """
     Handles software installation by building/installing from a tarball
     """
@@ -780,7 +770,6 @@ class LocalSourceTarInstaller(BaseLocalSourceInstaller):
 
 
 class RemoteSourceTarInstaller(BaseLocalSourceInstaller):
-
     """
     Handles software installation by building/installing from a remote tarball
     """
@@ -813,7 +802,6 @@ class GitRepoInstaller(BaseLocalSourceInstaller):
 
 
 class FailedInstaller:
-
     """
     Class used to be returned instead of the installer if a installation fails
 

--- a/virttest/build_helper.py
+++ b/virttest/build_helper.py
@@ -25,7 +25,6 @@ def _force_copy(src, dest):
 
 
 class GitRepoParamHelper(git.GitRepoHelper):
-
     """
     Helps to deal with git repos specified in cartersian config files
 
@@ -161,7 +160,6 @@ class GitRepoParamHelper(git.GitRepoHelper):
 
 
 class LocalSourceDirHelper(object):
-
     """
     Helper class to deal with source code sitting somewhere in the filesystem
     """
@@ -187,7 +185,6 @@ class LocalSourceDirHelper(object):
 
 
 class LocalSourceDirParamHelper(LocalSourceDirHelper):
-
     """
     Helps to deal with source dirs specified in cartersian config files
 
@@ -228,7 +225,6 @@ class LocalSourceDirParamHelper(LocalSourceDirHelper):
 
 
 class LocalTarHelper(object):
-
     """
     Helper class to deal with source code in a local tarball
     """
@@ -285,7 +281,6 @@ class LocalTarHelper(object):
 
 
 class LocalTarParamHelper(LocalTarHelper):
-
     """
     Helps to deal with source tarballs specified in cartersian config files
 
@@ -326,7 +321,6 @@ class LocalTarParamHelper(LocalTarHelper):
 
 
 class RemoteTarHelper(LocalTarHelper):
-
     """
     Helper that fetches a tarball and extracts it locally
     """
@@ -354,7 +348,6 @@ class RemoteTarHelper(LocalTarHelper):
 
 
 class RemoteTarParamHelper(RemoteTarHelper):
-
     """
     Helps to deal with remote source tarballs specified in cartersian config
 
@@ -395,7 +388,6 @@ class RemoteTarParamHelper(RemoteTarHelper):
 
 
 class PatchHelper(object):
-
     """
     Helper that encapsulates the patching of source code with patch files
     """
@@ -433,7 +425,6 @@ class PatchHelper(object):
 
 
 class PatchParamHelper(PatchHelper):
-
     """
     Helps to deal with patches specified in cartersian config files
 
@@ -482,7 +473,6 @@ class PatchParamHelper(PatchHelper):
 
 
 class GnuSourceBuildInvalidSource(Exception):
-
     """
     Exception raised when build source dir/file is not valid
     """
@@ -491,7 +481,6 @@ class GnuSourceBuildInvalidSource(Exception):
 
 
 class SourceBuildFailed(Exception):
-
     """
     Exception raised when building with parallel jobs fails
 
@@ -503,7 +492,6 @@ class SourceBuildFailed(Exception):
 
 
 class SourceBuildParallelFailed(Exception):
-
     """
     Exception raised when building with parallel jobs fails
 
@@ -515,7 +503,6 @@ class SourceBuildParallelFailed(Exception):
 
 
 class GnuSourceBuildHelper(object):
-
     """
     Handles software installation of GNU-like source code
 
@@ -712,7 +699,6 @@ class GnuSourceBuildHelper(object):
 
 
 class LinuxKernelBuildHelper(object):
-
     """
     Handles Building Linux Kernel.
     """
@@ -807,7 +793,6 @@ class LinuxKernelBuildHelper(object):
 
 
 class GnuSourceBuildParamHelper(GnuSourceBuildHelper):
-
     """
     Helps to deal with gnu_autotools build helper in cartersian config files
 

--- a/virttest/cartesian_config.py
+++ b/virttest/cartesian_config.py
@@ -377,7 +377,6 @@ class NegativeCondition(OnlyFilter):
 
 
 class StrReader(object):
-
     """
     Preprocess an input string for easy reading.
     """
@@ -436,7 +435,6 @@ class StrReader(object):
 
 
 class FileReader(StrReader):
-
     """
     Preprocess an input file for easy reading.
     """

--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -946,7 +946,6 @@ def get_cpu_info(session=None):
 
 
 class Flag(str):
-
     """
     Class for easy merge cpuflags.
     """

--- a/virttest/data_dir.py
+++ b/virttest/data_dir.py
@@ -47,7 +47,6 @@ class UnknownBackendError(Exception):
 
 
 class SubdirList(list):
-
     """
     List of all non-hidden subdirectories beneath basedir
     """
@@ -85,7 +84,6 @@ class SubdirList(list):
 
 
 class SubdirGlobList(SubdirList):
-
     """
     List of all files matching glob in all non-hidden basedir subdirectories
     """

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -224,11 +224,12 @@ def preprocess_vm(test, params, env, name):
                     nested_cmdline = params.get("virtinstall_qemu_cmdline", "")
                     # virt-install doesn't have option, so use qemu-cmdline
                     if "cap-nested-hv=on" not in nested_cmdline:
-                        params[
-                            "virtinstall_qemu_cmdline"
-                        ] = "%s -M %s,cap-nested-hv=on" % (
-                            nested_cmdline,
-                            params["machine_type"],
+                        params["virtinstall_qemu_cmdline"] = (
+                            "%s -M %s,cap-nested-hv=on"
+                            % (
+                                nested_cmdline,
+                                params["machine_type"],
+                            )
                         )
                 elif params.get("vm_type") == "qemu":
                     nested_cmdline = params.get("machine_type_extra_params", "")
@@ -736,7 +737,6 @@ def process_command(test, params, env, command, command_timeout, command_noncrit
 
 
 class _CreateImages(threading.Thread):
-
     """
     Thread which creates images. In case of failure it stores the exception
     in self.exc_info

--- a/virttest/graphical_console.py
+++ b/virttest/graphical_console.py
@@ -333,7 +333,6 @@ class BaseConsole(object):
 
 
 class DummyConsole(BaseConsole):
-
     """
     Dummy console
     """
@@ -342,7 +341,6 @@ class DummyConsole(BaseConsole):
 
 
 class QMPConsole(BaseConsole):
-
     """
     QMP console
     """

--- a/virttest/guest_agent.py
+++ b/virttest/guest_agent.py
@@ -111,7 +111,6 @@ class VAgentFreezeStatusError(VAgentError):
 
 
 class QemuAgent(Monitor):
-
     """
     Wraps qemu guest agent commands.
     """

--- a/virttest/installer.py
+++ b/virttest/installer.py
@@ -19,7 +19,6 @@ __all__ = [
 
 
 class InstallerRegistry(dict):
-
     """
     Holds information on known installer classes
 

--- a/virttest/ip_sniffing.py
+++ b/virttest/ip_sniffing.py
@@ -24,7 +24,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class AddrCache(object):
-
     """
     Address cache implementation.
     """
@@ -118,7 +117,6 @@ class AddrCache(object):
 
 
 class Sniffer(object):
-
     """
     Virtual base class of the ip sniffer abstraction.
 
@@ -242,7 +240,6 @@ class Sniffer(object):
 
 
 class TcpdumpSniffer(Sniffer):
-
     """
     Tcpdump sniffer class.
     """
@@ -292,7 +289,6 @@ class TcpdumpSniffer(Sniffer):
 
 
 class TSharkSniffer(Sniffer):
-
     """
     TShark sniffer base class.
     """
@@ -360,7 +356,6 @@ class TSharkSniffer(Sniffer):
 
 
 class TShark1To2(TSharkSniffer):
-
     """
     TShark sniffer class for version 1.0.0 - 2.x.x.
     """
@@ -377,7 +372,6 @@ class TShark1To2(TSharkSniffer):
 
 
 class TShark3ToLatest(TSharkSniffer):
-
     """
     TShark sniffer class for version 3.0.0 - latest.
     """

--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -174,7 +174,6 @@ def iscsi_discover(portal_ip):
 
 
 class _IscsiComm(object):
-
     """
     Provide an interface to complete the similar initialization
     """
@@ -352,7 +351,6 @@ class _IscsiComm(object):
 
 
 class IscsiTGT(_IscsiComm):
-
     """
     iscsi support TGT backend used in RHEL6.
     """
@@ -540,7 +538,6 @@ class IscsiTGT(_IscsiComm):
 
 
 class IscsiLIO(_IscsiComm):
-
     """
     iscsi support class for LIO backend used in RHEL7.
     """
@@ -783,7 +780,6 @@ class IscsiLIO(_IscsiComm):
 
 
 class Iscsi(object):
-
     """
     Basic iSCSI support class,
     which will handle the emulated iscsi export and

--- a/virttest/libvirt_cgroup.py
+++ b/virttest/libvirt_cgroup.py
@@ -3,6 +3,7 @@ Virtualization test - cgroup related utility functions for libvirt
 
 :copyright: 2019 Red Hat Inc.
 """
+
 import logging
 import os
 import re
@@ -71,7 +72,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 # cgroup related functions
 class CgroupTest(object):
-
     """Class for libvirt cgroup related test"""
 
     __vm_pid = ""
@@ -431,9 +431,9 @@ class CgroupTest(object):
                         if "dev" in io_value_list[i]:
                             dev_num = self.__get_dev_major_minor(io_value_list[i])
                             if dev_num not in dev_list:
-                                standardized_virsh_output_info[
-                                    dev_num
-                                ] = dev_init_dict.copy()
+                                standardized_virsh_output_info[dev_num] = (
+                                    dev_init_dict.copy()
+                                )
                                 dev_list.append(dev_num)
                             standardized_virsh_output_info[dev_num][
                                 virsh_output_mapping[io_item]

--- a/virttest/libvirt_installer.py
+++ b/virttest/libvirt_installer.py
@@ -23,7 +23,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class LIBVIRTBaseInstaller(base_installer.BaseInstaller):
-
     """
     Base class for libvirt installations
     """
@@ -107,7 +106,6 @@ class LIBVIRTBaseInstaller(base_installer.BaseInstaller):
 
 
 class GitRepoInstaller(LIBVIRTBaseInstaller, base_installer.GitRepoInstaller):
-
     """
     Installer that deals with source code on Git repositories
     """
@@ -118,7 +116,6 @@ class GitRepoInstaller(LIBVIRTBaseInstaller, base_installer.GitRepoInstaller):
 class LocalSourceDirInstaller(
     LIBVIRTBaseInstaller, base_installer.LocalSourceDirInstaller
 ):
-
     """
     Installer that deals with source code on local directories
     """
@@ -129,7 +126,6 @@ class LocalSourceDirInstaller(
 class LocalSourceTarInstaller(
     LIBVIRTBaseInstaller, base_installer.LocalSourceTarInstaller
 ):
-
     """
     Installer that deals with source code on local tarballs
     """
@@ -140,7 +136,6 @@ class LocalSourceTarInstaller(
 class RemoteSourceTarInstaller(
     LIBVIRTBaseInstaller, base_installer.RemoteSourceTarInstaller
 ):
-
     """
     Installer that deals with source code on remote tarballs
     """

--- a/virttest/libvirt_storage.py
+++ b/virttest/libvirt_storage.py
@@ -18,7 +18,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class QemuImg(storage.QemuImg):
-
     """
     libvirt class for handling operations of disk/block images.
     """
@@ -114,7 +113,6 @@ class QemuImg(storage.QemuImg):
 
 
 class StoragePool(object):
-
     """
     Pool Manager for libvirt storage with virsh commands
     """
@@ -430,7 +428,6 @@ class StoragePool(object):
 
 
 class PoolVolume(object):
-
     """Volume Manager for libvirt storage pool."""
 
     def __init__(self, pool_name, virsh_instance=virsh):

--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -168,7 +168,6 @@ class Monitor(object):
 
 
 class VM(virt_vm.BaseVM):
-
     """
     This class handles all basic VM operations for libvirt.
     """

--- a/virttest/libvirt_xml/accessors.py
+++ b/virttest/libvirt_xml/accessors.py
@@ -40,7 +40,6 @@ def add_to_slots(*args):
 
 
 class AccessorBase(PropCanBase):
-
     """
     Base class for a callable operating on a LibvirtXMLBase subclass instance
     """
@@ -158,7 +157,6 @@ class AccessorBase(PropCanBase):
 
 
 class ForbiddenBase(AccessorBase):
-
     """
     Raise LibvirtXMLAccessorError when called w/ or w/o a value arg.
     """
@@ -180,7 +178,6 @@ class ForbiddenBase(AccessorBase):
 
 
 class AccessorGeneratorBase(object):
-
     """
     Accessor method/class generator for specific property name
     """
@@ -264,7 +261,6 @@ class AccessorGeneratorBase(object):
 
 
 class AllForbidden(AccessorGeneratorBase):
-
     """
     Class of forbidden accessor classes for those undefined on libvirtxml
     """
@@ -284,7 +280,6 @@ class AllForbidden(AccessorGeneratorBase):
 
 
 class XMLElementText(AccessorGeneratorBase):
-
     """
     Class of accessor classes operating on element.text
     """
@@ -317,7 +312,6 @@ class XMLElementText(AccessorGeneratorBase):
         )
 
     class Getter(AccessorBase):
-
         """
         Retrieve text on element
         """
@@ -330,7 +324,6 @@ class XMLElementText(AccessorGeneratorBase):
             ).text
 
     class Setter(AccessorBase):
-
         """
         Set text to value on element
         """
@@ -345,7 +338,6 @@ class XMLElementText(AccessorGeneratorBase):
             self.xmltreefile().write()
 
     class Delter(AccessorBase):
-
         """
         Remove element and ignore if it doesn't exist (same as False)
         """
@@ -370,7 +362,6 @@ class XMLElementText(AccessorGeneratorBase):
 
 
 class XMLElementInt(AccessorGeneratorBase):
-
     """
     Class of accessor classes operating on element.text as an integer
     """
@@ -413,7 +404,6 @@ class XMLElementInt(AccessorGeneratorBase):
         )
 
     class Getter(AccessorBase):
-
         """
         Retrieve text on element and convert to int
         """
@@ -434,7 +424,6 @@ class XMLElementInt(AccessorGeneratorBase):
             return result
 
     class Setter(AccessorBase):
-
         """
         Set text on element after converting to int then to str
         """
@@ -454,7 +443,6 @@ class XMLElementInt(AccessorGeneratorBase):
 
 
 class XMLElementBool(AccessorGeneratorBase):
-
     """
     Class of accessor classes operating purely element existence
     """
@@ -487,7 +475,6 @@ class XMLElementBool(AccessorGeneratorBase):
         )
 
     class Getter(AccessorBase):
-
         """
         Retrieve text on element
         """
@@ -503,7 +490,6 @@ class XMLElementBool(AccessorGeneratorBase):
                 return False
 
     class Setter(AccessorBase):
-
         """
         Create element when True, delete when false
         """
@@ -521,7 +507,6 @@ class XMLElementBool(AccessorGeneratorBase):
 
 
 class XMLAttribute(AccessorGeneratorBase):
-
     """
     Class of accessor classes operating on an attribute of an element
     """
@@ -555,7 +540,6 @@ class XMLAttribute(AccessorGeneratorBase):
         )
 
     class Getter(AccessorBase):
-
         """
         Get attribute value
         """
@@ -575,7 +559,6 @@ class XMLAttribute(AccessorGeneratorBase):
             return value
 
     class Setter(AccessorBase):
-
         """
         Set attribute value
         """
@@ -590,7 +573,6 @@ class XMLAttribute(AccessorGeneratorBase):
             self.xmltreefile().write()
 
     class Delter(AccessorBase):
-
         """
         Remove attribute
         """
@@ -609,7 +591,6 @@ class XMLAttribute(AccessorGeneratorBase):
 
 
 class XMLElementDict(AccessorGeneratorBase):
-
     """
     Class of accessor classes operating as a dictionary of attributes
     """
@@ -640,7 +621,6 @@ class XMLElementDict(AccessorGeneratorBase):
         )
 
     class Getter(AccessorBase):
-
         """
         Retrieve attributes on element
         """
@@ -654,7 +634,6 @@ class XMLElementDict(AccessorGeneratorBase):
             return dict(list(element.items()))
 
     class Setter(AccessorBase):
-
         """
         Set attributes to value on element
         """
@@ -675,7 +654,6 @@ class XMLElementDict(AccessorGeneratorBase):
 
 
 class XMLElementNest(AccessorGeneratorBase):
-
     """
     Class of accessor classes operating on a LibvirtXMLBase subclass
     """
@@ -718,7 +696,6 @@ class XMLElementNest(AccessorGeneratorBase):
         )
 
     class Getter(AccessorBase):
-
         """
         Retrieve instance of subclass with it's xml set to rerooted xpath/tag
         """
@@ -745,7 +722,6 @@ class XMLElementNest(AccessorGeneratorBase):
             return nestedinst
 
     class Setter(AccessorBase):
-
         """
         Set attributes to value on element
         """
@@ -768,7 +744,6 @@ class XMLElementNest(AccessorGeneratorBase):
 
 
 class XMLElementList(AccessorGeneratorBase):
-
     """
     Class of accessor classes operating on a list of child elements
 
@@ -819,7 +794,6 @@ class XMLElementList(AccessorGeneratorBase):
         )
 
     class Getter(AccessorBase):
-
         """
         Retrieve list of values as returned by the marshal_to callable
         """
@@ -865,7 +839,6 @@ class XMLElementList(AccessorGeneratorBase):
             return result
 
     class Setter(AccessorBase):
-
         """
         Set child elements as returned by the marshal_to callable
         """
@@ -927,7 +900,6 @@ class XMLElementList(AccessorGeneratorBase):
             self.xmltreefile().write()
 
     class Delter(AccessorBase):
-
         """
         Remove ALL child elements for which marshal_to does NOT return None
         """

--- a/virttest/libvirt_xml/backup_xml.py
+++ b/virttest/libvirt_xml/backup_xml.py
@@ -2,6 +2,7 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatbackup.html
 """
+
 from virttest.libvirt_xml import accessors, base, xcepts
 
 

--- a/virttest/libvirt_xml/base.py
+++ b/virttest/libvirt_xml/base.py
@@ -13,7 +13,6 @@ virsh = lazy_import("virttest.virsh")
 
 
 class LibvirtXMLBase(propcan.PropCanBase):
-
     """
     Base class for common attributes/methods applying to all sub-classes
 

--- a/virttest/libvirt_xml/capability_xml.py
+++ b/virttest/libvirt_xml/capability_xml.py
@@ -8,7 +8,6 @@ from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class CapabilityXML(base.LibvirtXMLBase):
-
     """
     Handler of libvirt capabilities and nonspecific item operations.
 
@@ -282,7 +281,6 @@ class CapabilityXML(base.LibvirtXMLBase):
 
 
 class TopologyXML(base.LibvirtXMLBase):
-
     """
     Handler of cells topology element in libvirt capabilities.
 
@@ -328,7 +326,6 @@ class TopologyXML(base.LibvirtXMLBase):
 
 
 class CellXML(base.LibvirtXMLBase):
-
     """
     Handler of cell element in libvirt capabilities.
 
@@ -481,7 +478,6 @@ class CellXML(base.LibvirtXMLBase):
 
 
 class CellPagesXML(base.LibvirtXMLBase):
-
     """
     Handler of pages element under cell element in libvirt capabilities.
 

--- a/virttest/libvirt_xml/checkpoint_xml.py
+++ b/virttest/libvirt_xml/checkpoint_xml.py
@@ -2,6 +2,7 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatdomaincheckpoint.html
 """
+
 from virttest.libvirt_xml import accessors, base
 
 

--- a/virttest/libvirt_xml/devices/base.py
+++ b/virttest/libvirt_xml/devices/base.py
@@ -12,7 +12,6 @@ from virttest.xml_utils import ElementTree
 
 
 class UntypedDeviceBase(base.LibvirtXMLBase):
-
     """
     Base class implementing common functions for all device XML w/o a type attr.
     """
@@ -130,7 +129,6 @@ class UntypedDeviceBase(base.LibvirtXMLBase):
 
 
 class TypedDeviceBase(UntypedDeviceBase):
-
     """
     Base class implementing common functions for all device XML w/o a type attr.
     """
@@ -193,7 +191,6 @@ class TypedDeviceBase(UntypedDeviceBase):
 
 
 class StubDeviceMeta(type):
-
     """
     Metaclass for generating stub Device classes where not fully implemented yet
     """

--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -10,7 +10,6 @@ from virttest.libvirt_xml.devices.seclabel import Seclabel
 
 
 class Disk(base.TypedDeviceBase):
-
     """
     Disk device XML class
 
@@ -352,7 +351,6 @@ class Disk(base.TypedDeviceBase):
     Address = librarian.get("address")
 
     class DiskSource(base.base.LibvirtXMLBase):
-
         """
         Disk source device XML class
 
@@ -490,7 +488,6 @@ class Disk(base.TypedDeviceBase):
             return dict(attr_dict)  # return copy of dict, not reference
 
     class DiskDriverIOthreadsXML(base.base.LibvirtXMLBase):
-
         """
         iothreads tag XML class
 
@@ -598,7 +595,6 @@ class Disk(base.TypedDeviceBase):
                 return dict(attr_dict)
 
     class IOTune(base.base.LibvirtXMLBase):
-
         """
         IOTune device XML class
 
@@ -632,7 +628,6 @@ class Disk(base.TypedDeviceBase):
             self.xml = "<iotune/>"
 
     class Encryption(base.base.LibvirtXMLBase):
-
         """
         Encryption device XML class
 
@@ -664,7 +659,6 @@ class Disk(base.TypedDeviceBase):
             self.xml = "<encryption/>"
 
     class Auth(base.base.LibvirtXMLBase):
-
         """
         Auth device XML class
 
@@ -715,7 +709,6 @@ class Disk(base.TypedDeviceBase):
             self.xml = "<auth/>"
 
     class Slices(base.base.LibvirtXMLBase):
-
         """
         slices device XML class
         Typical xml looks like:
@@ -752,7 +745,6 @@ class Disk(base.TypedDeviceBase):
             self.xml = "<slices/>"
 
     class Reservations(base.base.LibvirtXMLBase):
-
         """
         Reservations device XML class
 

--- a/virttest/libvirt_xml/devices/filesystem.py
+++ b/virttest/libvirt_xml/devices/filesystem.py
@@ -58,7 +58,6 @@ class Filesystem(base.TypedDeviceBase):
         )
 
     class Binary(base.base.LibvirtXMLBase):
-
         """
         Filesystem binary subclass
         Typical xml looks like:

--- a/virttest/libvirt_xml/devices/hostdev.py
+++ b/virttest/libvirt_xml/devices/hostdev.py
@@ -3,6 +3,7 @@ hostdev device support class(es)
 
 http://libvirt.org/formatdomain.html#elementsHostDev
 """
+
 from virttest.libvirt_xml import accessors
 from virttest.libvirt_xml.devices import base, librarian
 

--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -349,7 +349,6 @@ class Interface(base.TypedDeviceBase):
         return new_one
 
     class Bandwidth(base.base.LibvirtXMLBase):
-
         """
         Interface bandwidth xml class.
 
@@ -374,7 +373,6 @@ class Interface(base.TypedDeviceBase):
             self.xml = "<bandwidth/>"
 
     class Driver(base.base.LibvirtXMLBase):
-
         """
         Interface Driver xml class.
 
@@ -404,7 +402,6 @@ class Interface(base.TypedDeviceBase):
             self.xml = "<driver/>"
 
     class Vlan(base.base.LibvirtXMLBase):
-
         """
         Interface vlan xml class.
 

--- a/virttest/libvirt_xml/devices/memory.py
+++ b/virttest/libvirt_xml/devices/memory.py
@@ -66,7 +66,6 @@ class Memory(base.UntypedDeviceBase):
     Address = librarian.get("address")
 
     class Target(base.base.LibvirtXMLBase):
-
         """
         Memory target xml class.
 
@@ -162,7 +161,6 @@ class Memory(base.UntypedDeviceBase):
             self.xml = "<target/>"
 
         class Label(base.base.LibvirtXMLBase):
-
             """
             Memory target label xml class.
 
@@ -190,7 +188,6 @@ class Memory(base.UntypedDeviceBase):
                 self.xml = "<label/>"
 
     class Source(base.base.LibvirtXMLBase):
-
         """
         Memory source xml class.
 

--- a/virttest/libvirt_xml/devices/rng.py
+++ b/virttest/libvirt_xml/devices/rng.py
@@ -50,7 +50,6 @@ class Rng(base.UntypedDeviceBase):
         return new_one
 
     class Backend(base.base.LibvirtXMLBase):
-
         """
         Rng backend xml class.
 

--- a/virttest/libvirt_xml/devices/seclabel.py
+++ b/virttest/libvirt_xml/devices/seclabel.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.devices import base
 
 
 class Seclabel(base.TypedDeviceBase):
-
     """
     Seclabel XML class
 

--- a/virttest/libvirt_xml/devices/tpm.py
+++ b/virttest/libvirt_xml/devices/tpm.py
@@ -32,7 +32,6 @@ class Tpm(base.UntypedDeviceBase):
         super(Tpm, self).__init__(device_tag="tpm", virsh_instance=virsh_instance)
 
     class Backend(base.base.LibvirtXMLBase):
-
         """
         Tpm backend xml class.
 

--- a/virttest/libvirt_xml/domcapability_xml.py
+++ b/virttest/libvirt_xml/domcapability_xml.py
@@ -2,6 +2,7 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatdomaincaps.html
 """
+
 import logging
 
 from virttest import xml_utils
@@ -11,7 +12,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class DomCapabilityXML(base.LibvirtXMLBase):
-
     """
     Handler of libvirt domcapabilities operations.
 

--- a/virttest/libvirt_xml/network_xml.py
+++ b/virttest/libvirt_xml/network_xml.py
@@ -13,7 +13,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class RangeList(list):
-
     """
     A list of start & end address tuples
     """
@@ -61,7 +60,6 @@ class RangeXML(base.LibvirtXMLBase):
 
 
 class IPXML(base.LibvirtXMLBase):
-
     """
     IP address block, optionally containing DHCP range information
 
@@ -180,7 +178,6 @@ class DhcpHostXML(base.LibvirtXMLBase):
 
 
 class DNSXML(base.LibvirtXMLBase):
-
     """
     DNS block, contains configuration information for the network's DNS server
 
@@ -238,7 +235,6 @@ class DNSXML(base.LibvirtXMLBase):
         self.xml = "<dns></dns>"
 
     class HostnameXML(base.LibvirtXMLBase):
-
         """
         Hostname element of dns
         """
@@ -256,7 +252,6 @@ class DNSXML(base.LibvirtXMLBase):
             self.xml = "<hostname/>"
 
     class HostXML(base.LibvirtXMLBase):
-
         """
         Hostname element of dns
         """
@@ -345,7 +340,6 @@ class DNSXML(base.LibvirtXMLBase):
 
 
 class PortgroupXML(base.LibvirtXMLBase):
-
     """
     Accessor methods for PortgroupXML class in NetworkXML.
 
@@ -406,7 +400,6 @@ class PortgroupXML(base.LibvirtXMLBase):
 
 
 class NetworkXMLBase(base.LibvirtXMLBase):
-
     """
     Accessor methods for NetworkXML class.
 
@@ -889,7 +882,6 @@ class NetworkXMLBase(base.LibvirtXMLBase):
 
 
 class NetworkXML(NetworkXMLBase):
-
     """
     Manipulators of a Virtual Network through it's XML definition.
     """

--- a/virttest/libvirt_xml/nodedev_xml.py
+++ b/virttest/libvirt_xml/nodedev_xml.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class CAPXML(base.LibvirtXMLBase):
-
     """
     The base class for capability.
     """
@@ -43,7 +42,6 @@ class CAPXML(base.LibvirtXMLBase):
 
 
 class SystemXML(CAPXML):
-
     """
     class for capability which type is system.
     """
@@ -208,7 +206,6 @@ class MdevXML(CAPXML):
 
 
 class StorageXML(CAPXML):
-
     """
     class for capability whose type is storage.
     """
@@ -242,7 +239,6 @@ class VDPAXML(CAPXML):
 
 
 class PCIXML(CAPXML):
-
     """
     class for capability whose type is pci.
     """
@@ -337,7 +333,6 @@ class PCIXML(CAPXML):
         self.xml = " <capability type='pci'></capability>"
 
     class Address(base.LibvirtXMLBase):
-
         """
         Address of Virtual Function device.
         """
@@ -461,7 +456,6 @@ class PCIXML(CAPXML):
 
 
 class NodedevXMLBase(base.LibvirtXMLBase):
-
     """
     Accessor methods for NodedevXML class.
 
@@ -613,7 +607,6 @@ class NodedevXMLBase(base.LibvirtXMLBase):
 
 
 class NodedevXML(NodedevXMLBase):
-
     """
     class for Node device XML.
     """

--- a/virttest/libvirt_xml/nwfilter_protocols/ah.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ah.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Ah(base.TypedDeviceBase):
-
     """
     Create new Ah xml instances
 
@@ -60,7 +59,6 @@ class Ah(base.TypedDeviceBase):
         return ah_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Ah attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/ah_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ah_ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Ah_ipv6(base.TypedDeviceBase):
-
     """
     Create new Ah_ipv6 xml instances
 
@@ -61,7 +60,6 @@ class Ah_ipv6(base.TypedDeviceBase):
         return ah_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Ah_ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/all.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/all.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class All(base.TypedDeviceBase):
-
     """
     Create new All xml instances
 
@@ -60,7 +59,6 @@ class All(base.TypedDeviceBase):
         return all_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         All attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/all_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/all_ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class All_ipv6(base.TypedDeviceBase):
-
     """
     Create new All_ipv6 xml instances
 
@@ -60,7 +59,6 @@ class All_ipv6(base.TypedDeviceBase):
         return all_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         All_ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/arp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/arp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Arp(base.TypedDeviceBase):
-
     """
     Create new Arp xml instances
 
@@ -61,7 +60,6 @@ class Arp(base.TypedDeviceBase):
         return arp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Arp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/base.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/base.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class UntypedDeviceBase(base.LibvirtXMLBase):
-
     """
     Base class implementing common functions for all rule protocol XML w/o a
     type attr.
@@ -71,7 +70,6 @@ class UntypedDeviceBase(base.LibvirtXMLBase):
 
 
 class TypedDeviceBase(UntypedDeviceBase):
-
     """
     Base class implementing common functions for all filter rule XML w/o a
     type attr.

--- a/virttest/libvirt_xml/nwfilter_protocols/esp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/esp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Esp(base.TypedDeviceBase):
-
     """
     Create new Esp xml instances
 
@@ -60,7 +59,6 @@ class Esp(base.TypedDeviceBase):
         return esp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Esp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/esp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/esp_ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Esp_ipv6(base.TypedDeviceBase):
-
     """
     Create new Esp_ipv6 xml instances
 
@@ -60,7 +59,6 @@ class Esp_ipv6(base.TypedDeviceBase):
         return esp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Esp_ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/icmp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/icmp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Icmp(base.TypedDeviceBase):
-
     """
     Create new Icmp xml instances
 
@@ -60,7 +59,6 @@ class Icmp(base.TypedDeviceBase):
         return icmp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Icmp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/icmpv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/icmpv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Icmpv6(base.TypedDeviceBase):
-
     """
     Create new Icmpv6 xml instances
 
@@ -57,7 +56,6 @@ class Icmpv6(base.TypedDeviceBase):
         return icmpv6_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Icmpv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/igmp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/igmp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Igmp(base.TypedDeviceBase):
-
     """
     Create new Igmp xml instances
 
@@ -57,7 +56,6 @@ class Igmp(base.TypedDeviceBase):
         return igmp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Igmp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/ip.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ip.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Ip(base.TypedDeviceBase):
-
     """
     Create new Ip xml instances
 
@@ -61,7 +60,6 @@ class Ip(base.TypedDeviceBase):
         return ip_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Ip attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Ipv6(base.TypedDeviceBase):
-
     """
     Create new Ipv6 xml instances
 
@@ -61,7 +60,6 @@ class Ipv6(base.TypedDeviceBase):
         return ipv6_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/mac.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/mac.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Mac(base.TypedDeviceBase):
-
     """
     Create new Mac xml instances
 
@@ -60,7 +59,6 @@ class Mac(base.TypedDeviceBase):
         return mac_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Mac attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/rarp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/rarp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Rarp(base.TypedDeviceBase):
-
     """
     Create new Rarp xml instances
 
@@ -60,7 +59,6 @@ class Rarp(base.TypedDeviceBase):
         return rarp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Rarp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/sctp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/sctp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Sctp(base.TypedDeviceBase):
-
     """
     Create new Sctp xml instances
 
@@ -61,7 +60,6 @@ class Sctp(base.TypedDeviceBase):
         return sctp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Sctp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/sctp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/sctp_ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Sctp_ipv6(base.TypedDeviceBase):
-
     """
     Create new Sctp_ipv6 xml instances
 
@@ -61,7 +60,6 @@ class Sctp_ipv6(base.TypedDeviceBase):
         return sctp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Sctp_ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/stp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/stp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Stp(base.TypedDeviceBase):
-
     """
     Create new Stp xml instances
 
@@ -60,7 +59,6 @@ class Stp(base.TypedDeviceBase):
         return stp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Stp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/tcp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/tcp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Tcp(base.TypedDeviceBase):
-
     """
     Create new Tcp xml instances
 
@@ -60,7 +59,6 @@ class Tcp(base.TypedDeviceBase):
         return tcp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Tcp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/tcp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/tcp_ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Tcp_ipv6(base.TypedDeviceBase):
-
     """
     Create new Tcp_ipv6 xml instances
 
@@ -60,7 +59,6 @@ class Tcp_ipv6(base.TypedDeviceBase):
         return tcp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Tcp_ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/udp.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udp.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Udp(base.TypedDeviceBase):
-
     """
     Create new Udp xml instances
 
@@ -60,7 +59,6 @@ class Udp(base.TypedDeviceBase):
         return udp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Udp attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/udp_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udp_ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Udp_ipv6(base.TypedDeviceBase):
-
     """
     Create new Udp_ipv6 xml instances
 
@@ -60,7 +59,6 @@ class Udp_ipv6(base.TypedDeviceBase):
         return udp_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Udp_ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/udplite.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udplite.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Udplite(base.TypedDeviceBase):
-
     """
     Create new Udplite xml instances
 
@@ -60,7 +59,6 @@ class Udplite(base.TypedDeviceBase):
         return udplite_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Udplite attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/udplite_ipv6.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/udplite_ipv6.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Udplite_ipv6(base.TypedDeviceBase):
-
     """
     Create new Udplite_ipv6 xml instances
 
@@ -63,7 +62,6 @@ class Udplite_ipv6(base.TypedDeviceBase):
         return udplite_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Udplite_ipv6 attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_protocols/vlan.py
+++ b/virttest/libvirt_xml/nwfilter_protocols/vlan.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.nwfilter_protocols import base
 
 
 class Vlan(base.TypedDeviceBase):
-
     """
     Create new Vlan xml instances
 
@@ -60,7 +59,6 @@ class Vlan(base.TypedDeviceBase):
         return vlan_attr
 
     class Attr(base.base.LibvirtXMLBase):
-
         """
         Vlan attribute XML class
 

--- a/virttest/libvirt_xml/nwfilter_xml.py
+++ b/virttest/libvirt_xml/nwfilter_xml.py
@@ -8,7 +8,6 @@ from virttest.libvirt_xml.nwfilter_protocols import librarian
 
 
 class NwfilterRulesProtocol(list):
-
     """
     List of protocol instances from classes handed out by librarian.get
     """
@@ -49,7 +48,6 @@ class NwfilterRulesProtocol(list):
 
 
 class NwfilterXMLRules(base.LibvirtXMLBase):
-
     """
     Create new NwfilterXMLRules instance.
 
@@ -141,7 +139,6 @@ class NwfilterXMLRules(base.LibvirtXMLBase):
 
 
 class NwfilterXMLBase(base.LibvirtXMLBase):
-
     """
     Accessor methods for NwfilterXML class.
 
@@ -308,7 +305,6 @@ class NwfilterXMLBase(base.LibvirtXMLBase):
 
 
 class NwfilterXML(NwfilterXMLBase):
-
     """
     Manipulators of a nwfilter through it's XML definition.
     """

--- a/virttest/libvirt_xml/pool_xml.py
+++ b/virttest/libvirt_xml/pool_xml.py
@@ -2,6 +2,7 @@
 Module simplifying manipulation of XML described at
 http://libvirt.org/formatstorage.html#StoragePool
 """
+
 import logging
 import os
 import tempfile
@@ -16,7 +17,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class SourceXML(base.LibvirtXMLBase):
-
     """
     Source block in pool xml, optionally containing different elements and
     attributes which dependent on pool type.
@@ -187,7 +187,6 @@ class SourceXML(base.LibvirtXMLBase):
 
 
 class PoolXMLBase(base.LibvirtXMLBase):
-
     """
     Accessor methods for PoolXML class.
 
@@ -305,7 +304,6 @@ class PoolXMLBase(base.LibvirtXMLBase):
 
 
 class PoolcapabilityXML(base.LibvirtXMLBase):
-
     """
     Handler of libvirt pool-capabilities.
 
@@ -380,7 +378,6 @@ class PoolcapabilityXML(base.LibvirtXMLBase):
 
 
 class PoolXML(PoolXMLBase):
-
     """
     Manipulators of a libvirt Pool through it's XML definition.
     """

--- a/virttest/libvirt_xml/secret_xml.py
+++ b/virttest/libvirt_xml/secret_xml.py
@@ -7,7 +7,6 @@ from virttest.libvirt_xml import accessors, base, xcepts
 
 
 class SecretXMLBase(base.LibvirtXMLBase):
-
     """
     Accessor methods for SecretXML class.
 
@@ -98,7 +97,6 @@ class SecretXMLBase(base.LibvirtXMLBase):
 
 
 class SecretXML(SecretXMLBase):
-
     """
     Manipulators of a secret through it's XML definition.
     """

--- a/virttest/libvirt_xml/snapshot_xml.py
+++ b/virttest/libvirt_xml/snapshot_xml.py
@@ -9,7 +9,6 @@ from virttest.libvirt_xml.devices.disk import Disk
 
 
 class SnapshotXMLBase(base.LibvirtXMLBase):
-
     """
     Accessor methods for SnapshotXML class.
 
@@ -67,7 +66,6 @@ class SnapshotXMLBase(base.LibvirtXMLBase):
 
 
 class SnapshotXML(SnapshotXMLBase):
-
     """
     Manipulators of a snapshot through it's XML definition.
     """
@@ -134,7 +132,6 @@ class SnapshotXML(SnapshotXMLBase):
         self.xmltreefile.write()
 
     class SnapDiskXML(Disk):
-
         """
         Manipulators disk xml in snapshot xml definition.
         Most properties are inherit from parent class Disk.

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -17,7 +17,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class VMXMLDevices(list):
-
     """
     List of device instances from classes handed out by librarian.get()
     """
@@ -58,7 +57,6 @@ class VMXMLDevices(list):
 
 
 class VMXMLBase(LibvirtXMLBase):
-
     """
     Accessor methods for VMXML class properties (items in __slots__)
 
@@ -753,7 +751,6 @@ class VMXMLBase(LibvirtXMLBase):
 
 
 class VMXML(VMXMLBase):
-
     """
     Higher-level manipulations related to VM's XML or guest/host state
     """
@@ -2068,7 +2065,6 @@ class VMXML(VMXMLBase):
 
 
 class VMCPUXML(base.LibvirtXMLBase):
-
     """
     Higher-level manipulations related to VM's XML(CPU)
     """
@@ -2202,7 +2198,6 @@ class VMCPUXML(base.LibvirtXMLBase):
 
     # Sub-element of cpu
     class InterconnectsXML(base.LibvirtXMLBase):
-
         """Interconnects element of numa"""
 
         __slots__ = ("latency", "bandwidth")
@@ -2503,7 +2498,6 @@ class VMCPUXML(base.LibvirtXMLBase):
 
 # Sub-element of cpu/numa
 class NumaCellXML(base.LibvirtXMLBase):
-
     """
     Cell element of numa
     """
@@ -2667,7 +2661,6 @@ class NumaCellXML(base.LibvirtXMLBase):
 
 
 class CellCacheXML(base.LibvirtXMLBase):
-
     """
     Cache of cell
     """
@@ -2747,7 +2740,6 @@ class CellCacheXML(base.LibvirtXMLBase):
 
 
 class VMClockXML(base.LibvirtXMLBase):
-
     """
     Higher-level manipulations related to VM's XML(Clock)
     """
@@ -2800,7 +2792,6 @@ class VMClockXML(base.LibvirtXMLBase):
 
     # Sub-element of clock
     class TimerXML(base.LibvirtXMLBase):
-
         """Timer element of clock"""
 
         __slots__ = (
@@ -2922,7 +2913,6 @@ class VMClockXML(base.LibvirtXMLBase):
 
 
 class CacheTuneXML(base.LibvirtXMLBase):
-
     """CacheTune XML"""
 
     __slots__ = ("vcpus", "caches", "monitors")
@@ -3015,7 +3005,6 @@ class CacheTuneXML(base.LibvirtXMLBase):
 
     # Sub-element of CacheTuneXML
     class CacheXML(base.LibvirtXMLBase):
-
         """Cache element of CacheTuneXML"""
 
         __slots__ = ("id", "level", "type", "size", "unit")
@@ -3070,7 +3059,6 @@ class CacheTuneXML(base.LibvirtXMLBase):
 
     # Sub-element of CacheTuneXML
     class MonitorXML(base.LibvirtXMLBase):
-
         """Monitor element of CacheTuneXML"""
 
         __slots__ = ("level", "vcpus")
@@ -3101,7 +3089,6 @@ class CacheTuneXML(base.LibvirtXMLBase):
 
 
 class MemoryTuneXML(base.LibvirtXMLBase):
-
     """Event element of perf"""
 
     __slots__ = ("vcpus", "nodes", "monitors")
@@ -3194,7 +3181,6 @@ class MemoryTuneXML(base.LibvirtXMLBase):
 
     # Sub-element of MemoryTuneXML
     class NodeXML(base.LibvirtXMLBase):
-
         """Node element of MemoryTuneXML"""
 
         __slots__ = ("id", "bandwidth")
@@ -3225,7 +3211,6 @@ class MemoryTuneXML(base.LibvirtXMLBase):
 
     # Sub-element of MemoryTuneXML
     class MonitorXML(base.LibvirtXMLBase):
-
         """Monitor element of MemoryTuneXML"""
 
         __slots__ = ("vcpus",)
@@ -3519,7 +3504,6 @@ class VMCPUTuneXML(base.LibvirtXMLBase):
 
 
 class VMOSXML(base.LibvirtXMLBase):
-
     """
     Class to access <os> tag of domain XML.
 
@@ -3787,7 +3771,6 @@ class VMOSXML(base.LibvirtXMLBase):
 
 
 class VMPMXML(base.LibvirtXMLBase):
-
     """
     VM power management tag XML class
 
@@ -3818,7 +3801,6 @@ class VMPMXML(base.LibvirtXMLBase):
 
 
 class VMFeaturesXML(base.LibvirtXMLBase):
-
     """
     Class to access <features> tag of domain XML.
 
@@ -3996,7 +3978,6 @@ class VMFeaturesXML(base.LibvirtXMLBase):
 
 
 class VMVCPUSXML(base.LibvirtXMLBase):
-
     """
     vcpus tag XML class
 
@@ -4044,7 +4025,6 @@ class VMVCPUSXML(base.LibvirtXMLBase):
 
 # Sub-element of memoryBacking
 class VMHugepagesXML(base.LibvirtXMLBase):
-
     """hugepages element"""
 
     __slots__ = ("pages",)
@@ -4064,7 +4044,6 @@ class VMHugepagesXML(base.LibvirtXMLBase):
 
     # Sub-element of hugepages
     class PageXML(base.LibvirtXMLBase):
-
         """Page element of hugepages"""
 
         __slots__ = ("size", "unit", "nodeset")
@@ -4124,7 +4103,6 @@ class VMHugepagesXML(base.LibvirtXMLBase):
 
 
 class VMMemBackingXML(base.LibvirtXMLBase):
-
     """
     memoryBacking tag XML class
 
@@ -4188,7 +4166,6 @@ class VMMemBackingXML(base.LibvirtXMLBase):
 
 
 class VMMemTuneXML(base.LibvirtXMLBase):
-
     """
     Memory Tuning tag XML class
 
@@ -4272,7 +4249,6 @@ class VMMemTuneXML(base.LibvirtXMLBase):
 
 
 class VMPerfXML(base.LibvirtXMLBase):
-
     """
     perf tag XML class
 
@@ -4298,7 +4274,6 @@ class VMPerfXML(base.LibvirtXMLBase):
 
     # Sub-element of perf
     class EventXML(base.LibvirtXMLBase):
-
         """Event element of perf"""
 
         __slots__ = ("name", "enabled")
@@ -4361,7 +4336,6 @@ class VMPerfXML(base.LibvirtXMLBase):
 
 
 class VMIothreadidsXML(base.LibvirtXMLBase):
-
     """
     iothreadids tag XML class
 
@@ -4602,7 +4576,6 @@ class VMFeaturesStimerXML(base.LibvirtXMLBase):
 
 
 class VMFeaturesHptXML(base.LibvirtXMLBase):
-
     """
     Hpt tag XML class of features tag
 
@@ -4689,7 +4662,6 @@ class VMKeywrapXML(base.LibvirtXMLBase):
 
 
 class VMSysinfoXML(base.LibvirtXMLBase):
-
     """
     Class to access <sysinfo> tag of domain XML
 

--- a/virttest/libvirt_xml/vol_xml.py
+++ b/virttest/libvirt_xml/vol_xml.py
@@ -8,7 +8,6 @@ from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
 
 
 class VolXMLBase(base.LibvirtXMLBase):
-
     """
     Accessor methods for VolXML class.
 
@@ -115,7 +114,6 @@ class VolXMLBase(base.LibvirtXMLBase):
 
 
 class VolXML(VolXMLBase):
-
     """
     Manipulators of a Virtual Vol through it's XML definition.
     """
@@ -195,7 +193,6 @@ class VolXML(VolXMLBase):
         return new_one
 
     class Encryption(base.LibvirtXMLBase):
-
         """
         Encryption volume XML class
 

--- a/virttest/libvirt_xml/xcepts.py
+++ b/virttest/libvirt_xml/xcepts.py
@@ -4,7 +4,6 @@ Module of common exceptions used in libvirt_xml package
 
 
 class LibvirtXMLError(Exception):
-
     """
     Error originating within libvirt_xml module
     """
@@ -18,7 +17,6 @@ class LibvirtXMLError(Exception):
 
 
 class LibvirtXMLAccessorError(LibvirtXMLError):
-
     """
     LibvirtXMLError related to an accessor generator class/method
     """
@@ -27,7 +25,6 @@ class LibvirtXMLAccessorError(LibvirtXMLError):
 
 
 class LibvirtXMLForbiddenError(LibvirtXMLError):
-
     """
     LibvirtXMLError raised when operating on a property is prohibited
     """
@@ -36,7 +33,6 @@ class LibvirtXMLForbiddenError(LibvirtXMLError):
 
 
 class LibvirtXMLNotFoundError(LibvirtXMLError):
-
     """
     LibvirtXMLError related when an element cannot be found
     """

--- a/virttest/libvirtd_decorator.py
+++ b/virttest/libvirtd_decorator.py
@@ -3,6 +3,7 @@ A decorator utility functions to apply libvirtd functions.
 
 Copyright: Red Hat Inc. 2020
 """
+
 import logging
 import os
 import re

--- a/virttest/logging_manager.py
+++ b/virttest/logging_manager.py
@@ -17,7 +17,6 @@ def do_not_report_as_logging_caller(func):
 
 
 class LoggingFile(object):
-
     """
     File-like object that will receive messages pass them to the logging
     infrastructure in an appropriate way.

--- a/virttest/lvm.py
+++ b/virttest/lvm.py
@@ -21,6 +21,7 @@ Required params:
     pv_name
         PhysicalVolume name eg, /dev/sdb or /dev/sdb1;
 """
+
 from __future__ import division
 
 import logging

--- a/virttest/lvsb.py
+++ b/virttest/lvsb.py
@@ -52,7 +52,6 @@ def make_sandboxes(params, env, extra_ns=None):
 
 
 class TestBaseSandboxes(lvsb_base.TestSandboxes):
-
     """
     Simplistic sandbox aggregate manager
     """
@@ -122,7 +121,6 @@ class TestBaseSandboxes(lvsb_base.TestSandboxes):
 
 
 class TestSimpleSandboxes(TestBaseSandboxes):
-
     """
     Executes a command with simple options
     """
@@ -141,7 +139,6 @@ class TestSimpleSandboxes(TestBaseSandboxes):
 
 
 class TestComplexSandboxes(TestBaseSandboxes):
-
     """
     Executes a command with complex options
     """

--- a/virttest/lvsb_base.py
+++ b/virttest/lvsb_base.py
@@ -14,7 +14,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class SandboxException(Exception):
-
     """
     Basic exception class for problems occurring in SandboxBase or subclasses
     """
@@ -30,7 +29,6 @@ class SandboxException(Exception):
 # This is to allow us to alter back-end session management w/o affecting
 # sandbox subclasses
 class SandboxSession(object):
-
     """
     Connection instance to asynchronous I/O redirector process
     """
@@ -150,7 +148,6 @@ class SandboxSession(object):
 
 
 class SandboxBase(object):
-
     """
     Base operations for sandboxed command
     """
@@ -268,7 +265,6 @@ class SandboxBase(object):
 
 
 class SandboxCommandBase(SandboxBase):
-
     """
     Connection to a single new or existing sandboxed command
     """
@@ -420,7 +416,6 @@ class SandboxCommandBase(SandboxBase):
 # Instances are similar to a list-of-lists- multiple kinds (classes) of
 # multiple sandbox executions.
 class TestSandboxes(object):
-
     """
     Aggregate manager class of SandboxCommandBase or subclass instances
     """

--- a/virttest/lvsbs.py
+++ b/virttest/lvsbs.py
@@ -8,7 +8,6 @@ from . import lvsb_base, virsh
 
 
 class SandboxService(object):
-
     """
     Management for a single new/existing sandboxed service
     """

--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -33,7 +33,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 # Migration Relative functions##############
 class MigrationTest(object):
-
     """Class for migration tests"""
 
     def __init__(self):

--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -2,6 +2,7 @@
 Basic nfs support for Linux host. It can support the remote
 nfs mount and the local nfs set up and mount.
 """
+
 import logging
 import re
 
@@ -50,7 +51,6 @@ def nfs_exported(session=None):
 
 
 class Exportfs(object):
-
     """
     Add or remove one entry to exported nfs file system.
     """
@@ -150,7 +150,6 @@ class Exportfs(object):
 
 
 class Nfs(object):
-
     """
     Nfs class for handle nfs mount and umount. If a local nfs service is
     required, it will configure a local nfs server according the params.
@@ -288,7 +287,6 @@ class Nfs(object):
 
 
 class NFSClient(object):
-
     """
     NFSClient class for handle nfs remotely mount and umount.
     """

--- a/virttest/nvme.py
+++ b/virttest/nvme.py
@@ -7,6 +7,7 @@ Available functions:
 - parse_uri: Parse the URI from NVMe image filename.
 
 """
+
 import re
 
 from avocado.utils import process

--- a/virttest/openvswitch.py
+++ b/virttest/openvswitch.py
@@ -90,7 +90,6 @@ class ServiceManager(VersionableClass):
 
 
 class OpenVSwitchControl(object):
-
     """
     Class select the best matches control class for installed version
     of OpenVSwitch.
@@ -219,7 +218,6 @@ class OpenVSwitchControl(object):
 
 
 class OpenVSwitchControlDB_140(OpenVSwitchControl):
-
     """
     Don't use this class directly. This class is automatically selected by
     OpenVSwitchControl.
@@ -247,7 +245,6 @@ class OpenVSwitchControlDB_CNT(VersionableClass):
 
 
 class OpenVSwitchControlCli_140(OpenVSwitchControl):
-
     """
     Don't use this class directly. This class is automatically selected by
     OpenVSwitchControl.
@@ -354,7 +351,6 @@ class OpenVSwitchControlCli_CNT(VersionableClass):
 
 
 class OpenVSwitchSystem(OpenVSwitchControlCli_CNT, OpenVSwitchControlDB_CNT):
-
     """
     OpenVSwtich class.
     """
@@ -462,7 +458,6 @@ class OpenVSwitchSystem(OpenVSwitchControlCli_CNT, OpenVSwitchControlDB_CNT):
 
 
 class OpenVSwitch(OpenVSwitchSystem):
-
     """
     OpenVSwtich class.
     """

--- a/virttest/ovirt.py
+++ b/virttest/ovirt.py
@@ -4,7 +4,6 @@ oVirt SDK wrapper module.
 :copyright: 2008-2012 Red Hat Inc.
 """
 
-
 import logging
 import time
 
@@ -83,7 +82,6 @@ def disconnect():
 
 
 class VMManager(virt_vm.BaseVM):
-
     """
     This class handles all basic VM operations for oVirt.
     """
@@ -629,7 +627,6 @@ class VMManager(virt_vm.BaseVM):
 
 
 class DataCenterManager(object):
-
     """
     This class handles all basic datacenter operations.
     """
@@ -678,7 +675,6 @@ class DataCenterManager(object):
 
 
 class ClusterManager(object):
-
     """
     This class handles all basic cluster operations.
     """
@@ -734,7 +730,6 @@ class ClusterManager(object):
 
 
 class HostManager(object):
-
     """
     This class handles all basic host operations.
     """
@@ -818,7 +813,6 @@ class HostManager(object):
 
 
 class StorageDomainManager(object):
-
     """
     This class handles all basic storage domain operations.
     """

--- a/virttest/postprocess_iozone.py
+++ b/virttest/postprocess_iozone.py
@@ -99,7 +99,6 @@ def compare_matrices(matrix1, matrix2, treshold=0.05):
 
 
 class IOzoneAnalyzer(object):
-
     """
     Analyze an unprocessed IOzone file, and generate the following types of
     report:
@@ -383,7 +382,6 @@ class IOzoneAnalyzer(object):
 
 
 class IOzonePlotter(object):
-
     """
     Plots graphs based on the results of an IOzone run.
 

--- a/virttest/propcan.py
+++ b/virttest/propcan.py
@@ -68,7 +68,6 @@ example:
 
 
 class PropCanInternal(object):
-
     """
     Semi-private methods for use only by PropCanBase subclasses (NOT instances)
     """
@@ -127,7 +126,6 @@ class classproperty(property):
 
 
 class PropCanBase(dict, PropCanInternal):
-
     """
     Objects with optional accessor methods and dict-like access to fixed set of keys
     """
@@ -281,7 +279,6 @@ class PropCanBase(dict, PropCanInternal):
 
 
 class PropCan(PropCanBase):
-
     """
     Special value handling on retrieval of None values
     """

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -67,7 +67,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class DevContainer(object):
-
     """
     Device container class
     """

--- a/virttest/qemu_devices/qdevices.py
+++ b/virttest/qemu_devices/qdevices.py
@@ -6,6 +6,7 @@ interact with qemu qdev structure.
 
 :copyright: 2012-2013 Red Hat Inc.
 """
+
 import json
 import logging
 import os
@@ -63,7 +64,6 @@ def _build_cmd(cmd, args=None, q_id=None):
 # Device objects
 #
 class QBaseDevice(object):
-
     """Base class of qemu objects"""
 
     def __init__(
@@ -378,7 +378,6 @@ class QBaseDevice(object):
 
 
 class QStringDevice(QBaseDevice):
-
     """
     General device which allows to specify methods by fixed or parametrizable
     strings in this format:
@@ -444,7 +443,6 @@ class QStringDevice(QBaseDevice):
 
 
 class QCustomDevice(QBaseDevice):
-
     """
     Representation of the '-$option $param1=$value1,$param2...' qemu object.
     This representation handles only cmdline.
@@ -515,7 +513,6 @@ class QCustomDevice(QBaseDevice):
 
 
 class QDrive(QCustomDevice):
-
     """
     Representation of the '-drive' qemu object without hotplug support.
     """
@@ -545,7 +542,6 @@ class QDrive(QCustomDevice):
 
 
 class QOldDrive(QDrive):
-
     """
     This is a variant for -drive without 'addr' support
     """
@@ -566,7 +562,6 @@ class QOldDrive(QDrive):
 
 
 class QHPDrive(QDrive):
-
     """
     Representation of the '-drive' qemu object with hotplug support.
     """
@@ -640,7 +635,6 @@ class QHPDrive(QDrive):
 
 
 class QRHDrive(QDrive):
-
     """
     Representation of the '-drive' qemu object with RedHat hotplug support.
     """
@@ -1118,7 +1112,6 @@ class QBlockdevProtocolFTPS(QBlockdevProtocol):
 
 
 class QDevice(QCustomDevice):
-
     """
     Representation of the '-device' qemu object. It supports all methods.
     :note: Use driver format in full form - 'driver' = '...' (usb-ehci, ide-hd)
@@ -1309,7 +1302,6 @@ class QDevice(QCustomDevice):
 
 
 class QGlobal(QBaseDevice):
-
     """
     Representation of qemu global setting (-global driver.property=value)
     """
@@ -1334,7 +1326,6 @@ class QGlobal(QBaseDevice):
 
 
 class QFloppy(QGlobal):
-
     """
     Imitation of qemu floppy disk defined by -global isa-fdc.drive?=$drive
     """
@@ -1368,7 +1359,6 @@ class QFloppy(QGlobal):
 
 
 class QObject(QCustomDevice):
-
     """
     Representation of the '-object backend' qemu object.
     """
@@ -1616,7 +1606,6 @@ class QThrottleGroup(QObject):
 
 
 class Memory(QObject):
-
     """
     QOM memory object, support for pinning memory on host NUMA nodes.
     The existing options in __attributes__ are subsumed by the QOM objects
@@ -2660,7 +2649,6 @@ class QNetdev(QCustomDevice):
 # virtio-serial-bus
 #
 class QSparseBus(object):
-
     """
     Universal bus representation object.
 
@@ -3062,7 +3050,6 @@ class QSparseBus(object):
 
 
 class QStrictCustomBus(QSparseBus):
-
     """
     Similar to QSparseBus. The address starts with 1 and addr is always set
     """
@@ -3089,7 +3076,6 @@ class QStrictCustomBus(QSparseBus):
 
 
 class QNoAddrCustomBus(QSparseBus):
-
     """
     This is the opposite of QStrictCustomBus. Even when addr is set it's not
     updated in the device's params.
@@ -3103,7 +3089,6 @@ class QNoAddrCustomBus(QSparseBus):
 
 
 class QUSBBus(QSparseBus):
-
     """
     USB bus representation including usb-hub handling.
     """
@@ -3179,7 +3164,6 @@ class QUSBBus(QSparseBus):
 
 
 class QDriveBus(QSparseBus):
-
     """
     QDrive bus representation (single slot, drive=...)
     """
@@ -3212,7 +3196,6 @@ class QDriveBus(QSparseBus):
 
 
 class QDenseBus(QSparseBus):
-
     """
     Dense bus representation. The only difference from SparseBus is the output
     string format. DenseBus iterates over all addresses and show free slots
@@ -3252,7 +3235,6 @@ class QDenseBus(QSparseBus):
 
 
 class QPCIBus(QSparseBus):
-
     """
     PCI Bus representation (bus&addr, uses hex digits)
     """
@@ -3514,7 +3496,6 @@ class QPCIEBus(QPCIBus):
 
 
 class QPCISwitchBus(QPCIBus):
-
     """
     PCI Switch bus representation (creates downstream device while inserting
     a device).
@@ -3569,7 +3550,6 @@ class QPCISwitchBus(QPCIBus):
 
 
 class QSCSIBus(QSparseBus):
-
     """
     SCSI bus representation (bus + 2 leves, don't iterate over lun by default)
     """
@@ -3598,7 +3578,6 @@ class QSCSIBus(QSparseBus):
 
 
 class QBusUnitBus(QDenseBus):
-
     """Implementation of bus-unit/nr bus (ahci, ide, virtio-serial)"""
 
     def __init__(
@@ -3663,7 +3642,6 @@ class QBusUnitBus(QDenseBus):
 
 
 class QSerialBus(QBusUnitBus):
-
     """Serial bus representation"""
 
     def __init__(self, busid, bus_type, aobject=None, max_ports=32):
@@ -3681,7 +3659,6 @@ class QSerialBus(QBusUnitBus):
 
 
 class QAHCIBus(QBusUnitBus):
-
     """AHCI bus (ich9-ahci, ahci)"""
 
     def __init__(self, busid, aobject=None):
@@ -3690,7 +3667,6 @@ class QAHCIBus(QBusUnitBus):
 
 
 class QIDEBus(QBusUnitBus):
-
     """IDE bus (piix3-ide)"""
 
     def __init__(self, busid, aobject=None):
@@ -3699,7 +3675,6 @@ class QIDEBus(QBusUnitBus):
 
 
 class QFloppyBus(QDenseBus):
-
     """
     Floppy bus (-global isa-fdc.drive?=$drive)
     """
@@ -3735,7 +3710,6 @@ class QFloppyBus(QDenseBus):
 
 
 class QOldFloppyBus(QDenseBus):
-
     """
     Floppy bus (-drive index=n)
     """

--- a/virttest/qemu_devices/utils.py
+++ b/virttest/qemu_devices/utils.py
@@ -11,14 +11,12 @@ import six
 # Exceptions
 #
 class DeviceError(Exception):
-
     """General device exception"""
 
     pass
 
 
 class DeviceInsertError(DeviceError):
-
     """Fail to insert device"""
 
     def __init__(self, device, reason, vmdev):
@@ -42,7 +40,6 @@ class DeviceInsertError(DeviceError):
 
 
 class DeviceRemoveError(DeviceInsertError):
-
     """Fail to remove device"""
 
     def __init__(self, device, reason, vmdev):
@@ -51,7 +48,6 @@ class DeviceRemoveError(DeviceInsertError):
 
 
 class DeviceHotplugError(DeviceInsertError):
-
     """Fail to hotplug device"""
 
     def __init__(self, device, reason, vmdev, ver_out=None):
@@ -61,7 +57,6 @@ class DeviceHotplugError(DeviceInsertError):
 
 
 class DeviceUnplugError(DeviceHotplugError):
-
     """Fail to unplug device"""
 
     def __init__(self, device, reason, vmdev):

--- a/virttest/qemu_installer.py
+++ b/virttest/qemu_installer.py
@@ -23,7 +23,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class QEMUBaseInstaller(base_installer.BaseInstaller):
-
     """
     Base class for KVM installations
     """
@@ -234,7 +233,6 @@ class QEMUBaseInstaller(base_installer.BaseInstaller):
 
 
 class GitRepoInstaller(QEMUBaseInstaller, base_installer.GitRepoInstaller):
-
     """
     Installer that deals with source code on Git repositories
     """
@@ -245,7 +243,6 @@ class GitRepoInstaller(QEMUBaseInstaller, base_installer.GitRepoInstaller):
 class LocalSourceDirInstaller(
     QEMUBaseInstaller, base_installer.LocalSourceDirInstaller
 ):
-
     """
     Installer that deals with source code on local directories
     """
@@ -256,7 +253,6 @@ class LocalSourceDirInstaller(
 class LocalSourceTarInstaller(
     QEMUBaseInstaller, base_installer.LocalSourceTarInstaller
 ):
-
     """
     Installer that deals with source code on local tarballs
     """
@@ -267,7 +263,6 @@ class LocalSourceTarInstaller(
 class RemoteSourceTarInstaller(
     QEMUBaseInstaller, base_installer.RemoteSourceTarInstaller
 ):
-
     """
     Installer that deals with source code on remote tarballs
     """

--- a/virttest/qemu_io.py
+++ b/virttest/qemu_io.py
@@ -7,7 +7,6 @@ from virttest import error_context, utils_logfile, utils_misc
 
 
 class QemuIOParamError(Exception):
-
     """
     Parameter Error for qemu-io command
     """
@@ -16,7 +15,6 @@ class QemuIOParamError(Exception):
 
 
 class QemuIO(object):
-
     """
     A class for execute qemu-io command
     """
@@ -100,7 +98,6 @@ class QemuIO(object):
 
 
 class QemuIOShellSession(QemuIO):
-
     """
     Use a shell session to execute qemu-io command
     """
@@ -179,7 +176,6 @@ class QemuIOShellSession(QemuIO):
 
 
 class QemuIOSystem(QemuIO):
-
     """
     Run qemu-io with a command line which will return immediately
     """

--- a/virttest/qemu_monitor.py
+++ b/virttest/qemu_monitor.py
@@ -269,7 +269,6 @@ class VM(object):
 
 
 class Monitor(object):
-
     """
     Common code for monitor classes.
     """

--- a/virttest/qemu_qtree.py
+++ b/virttest/qemu_qtree.py
@@ -4,6 +4,7 @@ Utility classes and functions to handle KVM Qtree parsing and verification.
 :author: Lukas Doktor <ldoktor@redhat.com>
 :copyright: 2012 Red Hat Inc.
 """
+
 import json
 import logging
 import os
@@ -41,7 +42,6 @@ class IncompatibleTypeError(TypeError):
 
 
 class QtreeNode(object):
-
     """
     Generic Qtree node
     """
@@ -143,7 +143,6 @@ class QtreeNode(object):
 
 
 class QtreeBus(QtreeNode):
-
     """bus: qtree object"""
 
     def __init__(self):
@@ -159,7 +158,6 @@ class QtreeBus(QtreeNode):
 
 
 class QtreeDev(QtreeNode):
-
     """dev: qtree object"""
 
     def __init__(self):
@@ -180,7 +178,6 @@ class QtreeDev(QtreeNode):
 
 
 class QtreeDisk(QtreeDev):
-
     """qtree disk object"""
 
     def __init__(self):
@@ -242,7 +239,6 @@ class QtreeDisk(QtreeDev):
 
 
 class QtreeContainer(object):
-
     """Container for Qtree"""
 
     def __init__(self):
@@ -391,7 +387,6 @@ class QtreeContainer(object):
 
 
 class QtreeDisksContainer(object):
-
     """
     Container for QtreeDisks verification.
     It's necessary because some information can be verified only from
@@ -567,7 +562,7 @@ class QtreeDisksContainer(object):
                 data_dir.get_data_dir(), params.object_params(name).get("cdrom", "")
             )
             image_name = os.path.realpath(image_name)
-            for (qname, disk) in six.iteritems(disks):
+            for qname, disk in six.iteritems(disks):
                 if disk[0].get("image_name") == image_name:
                     break
             else:
@@ -582,7 +577,7 @@ class QtreeDisksContainer(object):
             image_name = os.path.realpath(
                 storage.get_image_filename(image_params, base_dir)
             )
-            for (qname, disk) in six.iteritems(disks):
+            for qname, disk in six.iteritems(disks):
                 if disk[0].get("image_name") == image_name:
                     current = disk[0]
                     current_node = disk[1]

--- a/virttest/qemu_storage.py
+++ b/virttest/qemu_storage.py
@@ -5,6 +5,7 @@ This exports:
   - two functions for get image/blkdebug filename
   - class for image operates and basic parameters
 """
+
 import collections
 import json
 import logging
@@ -2098,7 +2099,6 @@ class QemuImg(storage.QemuImg):
 
 
 class Iscsidev(storage.Iscsidev):
-
     """
     Class for handle iscsi devices for VM
     """
@@ -2151,7 +2151,6 @@ class Iscsidev(storage.Iscsidev):
 
 
 class LVMdev(storage.LVMdev):
-
     """
     Class for handle lvm devices for VM
     """

--- a/virttest/qemu_virtio_port.py
+++ b/virttest/qemu_virtio_port.py
@@ -3,6 +3,7 @@ Interfaces and helpers for the virtio_serial ports.
 
 :copyright: 2012 Red Hat Inc.
 """
+
 from __future__ import division
 
 import logging
@@ -28,21 +29,18 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class VirtioPortException(Exception):
-
     """General virtio_port exception"""
 
     pass
 
 
 class VirtioPortFatalException(VirtioPortException):
-
     """Fatal virtio_port exception"""
 
     pass
 
 
 class _VirtioPort(object):
-
     """
     Define structure to keep information about used port.
     """
@@ -165,7 +163,6 @@ class _VirtioPort(object):
 
 
 class VirtioSerial(_VirtioPort):
-
     """Class for handling virtio-serialport"""
 
     def __init__(self, qemu_id, name, hostfile, port_type="unix_socket"):
@@ -178,7 +175,6 @@ class VirtioSerial(_VirtioPort):
 
 
 class VirtioConsole(_VirtioPort):
-
     """Class for handling virtio-console"""
 
     def __init__(self, qemu_id, name, hostfile, port_type="unix_socket"):
@@ -191,7 +187,6 @@ class VirtioConsole(_VirtioPort):
 
 
 class GuestWorker(object):
-
     """
     Class for executing "virtio_console_guest" script on guest
     """
@@ -522,7 +517,6 @@ class GuestWorker(object):
 
 
 class ThSend(Thread):
-
     """
     Random data sender thread.
     """
@@ -560,7 +554,6 @@ class ThSend(Thread):
 
 
 class ThSendCheck(Thread):
-
     """
     Random data sender thread.
     """
@@ -704,7 +697,6 @@ class ThSendCheck(Thread):
 
 
 class ThRecv(Thread):
-
     """
     Receives data and throws it away.
     """
@@ -745,7 +737,6 @@ class ThRecv(Thread):
 
 
 class ThRecvCheck(Thread):
-
     """
     Random data receiver/checker thread.
     """

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -80,7 +80,6 @@ class QemuSegFaultError(virt_vm.VMError):
 
 
 class VMMigrateProtoUnsupportedError(virt_vm.VMMigrateProtoUnknownError):
-
     """
     When QEMU tells us it doesn't know about a given migration protocol.
 
@@ -149,7 +148,6 @@ def qemu_proc_term_handler(vm, monitor_exit_status, exit_status):
 
 
 class VM(virt_vm.BaseVM):
-
     """
     This class handles all basic VM operations.
     """
@@ -500,6 +498,7 @@ class VM(virt_vm.BaseVM):
                nic_model -- string to pass as 'model' parameter for this
                NIC (e.g. e1000)
         """
+
         # Helper function for command line option wrappers
         def _add_option(option, value, option_type=None, first=False):
             """
@@ -2100,11 +2099,9 @@ class VM(virt_vm.BaseVM):
                     vcpu_threads = vcpu_threads or missing_value
             elif smp_values.count(0) > 1:
                 if vcpu_maxcpus == 1 and max(smp_values) < 2:
-                    vcpu_drawers = (
-                        vcpu_books
-                    ) = (
-                        vcpu_sockets
-                    ) = vcpu_dies = vcpu_clusters = vcpu_cores = vcpu_threads = 1
+                    vcpu_drawers = vcpu_books = vcpu_sockets = vcpu_dies = (
+                        vcpu_clusters
+                    ) = vcpu_cores = vcpu_threads = 1
 
             hotpluggable_cpus = len(params.objects("vcpu_devices"))
             if params["machine_type"].startswith("pseries"):
@@ -4075,7 +4072,7 @@ class VM(virt_vm.BaseVM):
                     session = self.login()
                 else:
                     session = self.serial_login()
-            except (IndexError) as e:
+            except IndexError as e:
                 try:
                     session = self.serial_login()
                 except (remote.LoginError, virt_vm.VMError) as e:
@@ -5384,7 +5381,7 @@ class VM(virt_vm.BaseVM):
             self.monitor.migrate(uri)
 
             if mig_inner_funcs:
-                for (func, param) in mig_inner_funcs:
+                for func, param in mig_inner_funcs:
                     if func == "postcopy":
                         # trigger a postcopy at somewhere below the given % of
                         # the 1st pass
@@ -5846,7 +5843,7 @@ class VM(virt_vm.BaseVM):
                 for key, value in six.iteritems(p_dict):
                     if is_json_data(value):
                         value = parse_json(value)
-                    for (k, v) in traverse_nested_dict(block):
+                    for k, v in traverse_nested_dict(block):
                         if is_json_data(v):
                             v = parse_json(v)
                         if k != key:

--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -1,6 +1,7 @@
 """
 Functions and classes used for logging into guests and transferring files.
 """
+
 from __future__ import division
 
 import logging
@@ -22,7 +23,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class AexpectIOWrapperOut(messenger.StdIOWrapperOutBase64):
-
     """
     Basic implementation of IOWrapper for stdout
     """
@@ -212,7 +212,6 @@ class Remote_Package(object):
 
 
 class RemoteFile(object):
-
     """
     Class to handle the operations of file on remote host or guest.
     """
@@ -457,7 +456,6 @@ class RemoteFile(object):
 
 
 class RemoteRunner(object):
-
     """
     Class to provide a utils.run-like method to execute command on
     remote host or guest. Provide a similar interface with utils.run

--- a/virttest/remote_commander/messenger.py
+++ b/virttest/remote_commander/messenger.py
@@ -30,7 +30,6 @@ else:
 
 
 class IOWrapper(object):
-
     """
     Class encaptulates io operation to be more consist in different
     implementations. (stdio, sockets, etc..)
@@ -94,7 +93,6 @@ class IOWrapper(object):
 
 
 class DataWrapper(object):
-
     """
     Basic implementation of IOWrapper for stdio.
     """
@@ -117,7 +115,6 @@ class DataWrapper(object):
 
 
 class DataWrapperBase64(DataWrapper):
-
     """
     Basic implementation of IOWrapper for stdio.
     """
@@ -130,7 +127,6 @@ class DataWrapperBase64(DataWrapper):
 
 
 class StdIOWrapper(IOWrapper, DataWrapper):
-
     """
     Basic implementation of IOWrapper for stdio.
     """
@@ -143,7 +139,6 @@ class StdIOWrapper(IOWrapper, DataWrapper):
 
 
 class StdIOWrapperIn(StdIOWrapper):
-
     """
     Basic implementation of IOWrapper for stdin
     """
@@ -156,7 +151,6 @@ class StdIOWrapperIn(StdIOWrapper):
 
 
 class StdIOWrapperOut(StdIOWrapper):
-
     """
     Basic implementation of IOWrapper for stdout
     """
@@ -166,14 +160,12 @@ class StdIOWrapperOut(StdIOWrapper):
 
 
 class StdIOWrapperInBase64(StdIOWrapperIn, DataWrapperBase64):
-
     """
     Basic implementation of IOWrapper for stdin
     """
 
 
 class StdIOWrapperOutBase64(StdIOWrapperOut, DataWrapperBase64):
-
     """
     Basic implementation of IOWrapper for stdout
     """
@@ -198,7 +190,6 @@ def _map_path(mod_name, kls_name):
 
 
 class Messenger(object):
-
     """
     Class could be used for communication between two python process connected
     by communication canal wrapped by IOWrapper class. Pickling is used

--- a/virttest/remote_commander/remote_interface.py
+++ b/virttest/remote_commander/remote_interface.py
@@ -4,11 +4,11 @@ Created on Dec 11, 2013
 :author: jzupka, astepano
 :contact: Andrei Stepanov <astepano@redhat.com>
 """
+
 import copy
 
 
 class MessengerError(Exception):
-
     """
     Represented error in messanger.
     """
@@ -22,7 +22,6 @@ class MessengerError(Exception):
 
 
 class CommanderError(MessengerError):
-
     """
     Represent error in Commander
     """
@@ -35,7 +34,6 @@ class CommanderError(MessengerError):
 
 
 class CmdTraceBack(Exception):
-
     """
     Represent back-trace used for error tracing on remote side.
     """
@@ -49,7 +47,6 @@ class CmdTraceBack(Exception):
 
 
 class CmdMessage(object):
-
     """
     Base cmd message class
     """
@@ -73,7 +70,6 @@ class CmdMessage(object):
 
 
 class StdStream(CmdMessage):
-
     """
     Represent message string data from remote client
     """
@@ -96,7 +92,6 @@ class StdStream(CmdMessage):
 
 
 class StdOut(StdStream):
-
     """
     Represent message from stdout string data from remote client
     """
@@ -115,7 +110,6 @@ class StdOut(StdStream):
 
 
 class StdErr(StdStream):
-
     """
     Represent message from stderr string data from remote client
     """
@@ -160,7 +154,6 @@ class CmdRespond(object):
 
 
 class BaseCmd(CmdMessage):
-
     """
     Class used for moving information about commands between master and slave.
     """

--- a/virttest/remote_commander/remote_master.py
+++ b/virttest/remote_commander/remote_master.py
@@ -31,7 +31,6 @@ def wait_timeout(timeout):
 
 
 class CmdMaster(object):
-
     """
     Representation of BaseCmd on master side.
     """
@@ -146,7 +145,6 @@ class CmdMaster(object):
 
 
 class CmdEncapsulation(object):
-
     """
     Class parse command name   cmd.nohup.shell -> ["nohup", "shell"]
     """
@@ -171,7 +169,6 @@ class CmdEncapsulation(object):
 
 
 class CmdTimeout(remote_interface.MessengerError):
-
     """
     Raised when waiting for cmd exceeds time define by timeout.
     """
@@ -184,7 +181,6 @@ class CmdTimeout(remote_interface.MessengerError):
 
 
 class Commander(object):
-
     """
     Commander representation for transfer over network.
     """
@@ -193,7 +189,6 @@ class Commander(object):
 
 
 class CommanderMaster(messenger.Messenger):
-
     """
     Class commander master is responsible for communication with commander
     slave. It invoke commands to slave part and receive messages from them.

--- a/virttest/remote_commander/remote_runner.py
+++ b/virttest/remote_commander/remote_runner.py
@@ -239,7 +239,6 @@ def close_unused_fds(fds):
 
 
 class CmdFinish(object):
-
     """
     Class used for communication with child process. This class
     """
@@ -255,7 +254,6 @@ class CmdFinish(object):
 
 
 class CmdSlave(object):
-
     """
     Representation of BaseCmd on slave side.
     """
@@ -544,7 +542,6 @@ class CmdSlave(object):
 
 
 class CommanderSlave(ms.Messenger):
-
     """
     Class commander slace is responsible for communication with commander
     master. It invoke commands to slave part and receive messages from them.
@@ -646,7 +643,6 @@ class CommanderSlave(ms.Messenger):
 
 
 class CommanderSlaveCmds(CommanderSlave):
-
     """
     Class extends CommanderSlave and adds to them special commands like
     shell process, interactive python, send_msg to cmd.

--- a/virttest/scheduler.py
+++ b/virttest/scheduler.py
@@ -7,7 +7,6 @@ from virttest import utils_env, virt_vm
 
 
 class scheduler:
-
     """
     A scheduler that manages several parallel test execution pipelines on a
     single host.

--- a/virttest/shared/deps/run_autotest/boottool.py
+++ b/virttest/shared/deps/run_autotest/boottool.py
@@ -113,7 +113,6 @@ def find_header(hdr):
 
 
 class EfiVar(object):
-
     """
     Helper class to manipulate EFI firmware variables
 
@@ -210,7 +209,6 @@ class EfiVar(object):
 
 
 class EfiToolSys(object):
-
     """
     Interfaces with /sys/firmware/efi/vars provided by the kernel
 
@@ -305,7 +303,6 @@ class EfiToolSys(object):
 
 
 class EliloConf(object):
-
     """
     A simple parser for elilo configuration file
 
@@ -520,7 +517,6 @@ def detect_distro_type():
 
 
 class DebianBuildDeps(object):
-
     """
     Checks and install grubby build dependencies on Debian (like) systems
 
@@ -570,7 +566,6 @@ class DebianBuildDeps(object):
 
 
 class RPMBuildDeps(object):
-
     """
     Base class for RPM based systems
     """
@@ -598,7 +593,6 @@ class RPMBuildDeps(object):
 
 
 class SuseBuildDeps(RPMBuildDeps):
-
     """
     Checks and install grubby build dependencies on SuSE (like) systems
 
@@ -624,7 +618,6 @@ class SuseBuildDeps(RPMBuildDeps):
 
 
 class RedHatBuildDeps(RPMBuildDeps):
-
     """
     Checks and install grubby build dependencies on RedHat (like) systems
 
@@ -722,7 +715,6 @@ def install_grubby_if_necessary(path=None):
 
 
 class GrubbyInstallException(Exception):
-
     """
     Exception that signals failure when doing grubby installation
     """
@@ -731,7 +723,6 @@ class GrubbyInstallException(Exception):
 
 
 class Grubby(object):
-
     """
     Grubby wrapper
 
@@ -1819,7 +1810,6 @@ class Grubby(object):
 
 
 class OptionParser(optparse.OptionParser):
-
     """
     Command line option parser
 
@@ -2047,7 +2037,6 @@ class OptionParser(optparse.OptionParser):
 
 
 class BoottoolApp(object):
-
     """
     The boottool application itself
     """

--- a/virttest/shared/scripts/ksm_overcommit_guest.py
+++ b/virttest/shared/scripts/ksm_overcommit_guest.py
@@ -26,7 +26,6 @@ TMPFS_OVERHEAD = 0.0022  # overhead on 1MB of write data
 
 
 class MemFill(object):
-
     """
     Fills guest memory according to certain patterns.
     """

--- a/virttest/shared/scripts/virtio_console_guest.py
+++ b/virttest/shared/scripts/virtio_console_guest.py
@@ -73,7 +73,6 @@ virt = None
 
 
 class VirtioGuest:
-
     """
     Test tools of virtio_ports.
     """
@@ -230,7 +229,6 @@ class VirtioGuest:
 
 
 class VirtioGuestPosix(VirtioGuest):
-
     """
     Test tools of virtio_ports.
     """
@@ -367,7 +365,6 @@ class VirtioGuestPosix(VirtioGuest):
         print("PASS: Init and check virtioconsole files in system.")
 
     class Switch(Thread):
-
         """
         Thread that sends data between ports.
         """
@@ -554,7 +551,6 @@ class VirtioGuestPosix(VirtioGuest):
                 self._reconnect_none_mode()
 
     class Sender(Thread):
-
         """
         Creates a thread which sends random blocks of data to dst port.
         """
@@ -980,7 +976,6 @@ class VirtioGuestPosix(VirtioGuest):
 
 
 class VirtioGuestNt(VirtioGuest):
-
     """
     Test tools of virtio_ports.
     """
@@ -1137,7 +1132,6 @@ class VirtioGuestNt(VirtioGuest):
         print("PASS: All threads finished")
 
     class Switch(Thread):
-
         """
         Thread that sends data between ports.
         """
@@ -1189,7 +1183,6 @@ class VirtioGuestNt(VirtioGuest):
             self._none_mode()
 
     class Sender(Thread):
-
         """
         Creates a thread which sends random blocks of data to dst port.
         """
@@ -1387,7 +1380,6 @@ def sigusr_handler(sig, frame):
 
 
 class Daemon:
-
     """
     Daemonize guest
     """

--- a/virttest/staging/service.py
+++ b/virttest/staging/service.py
@@ -371,7 +371,6 @@ COMMANDS = (
 
 
 class _ServiceCommTool(object):
-
     """
     Provide an interface to complete the similar initialization
     """
@@ -389,7 +388,6 @@ class _ServiceCommTool(object):
 
 
 class _ServiceResultParser(_ServiceCommTool):
-
     """
     A class that contains staticmethods to parse the result of service command.
     """
@@ -421,7 +419,6 @@ class _ServiceResultParser(_ServiceCommTool):
 
 
 class _ServiceCommandGenerator(_ServiceCommTool):
-
     """
     A class that contains staticmethods that generate partial functions that
     generate command lists for starting/stopping services.
@@ -512,7 +509,6 @@ class _SpecificServiceManager(object):
 
 
 class _GenericServiceManager(object):
-
     """
     Base class for SysVInitServiceManager and SystemdServiceManager.
     """
@@ -581,7 +577,6 @@ class _GenericServiceManager(object):
 
 
 class _SysVInitServiceManager(_GenericServiceManager):
-
     """
     Concrete class that implements the SysVInitServiceManager
     """
@@ -664,7 +659,6 @@ def convert_systemd_target_to_runlevel(target):
 
 
 class _SystemdServiceManager(_GenericServiceManager):
-
     """
     Concrete class that implements the SystemdServiceManager
     """
@@ -701,7 +695,6 @@ class _SystemdServiceManager(_GenericServiceManager):
 
 
 class Factory(object):
-
     """
     Class to create different kinds of ServiceManager.
     The all interfaces to create manager are staticmethod,
@@ -744,7 +737,6 @@ class Factory(object):
     """
 
     class FactoryHelper(object):
-
         """
         Internal class to help create service manager.
 

--- a/virttest/staging/utils_cgroup.py
+++ b/virttest/staging/utils_cgroup.py
@@ -26,7 +26,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class Cgroup(object):
-
     """
     Cgroup handling class.
     """
@@ -523,7 +522,6 @@ class Cgroup(object):
 
 
 class CgroupModules(object):
-
     """
     Handles the list of different cgroup filesystems.
     """
@@ -722,7 +720,6 @@ def resolve_task_cgroup_path(pid, controller):
 
 
 class CgconfigService(object):
-
     """
     Cgconfig service class.
     """

--- a/virttest/staging/utils_koji.py
+++ b/virttest/staging/utils_koji.py
@@ -39,7 +39,6 @@ class KojiDownloadError(IOError):
 
 
 class KojiDirIndexParser(HTMLParser):
-
     """
     Parser for HTML directory index pages, specialized to look for RPM links
     """
@@ -64,7 +63,6 @@ class KojiDirIndexParser(HTMLParser):
 
 
 class RPMFileNameInfo:
-
     """
     Simple parser for RPM based on information present on the filename itself
     """
@@ -113,7 +111,6 @@ class RPMFileNameInfo:
 
 
 class KojiClient(object):
-
     """
     Stablishes a connection with the build system, either koji or brew.
 
@@ -573,7 +570,6 @@ def get_default_koji_tag():
 
 
 class KojiPkgSpec(object):
-
     """
     A package specification syntax parser for Koji
 
@@ -848,7 +844,6 @@ class KojiPkgSpec(object):
 
 
 class KojiScratchPkgSpec(object):
-
     """
     A package specification syntax parser for Koji scratch builds
 

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -5,6 +5,7 @@ This exports:
   - two functions for get image/blkdebug filename
   - class for image operates and basic parameters
 """
+
 from __future__ import division
 
 import collections
@@ -804,7 +805,6 @@ class ImageEncryption(object):
 
 
 class ImageSlicesInfo:
-
     """Slices information associated with images."""
 
     def __init__(self, image, slices):
@@ -840,7 +840,6 @@ class ImageSlicesInfo:
 
 
 class SliceProperties(propcan.PropCan):
-
     """Properties of a single slice associated with images."""
 
     __slots__ = ["offset", "size"]
@@ -881,7 +880,6 @@ def copy_nfs_image(params, root_dir, basename=False):
 
 
 class OptionMissing(Exception):
-
     """
     Option not found in the odbject
     """
@@ -894,7 +892,6 @@ class OptionMissing(Exception):
 
 
 class QemuImg(object):
-
     """
     A basic class for handling operations of disk/block images.
     """
@@ -1259,7 +1256,6 @@ class QemuImg(object):
 
 
 class Rawdev(object):
-
     """
     Base class for raw storage devices such as iscsi and local disks
     """
@@ -1283,7 +1279,6 @@ class Rawdev(object):
 
 
 class Iscsidev(Rawdev):
-
     """
     Class for handle iscsi devices for VM
     """
@@ -1310,7 +1305,6 @@ class Iscsidev(Rawdev):
 
 
 class LVMdev(Rawdev):
-
     """
     Class for handle LVM devices for VM
     """

--- a/virttest/syslog_server.py
+++ b/virttest/syslog_server.py
@@ -33,7 +33,6 @@ def get_default_format():
 
 
 class RequestHandler(socketserver.BaseRequestHandler):
-
     """
     A request handler that relays all received messages as DEBUG
     """

--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -1,4 +1,5 @@
 """Library to perform pre/post test setup for virt test."""
+
 from __future__ import division
 
 import ipaddress
@@ -41,7 +42,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class THPError(Exception):
-
     """
     Base exception for Transparent Hugepage setup.
     """
@@ -50,7 +50,6 @@ class THPError(Exception):
 
 
 class THPNotSupportedError(THPError):
-
     """
     Thrown when host does not support transparent hugepages.
     """
@@ -59,7 +58,6 @@ class THPNotSupportedError(THPError):
 
 
 class THPWriteConfigError(THPError):
-
     """
     Thrown when host does not support transparent hugepages.
     """
@@ -68,7 +66,6 @@ class THPWriteConfigError(THPError):
 
 
 class THPKhugepagedError(THPError):
-
     """
     Thrown when khugepaged is not behaving as expected.
     """
@@ -77,7 +74,6 @@ class THPKhugepagedError(THPError):
 
 
 class PolkitConfigError(Exception):
-
     """
     Base exception for Polkit Config setup.
     """
@@ -86,7 +82,6 @@ class PolkitConfigError(Exception):
 
 
 class PolkitRulesSetupError(PolkitConfigError):
-
     """
     Thrown when setup polkit rules is not behaving as expected.
     """
@@ -95,7 +90,6 @@ class PolkitRulesSetupError(PolkitConfigError):
 
 
 class PolkitWriteLibvirtdConfigError(PolkitConfigError):
-
     """
     Thrown when setup libvirtd config file is not behaving as expected.
     """
@@ -104,7 +98,6 @@ class PolkitWriteLibvirtdConfigError(PolkitConfigError):
 
 
 class PolkitConfigCleanupError(PolkitConfigError):
-
     """
     Thrown when polkit config cleanup is not behaving as expected.
     """
@@ -198,7 +191,7 @@ class TransparentHugePageConfig(object):
             """
             Check the status of khugepaged when set value to specify file.
             """
-            for (act, ret) in action_list:
+            for act, ret in action_list:
                 LOG.info(
                     "Writing path %s: %s, expected khugepage rc: %s ",
                     file_name,
@@ -1048,7 +1041,6 @@ class PrivateOvsBridgeConfig(PrivateBridgeConfig):
 
 
 class PciAssignable(object):
-
     """
     Request PCI assignable devices on host. It will check whether to request
     PF (physical Functions) or VF (Virtual Functions).
@@ -1905,7 +1897,6 @@ class PciAssignable(object):
 
 
 class LibvirtPolkitConfig(object):
-
     """
     Enable polkit access driver for libvirtd and set polkit rules.
 
@@ -2059,6 +2050,7 @@ class LibvirtPolkitConfig(object):
         """
         Set polkit libvirt ACL rule config file
         """
+
         # polkit template string
         def _get_one_rule(action_lookup_list, lookup_oper):
             """
@@ -2199,7 +2191,6 @@ class LibvirtPolkitConfig(object):
 
 
 class EGDConfigError(Exception):
-
     """
     Raise when setup local egd.pl server failed.
     """
@@ -2208,7 +2199,6 @@ class EGDConfigError(Exception):
 
 
 class EGDConfig(object):
-
     """
     Setup egd.pl server on localhost, support startup with socket unix or tcp.
     """
@@ -2313,7 +2303,6 @@ class EGDConfig(object):
 
 
 class StraceQemu(object):
-
     """
     Attach strace to qemu VM processes, if enable_strace is 'yes'.
     It's useful to analyze qemu hang issue. But it will generate

--- a/virttest/test_setup/core.py
+++ b/virttest/test_setup/core.py
@@ -8,7 +8,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 @six.add_metaclass(ABCMeta)
 class Setuper(object):
-
     """
     Virtual base abstraction of setuper.
     """
@@ -40,7 +39,6 @@ class Setuper(object):
 
 
 class SetupManager(object):
-
     """
     Setup Manager implementation.
 

--- a/virttest/test_setup/networking.py
+++ b/virttest/test_setup/networking.py
@@ -1,5 +1,6 @@
 """ Define set/clean up procedures for network proxies
 """
+
 import re
 import urllib.request
 

--- a/virttest/test_setup/storage.py
+++ b/virttest/test_setup/storage.py
@@ -1,5 +1,6 @@
 """ Define set/clean up procedures for storage devices
 """
+
 import os
 
 from avocado.utils import distro

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -103,7 +103,6 @@ def terminate_unattended_server_thread():
 
 
 class RemoteInstall(object):
-
     """
     Represents a install http server that we can master according to our needs.
     """
@@ -133,7 +132,6 @@ class RemoteInstall(object):
 
 
 class UnattendedInstallConfig(object):
-
     """
     Creates a floppy disk image that will contain a config file for unattended
     OS install. The parameters to the script are retrieved from environment

--- a/virttest/unittest_utils/mock.py
+++ b/virttest/unittest_utils/mock.py
@@ -24,7 +24,6 @@ class CheckPlaybackError(Exception):
 
 
 class SaveDataAfterCloseStringIO(StringIO):
-
     """Saves the contents in a final_data property when close() is called.
 
     Useful as a mock output file object to test both that the file was
@@ -178,7 +177,6 @@ class function_mapping(base_mapping):
 
 
 class function_any_args_mapping(function_mapping):
-
     """A mock function mapping that doesn't verify its arguments."""
 
     def match(self, *args, **dargs):

--- a/virttest/utils_backup.py
+++ b/virttest/utils_backup.py
@@ -16,7 +16,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class BackupError(Exception):
-
     """
     Class of backup exception
     """
@@ -26,7 +25,6 @@ class BackupError(Exception):
 
 
 class BackupBeginError(BackupError):
-
     """
     Class of backup begin exception
     """
@@ -40,7 +38,6 @@ class BackupBeginError(BackupError):
 
 
 class BackupTLSError(BackupError):
-
     """
     Class of backup TLS exception
     """
@@ -54,7 +51,6 @@ class BackupTLSError(BackupError):
 
 
 class BackupCanceledError(BackupError):
-
     """
     Class of backup canceled exception
     """

--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -44,7 +44,6 @@ class LibvirtConfigUnknownKeyError(ConfigError):
 
 
 class SectionlessConfig(object):
-
     """
     This is a wrapper class for python's internal library configparser except
     allows manipulating sectionless configuration file with a dict-like way.
@@ -204,7 +203,6 @@ class SectionlessConfig(object):
 
 
 class LibvirtConfigCommon(SectionlessConfig):
-
     """
     A abstract class to manipulate options of a libvirt related configure files
     in a property's way.
@@ -310,7 +308,6 @@ class LibvirtConfigCommon(SectionlessConfig):
 
 
 class LibvirtConfig(LibvirtConfigCommon):
-
     """
     Class for libvirt config file.
     """
@@ -324,7 +321,6 @@ class LibvirtConfig(LibvirtConfigCommon):
 
 
 class LibvirtdConfig(LibvirtConfigCommon):
-
     """
     Class for libvirt daemon config file.
     """
@@ -389,7 +385,6 @@ class LibvirtdConfig(LibvirtConfigCommon):
 
 
 class LibvirtQemuConfig(LibvirtConfigCommon):
-
     """
     Class for libvirt qemu config file.
     """
@@ -488,7 +483,6 @@ class LibvirtQemuConfig(LibvirtConfigCommon):
 
 
 class LibvirtdSysConfig(LibvirtConfigCommon):
-
     """
     Class for sysconfig libvirtd config file.
     """
@@ -509,7 +503,6 @@ class LibvirtdSysConfig(LibvirtConfigCommon):
 
 
 class LibvirtGuestsConfig(LibvirtConfigCommon):
-
     """
     Class for sysconfig libvirt-guests config file.
     """
@@ -529,7 +522,6 @@ class LibvirtGuestsConfig(LibvirtConfigCommon):
 
 
 class LibvirtSanLockConfig(LibvirtConfigCommon):
-
     """
     Class for libvirt san lock config file.
     """
@@ -546,7 +538,6 @@ class LibvirtSanLockConfig(LibvirtConfigCommon):
 
 
 class VirtQemudConfig(LibvirtConfigCommon):
-
     """
     Class for libvirt virtqemud config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -595,7 +586,6 @@ class VirtQemudConfig(LibvirtConfigCommon):
 
 
 class VirtInterfacedConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtinterfaced config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -605,7 +595,6 @@ class VirtInterfacedConfig(VirtQemudConfig):
 
 
 class VirtLockdConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtlock config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -615,7 +604,6 @@ class VirtLockdConfig(VirtQemudConfig):
 
 
 class VirtLogdConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtlogd config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -625,7 +613,6 @@ class VirtLogdConfig(VirtQemudConfig):
 
 
 class VirtNetworkdConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtnetworkd config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -635,7 +622,6 @@ class VirtNetworkdConfig(VirtQemudConfig):
 
 
 class VirtNodedevdConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtnodedevd config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -645,7 +631,6 @@ class VirtNodedevdConfig(VirtQemudConfig):
 
 
 class VirtNwfilterdConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtnwfilterd config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -655,7 +640,6 @@ class VirtNwfilterdConfig(VirtQemudConfig):
 
 
 class VirtSecretdConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtsecretd config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -665,7 +649,6 @@ class VirtSecretdConfig(VirtQemudConfig):
 
 
 class VirtStoragedConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtstoraged config file.
     This is used to represent split daemons changes after libvirt version 5.6.0
@@ -675,7 +658,6 @@ class VirtStoragedConfig(VirtQemudConfig):
 
 
 class VirtProxydConfig(VirtQemudConfig):
-
     """
     Class for libvirt virtproxyd config file.
     This is used to represent split daemons changes after libvirt version 5.6.0

--- a/virttest/utils_conn.py
+++ b/virttest/utils_conn.py
@@ -26,7 +26,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class ConnectionError(Exception):
-
     """
     The base error in connection.
     """
@@ -35,7 +34,6 @@ class ConnectionError(Exception):
 
 
 class ConnForbiddenError(ConnectionError):
-
     """
     Error in forbidden operation.
     """
@@ -49,7 +47,6 @@ class ConnForbiddenError(ConnectionError):
 
 
 class ConnCopyError(ConnectionError):
-
     """
     Error in coping file.
     """
@@ -64,7 +61,6 @@ class ConnCopyError(ConnectionError):
 
 
 class ConnNotImplementedError(ConnectionError):
-
     """
     Error in calling unimplemented method
     """
@@ -82,7 +78,6 @@ class ConnNotImplementedError(ConnectionError):
 
 
 class ConnLoginError(ConnectionError):
-
     """
     Error in login.
     """
@@ -100,7 +95,6 @@ class ConnLoginError(ConnectionError):
 
 
 class ConnToolNotFoundError(ConnectionError):
-
     """
     Error in not found tools.
     """
@@ -118,7 +112,6 @@ class ConnToolNotFoundError(ConnectionError):
 
 
 class ConnSCPError(ConnectionError):
-
     """
     Error in SCP.
     """
@@ -142,7 +135,6 @@ class ConnSCPError(ConnectionError):
 
 
 class SSHCheckError(ConnectionError):
-
     """
     Base Error in check of SSH connection.
     """
@@ -157,7 +149,6 @@ class SSHCheckError(ConnectionError):
 
 
 class SSHRmAuthKeysError(ConnectionError):
-
     """
     Error in removing authorized_keys file.
     """
@@ -175,7 +166,6 @@ class SSHRmAuthKeysError(ConnectionError):
 
 
 class ConnCmdClientError(ConnectionError):
-
     """
     Error in executing cmd on client.
     """
@@ -193,7 +183,6 @@ class ConnCmdClientError(ConnectionError):
 
 
 class ConnPrivKeyError(ConnectionError):
-
     """
     Error in building private key with certtool command.
     """
@@ -211,7 +200,6 @@ class ConnPrivKeyError(ConnectionError):
 
 
 class ConnCertError(ConnectionError):
-
     """
     Error in building certificate file with certtool command.
     """
@@ -229,7 +217,6 @@ class ConnCertError(ConnectionError):
 
 
 class ConnRmCertError(ConnectionError):
-
     """
     Error in removing certificate file with rm command.
     """
@@ -247,7 +234,6 @@ class ConnRmCertError(ConnectionError):
 
 
 class ConnMkdirError(ConnectionError):
-
     """
     Error in making directory.
     """
@@ -265,7 +251,6 @@ class ConnMkdirError(ConnectionError):
 
 
 class ConnServerRestartError(ConnectionError):
-
     """
     Error in restarting libvirtd on server.
     """
@@ -281,7 +266,6 @@ class ConnServerRestartError(ConnectionError):
 
 
 class ListenUNIXSocketError(ConnectionError):
-
     """
     Error in starting a proxy that listens on UNIX socket.
     """
@@ -299,7 +283,6 @@ class ListenUNIXSocketError(ConnectionError):
 
 
 class ConnUNIXSocketError(ConnectionError):
-
     """
     Error in starting a proxy that listens on network and connects to UNIX socket.
     """
@@ -317,7 +300,6 @@ class ConnUNIXSocketError(ConnectionError):
 
 
 class ConnectionBase(propcan.PropCanBase):
-
     """
     Base class of a connection between server and client.
 
@@ -559,7 +541,6 @@ class ConnectionBase(propcan.PropCanBase):
 
 
 class SSHConnection(ConnectionBase):
-
     """
     Connection of SSH transport.
 
@@ -757,7 +738,6 @@ class SSHConnection(ConnectionBase):
 
 
 class TCPConnection(ConnectionBase):
-
     """
     Connection class for TCP transport.
 
@@ -933,9 +913,9 @@ class TCPConnection(ConnectionBase):
         # a whitelist of allowed SASL usernames, it's a list.
         # If the list is an empty, no client can connect
         if sasl_allowed_users:
-            pattern_to_repl[
-                r".*sasl_allowed_username_list\s*=.*"
-            ] = "sasl_allowed_username_list=%s" % (sasl_allowed_users)
+            pattern_to_repl[r".*sasl_allowed_username_list\s*=.*"] = (
+                "sasl_allowed_username_list=%s" % (sasl_allowed_users)
+            )
         if listen_addr:
             pattern_to_repl[r".*listen_addr\s*=.*"] = "listen_addr='%s'" % (listen_addr)
         if tcp_min_ssf:
@@ -1000,7 +980,6 @@ class TCPConnection(ConnectionBase):
 
 
 class TLSConnection(ConnectionBase):
-
     """
     Connection of TLS transport.
 
@@ -2011,7 +1990,6 @@ def build_CA(tmp_dir, cn="AUTOTEST.VIRT", certtool="certtool", credential_dict=N
 
 
 class UNIXConnection(ConnectionBase):
-
     """
     Connection class for UNIX transport.
 

--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -3,6 +3,7 @@ Virtualization test - Virtual disk related utility functions
 
 :copyright: Red Hat Inc.
 """
+
 import configparser
 import glob
 import logging
@@ -1323,7 +1324,6 @@ def dd_data_to_vm_disk(session, disk, bs="1M", seek="0", count="100"):
 
 
 class Disk(object):
-
     """
     Abstract class for Disk objects, with the common methods implemented.
     """
@@ -1352,7 +1352,6 @@ class Disk(object):
 
 
 class FloppyDisk(Disk):
-
     """
     Represents a floppy disk. We can copy files to it, and setup it in
     convenient ways.
@@ -1469,7 +1468,6 @@ class FloppyDisk(Disk):
 
 
 class CdromDisk(Disk):
-
     """
     Represents a CDROM disk that we can master according to our needs.
     """
@@ -1544,7 +1542,6 @@ class CdromDisk(Disk):
 
 
 class CdromInstallDisk(Disk):
-
     """
     Represents a install CDROM disk that we can master according to our needs.
     """
@@ -1600,7 +1597,6 @@ class CdromInstallDisk(Disk):
 
 
 class GuestFSModiDisk(object):
-
     """
     class of guest disk using guestfs lib to do some operation(like read/write)
     on guest disk:

--- a/virttest/utils_env.py
+++ b/virttest/utils_env.py
@@ -49,7 +49,6 @@ def lock_safe(function):
 
 
 class Env(IterableUserDict):
-
     """
     A dict-like object containing global objects used by tests.
     """

--- a/virttest/utils_gdb.py
+++ b/virttest/utils_gdb.py
@@ -18,7 +18,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class GDBError(Exception):
-
     """
     General module exception class
     """
@@ -27,7 +26,6 @@ class GDBError(Exception):
 
 
 class GDBCmdError(GDBError):
-
     """
     Exception raised when calling an gdb command.
     """
@@ -109,7 +107,6 @@ def _parse_result(result_str):
 
 
 class GDB(aexpect.Expect):
-
     """
     Class to manipulate a inferior process in gdb.
     """

--- a/virttest/utils_iptables.py
+++ b/virttest/utils_iptables.py
@@ -1,6 +1,7 @@
 """
 Library to perform iptables configuration for virt test.
 """
+
 import logging
 
 from aexpect import remote

--- a/virttest/utils_libguestfs.py
+++ b/virttest/utils_libguestfs.py
@@ -16,7 +16,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class LibguestfsCmdError(Exception):
-
     """
     Error of libguestfs-tool command.
     """
@@ -106,7 +105,6 @@ def lgf_command(cmd, ignore_status=True, debug=False, timeout=60):
 
 
 class LibguestfsBase(propcan.PropCanBase):
-
     """
     Base class of libguestfs tools.
     """
@@ -185,7 +183,6 @@ class LibguestfsBase(propcan.PropCanBase):
 
 
 class Guestfish(LibguestfsBase):
-
     """
     Execute guestfish, using a new guestfish shell each time.
     """
@@ -270,7 +267,6 @@ class Guestfish(LibguestfsBase):
 
 
 class GuestfishSession(aexpect.ShellSession):
-
     """
     A shell session of guestfish.
     """
@@ -332,7 +328,6 @@ class GuestfishSession(aexpect.ShellSession):
 
 
 class GuestfishRemote(object):
-
     """
     Remote control of guestfish.
     """
@@ -422,7 +417,6 @@ class GuestfishRemote(object):
 
 
 class GuestfishPersistent(Guestfish):
-
     """
     Execute operations using persistent guestfish session.
     """

--- a/virttest/utils_libvirt/libvirt_cpu.py
+++ b/virttest/utils_libvirt/libvirt_cpu.py
@@ -3,7 +3,6 @@ Module simplifying manipulation of CPU model and topology part described at
 http://libvirt.org/formatdomain.html
 """
 
-
 import logging
 
 from virttest.libvirt_xml import vm_xml

--- a/virttest/utils_libvirt/libvirt_disk.py
+++ b/virttest/utils_libvirt/libvirt_disk.py
@@ -1,6 +1,7 @@
 """
 libvirt disk related utility functions
 """
+
 import collections
 import logging
 import os

--- a/virttest/utils_libvirt/libvirt_embedded_qemu.py
+++ b/virttest/utils_libvirt/libvirt_embedded_qemu.py
@@ -1,6 +1,7 @@
 """
 Classes and functions for embedded qemu driver.
 """
+
 import logging
 import re
 
@@ -20,7 +21,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class EmbeddedQemuSession(object):
-
     """
     Interaction embeddedQemu session can start a qemu process.
     """

--- a/virttest/utils_libvirt/libvirt_keywrap.py
+++ b/virttest/utils_libvirt/libvirt_keywrap.py
@@ -1,6 +1,7 @@
 """
 Module to contain logic testing protected key module 'pkey'
 """
+
 import logging
 import os
 

--- a/virttest/utils_libvirt/libvirt_network.py
+++ b/virttest/utils_libvirt/libvirt_network.py
@@ -1,6 +1,7 @@
 """
 Virsh net* command related utility functions
 """
+
 import ast
 import logging
 import re

--- a/virttest/utils_libvirt/libvirt_numa.py
+++ b/virttest/utils_libvirt/libvirt_numa.py
@@ -3,7 +3,6 @@ Module simplifying manipulation of numa & hmat related part described at
 http://libvirt.org/formatdomain.html
 """
 
-
 import ast
 import logging
 

--- a/virttest/utils_libvirt/libvirt_vfio.py
+++ b/virttest/utils_libvirt/libvirt_vfio.py
@@ -3,6 +3,7 @@ Libvirt vfio related utilities.
 
 :copyright: 2021 Red Hat Inc.
 """
+
 import logging
 
 from avocado.core import exceptions

--- a/virttest/utils_libvirt/libvirt_vmxml.py
+++ b/virttest/utils_libvirt/libvirt_vmxml.py
@@ -3,7 +3,6 @@ Module simplifying manipulation of the vm attributes described at
 http://libvirt.org/formatdomain.html
 """
 
-
 import logging
 import re
 

--- a/virttest/utils_libvirtd.py
+++ b/virttest/utils_libvirtd.py
@@ -1,6 +1,7 @@
 """
 Module to control libvirtd service.
 """
+
 import logging
 import re
 
@@ -24,7 +25,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class Libvirtd(object):
-
     """
     Class to manage libvirtd service on host or guest.
     """
@@ -149,7 +149,6 @@ class Libvirtd(object):
 
 
 class DaemonSocket(object):
-
     """
     Class to manage libvirt/virtproxy tcp/tls socket on host or guest.
     """
@@ -207,7 +206,6 @@ class DaemonSocket(object):
 
 
 class LibvirtdSession(object):
-
     """
     Interaction daemon session by directly call the command.
     With gdb debugging feature can be optionally started.

--- a/virttest/utils_logfile.py
+++ b/virttest/utils_logfile.py
@@ -7,6 +7,7 @@ Naive module that keeps tacks of some opened files and somehow manages them.
 
 :copyright: 2020 Red Hat Inc.
 """
+
 import logging
 import os
 import re

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -91,7 +91,6 @@ ARCH = platform.machine()
 
 
 class InterruptedThread(threading.Thread):
-
     """
     Run a function in a background thread.
     """
@@ -1481,7 +1480,6 @@ def is_symlink(link_name, session=None):
 
 
 class NumaInfo(object):
-
     """
     Numa topology for host. Also provide the function for check the memory status
     of the node.
@@ -1673,7 +1671,6 @@ class NumaInfo(object):
 
 
 class NumaNode(object):
-
     """
     Numa node to control processes and shared memory.
     """
@@ -2123,7 +2120,6 @@ class ForAll(list):
 
 
 class ForAllP(list):
-
     """
     Parallel version of ForAll
     """
@@ -2143,7 +2139,6 @@ class ForAllP(list):
 
 
 class ForAllPSE(list):
-
     """
     Parallel version of and suppress exception.
     """
@@ -3006,7 +3001,6 @@ def get_test_entrypoint_func(name, module):
 
 
 class KSMError(Exception):
-
     """
     Base exception for KSM setup
     """
@@ -3015,7 +3009,6 @@ class KSMError(Exception):
 
 
 class KSMNotSupportedError(KSMError):
-
     """
     Thrown when host does not support KSM.
     """
@@ -3024,7 +3017,6 @@ class KSMNotSupportedError(KSMError):
 
 
 class KSMTunedError(KSMError):
-
     """
     Thrown when KSMTuned Error happen.
     """
@@ -3033,7 +3025,6 @@ class KSMTunedError(KSMError):
 
 
 class KSMTunedNotSupportedError(KSMTunedError):
-
     """
     Thrown when host does not support KSMTune.
     """
@@ -3042,7 +3033,6 @@ class KSMTunedNotSupportedError(KSMTunedError):
 
 
 class KSMController(object):
-
     """KSM Manager"""
 
     def __init__(self):
@@ -3661,7 +3651,6 @@ class VFIOError(Exception):
 
 
 class VFIOController(object):
-
     """Control Virtual Function for testing"""
 
     def __init__(self, load_modules=True, allow_unsafe_interrupts=True):
@@ -3772,7 +3761,6 @@ class VFIOController(object):
 
 
 class SELinuxBoolean(object):
-
     """
     SELinuxBoolean class for managing SELinux boolean value.
     """

--- a/virttest/utils_nbd.py
+++ b/virttest/utils_nbd.py
@@ -10,6 +10,7 @@ disk xml:
       <target dev='sda' bus='scsi'/>
     </disk>
 """
+
 import logging
 import os
 import shutil
@@ -183,9 +184,9 @@ class NbdExport(object):
         client_credential_dict["clientkey"] = "client-key.pem"
         client_credential_dict["clientcert"] = "client-cert.pem"
         if self.private_key_encrypt_passphrase:
-            client_credential_dict[
-                "clientprivatekeypass"
-            ] = self.private_key_encrypt_passphrase
+            client_credential_dict["clientprivatekeypass"] = (
+                self.private_key_encrypt_passphrase
+            )
         server_credential_dict["ca_cakey_path"] = tmp_ca_cert_dir
 
         # build a client key.

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -385,7 +385,6 @@ def warp_init_del(func):
 
 
 class Interface(object):
-
     """Class representing a Linux network device."""
 
     def __init__(self, name):
@@ -691,7 +690,6 @@ class Interface(object):
 
 
 class Macvtap(Interface):
-
     """
     class of macvtap, base Interface
     """
@@ -754,7 +752,6 @@ class Macvtap(Interface):
 
 
 class IPAddress(object):
-
     """
     Class to manipulate IPv4 or IPv6 address.
     """
@@ -2316,7 +2313,6 @@ def if_set_macaddress(ifname, mac):
 
 
 class IPv6Manager(propcan.PropCanBase):
-
     """
     Setup and cleanup IPv6 environment.
     """
@@ -2622,7 +2618,6 @@ ieee_eui64_assignment = ieee_eui_assignment(64)
 
 
 class VirtIface(propcan.PropCan, object):
-
     """
     Networking information for single guest interface and host connection.
     """
@@ -2765,7 +2760,6 @@ class VirtIface(propcan.PropCan, object):
 
 
 class LibvirtIface(VirtIface):
-
     """
     Networking information specific to libvirt
     """
@@ -2774,7 +2768,6 @@ class LibvirtIface(VirtIface):
 
 
 class QemuIface(VirtIface):
-
     """
     Networking information specific to Qemu
     """
@@ -2799,7 +2792,6 @@ class QemuIface(VirtIface):
 
 
 class VMNet(list):
-
     """
     Collection of networking information.
     """
@@ -2953,7 +2945,6 @@ class VMNet(list):
 # for xen networking.  This will also enable further extensions
 # to network information handing in the future.
 class VMNetStyle(dict):
-
     """
     Make decisions about needed info from vm_type and driver_type params.
     """
@@ -3000,7 +2991,6 @@ class VMNetStyle(dict):
 
 
 class ParamsNet(VMNet):
-
     """
     Networking information from Params
 
@@ -3123,7 +3113,6 @@ class ParamsNet(VMNet):
 
 
 class DbNet(VMNet):
-
     """
     Networking information from database
 
@@ -3268,7 +3257,6 @@ def clean_tmp_files():
 
 
 class VirtNet(DbNet, ParamsNet):
-
     """
     Persistent collection of VM's networking information.
     """

--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -1,6 +1,7 @@
 """
 Package utility for manage package operation on host
 """
+
 import logging
 
 import aexpect
@@ -141,7 +142,6 @@ class RemotePackageMgr(object):
 
 
 class LocalPackageMgr(manager.SoftwareManager):
-
     """
     Local package manage class
     """

--- a/virttest/utils_params.py
+++ b/virttest/utils_params.py
@@ -16,7 +16,6 @@ class ParamNotFound(exceptions.TestSkipError):
 
 
 class Params(IterableUserDict):
-
     """
     A dict-like object passed to every test.
     """

--- a/virttest/utils_pyvmomi.py
+++ b/virttest/utils_pyvmomi.py
@@ -4,6 +4,7 @@ A module is used to interact with VMware Vshpere Server
 For more examples of pyvmomi, please refer:
 https://github.com/vmware/pyvmomi-community-samples
 """
+
 import datetime
 import logging
 from functools import wraps

--- a/virttest/utils_qemu.py
+++ b/virttest/utils_qemu.py
@@ -1,6 +1,7 @@
 """
 QEMU related utility functions.
 """
+
 import json
 import re
 

--- a/virttest/utils_sasl.py
+++ b/virttest/utils_sasl.py
@@ -15,7 +15,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class SASL(propcan.PropCanBase):
-
     """
     Base class of a connection between server and client.
     """
@@ -159,7 +158,6 @@ class SASL(propcan.PropCanBase):
 
 
 class VirshSessionSASL(virsh.VirshSession):
-
     """
     A wrap class for virsh session which used SASL infrastructure.
     """

--- a/virttest/utils_scheduling.py
+++ b/virttest/utils_scheduling.py
@@ -3,6 +3,7 @@ Virtualization test utility functions.
 
 :copyright: 2008-2009 Red Hat Inc.
 """
+
 import functools
 import multiprocessing.pool
 

--- a/virttest/utils_selinux.py
+++ b/virttest/utils_selinux.py
@@ -14,7 +14,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class SelinuxError(Exception):
-
     """
     Error selinux utility functions.
     """
@@ -23,7 +22,6 @@ class SelinuxError(Exception):
 
 
 class SeCmdError(SelinuxError):
-
     """
     Error in executing cmd.
     """
@@ -40,7 +38,6 @@ class SeCmdError(SelinuxError):
 
 
 class SemanageError(SelinuxError):
-
     """
     Error when semanage binary is not found
     """

--- a/virttest/utils_spice.py
+++ b/virttest/utils_spice.py
@@ -2,6 +2,7 @@
 Common spice test utility functions.
 
 """
+
 import logging
 import os
 import sys
@@ -16,7 +17,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class RVConnectError(Exception):
-
     """Exception raised in case that remote-viewer fails to connect"""
 
     pass

--- a/virttest/utils_split_daemons.py
+++ b/virttest/utils_split_daemons.py
@@ -1,6 +1,7 @@
 """
 Module to control split daemon service.
 """
+
 import logging
 
 # pylint: disable=E0611
@@ -20,7 +21,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class VirtDaemonCommon(object):
-
     """
     Common class to manage libvirt split daemon service on host or guest.
     """
@@ -115,7 +115,6 @@ class VirtProxyd(VirtDaemonCommon):
 
 
 class VirtQemudSession(object):
-
     """
     Interaction virtqemud daemon session by directly call the virtqemud command.
     With gdb debugging feature can be optionally started.

--- a/virttest/utils_stress.py
+++ b/virttest/utils_stress.py
@@ -211,14 +211,18 @@ class VMStressEvents:
         """
         for itr in range(self.host_iterations):
             if "cpu_freq_governor" in event:
-                cpu.set_freq_governor() if hasattr(
-                    cpu, "set_freq_governor"
-                ) else cpu.set_cpufreq_governor()
+                (
+                    cpu.set_freq_governor()
+                    if hasattr(cpu, "set_freq_governor")
+                    else cpu.set_cpufreq_governor()
+                )
                 LOG.debug(
                     "Current governor: %s",
-                    cpu.get_freq_governor()
-                    if hasattr(cpu, "get_freq_governor")
-                    else cpu.get_cpufreq_governor(),
+                    (
+                        cpu.get_freq_governor()
+                        if hasattr(cpu, "get_freq_governor")
+                        else cpu.get_cpufreq_governor()
+                    ),
                 )
                 time.sleep(self.event_sleep_time)
             elif "cpu_idle" in event:
@@ -227,13 +231,17 @@ class VMStressEvents:
                     if hasattr(cpu, "get_idle_state")
                     else cpu.get_cpuidle_state()
                 )
-                cpu.set_idle_state() if hasattr(
-                    cpu, "set_idle_state"
-                ) else cpu.set_cpuidle_state()
+                (
+                    cpu.set_idle_state()
+                    if hasattr(cpu, "set_idle_state")
+                    else cpu.set_cpuidle_state()
+                )
                 time.sleep(self.event_sleep_time)
-                cpu.set_idle_state(setstate=idlestate) if hasattr(
-                    cpu, "set_idle_state"
-                ) else cpu.set_cpuidle_state(setstate=idlestate)
+                (
+                    cpu.set_idle_state(setstate=idlestate)
+                    if hasattr(cpu, "set_idle_state")
+                    else cpu.set_cpuidle_state(setstate=idlestate)
+                )
                 time.sleep(self.event_sleep_time)
             elif "cpuoffline" in event:
                 online_count = (

--- a/virttest/utils_switchdev.py
+++ b/virttest/utils_switchdev.py
@@ -3,6 +3,7 @@ Virtualization test - SwitchDev related utilities
 
 :copyright: Red Hat Inc.
 """
+
 import logging
 import os
 

--- a/virttest/utils_test/libguestfs.py
+++ b/virttest/utils_test/libguestfs.py
@@ -151,7 +151,6 @@ def cleanup_vm(vm_name=None, disk=None):
 
 
 class VirtTools(object):
-
     """
     Useful functions for virt-commands.
 
@@ -512,7 +511,6 @@ class VirtTools(object):
 
 
 class GuestfishTools(lgf.GuestfishPersistent):
-
     """Useful Tools for Guestfish class."""
 
     __slots__ = ("params",)

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -87,7 +87,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class LibvirtNetwork(object):
-
     """
     Class to create a temporary network for testing.
     """
@@ -948,7 +947,6 @@ def check_vm_state(vm_name, state="paused", reason=None, uri=None):
 
 
 class PoolVolumeTest(object):
-
     """Test class for storage pool or volume"""
 
     def __init__(self, test, params):

--- a/virttest/utils_test/qemu/__init__.py
+++ b/virttest/utils_test/qemu/__init__.py
@@ -269,7 +269,6 @@ def setup_runlevel(params, session):
 
 
 class GuestSuspend(object):
-
     """
     Suspend guest, supports both Linux and Windows.
 
@@ -430,7 +429,6 @@ class GuestSuspend(object):
 
 
 class MemoryBaseTest(object):
-
     """
     Base class for memory functions.
     """
@@ -590,7 +588,6 @@ class MemoryBaseTest(object):
 
 
 class MemoryHotplugTest(MemoryBaseTest):
-
     """
     Class for memory hotplug/unplug test.
     """

--- a/virttest/utils_test/qemu/migration.py
+++ b/virttest/utils_test/qemu/migration.py
@@ -282,7 +282,6 @@ class MigrationData(object):
 
 
 class MultihostMigration(object):
-
     """
     Class that provides a framework for multi-host migration.
 
@@ -1432,7 +1431,6 @@ class MultihostMigrationRdma(MultihostMigration):
 
 
 class MigrationBase(object):
-
     """Class that provides some general functions for multi-host migration."""
 
     def __setup__(self, test, params, env, srchost, dsthost):

--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -46,7 +46,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class Uri(object):
-
     """
     This class is used for generating uri.
     """
@@ -132,7 +131,6 @@ class Uri(object):
 
 
 class Target(object):
-
     """
     This class is used for generating command options.
     """
@@ -362,12 +360,14 @@ class Target(object):
                 # Invalid vddk thumbprint if no ':'
                 if self.vddk_thumbprint is None or ":" not in self.vddk_thumbprint:
                     self.vddk_thumbprint = get_vddk_thumbprint(
-                        *(self.esxi_host, self.esxi_password, self.src_uri_type)
-                        if self.src_uri_type == "esx"
-                        else (
-                            self.vcenter_host,
-                            self.vcenter_password,
-                            self.src_uri_type,
+                        *(
+                            (self.esxi_host, self.esxi_password, self.src_uri_type)
+                            if self.src_uri_type == "esx"
+                            else (
+                                self.vcenter_host,
+                                self.vcenter_password,
+                                self.src_uri_type,
+                            )
                         )
                     )
 
@@ -594,7 +594,6 @@ class Target(object):
 
 
 class VMCheck(object):
-
     """
     This is VM check class dispatcher.
     """
@@ -726,7 +725,6 @@ class VMCheck(object):
 
 
 class LinuxVMCheck(VMCheck):
-
     """
     This class handles all basic linux VM check operations.
     """
@@ -1009,7 +1007,6 @@ class LinuxVMCheck(VMCheck):
 
 
 class WindowsVMCheck(VMCheck):
-
     """
     This class handles all basic Windows VM check operations.
     """

--- a/virttest/utils_vdpa.py
+++ b/virttest/utils_vdpa.py
@@ -3,6 +3,7 @@ Virtualization test - vDPA related utilities
 
 :copyright: Red Hat Inc.
 """
+
 import glob
 import json
 import logging

--- a/virttest/vdpa_blk.py
+++ b/virttest/vdpa_blk.py
@@ -5,6 +5,7 @@ Available functions:
 - get_image_filename: Get the device path from vdpa.
 
 """
+
 from virttest import utils_vdpa
 
 

--- a/virttest/versionable_class.py
+++ b/virttest/versionable_class.py
@@ -184,7 +184,6 @@ def isclass(obj):
 
 
 class ModuleWrapper(object):
-
     """
     Wrapper around module.
 
@@ -223,7 +222,6 @@ class ModuleWrapper(object):
 
 
 class VersionableClass(object):
-
     """
     Class used for marking of mutable class.
     """

--- a/virttest/video_maker.py
+++ b/virttest/video_maker.py
@@ -7,7 +7,6 @@ This relies on generally available multimedia libraries, frameworks
 and tools.
 """
 
-
 import glob
 import logging
 import os
@@ -72,7 +71,6 @@ class EncodingError(Exception):
 
 
 class GiEncoder(object):
-
     """
     Encodes a video from Virtual Machine screenshots (jpg files).
 
@@ -265,7 +263,6 @@ class GiEncoder(object):
 
 
 class GstEncoder(object):
-
     """
     Encodes a video from Virtual Machine screenshots (jpg files).
 

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -81,7 +81,6 @@ except path.CmdNotFoundError:
 
 
 class VirshBase(propcan.PropCanBase):
-
     """
     Base Class storing libvirt Connection & state to a host
     """
@@ -112,7 +111,6 @@ class VirshBase(propcan.PropCanBase):
 
 
 class VirshSession(aexpect.ShellSession):
-
     """
     A virsh shell session, used with Virsh instances.
     """
@@ -387,7 +385,6 @@ class VirshSession(aexpect.ShellSession):
 # Work around for inconsistent builtin closure local reference problem
 # across different versions of python
 class VirshClosure(object):
-
     """
     Callable with weak ref. to override ``**dargs`` when calling reference_function
     """
@@ -421,7 +418,6 @@ class VirshClosure(object):
 
 
 class Virsh(VirshBase):
-
     """
     Execute libvirt operations, using a new virsh shell each time.
     """
@@ -447,7 +443,6 @@ class Virsh(VirshBase):
 
 
 class VirshPersistent(Virsh):
-
     """
     Execute libvirt operations using persistent virsh session.
     """
@@ -600,7 +595,6 @@ class VirshPersistent(Virsh):
 
 
 class VirshConnectBack(VirshPersistent):
-
     """
     Persistent virsh session connected back from a remote host
     """
@@ -746,9 +740,11 @@ class EventTracker(object):
                 return (
                     kwargs.get(arg)
                     if arg in kwargs
-                    else inspect.signature(func).parameters[arg].default
-                    if arg in inspect.signature(func).parameters
-                    else None
+                    else (
+                        inspect.signature(func).parameters[arg].default
+                        if arg in inspect.signature(func).parameters
+                        else None
+                    )
                 )
 
             def _get_event_output(session):
@@ -1133,7 +1129,6 @@ def reboot(
     event_timeout=30,
     **dargs,
 ):
-
     """
     Run a reboot command in the target domain.
 

--- a/virttest/virt_admin.py
+++ b/virttest/virt_admin.py
@@ -74,7 +74,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class VirtadminBase(propcan.PropCanBase):
-
     """
     Base Class storing libvirt Connection & state to a host
     """
@@ -105,7 +104,6 @@ class VirtadminBase(propcan.PropCanBase):
 
 
 class VirtadminSession(aexpect.ShellSession):
-
     """
     A virtadmin shell session, used with Virtadmin instances.
     """
@@ -390,7 +388,6 @@ class VirtadminSession(aexpect.ShellSession):
 # Work around for inconsistent builtin closure local reference problem
 # across different versions of python
 class VirtadminClosure(object):
-
     """
     Callable with weak ref. to override ``**dargs`` when calling reference_function
     """
@@ -424,7 +421,6 @@ class VirtadminClosure(object):
 
 
 class Virtadmin(VirtadminBase):
-
     """
     Execute libvirt operations, using a new virtadmin shell each time.
     """
@@ -449,7 +445,6 @@ class Virtadmin(VirtadminBase):
 
 
 class VirtadminPersistent(Virtadmin):
-
     """
     Execute libvirt operations using persistent virtadmin session.
     """
@@ -602,7 +597,6 @@ class VirtadminPersistent(Virtadmin):
 
 
 class VirtadminConnectBack(VirtadminPersistent):
-
     """
     Persistent virtadmin session connected back from a remote host
     """

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -470,7 +470,6 @@ class VMSMPTopologyInvalidError(VMError):
 
 
 class CpuInfo(object):
-
     """
     A class for VM's cpu information.
     """
@@ -553,7 +552,6 @@ def session_handler(func):
 
 
 class BaseVM(object):
-
     """
     Base class for all hypervisor specific VM subclasses.
 
@@ -926,6 +924,7 @@ class BaseVM(object):
         """
         Wait for a nic to acquire an IP address, then return it.
         """
+
         # Don't let VMIPAddressMissingError/VMAddressVerificationError through
         def _get_address():
             try:

--- a/virttest/vt_iothread.py
+++ b/virttest/vt_iothread.py
@@ -1,4 +1,5 @@
 """AUTOtest implementation of iothread manager classes for QEMU."""
+
 import itertools
 
 from virttest.qemu_devices.qdevices import QIOThread

--- a/virttest/xml_utils.py
+++ b/virttest/xml_utils.py
@@ -57,7 +57,6 @@ LOG = logging.getLogger("avocado." + __name__)
 
 
 class TempXMLFile(io.FileIO):
-
     """
     Temporary XML file auto-removed on instance del / module exit.
     """
@@ -113,7 +112,6 @@ class TempXMLFile(io.FileIO):
 
 
 class XMLBackup(TempXMLFile):
-
     """
     Backup file copy of XML data, automatically removed on instance destruction.
     """
@@ -164,7 +162,6 @@ class XMLBackup(TempXMLFile):
 
 
 class XMLTreeFile(ElementTree.ElementTree, XMLBackup):
-
     """
     Combination of ElementTree root and auto-cleaned XML backup file.
     """
@@ -350,7 +347,6 @@ class XMLTreeFile(ElementTree.ElementTree, XMLBackup):
 
 
 class Sub(object):
-
     """String substituter using string.Template"""
 
     def __init__(self, **mapping):
@@ -369,7 +365,6 @@ class Sub(object):
 
 
 class TemplateXMLTreeBuilder(ElementTree.XMLParser, Sub):
-
     """Resolve XML templates into temporary file-backed ElementTrees"""
 
     BuilderClass = ElementTree.TreeBuilder
@@ -389,7 +384,6 @@ class TemplateXMLTreeBuilder(ElementTree.XMLParser, Sub):
 
 
 class TemplateXML(XMLTreeFile):
-
     """Template-sourced XML ElementTree backed by temporary file."""
 
     ParserClass = TemplateXMLTreeBuilder

--- a/virttest/yumrepo.py
+++ b/virttest/yumrepo.py
@@ -3,7 +3,6 @@ This module implements classes that allow a user to create, enable and disable
 YUM repositories on the system.
 """
 
-
 import os
 
 __all__ = ["REPO_DIR", "YumRepo"]
@@ -13,7 +12,6 @@ REPO_DIR = "/etc/yum.repos.d"
 
 
 class YumRepo(object):
-
     """
     Represents a YUM repository
 


### PR DESCRIPTION
This enables the bare minimum of the avocado-static-checks usage, adds
the submodule switches the "isort" check and the "style" check. This
change will help to keep style align with avocado.

Reference: https://github.com/avocado-framework/avocado-vt/issues/3966, https://github.com/avocado-framework/avocado-vt/issues/3964
Signed-off-by: Jan Richter <jarichte@redhat.com>