### PR TITLE
CentOS Stream 10 definition and image mode guest support

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux/CentOS-Stream/10.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/CentOS-Stream/10.cfg
@@ -1,0 +1,47 @@
+- 10:
+    variants:
+        - aarch64:
+            vm_arch_name = aarch64
+        - ppc64le:
+            vm_arch_name = ppc64le
+        - s390x:
+            vm_arch_name = s390x
+        - x86_64:
+            vm_arch_name = x86_64
+    os_variant = centos-stream10
+    mem = 4096
+    image_size = 15G
+    unattended_install.url:
+        url = https://mirror.stream.centos.org/10-stream/BaseOS/${vm_arch_name}/os/
+    nic_hotplug:
+        modprobe_module =
+    block_hotplug:
+        modprobe_module =
+    no unattended_install..floppy_ks
+    unattended_install, check_block_size..extra_cdrom_ks,svirt_install:
+        cdrom_unattended = images/${os_variant}-${vm_arch_name}/ks.iso
+        syslog_server_proto = udp
+    unattended_install, svirt_install:
+        kernel = images/${os_variant}-${vm_arch_name}/vmlinuz
+        initrd = images/${os_variant}-${vm_arch_name}/initrd.img
+        # ARCH dependent things
+        aarch64:
+            grub_file = /boot/efi/EFI/redhat/grub.cfg
+            install_timeout = 7200
+            kernel_params = "console=ttyAMA0 console=ttyS0"
+        ppc64le:
+            no guest_s3, guest_s4
+            mem_chk_cmd = numactl --hardware | awk -F: '/size/ {print $2}'
+            netdev_peer_re = "(.*?): .*?\\\s(.*?):"
+            kernel_params = "console=hvc0 console=ttyS0"
+        s390x:
+            grub_file = /boot/grub/grub.conf
+            install_timeout = 7200
+            kernel = images/${os_variant}-${vm_arch_name}/kernel.img
+            kernel_params = "console=ttysclp0 console=ttyS0"
+        x86_64:
+            grub_file = /boot/grub2/grub.cfg
+            kernel_params = "console=tty0 console=ttyS0"
+        extra_cdrom_ks:
+            kernel_params += " inst.ks=cdrom"
+        kernel_params += " inst.sshd ip=dhcp"

--- a/virttest/shared/cfg/guest-os/Linux/CentOS-Stream/10/10.bootc.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/CentOS-Stream/10/10.bootc.cfg
@@ -1,0 +1,11 @@
+- bootc:
+    # Uses defaults set in 10.cfg
+    # Adding x.y versions should only require changing the kickstart
+    # and adding per-arch image sha.
+    image_name = images/${os_variant}devel-${vm_arch_name}
+    unattended_install.cdrom:
+        # NOTE: Reuse devel ISO or point to a new location for bootc
+        cdrom_cd1 = isos/linux/CentOS-Stream-10-devel-${vm_arch_name}.iso
+    unattended_install, check_block_size, svirt_install:
+        unattended_file = unattended/CentOS-Stream-10-bootc.ks
+        kickstart_bootc_image = quay.io/centos-bootc/centos-bootc:stream10

--- a/virttest/shared/cfg/guest-os/Linux/CentOS-Stream/10/10.devel.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/CentOS-Stream/10/10.devel.cfg
@@ -1,0 +1,9 @@
+- devel:
+    # Uses defaults set in 10.cfg
+    # Adding x.y versions should only require changing the kickstart
+    # and adding per-arch image sha.
+    image_name = images/${os_variant}devel-${vm_arch_name}
+    unattended_install.cdrom:
+        cdrom_cd1 = isos/linux/CentOS-Stream-10-devel-${vm_arch_name}.iso
+    unattended_install, check_block_size, svirt_install:
+        unattended_file = unattended/CentOS-Stream-10-devel.ks

--- a/virttest/shared/unattended/CentOS-Stream-10-bootc.ks
+++ b/virttest/shared/unattended/CentOS-Stream-10-bootc.ks
@@ -1,0 +1,72 @@
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+poweroff
+lang en_US.UTF-8
+keyboard us
+network --onboot yes --device eth0 --bootproto dhcp
+rootpw --plaintext 123456
+firstboot --disable
+user --name=test --password=123456
+# Disable firewalld, as pkg may not be installed in the bootable image
+firewall --disabled
+selinux --enforcing
+timezone --utc America/New_York
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+KVM_TEST_LOGGING
+clearpart --all --initlabel
+autopart
+xconfig --startxonboot
+# Additional repositories could be specified in 'kickstart_extra_repos' parameter
+KVM_TEST_REPOS
+
+ostreecontainer --url BOOTC_IMAGE
+
+%post
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `cat /proc/consoles | grep -v ttyS0 | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
+ECHO "OS install is completed"
+case $(arch) in
+    "x86_64")
+        arg="console=tty0 console=ttyS0"
+        ;;
+    "s390x")
+        arg="console=hvc0 console=ttyS0"
+        ;;
+    "ppc64le")
+        arg="console=hvc0 console=ttyS0"
+        ;;
+    "aarch64")
+        arg="console=ttyAMA0 console=ttyS0"
+        ;;
+esac
+ECHO "remove rhgb quiet by grubby and add kernel console parameters"
+grubby --remove-args="rhgb quiet" --args="$arg" --update-kernel=$(grubby --default-kernel)
+ECHO "dhclient"
+dhclient
+ECHO "systemctl enable sshd"
+sed -i "s/^#PermitRootLogin .*/PermitRootLogin yes/g" /etc/ssh/sshd_config
+systemctl enable sshd
+ECHO "iptables -F"
+iptables -F
+ECHO "systemctl enable NetworkManager"
+systemctl enable NetworkManager.service
+ECHO "Disable lock cdrom udev rules"
+sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
+#Workaround for graphical boot as anaconda seems to always instert skipx
+systemctl set-default graphical.target
+cat > '/etc/gdm/custom.conf' << EOF
+[daemon]
+AutomaticLogin=test
+AutomaticLoginEnable=True
+EOF
+cat >> '/etc/sudoers' << EOF
+test ALL = NOPASSWD: /sbin/shutdown -r now,/sbin/shutdown -h now
+EOF
+cat >> '/home/test/.bashrc' << EOF
+alias shutdown='sudo shutdown'
+EOF
+ECHO 'Post set up finished'
+%end

--- a/virttest/shared/unattended/CentOS-Stream-10-devel.ks
+++ b/virttest/shared/unattended/CentOS-Stream-10-devel.ks
@@ -1,0 +1,105 @@
+KVM_TEST_MEDIUM
+GRAPHICAL_OR_TEXT
+poweroff
+lang en_US.UTF-8
+keyboard us
+network --onboot yes --device eth0 --bootproto dhcp
+rootpw --plaintext 123456
+firstboot --disable
+user --name=test --password=123456
+firewall --enabled --ssh
+selinux --enforcing
+timezone --utc America/New_York
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+KVM_TEST_LOGGING
+clearpart --all --initlabel
+autopart
+xconfig --startxonboot
+# Additional repositories could be specified in 'kickstart_extra_repos' parameter
+KVM_TEST_REPOS
+
+%packages --ignoremissing
+@base
+@core
+@development
+@additional-devel
+@debugging
+@network-tools
+@gnome-desktop
+@fonts
+@smart-card
+dhcp-client
+python3-six
+python3-pyparsing
+net-tools
+NetworkManager
+dconf
+watchdog
+coreutils
+usbutils
+docbook-utils
+sgml-common
+openjade
+virt-viewer
+pulseaudio-libs-devel
+mesa-libGL-devel
+libjpeg-turbo-devel
+spice-vdagent
+usbredir
+SDL
+totem
+dmidecode
+alsa-utils
+sg3_utils
+-gnome-initial-setup
+%end
+
+%post
+# Output to all consoles defined in /proc/consoles, use "major:minor" as
+# device names are unreliable on some platforms
+# https://bugzilla.redhat.com/show_bug.cgi?id=1351968
+function ECHO { for TTY in `cat /proc/consoles | grep -v ttyS0 | awk '{print $NF}'`; do source "/sys/dev/char/$TTY/uevent" && echo "$*" > /dev/$DEVNAME; done }
+ECHO "OS install is completed"
+case $(arch) in
+    "x86_64")
+        arg="console=tty0 console=ttyS0"
+        ;;
+    "s390x")
+        arg="console=hvc0 console=ttyS0"
+        ;;
+    "ppc64le")
+        arg="console=hvc0 console=ttyS0"
+        ;;
+    "aarch64")
+        arg="console=ttyAMA0 console=ttyS0"
+        ;;
+esac
+ECHO "remove rhgb quiet by grubby and add kernel console parameters"
+grubby --remove-args="rhgb quiet" --args="$arg" --update-kernel=$(grubby --default-kernel)
+ECHO "dhclient"
+dhclient
+ECHO "systemctl enable sshd"
+sed -i "s/^#PermitRootLogin .*/PermitRootLogin yes/g" /etc/ssh/sshd_config
+systemctl enable sshd
+ECHO "iptables -F"
+iptables -F
+ECHO "systemctl enable NetworkManager"
+systemctl enable NetworkManager.service
+ECHO "Disable lock cdrom udev rules"
+sed -i "/--lock-media/s/^/#/" /usr/lib/udev/rules.d/60-cdrom_id.rules 2>/dev/null>&1
+#Workaround for graphical boot as anaconda seems to always instert skipx
+systemctl set-default graphical.target
+cat > '/etc/gdm/custom.conf' << EOF
+[daemon]
+AutomaticLogin=test
+AutomaticLoginEnable=True
+EOF
+cat >> '/etc/sudoers' << EOF
+test ALL = NOPASSWD: /sbin/shutdown -r now,/sbin/shutdown -h now
+EOF
+cat >> '/home/test/.bashrc' << EOF
+alias shutdown='sudo shutdown'
+EOF
+ECHO 'Post set up finished'
+%end

--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -488,6 +488,12 @@ class UnattendedInstallConfig(object):
             pkgs = self.params.get("kickstart_lock_pkgs", "")
             contents = re.sub(dummy_lock_pkgs_re, pkgs, contents)
 
+        dummy_bootc_image_re = r"\bBOOTC_IMAGE\b"
+        if re.search(dummy_bootc_image_re, contents):
+            # Path to the bootloader image
+            bootc_image = self.params.get("kickstart_bootc_image", "")
+            contents = re.sub(dummy_bootc_image_re, bootc_image, contents)
+
         dummy_logging_re = r"\bKVM_TEST_LOGGING\b"
         if re.search(dummy_logging_re, contents):
             if self.syslog_server_enabled == "yes":


### PR DESCRIPTION
- This adds guest os configuration and kickstart file to support tests on CentOS Stream 10.
- Introduce new kickstart file with ostreecontainer resource support
- Add guest configuration file with image mode installation parameters

ID: 3462
Signed-off-by: Yihuang Yu <yihyu@redhat.com>