### PR TITLE
avocado_vt/test: enable storage of VM logs

### DIFF
--- a/avocado_vt/test.py
+++ b/avocado_vt/test.py
@@ -18,6 +18,7 @@ Avocado VT plugin
 
 import os
 import shlex
+import shutil
 import sys
 
 from avocado.core import exceptions, test
@@ -153,6 +154,14 @@ class VirtTest(test.Test, utils.TestUtils):
             self.__exc_info = sys.exc_info()
             self.__status = self.__exc_info[1]
         finally:
+            if (
+                self.params.get("vm_type") == "libvirt"
+                and self.params.get("store_libvirt_vm_logs", "yes") == "yes"
+            ):
+                source_dir = "/var/log/libvirt/qemu"
+                file_names = os.listdir(source_dir)
+                for file_name in file_names:
+                    shutil.move(os.path.join(source_dir, file_name), self.debugdir)
             # Clean libvirtd debug logs if the test is not fail or error
             if self.params.get("libvirtd_log_cleanup", "no") == "yes":
                 if (

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -827,6 +827,11 @@ virtinstall_extra_args = ""
 #realtime_mlock = on
 #keyboard_layout = en-us
 
+# If to move VM logs - usually located under /var/log/libvirt/qemu/
+# into the test debug directory. This can help confirm the qemu command
+# and crashes.
+store_libvirt_vm_logs = "yes"
+
 # Params for enable/disable Libvirtd debug logs by default it is
 # enabled and retrieve logs for fail and error tests, the logs
 # are saved in default debug dir


### PR DESCRIPTION
For libvirt type VMs, store the VM log into the test debug directory. The motivating use case is to confirm if a guest has crashed.