### PR TITLE
env_process: Refactor transparent huge pages setup/cleanup

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -46,7 +46,7 @@ from virttest.test_setup.core import SetupManager
 from virttest.test_setup.gcov import ResetQemuGCov
 from virttest.test_setup.kernel import ReloadKVMModules
 from virttest.test_setup.libvirt_setup import LibvirtdDebugLogConfig
-from virttest.test_setup.memory import HugePagesSetup
+from virttest.test_setup.memory import HugePagesSetup, TransparentHugePagesSetup
 from virttest.test_setup.migration import MigrationEnvSetup
 from virttest.test_setup.networking import (
     BridgeConfig,
@@ -1020,6 +1020,7 @@ def preprocess(test, params, env):
     _setup_manager.register(CheckLibvirtVersion)
     _setup_manager.register(LogVersionInfo)
     _setup_manager.register(HugePagesSetup)
+    _setup_manager.register(TransparentHugePagesSetup)
     _setup_manager.do_setup()
 
     vm_type = params.get("vm_type")
@@ -1027,10 +1028,6 @@ def preprocess(test, params, env):
     base_dir = data_dir.get_data_dir()
 
     libvirtd_inst = None
-
-    if params.get("setup_thp") == "yes":
-        thp = test_setup.TransparentHugePageConfig(test, params, env)
-        thp.setup()
 
     if params.get("setup_ksm") == "yes":
         ksm = test_setup.KSMConfig(params, env)
@@ -1512,14 +1509,6 @@ def postprocess(test, params, env):
 
     libvirtd_inst = None
     vm_type = params.get("vm_type")
-
-    if params.get("setup_thp") == "yes":
-        try:
-            thp = test_setup.TransparentHugePageConfig(test, params, env)
-            thp.cleanup()
-        except Exception as details:
-            err += "\nTHP cleanup: %s" % str(details).replace("\\n", "\n  ")
-            LOG.error(details)
 
     if params.get("setup_ksm") == "yes":
         try:

--- a/virttest/test_setup/memory.py
+++ b/virttest/test_setup/memory.py
@@ -34,3 +34,15 @@ class HugePagesSetup(Setuper):
             if post_hugepages_surp > self._pre_hugepages_surp:
                 leak_num = post_hugepages_surp - self._pre_hugepages_surp
                 raise test_setup.HugePagesLeakError("%d huge pages leaked!" % leak_num)
+
+
+class TransparentHugePagesSetup(Setuper):
+    def setup(self):
+        if self.params.get("setup_thp") == "yes":
+            thp = test_setup.TransparentHugePageConfig(self.test, self.params, self.env)
+            thp.setup()
+
+    def cleanup(self):
+        if self.params.get("setup_thp") == "yes":
+            thp = test_setup.TransparentHugePageConfig(self.test, self.params, self.env)
+            thp.cleanup()


### PR DESCRIPTION
Rewriting the transparent huge pages setup/cleanup steps into a setuper and registering it into the env_process setup_manager.

This is a patch from a larger patch series refactoring the env_process preprocess and postprocess functions. In each of these patches, a pre/post process step is identified and replaced with a Setuper subclass so the following can finally be met:
    - Only cleanup steps of successful setup steps are run to avoid possible environment corruption or hard to read errors.
    - Running setup/cleanup steps symmetrically during env pre/post process.
    - Reduce explicit pre/post process function code length.

ID: 2939