### PR TITLE
disk.py: add elements of ssh/https network disk

### DIFF
--- a/virttest/utils_config.py
+++ b/virttest/utils_config.py
@@ -480,6 +480,7 @@ class LibvirtQemuConfig(LibvirtConfigCommon):
         "backup_tls_x509_secret_uuid": "string",
         "sched_core": "string",
         "virtiofsd_debug": "int",
+        "storage_use_nbdkit": "int",
     }
 
 


### PR DESCRIPTION
1. Add the new elements for disk source:
   - knownHosts
   - identity
   - ssl
   - readahead
   - timeout
   - cookies
2. Add storage_use_nbdkit which can be used with ssh/https network disks in utils_config.py.