### PR TITLE
vm_xml:func sync() set ignore_status=True when trying to define vm

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -839,7 +839,7 @@ class VMXML(VMXMLBase):
         func_used = backup.undefine if backup else self.undefine
         if not func_used(options, virsh_instance=virsh_instance):
             raise xcepts.LibvirtXMLError("Failed to undefine %s." % self.vm_name)
-        result_define = virsh_instance.define(self.xml)
+        result_define = virsh_instance.define(self.xml, ignore_status=True)
         # Vm define failed
         if result_define.exit_status:
             if backup:


### PR DESCRIPTION
virsh instance of virsh.Virsh has ignore_status set to False by default which would cause the failure of define in function sync() with wrong xml and could not revert to the original xml.