### PR TITLE
storage: Fix the external data file backup dir issue

### DIFF
--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -970,6 +970,7 @@ class QemuImg(object):
                 "image_format": "raw",
                 "image_size": image_size,
                 "image_raw_device": "yes",
+                "backup_dir": params.get("backup_dir", "")
             }
         )
         return cls(data_file_params, root_dir, "%s_data_file" % tag)


### PR DESCRIPTION
The backup directory depends on the setting of the parameter backup_dir,
we didn't add backup_dir as a parameter of the external data file, then
the root_dir is used because backup_dir = "", so adding backup_dir param
for the external data file can fix this.

ID: 3516