### PR TITLE
env_process: Refactor Kernel Same-Page Merging setup

### DIFF
--- a/virttest/test_setup/kernel.py
+++ b/virttest/test_setup/kernel.py
@@ -1,4 +1,4 @@
-from virttest import arch, utils_kernel_module
+from virttest import arch, test_setup, utils_kernel_module
 from virttest.test_setup.core import Setuper
 
 
@@ -26,3 +26,15 @@ class ReloadKVMModules(Setuper):
     def cleanup(self):
         for kvm_module in self.kvm_module_handlers:
             kvm_module.restore()
+
+
+class KSMSetup(Setuper):
+    def setup(self):
+        if self.params.get("setup_ksm") == "yes":
+            ksm = test_setup.KSMConfig(self.params, self.env)
+            ksm.setup(self.env)
+
+    def cleanup(self):
+        if self.params.get("setup_ksm") == "yes":
+            ksm = test_setup.KSMConfig(self.params, self.env)
+            ksm.cleanup(self.env)


### PR DESCRIPTION
Write the logic setting and cleaning Kernel Same-Page Merging up in virttest.env_process preprocess and postprocess into a Setuper, and register it in the env_process setup_manager.

This is a patch from a larger patch series refactoring the env_process preprocess and postprocess functions. In each of these patches, a pre/post process step is identified and replaced with a Setuper subclass so the following can finally be met:
    - Only cleanup steps of successful setup steps are run to avoid possible environment corruption or hard to read errors.
    - Running setup/cleanup steps symmetrically during env pre/post process.
    - Reduce explicit pre/post process function code length.

Tested by `--tescase=ksm_services.ksmtuned,ksm_base,ksm_overcommit`:
```{bash}
 (1/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_base.disable.other_host.q35: STARTED
(1/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_base.disable.other_host.q35:  PASS (326.
38 s)                                                                                                                                                   
 (2/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_base.base.q35: STARTED                  
 (2/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_base.base.q35:  PASS (328.05 s)         
 (3/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_base.negative.q35: STARTED              
 (3/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_base.negative.q35:  PASS (331.33 s)     
 (4/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_overcommit.ksm_serial.q35: STARTED      
 (4/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_overcommit.ksm_serial.q35:  PASS (2981.0
4 s)                                                                                                                                                    
 (5/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_overcommit.ksm_parallel.q35: STARTED    
 (5/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_overcommit.ksm_parallel.q35:  PASS (1643
.88 s)                                                                                                                                                                                                                               
 (6/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_services.ksmtuned.q35: STARTED          
 (6/6) Host_RHEL.m9.u5.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.ksm_services.ksmtuned.q35:  PASS (5.21 s)   
```

No regressions.

ID: 2940