### PR TITLE
utils_sys: moved update_boot_option from utils_test

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -38,6 +38,9 @@ from avocado.core import exceptions
 from avocado.utils import archive, aurl, crypto, download, path, process
 from six.moves import xrange
 
+# imported so code that relies on update_boot_option being in this file do not need updates
+from utils_sys import update_boot_option
+
 # Import from the top level virttest namespace
 from virttest import asset, bootstrap, data_dir, error_context, qemu_virtio_port
 from virttest import remote as remote_old
@@ -159,96 +162,6 @@ def __run_cmd_and_handle_error(msg, cmd, session, test_fail_msg):
     if status != 0:
         LOG.error(output)
         raise exceptions.TestError(test_fail_msg)
-
-
-def update_boot_option(
-    vm,
-    args_removed="",
-    args_added="",
-    need_reboot=True,
-    guest_arch_name="x86_64",
-    serial_login=False,
-):
-    """
-    Update guest default kernel option.
-
-    :param vm: The VM object.
-    :param args_removed: Kernel options want to remove.
-    :param args_added: Kernel options want to add.
-    :param need_reboot: Whether need reboot VM or not.
-    :param guest_arch_name: Guest architecture, e.g. x86_64, s390x
-    :param serial_login: Login guest via serial session
-    :raise exceptions.TestError: Raised if fail to update guest kernel cmdline.
-
-    """
-    session = None
-    if vm.params.get("os_type") == "windows":
-        # this function is only for linux, if we need to change
-        # windows guest's boot option, we can use a function like:
-        # update_win_bootloader(args_removed, args_added, reboot)
-        # (this function is not implement.)
-        # here we just:
-        msg = "update_boot_option() is supported only for Linux guest"
-        LOG.warning(msg)
-        return
-    login_timeout = int(vm.params.get("login_timeout"))
-    session = vm.wait_for_login(
-        timeout=login_timeout, serial=serial_login, restart_network=True
-    )
-    try:
-        # check for args that are really required to be added/removed
-        req_args, req_remove_args = check_kernel_cmdline(
-            session, remove_args=args_removed, args=args_added
-        )
-        if "ubuntu" in vm.get_distro().lower():
-            if req_args:
-                update_boot_option_ubuntu(req_args, session=session)
-            if req_remove_args:
-                update_boot_option_ubuntu(
-                    req_remove_args, session=session, remove_args=True
-                )
-        else:
-            if not utils_package.package_install("grubby", session=session):
-                raise exceptions.TestError("Failed to install grubby package")
-            msg = "Update guest kernel option. "
-            cmd = "grubby --update-kernel=`grubby --default-kernel` "
-            if req_remove_args:
-                msg += " remove args: %s" % req_remove_args
-                cmd += '--remove-args="%s" ' % req_remove_args
-            if req_args:
-                msg += " add args: %s" % req_args
-                cmd += '--args="%s"' % req_args
-            if req_remove_args or req_args:
-                __run_cmd_and_handle_error(
-                    msg, cmd, session, "Failed to modify guest kernel option"
-                )
-
-        if guest_arch_name == "s390x":
-            msg = "Update boot media with zipl"
-            cmd = "zipl"
-            __run_cmd_and_handle_error(
-                msg, cmd, session, "Failed to update boot media with zipl"
-            )
-
-        # reboot is required only if we really add/remove any args
-        if need_reboot and (req_args or req_remove_args):
-            LOG.info("Rebooting guest ...")
-            session = vm.reboot(
-                session=session, timeout=login_timeout, serial=serial_login
-            )
-            # check nothing is required to be added/removed by now
-            req_args, req_remove_args = check_kernel_cmdline(
-                session, remove_args=args_removed, args=args_added
-            )
-            if req_remove_args:
-                err = "Fail to remove guest kernel option %s" % args_removed
-                raise exceptions.TestError(err)
-            if req_args:
-                err = "Fail to add guest kernel option %s" % args_added
-                raise exceptions.TestError(err)
-    finally:
-        if session:
-            session.close()
 
 
 def stop_windows_service(session, service, timeout=120):


### PR DESCRIPTION
Depends on: https://github.com/avocado-framework/avocado-vt/pull/4070

Moved update_boot_option from utils_test to utils_sys so that __init__.py is not as long.