### PR TITLE
env_process: Refactor EGD setup

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -66,6 +66,7 @@ from virttest.test_setup.requirement_checks import (
     LogBootloaderVersion,
     LogVersionInfo,
 )
+from virttest.test_setup.rng_egd import EGDSetup
 from virttest.test_setup.storage import StorageConfig
 from virttest.test_setup.verify import VerifyHostDMesg
 from virttest.test_setup.vms import ProcessVMOff, UnrequestedVMHandler
@@ -1022,6 +1023,7 @@ def preprocess(test, params, env):
     _setup_manager.register(HugePagesSetup)
     _setup_manager.register(TransparentHugePagesSetup)
     _setup_manager.register(KSMSetup)
+    _setup_manager.register(EGDSetup)
     _setup_manager.do_setup()
 
     vm_type = params.get("vm_type")
@@ -1029,10 +1031,6 @@ def preprocess(test, params, env):
     base_dir = data_dir.get_data_dir()
 
     libvirtd_inst = None
-
-    if params.get("setup_egd") == "yes":
-        egd = test_setup.EGDConfig(params, env)
-        egd.setup()
 
     if vm_type == "libvirt":
         connect_uri = params.get("connect_uri")
@@ -1506,14 +1504,6 @@ def postprocess(test, params, env):
 
     libvirtd_inst = None
     vm_type = params.get("vm_type")
-
-    if params.get("setup_egd") == "yes" and params.get("kill_vm") == "yes":
-        try:
-            egd = test_setup.EGDConfig(params, env)
-            egd.cleanup()
-        except Exception as details:
-            err += "\negd.pl cleanup: %s" % str(details).replace("\\n", "\n  ")
-            LOG.error(details)
 
     if vm_type == "libvirt":
         if params.get("setup_libvirt_polkit") == "yes":

--- a/virttest/test_setup/rng_egd.py
+++ b/virttest/test_setup/rng_egd.py
@@ -1,0 +1,17 @@
+from virttest import test_setup
+from virttest.test_setup.core import Setuper
+
+
+class EGDSetup(Setuper):
+    def setup(self):
+        if self.params.get("setup_egd") == "yes":
+            egd = test_setup.EGDConfig(self.params, self.env)
+            egd.setup()
+
+    def cleanup(self):
+        if (
+            self.params.get("setup_egd") == "yes"
+            and self.params.get("kill_vm") == "yes"
+        ):
+            egd = test_setup.EGDConfig(self.params, self.env)
+            egd.cleanup()


### PR DESCRIPTION
Replace the steps setting and cleaning EGD up into a Setuper that is registered into the setup_manager in env_process.

This is a patch from a larger patch series refactoring the env_process preprocess and postprocess functions. In each of these patches, a pre/post process step is identified and replaced with a Setuper subclass so the following can finally be met:
    - Only cleanup steps of successful setup steps are run to avoid possible environment corruption or hard to read errors.
    - Running setup/cleanup steps symmetrically during env pre/post process.
    - Reduce explicit pre/post process function code length.

This patch shouldn't introduce any regression or breaking change.
With `--testcase=boot --rng_type=virtio_rng.rng_egd`:
```
 (1/1) Host_RHEL.m9.u5.ovmf.virtio_rng.rng_egd.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.boot.q35: STARTED
 (1/1) Host_RHEL.m9.u5.ovmf.virtio_rng.rng_egd.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.9.4.0.x86_64.io-github-autotest-qemu.boot.q35:  PASS (73.16 s)
```

ID: 2941