### PR TITLE
video: add resolution sub element

### DIFF
--- a/virttest/libvirt_xml/devices/video.py
+++ b/virttest/libvirt_xml/devices/video.py
@@ -21,6 +21,7 @@ class Video(base.UntypedDeviceBase):
         "acceleration",
         "address",
         "driver",
+        "resolution",
     )
 
     def __init__(self, virsh_instance=base.base.virsh):
@@ -50,4 +51,7 @@ class Video(base.UntypedDeviceBase):
         )
         accessors.XMLElementDict("address", self, parent_xpath="/", tag_name="address")
         accessors.XMLElementDict("driver", self, parent_xpath="/", tag_name="driver")
+        accessors.XMLElementDict(
+            "resolution", self, parent_xpath="/model", tag_name="resolution"
+        )
         super(Video, self).__init__(device_tag="video", virsh_instance=virsh_instance)


### PR DESCRIPTION
Support below resolution sub element.

```
<video>
<model type='virtio' heads='1' primary='yes'>
<resolution x='507' y='510'/>
</model>
</video>
```

Signed-off-by: Dan Zheng <dzheng@redhat.com>