### PR TITLE
add new clear_logfile method:

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -4115,7 +4115,7 @@ def check_logfile(
 
     :param search_str: the string to be searched
     :param log_file: the given file
-    :param str_in_log: True if the file should include the given string,
+    :param str_in_log: bool, True if the file should include the given string,
                         otherwise, False
     :param cmd_parms: The parms for remote executing
     :param runner_on_target:  Remote runner
@@ -4132,6 +4132,7 @@ def check_logfile(
         cmdRes = process.run(cmd, shell=True, ignore_status=True)
     else:
         cmdRes = remote_old.run_remote_cmd(cmd, cmd_parms, runner_on_target)
+
     if str_in_log == bool(int(cmdRes.exit_status)):
         error_msg = "The string '{}' {} included in {}".format(
             search_str, "is not" if str_in_log else "is", log_file


### PR DESCRIPTION
- this will clear defined log_file - so the test will consider only the messages added in the test run.
- previous log can be backuped to the tmp dir if requrired (the restore not yet prepared)

add new backup_logfile method: used in clear_logfile, but it can be used just as is

+ minor refactor to process not only bollean str_in_log variable (as it comes from test in my case as str)