### PR TITLE
update delete_partition function running cmd

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -486,7 +486,7 @@ def delete_partition_linux(session, partition_name, timeout=360):
                     err_msg = "Failed to umount partition '%s'"
                     raise exceptions.TestError(err_msg % partition_name)
             break
-    session.cmd(rm_cmd % (kname, partition[0]))
+    session.cmd(rm_cmd % (kname, re.findall(r"\d+", partition[0])[0]))
     session.cmd("partprobe /dev/%s" % kname, timeout=timeout)
     if not wait.wait_for(
         lambda: not re.search(regex, session.cmd(ls_block_cmd), re.M),


### PR DESCRIPTION
  cmd should be parted -s "/dev/sda" rm 1 instead of  parted -s "/dev/sda" rm sda1
Signed-off-by: nanli <nanli@redhat.com>

For https://github.com/autotest/tp-libvirt/pull/6254/files 
```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 virtual_disks.usb_startuppolicy_config.positive.coldplug.set_mandatory_startuppolicy.with_usb_device_plugged.start_guest --vt-connect-uri qemu:///system 
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.usb_startuppolicy_config.positive.coldplug.set_mandatory_startuppolicy.with_usb_device_plugged.start_guest: PASS (83.79 s)

```