### PR TITLE
Add support and testing for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build setuptools
+        pip install build setuptools wheel
     - name: Build package
       run: python -m build
-    - name: Build eggs
+    - name: Build eggs (legacy)
+      if: ${{ contains(fromJSON('["3.9","3.10","3.11"]'), matrix.python-version) }}
       run: python setup.py bdist_egg
     - run: echo "🥑 This job's status is ${{ job.status }}."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
+          cache: 'pip'
+          cache-dependency-path: requirements-travis.txt
       - name: Install dependencies
         run: pip install -r requirements-travis.txt
       - name: Check out Avocado libs
@@ -91,6 +94,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        check-latest: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:
@@ -94,7 +94,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install build setuptools
     - name: Build package
       run: python -m build
     - name: Build eggs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: &py_versions ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: *py_versions
       fail-fast: false
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI Python compatibility to include 3.12 and 3.13.
  * Centralized the Python version matrix for reuse across CI jobs.
  * Improved Python setup and enabled dependency caching to speed CI runs.
  * Added packaging dependencies for more reliable builds.
  * Restricted legacy egg builds to older Python versions (3.9–3.11); skipped for 3.12/3.13.
  * No functional/product behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->