### PR TITLE
add support for new hyperv tag

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -4534,11 +4534,13 @@ class VMFeaturesHypervXML(base.LibvirtXMLBase):
             parent_xpath="/",
             tag_name="reenlightenment",
         )
-        accessors.XMLElementDict(
+        accessors.XMLElementNest(
             property_name="tlbflush",
             libvirtxml=self,
             parent_xpath="/",
+            subclass=VMFeaturestlbflushXML,
             tag_name="tlbflush",
+            subclass_dargs={"virsh_instance": virsh_instance},
         )
         accessors.XMLElementDict(
             property_name="ipi", libvirtxml=self, parent_xpath="/", tag_name="ipi"
@@ -4931,3 +4933,36 @@ class VMOSACPIXML(base.LibvirtXMLBase):
         accessors.XMLElementText("table", self, parent_xpath="/", tag_name="table")
         super(VMOSACPIXML, self).__init__(virsh_instance=virsh_instance)
         self.xml = "<acpi/>"
+
+
+class VMFeaturestlbflushXML(base.LibvirtXMLBase):
+    """
+    tlbflush tag XML class of features tag
+    """
+
+    __slots__ = ("state", "extended", "direct")
+
+    def __init__(self, virsh_instance=base.virsh):
+        accessors.XMLAttribute(
+            property_name="state",
+            libvirtxml=self,
+            parent_xpath="/",
+            tag_name="tlbflush",
+            attribute="state",
+        )
+        accessors.XMLElementDict(
+            property_name="extended",
+            libvirtxml=self,
+            forbidden=None,
+            parent_xpath="/",
+            tag_name="extended",
+        )
+        accessors.XMLElementDict(
+            property_name="direct",
+            libvirtxml=self,
+            forbidden=None,
+            parent_xpath="/",
+            tag_name="direct",
+        )
+        super(VMFeaturestlbflushXML, self).__init__(virsh_instance=virsh_instance)
+        self.xml = "<tlbflush/>"


### PR DESCRIPTION
   Start a guest with emsr_bitmap, xmm_input, tlbflush-direct and tlbflush-ext
Signed-off-by: nanli <nanli@redhat.com>
For https://github.com/autotest/tp-libvirt/pull/6267 

The showing xml
 ```
 <hyperv mode="custom">
    <tlbflush state="on">
      <direct state="on"/>
      <extended state="on"/>
    </tlbflush>
  </hyperv>
```



 ```
avocado run --vt-type libvirt --vt-machine-type q35 vm_features

 (01/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.features_in_domcapabilities: STARTED
 (01/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.features_in_domcapabilities: PASS (22.22 s)
 (02/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush: STARTED
 (02/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush: PASS (21.91 s)
 (03/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush_direct_extended: STARTED
 (03/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush_direct_extended: PASS (21.90 s)
 (04/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.emsr_bitmap: STARTED
 (04/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.emsr_bitmap: PASS (22.22 s)
 (05/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.xmm_input: STARTED
 (05/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.xmm_input: PASS (22.16 s)
 (06/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.frequencies: STARTED
 (06/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.frequencies: PASS (21.99 s)
 (07/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.reenlightenment: STARTED
 (07/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.reenlightenment: PASS (22.00 s)
 (08/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.enable: STARTED
 (08/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.enable: PASS (21.97 s)
 (09/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.disable: STARTED
 (09/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.disable: PASS (21.95 s)
 (10/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pmu.enable: STARTED
 (10/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pmu.enable: PASS (21.95 s)
 (11/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pmu.disable: STARTED
 (11/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pmu.disable: PASS (22.04 s)
 (12/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pvspinlock.enable: STARTED
 (12/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pvspinlock.enable: PASS (44.48 s)
 (13/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pvspinlock.disable: STARTED
 (13/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.pvspinlock.disable: PASS (21.99 s)
 (14/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: STARTED
 (14/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: PASS (43.19 s)
 (15/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.disable: STARTED
 (15/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.disable: PASS (23.37 s)
 (16/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_poll_control.enable: STARTED
 (16/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_poll_control.enable: PASS (21.94 s)
 (17/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_poll_control.disable: STARTED
 (17/18) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_poll_control.disable: PASS (21.56 s)
 (18/18) type_specific.io-github-autotest-libvirt.vm_features.negative_test.hyperv.features_not_in_domcapabilities: STARTED
 (18/18) type_specific.io-github-autotest-libvirt.vm_features.negative_test.hyperv.features_not_in_domcapabilities: CANCEL: Can not find an unsupported hyperv feature on the host. (6.26 s)

```