### PR TITLE
Env process refactoring kill tail threads

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -11,7 +11,6 @@ import sys
 import threading
 import time
 
-import aexpect
 import six
 from aexpect import remote
 from avocado.core import exceptions
@@ -42,6 +41,7 @@ from virttest import (
 
 # lazy imports for dependencies that are not needed in all modes of use
 from virttest._wrappers import lazy_import
+from virttest.test_setup.aexpect import KillTailThreads
 from virttest.test_setup.core import SetupManager
 from virttest.test_setup.gcov import ResetQemuGCov
 from virttest.test_setup.kernel import KSMSetup, ReloadKVMModules
@@ -1009,6 +1009,7 @@ def preprocess(test, params, env):
     _setup_manager.register(BridgeConfig)
     _setup_manager.register(StorageConfig)
     _setup_manager.register(FirewalldService)
+    _setup_manager.register(KillTailThreads)
     _setup_manager.register(IPSniffer)
     _setup_manager.register(MigrationEnvSetup)
     _setup_manager.register(UnrequestedVMHandler)
@@ -1467,9 +1468,6 @@ def postprocess(test, params, env):
         if destroy and not vm.is_dead():
             LOG.debug("Image of VM %s was removed, destroying it.", vm.name)
             vm.destroy()
-
-    # Kill all aexpect tail threads
-    aexpect.kill_tail_threads()
 
     # collect sosreport of host/remote host during postprocess if enabled
     if params.get("enable_host_sosreport", "no") == "yes":

--- a/virttest/storage.py
+++ b/virttest/storage.py
@@ -970,7 +970,7 @@ class QemuImg(object):
                 "image_format": "raw",
                 "image_size": image_size,
                 "image_raw_device": "yes",
-                "backup_dir": params.get("backup_dir", "")
+                "backup_dir": params.get("backup_dir", ""),
             }
         )
         return cls(data_file_params, root_dir, "%s_data_file" % tag)

--- a/virttest/test_setup/aexpect.py
+++ b/virttest/test_setup/aexpect.py
@@ -1,0 +1,12 @@
+import aexpect
+
+from virttest.test_setup.core import Setuper
+
+
+class KillTailThreads(Setuper):
+    def setup(self):
+        pass
+
+    def cleanup(self):
+        # Kill all aexpect tail threads
+        aexpect.kill_tail_threads()


### PR DESCRIPTION
The order in which `aexpect.kill_tail_threads` was called during env_process.postprocess changed while we were refactoring it. Now, tail threads were killed before the IPSniffer or other processes using Tail objects were cleaned up.
Calling `aexpect.kill_tail_threads` when it was supposed to: right after the IPSniffer is cleaned up.

ID: 3698