### PR TITLE
remote: handle error when remote file doesn't exist

### DIFF
--- a/virttest/remote.py
+++ b/virttest/remote.py
@@ -274,8 +274,10 @@ class RemoteFile(object):
         # Get file from remote.
         try:
             self._pull_file()
-        except SCPTransferFailedError:
-            # Remote file doesn't exist, create empty file on local
+        except Exception as e:
+            LOG.debug("Remote file doesn't exist.")
+            LOG.debug("Create empty file on local.")
+            LOG.debug(f"Error was {e}")
             self._write_local([])
 
         # Save a backup.


### PR DESCRIPTION
`SCPTransferFailedError` doesn't exist.
This was raised occasionally when the file couldn't be pulled. The documented intention was to create a local file in this case. So, do that, and log the Exception.

In my case it was `ExpectProcessTerminatedError`.