### PR TITLE
ci(runner): Update CI runner from 20.04 to 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
   static-checks:
     name: Static checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
   travis-check:
 
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -78,7 +78,7 @@ jobs:
 
   package-build:
     name: Build Package for Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -41,17 +41,17 @@ jobs:
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}"
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install -r requirements-travis.txt
       - name: Check out Avocado libs
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'avocado-framework/avocado'
           path: 'avocado-libs'
@@ -86,9 +86,9 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.1, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.1, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check:
 	./avocado-static-checks/check-style
 	./avocado-static-checks/check-import-order
 	inspekt lint --disable W,R,C,E0203,E0601,E1002,E1101,E1102,E1103,E1120,F0401,I0011,E1003,W605,I1101 --exclude avocado-libs,scripts/github
-	pylint --errors-only --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
+	pylint --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
 
 clean:
 	$(PYTHON) setup.py clean

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,6 +1,6 @@
 Sphinx==1.3b1
 # inspektor (static and style checks)
-pylint==2.15.10
+pylint==3.0.0
 inspektor==0.5.3
 aexpect>=1.6.4
 netifaces==0.11.0

--- a/spell.ignore
+++ b/spell.ignore
@@ -92,7 +92,6 @@ guestfish
 rbd
 attrs
 os
-vms
 filesystems
 NFS
 qtree
@@ -140,7 +139,6 @@ dstmacaddr
 hugepage
 json
 tmp
-VMs
 Augeas
 KVM
 proc
@@ -445,7 +443,6 @@ asc
 Autostart
 blk
 callables
-cgroups
 cid
 cls
 cn
@@ -514,7 +511,6 @@ userspace
 vdb
 verison
 vfs
-VFs
 vgname
 vmlinuz
 vnc
@@ -539,7 +535,6 @@ chipds
 chpids
 clocksource
 cmdresult
-cmds
 cpuid
 cpulist
 ctrl
@@ -646,7 +641,6 @@ unittests
 unpickling
 Unregister
 usbdev
-vcpus
 vddk
 vfd
 vhbas
@@ -780,6 +774,18 @@ LENOVO
 idmap
 gid
 tc
+mgmtdev
+dat
+ps
+vdc
+gcc
+iommufd
+passt
+Passt
+urllib
+sndbuf
+crashkernel
+LWP
 
 # The list below needs a second review
 abc
@@ -889,7 +895,6 @@ cellno
 cephfs
 cfq
 cgcreate
-cgroups
 cgset
 chcon
 checkbutton
@@ -903,7 +908,6 @@ clksrc
 CmdError
 cmdlines
 Cmdobject
-cmds
 CML
 codec
 codeset
@@ -930,7 +934,6 @@ cp
 cpuflags
 cpuinfo
 Cpuinfo
-cpus
 cpustats
 cputime
 crb
@@ -981,7 +984,6 @@ descendents
 Destructor
 DevContainer
 devel
-devid
 devmajor
 devminor
 devname
@@ -990,7 +992,6 @@ dfile
 dgram
 dic
 dics
-dicts
 dids
 Dimitrov
 directsync
@@ -1247,7 +1248,6 @@ iothreadscheds
 iotune
 ips
 IPs
-IPs
 iptable
 IQN
 isapc
@@ -1441,8 +1441,6 @@ newname
 newvm
 newvolgroup
 nfspath
-nics
-NICs
 NMI
 nodedevice
 nodefconfig
@@ -1517,8 +1515,6 @@ persistdest
 pesistent
 pflash
 pfs
-pfs
-PFs
 pgrep
 pgroup
 physvols
@@ -1603,7 +1599,6 @@ qed
 qemuarg
 qemudir
 qemudirarg
-qemus
 qemus
 qeury
 QFloppy
@@ -1723,7 +1718,6 @@ sdaa
 sdc
 SDK
 SDL
-seclabels
 seclables
 sectionless
 sectorsize
@@ -1976,7 +1970,6 @@ vbox
 VBox
 vcpucoutn
 vcpupins
-vcpus
 vcpusched
 vcpuscheds
 vcputime
@@ -1990,7 +1983,6 @@ versionable
 versioned
 versioning
 vdpa
-VFs
 vfstype
 vga
 vgcreate
@@ -2009,13 +2001,10 @@ vio
 viostor
 vlanid
 vlans
-vlans
 vmcoreinfo
 vmdk
 vmname
 VMname
-vms
-VMs
 vmstat
 vmtype
 vmware
@@ -2083,5 +2072,34 @@ zfgrepi
 zfile
 zgrep
 zgrepi
+zlib
+zstd
 Zuo
 zzz
+sizeunit
+refcnt
+mnonce
+getfd
+multipeerroundrobin
+groupname
+nodexx
+vq
+ioport
+yy
+KVER
+maxMemory
+valuenn
+fcntl
+tapname
+hgps
+slic
+tlbflush
+openfiles
+memoryBacking
+nosp
+zpci
+Devcontainer
+subuid
+subgid
+uids
+gids

--- a/virttest/libvirt_xml/devices/disk.py
+++ b/virttest/libvirt_xml/devices/disk.py
@@ -887,7 +887,7 @@ class Disk(base.TypedDeviceBase):
             file:
                 string, attribute of backingStore/source tag
             datastore:
-                dict, nexted xml of backingStore/source/dataStore tag
+                dict, nested xml of backingStore/source/dataStore tag
             """
 
             __slots__ = (

--- a/virttest/lvsb_base.py
+++ b/virttest/lvsb_base.py
@@ -304,7 +304,7 @@ class SandboxCommandBase(SandboxBase):
         if self._name is None:
             class_name = self.__class__.__name__
             class_initials = class_name.translate(None, "abcdefghijklmnopqrstuvwxyz")
-            self._name = "%s_%d" % (class_initials, self.identifier)
+            self._name = "%s_%s" % (class_initials, self.identifier)
         return self._name
 
     @staticmethod

--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -440,7 +440,7 @@ class DevContainer(object):
 
         # QMP: block-stream/block-commit @backing-mask-protocol
         # TODO: probe cap via using the qmp command `query-qmp-schema`
-        #       instead of hardcoding the version range
+        #       instead of hard-coding the version range
         if self.__qemu_ver in VersionInterval(
             self.BLOCKJOB_BACKING_MASK_PROTOCOL_VERSION_SCOPE
         ):

--- a/virttest/utils_ids.py
+++ b/virttest/utils_ids.py
@@ -16,7 +16,7 @@ from avocado.utils import process
 
 def get_user_ids(user):
     """
-    Returns user uid, gid and their respective subuids and subgids
+    Returns user uid, gid and their respective sub-uids and sub-gids
     along with their names as a dictionary:
 
     {

--- a/virttest/utils_libvirt/libvirt_monitor.py
+++ b/virttest/utils_libvirt/libvirt_monitor.py
@@ -43,7 +43,7 @@ def _check_items(value_type, tmp_domjobinfo):
 
     :param value_type: value type, contain 'all_items', 'str_itmes' and 'int_items'
     :param tmp_domjobinfo: domain job info
-    :retrun: new domain job info
+    :return: new domain job info
     """
     if value_type in tmp_domjobinfo:
         if len(tmp_domjobinfo[value_type]) > 0:
@@ -61,7 +61,7 @@ def _get_value(expect_key, out):
 
     :param expect_key: expect key
     :param out: domain job info
-    :retrun: the value of expect key
+    :return: the value of expect key
     """
     for line in out.splitlines():
         key = line.split(":")[0]

--- a/virttest/utils_libvirt/libvirt_unprivileged.py
+++ b/virttest/utils_libvirt/libvirt_unprivileged.py
@@ -11,7 +11,7 @@ def get_unprivileged_vm(vm_name, user, passwd, **args):
     """
     To get the instance of the given unprivileged vm.
 
-    :param vm_name: name of the unprileged vm
+    :param vm_name: name of the unprivileged vm
     :param user: name of the unprivileged user
     :param passwd: password of the unprivileged user
     :param args: other arguments

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4184,7 +4184,7 @@ def get_default_gateway(
         LOG.error("Failed to get the default GateWay")
         return None
     # historically the function was implemented with grep and pipes
-    # therefore, there could be a multiline match with multiline
+    # therefore, there could be a multi-line match with multi-line
     # result and tests expect that
     return "\n".join(gateways)
 

--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -732,7 +732,7 @@ def verify_virsh_console(session, user, passwd, timeout=10, debug=False):
         # Do not use remote.handle_prompts here because it will inhibit the
         # login failure.
         # Sometimes kernel will continue printing more kernel infos after
-        # login prompts. We should do a check to determin if it's correct.
+        # login prompts. We should do a check to determine if it's correct.
         virsh_console_login(session, user, passwd, timeout, debug=debug)
         status, output = session.cmd_status_output(console_cmd)
         LOG.info("output of command:\n%s", output)

--- a/virttest/utils_vdpa.py
+++ b/virttest/utils_vdpa.py
@@ -241,7 +241,7 @@ class VDPASimulatorTest(object):
 
     def get_vdpa_dev_info(self, dev="dev"):
         """
-        Get vDPA devices' infomation
+        Get vDPA devices' information
 
         :param dev: device type, dev(vdpa device) or mgmtdev(vdpa management device)
         :return: devices' information

--- a/virttest/vdpa_blk.py
+++ b/virttest/vdpa_blk.py
@@ -17,7 +17,7 @@ def get_image_filename(name):
 
     :param name: the name of device
     :type name: str
-    :return: The path from vdpa in vpda protocol
+    :return: The path from vdpa in vdpa protocol
              e.g: vdpa:///dev/vhost-vdpa
     :rtype: str
     """


### PR DESCRIPTION
ubuntu-20.04 runner image is unsupported since 2025-04-15, let's upgrade
to use ubuntu-24.04 runner.

Ref: actions/runner-images#11101
Signed-off-by: Yihuang Yu <yihyu@redhat.com>