### PR TITLE
Fix migration template bugs

### DIFF
--- a/virttest/migration_template.py
+++ b/virttest/migration_template.py
@@ -1001,6 +1001,7 @@ class MigrationTemplate(object):
             self.objs_list.reverse()
             for obj in self.objs_list:
                 obj.__del__()
+                obj.auto_recover = False
 
         # Cleanup migrate_pre_setup
         LOG.debug("Clean up migration setup on dest host")
@@ -1030,6 +1031,11 @@ class MigrationTemplate(object):
                 session=self.remote_session,
                 cleanup=True,
             )
+
+        # Restore vm connection uri
+        for vm in self.vms:
+            if self.migrate_vm_back != "yes":
+                vm.connect_uri = "qemu:///system"
 
 
 def vm_session_handler(func):


### PR DESCRIPTION
1. set connection obj auto_recover to False to avoid duplicate connection release
2. restore connection uri after migration clean up

related test results:
 (1/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.one_cluster_on_numa: STARTED
 (1/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.one_cluster_on_numa: PASS (414.32 s)
 (2/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.multi_cluster_on_numa: STARTED
 (2/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.multi_cluster_on_numa: PASS (414.07 s)
 (3/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.one_cluster_on_numa: STARTED
 (3/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.one_cluster_on_numa: PASS (505.06 s)
 (4/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.multi_cluster_on_numa: STARTED
 (4/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.multi_cluster_on_numa: PASS (493.82 s)
 (5/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.one_cluster_on_numa: STARTED
 (5/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.one_cluster_on_numa: PASS (413.16 s)
 (6/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.multi_cluster_on_numa: STARTED
 (6/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.multi_cluster_on_numa: PASS (413.75 s)