### PR TITLE
ci.yml: update ubuntu and python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
   travis-check:
 
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.1, 3.11]
+        python-version: [3.8, 3.9, 3.11, 3.12]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Workflows using the ubuntu-20.04 image label should be updated to ubuntu-latest, ubuntu-22.04, ubuntu-24.04 .

See https://github.com/actions/runner-images/issues/11101

Signed-off-by: Dan Zheng <dzheng@redhat.com>