### PR TITLE
Revert "ci.yml: update ubuntu and python version"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
   travis-check:
 
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.11, 3.12]
+        python-version: [3.8, 3.9, 3.10.1, 3.11]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Reverts avocado-framework/avocado-vt#4113

This commit does not completely solve the CI problem, and some CI work still fails, please check the PR #4110 for details.