### PR TITLE
update qdevice_format.py module

### DIFF
--- a/virttest/qemu_devices/qdevice_format.py
+++ b/virttest/qemu_devices/qdevice_format.py
@@ -72,7 +72,6 @@ class _QDeviceFormatManagement(object):
                 },
                 "virtio-rng-pci": {
                     "period": self._str_to_dec,
-                    "max-bytes": self._str_to_dec,
                 },
                 "scsi-hd": {
                     "discard_granularity": self._str_to_dec,
@@ -180,6 +179,13 @@ class _QDeviceFormatManagement(object):
                     #   In fact: The "guest-cid" is accepted by function
                     #   _str_to_dec instead of function _hex_in_str_to_dec.
                     "guest-cid": self._str_to_dec,
+                },
+                "virtio-rng-pci": {
+                    #   About "max-bytes" in qemu output:
+                    #       max-bytes=<uint64>     -  (default: 9223372036854775807)
+                    #   In fact: The "max-bytes" is accepted by function
+                    #   _str_to_dec instead of function _hex_in_str_to_dec.
+                    "max-bytes": self._str_to_dec,
                 },
             }
         }


### PR DESCRIPTION
- Set "max-bytes" type to int32.

ID: 3739