### PR TITLE
qdevice_format: change value of "usb-storage", "usb-tablet"

### DIFF
--- a/virttest/qemu_devices/qdevice_format.py
+++ b/virttest/qemu_devices/qdevice_format.py
@@ -187,6 +187,14 @@ class _QDeviceFormatManagement(object):
                     #   _str_to_dec instead of function _hex_in_str_to_dec.
                     "max-bytes": self._str_to_dec,
                 },
+                "usb-storage": {
+                    # In fact: qemu wants "on" instead of "NO_EQUAL_STRING".
+                    "serial": self._on,
+                },
+                "usb-tablet": {
+                    # In fact: qemu wants "on" instead of "NO_EQUAL_STRING".
+                    "serial": self._on,
+                },
             }
         }
         self._type_func_mapping = {


### PR DESCRIPTION
For usb-storage and usb-tablet,
the "serial" value is "NO_EQUAL_STRING" now.
However, qemu wants "on" instead of "NO_EQUAL_STRING".
Meanwhile, the "port" type is int now.
However, qemu wants string type instead of int type.

ID: 3798