### PR TITLE
Remove virt-manager as dependence when bootstraping virttools

### DIFF
--- a/virttest/bootstrap.py
+++ b/virttest/bootstrap.py
@@ -44,7 +44,7 @@ mandatory_programs = {
     "v2v": basic_program_requirements,
     "libguestfs": basic_program_requirements,
     "virttools": basic_program_requirements
-    + ["virt-install", "virt-clone", "virt-manager", "virt-xml"],
+    + ["virt-install", "virt-clone", "virt-xml"],
 }
 
 mandatory_headers = {


### PR DESCRIPTION
Remove virt-manager as dependence when bootstraping virttools
virt-manager is UI version of virt-install, and virt-tools test cases doesn't really use it