### PR TITLE
utils_misc:add ID_SCSI_SERIAL into get_linux_drive_path search field

### DIFF
--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -2770,7 +2770,10 @@ def get_linux_drive_path(session, did, timeout=120):
     if status != 0:
         LOG.error("Can not get drive information:\n%s" % output)
         return ""
-    p = r"DEVNAME=([^\s]+)\s.*(?:ID_SERIAL|ID_SERIAL_SHORT|ID_WWN)=%s" % did
+    p = (
+        r"DEVNAME=([^\s]+)\s.*(?:ID_SERIAL|ID_SERIAL_SHORT|ID_SCSI_SERIAL|ID_WWN)=%s"
+        % did
+    )
     dev = re.search(p, output, re.M)
     if dev:
         return dev.groups()[0]


### PR DESCRIPTION
The serial and device can be set both on scsi-hd.

-device '{"driver": "scsi-hd", ..., "serial": "stg5_serial", "device_id": "stg5_device"}' \

The device_id is mapped to ID_SERIAL
The serial is mapped to ID_SCSI_SERIAL in the udevadm info output

Currently we miss ID_SCSI_SERIAL in the search field. It will fail if we want to find a disk by serial instead of device_id