### PR TITLE
utils_net:Fix index error when trying to get defaut gateway

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4114,7 +4114,7 @@ def get_default_gateway_json(
         default_route_list = [
             x
             for x in default_route_list
-            if x.get("metric")
+            if x.get("metric", float("inf"))
             == min([y.get("metric", float("inf")) for y in default_route_list])
         ]
 


### PR DESCRIPTION
Set default value when trying to get metrix of a gateway to avoid clearing up default_route_list which leads to IndexError