### PR TITLE
qcontainer.py: support to set iothread-vq-mapping in virtio-scsi-pci

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -324,9 +324,7 @@ class DevContainer(object):
             return True
         options = "--device %s,\\?" % device
         out = self.execute_qemu(options)
-        if re.findall("iothread-vq-mapping=<[^>]+>+", out) and (
-            not device.startswith("virtio-scsi-pci")
-        ):
+        if re.findall("iothread-vq-mapping=<[^>]+>+", out):
             self.__iothread_vq_mapping_supported_devices.add(device)
             return True
         return False


### PR DESCRIPTION
Allow setting iothread-vq-mapping in virtio-scsi-pci driver based on the qemu 10.

ID: 3513