### PR TITLE
test_setup: fix HugePageConfig

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -280,7 +280,7 @@ class TransparentHugePageConfig(object):
 
 
 class HugePageConfig(object):
-    def __init__(self, params, session):
+    def __init__(self, params, session=None):
         """
         Gets environment variable values and calculates the target number
         of huge memory pages.


### PR DESCRIPTION
b4a6f2700a97e31a0bd3e04394fa0e27ff22606e added remote capability for remote but forgot to set a default value for the new parameter.

This change fixes

```
ERROR: HugePageConfig.__init__() missing 1 required positiona
l argument: 'session'
```