### PR TITLE
libvirt_disk: Add "/sysroot" as root mountpoint

### DIFF
--- a/virttest/utils_libvirt/libvirt_disk.py
+++ b/virttest/utils_libvirt/libvirt_disk.py
@@ -92,7 +92,7 @@ def get_non_root_disk_names(session, ignore_status=False):
             else:
                 idx = idx - 1
                 continue
-        if mpoint == "/":
+        if mpoint in ["/", "/sysroot"]:
             root_mounted = True
             if is_disk:
                 root_disk = line


### PR DESCRIPTION
    libvirt_disk: Assume "/sysroot" as root mountpoint
    
    For the common images, the root mountpoint is "/". It looks like:
    vda
    ├─vda1        /boot/efi
    ├─vda2        /boot
    └─vda3
      ├─rhel-root /
      └─rhel-swap [SWAP]
    
    For the image of rhel image mode, the root mountpoint is "/sysroot".
    It looks like:
    vda
    ├─vda1
    ├─vda2 /boot/efi
    ├─vda3 /boot
    └─vda4 /sysroot
    
    Add "/sysroot" as root mountpoint for image mode.
