### PR TITLE
Some device number is missing on s390x

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -3154,7 +3154,7 @@ class DevContainer(object):
                 if bus_type == "virtio-serial-device":
                     pci_bus = {"type": "virtio-bus"}
                 elif bus_type == "virtio-serial-ccw":
-                    pci_bus = None
+                    pci_bus = {"type": "virtual-css-bus"}
                 else:
                     pci_bus = {"aobject": "pci.0"}
                 if bus != "<new>":

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -1068,7 +1068,7 @@ class VM(virt_vm.BaseVM):
             machine_type = self.params.get("machine_type", "pc")
             if "s390" in machine_type:
                 dev_type = "virtio-rng-ccw"
-                parent_bus = None
+                parent_bus = {"type": "virtual-css-bus"}
             if devices.has_device(dev_type):
                 rng_pci = QDevice(dev_type, parent_bus=parent_bus)
                 set_dev_params(rng_pci, rng_params, None, "virtio-rng")
@@ -2837,7 +2837,11 @@ class VM(virt_vm.BaseVM):
                 if "-mmio:" in params.get("machine_type"):
                     dev_vsock = QDevice("vhost-vsock-device", vsock_params)
                 elif params.get("machine_type").startswith("s390"):
-                    dev_vsock = QDevice("vhost-vsock-ccw", vsock_params)
+                    dev_vsock = QDevice(
+                        "vhost-vsock-ccw",
+                        vsock_params,
+                        parent_bus={"type": "virtual-css-bus"},
+                    )
                 else:
                     dev_vsock = QDevice(
                         "vhost-vsock-pci", vsock_params, parent_bus=pci_bus


### PR DESCRIPTION
Genaral: Adding the missing devno for virtio-serial-ccw, vhost-vsock-
ccw and virtio-rng-ccw on s390x

ID: 4038

Signed-off-by: bfu <bfu@redhat.com>