### PR TITLE
docs: add CI, Cirrus, black, DeepWiki and PyPI badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,12 @@ Getting started with Avocado-VT
 ===============================
 
 The recommended way of installing Avocado-VT is through RPM packages.
-Documentation on how to install it can be found at:
+Documentation on how to install it can be found on `Read the Docs <http://avocado-vt.readthedocs.org/en/latest/GetStartedGuide.html>`__.
 
-http://avocado-vt.readthedocs.org/en/latest/GetStartedGuide.html
+For a more interactive and auto-updating experience, you can also refer to
+the `Avocado-VT DeepWiki page <https://deepwiki.com/avocado-framework/avocado-vt>`__,
+which provides a different way to browse and search the project's
+documentation.
 
 AI-Generated code policy
 ========================

--- a/README.rst
+++ b/README.rst
@@ -31,9 +31,7 @@ Getting started with Avocado
 =============================
 
 First of all, make sure you have Avocado itself installed. You can check
-the Avocado online documentation at:
-
-https://avocado-framework.readthedocs.io/en/latest/guides/user/chapters/installing.html
+the `Avocado online documentation <https://avocado-framework.readthedocs.io/en/latest/guides/user/chapters/installing.html>`__.
 
 Getting started with Avocado-VT
 ===============================
@@ -49,7 +47,4 @@ documentation.
 AI-Generated code policy
 ========================
 The Avocado-vt project allows the use of AI-generated code, but it has to follow
-the guidelines and requirements outlined in the Policy for AI-Generated Code
-which can be found at:
-
-https://avocado-framework.readthedocs.io/en/latest/guides/contributor/chapters/ai_policy.html
+the guidelines and requirements outlined in the `Policy for AI-Generated Code <https://avocado-framework.readthedocs.io/en/latest/guides/contributor/chapters/ai_policy.html>`__

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,21 @@
+.. |black| image:: https://img.shields.io/badge/black-000000.svg?logo=black&label=code%20style
+   :target: https://github.com/psf/black
+   :alt: Black
+
+.. |ci| image:: https://img.shields.io/github/actions/workflow/status/avocado-framework/avocado-vt/ci.yml?logo=githubactions&label=ci
+   :target: https://github.com/avocado-framework/avocado-vt/actions/workflows/ci.yml
+   :alt: Avocado-vt CI
+
+.. |cirrus| image:: https://img.shields.io/cirrus/github/avocado-framework/avocado-vt?logo=cirrusci&label=Cirrus
+   :target: https://cirrus-ci.com/github/avocado-framework/avocado-vt
+   :alt: Cirrus CI
+
+.. |pypi-version| image:: https://img.shields.io/pypi/v/avocado-framework-plugin-vt?logo=pypi&label=Pypi
+   :target: https://pypi.org/project/avocado-framework-plugin-vt
+   :alt: PyPI - Version
+
+|ci| |cirrus| |black| |pypi-version|
+
 Avocado VT Plugin
 =================
 
@@ -5,7 +23,7 @@ Avocado-VT is a compatibility plugin that lets you execute virtualization
 related tests (then known as virt-test), with all conveniences provided by
 Avocado.
 
-Gettings started with Avocado
+Getting started with Avocado
 =============================
 
 First of all, make sure you have Avocado itself installed. You can check

--- a/README.rst
+++ b/README.rst
@@ -10,11 +10,15 @@
    :target: https://cirrus-ci.com/github/avocado-framework/avocado-vt
    :alt: Cirrus CI
 
+.. |deepwiki| image:: https://deepwiki.com/badge.svg
+   :target: https://deepwiki.com/avocado-framework/avocado-vt
+   :alt: DeepWiki
+
 .. |pypi-version| image:: https://img.shields.io/pypi/v/avocado-framework-plugin-vt?logo=pypi&label=Pypi
    :target: https://pypi.org/project/avocado-framework-plugin-vt
    :alt: PyPI - Version
 
-|ci| |cirrus| |black| |pypi-version|
+|ci| |cirrus| |black| |deepwiki| |pypi-version|
 
 Avocado VT Plugin
 =================

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -166,6 +166,7 @@ Now let's run a virt test::
 If you have trouble executing the steps provided in this guide, you have a few
 options:
 
+* For in-depth information, or to ask questions, please consult the `deepwiki <https://deepwiki.com/avocado-framework/avocado-vt>`__.
 * Send an e-mail to `the avocado mailing list <https://www.redhat.com/mailman/listinfo/avocado-devel>`__.
 * Open an issue on `the avocado-vt github area <https://github.com/avocado-framework/avocado-vt/issues/new>`__.
 * We also hang out on `IRC (irc.oftc.net, #avocado) <irc://irc.oftc.net/#avocado>`__.

--- a/docs/source/contributing/Guidelines.rst
+++ b/docs/source/contributing/Guidelines.rst
@@ -5,7 +5,11 @@ Contributions Guidelines and Tips
 Code
 ====
 
-Contributions of additional tests and code are always welcome. If in
+Contributions of additional tests and code are always welcome.
+
+For more in-depth technical information, please refer to the `DeepWiki <https://deepwiki.com/avocado-framework/avocado-vt>`__.
+
+If in
 doubt, and/or for advice on approaching a particular problem, please
 contact the projects members (see section _collaboration) Before submitting code,
 please review the `git repository configuration guidelines <https://autotest.readthedocs.io/en/latest/main/developer/GitWorkflow.html>`_.


### PR DESCRIPTION
This commit adds badges for the GitHub Actions CI, Cirrus CI, black code
style and the PyPI version to the README file. It also fixes a typo.

Adding the DeepWiki badge to the README file enables the auto-refresh
feature for the project's documentation on DeepWiki. This ensures that
the documentation stays up-to-date with the latest changes in the
repository.

Closes #4145
ID: 4151
Signed-off-by: Yihuang Yu <yihyu@redhat.com>