### PR TITLE
Add nfs4 type to nfs umount

### DIFF
--- a/virttest/nfs.py
+++ b/virttest/nfs.py
@@ -230,7 +230,7 @@ class Nfs(object):
         """
         Umount the given mount point.
         """
-        return utils_misc.umount(self.mount_src, self.mount_dir, "nfs")
+        return utils_misc.umount(self.mount_src, self.mount_dir, "nfs,nfs4")
 
     def setup(self):
         """


### PR DESCRIPTION
Since https://github.com/avocado-framework/avocado-vt/pull/4098, using findmnt to find mount points. It is file type sensitive, so add nfs4 to support nfs4 type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unmount operation to support both NFS and NFSv4 protocols, enhancing compatibility during unmounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->