### PR TITLE
update the way of getting the release number of a package

### DIFF
--- a/virttest/utils_v2v.py
+++ b/virttest/utils_v2v.py
@@ -1857,11 +1857,12 @@ def compare_version(interval, version=None, cmd=None):
     """
     if not version:
         if not cmd:
-            cmd = "rpm -q --qf '%{RPMTAG_VERSION}-%{RPMTAG_RELEASE}\n' virt-v2v"
+            cmd = "rpm -q --qf '%{RPMTAG_VERSION} %{RPMTAG_RELEASE}\n' virt-v2v"
         res = process.run(cmd, shell=True, ignore_status=True)
         if res.exit_status != 0:
             return False
-        version = res.stdout_text.rsplit(".", maxsplit=1)[0]
+        v, r = res.stdout_text.split()
+        version = "-".join((v, r.split(".")[0]))
 
     return check_version(version, interval)
 
@@ -1889,7 +1890,7 @@ def multiple_versions_compare(interval):
 
         pkg_name = re.search(re_pkg_name, ver).group(1)
         _ver_i = re.sub(pkg_name + "-", "", ver_i)
-        cmd = 'rpm -q --qf "%{{RPMTAG_VERSION}}-%{{RPMTAG_RELEASE}}\\n" {}'.format(
+        cmd = 'rpm -q --qf "%{{RPMTAG_VERSION}} %{{RPMTAG_RELEASE}}\\n" {}'.format(
             pkg_name
         )
         if not compare_version(_ver_i, cmd=cmd):


### PR DESCRIPTION
The previous way will fail when it's like "1.56.0-1.el10.1". Now we only get the release number before the first '.' and ignore other information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in extracting and comparing package version information for virt-v2v and related packages, ensuring more reliable version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->