### PR TITLE
fix: correct indentation in Stress class uninstall method

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -2567,10 +2567,10 @@ class Stress(object):
                 if mgr.is_installed(self.stress_package):
                     return
 
-            install_path = os.path.join(self.dst_path, self.base_name)
-            if self.cmd_status("cd %s" % install_path) != 0:
-                LOG.error("No source files found in path %s", path)
-                return
+        install_path = os.path.join(self.dst_path, self.base_name)
+        if self.cmd_status("cd %s" % install_path) != 0:
+            LOG.error("No source files found in path %s", install_path)
+            return
 
         LOG.info("Uninstall %s", self.stress_type)
         status, output = self.cmd_status_output(self.uninstall_cmds)


### PR DESCRIPTION
Fix indentation of install_path logic in virttest/utils_test/__init__.py that was incorrectly nested inside the package manager check.

ID: 4194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic to improve code readability and maintainability. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->