### PR TITLE
libvirt_memory: add timeout

### DIFF
--- a/virttest/utils_libvirt/libvirt_memory.py
+++ b/virttest/utils_libvirt/libvirt_memory.py
@@ -71,13 +71,14 @@ def normalize_mem_size(mem_size, mem_unit):
     return int(mem_size * 1024**mem_unit_idx)
 
 
-def consume_vm_freememory(vm_session, remain_mem=100000, repeat_times=1):
+def consume_vm_freememory(vm_session, remain_mem=100000, repeat_times=1, timeout=360):
     """
     Verify the free memory of the vm can be consumed normally
 
     :param vm_session: vm session
     :param remain_mem: remained memory value without allocation, default 100000
     :param repeat_times: consume memory times, default 1
+    :param timeout: wait for time (seconds) for the command
     """
     vm_session.cmd_status("swapoff -a")
     free_mem = utils_memory.freememtotal(vm_session)
@@ -86,5 +87,5 @@ def consume_vm_freememory(vm_session, remain_mem=100000, repeat_times=1):
             "Fail to install package 'numactl' which provides command 'memhog'"
         )
     cmd = "memhog -r%d %dk" % (repeat_times, (free_mem - remain_mem))
-    status, stdout = vm_session.cmd_status_output(cmd, timeout=60)
+    status, stdout = vm_session.cmd_status_output(cmd, timeout=timeout)
     return (status, stdout)


### PR DESCRIPTION
When vm has bigger memory, the memhog command needs more time to consume.

Signed-off-by: Dan Zheng <dzheng@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional timeout setting for memory consumption operations in virtual machines, allowing users to customize the duration of these tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->