### PR TITLE
docs/contributions: fix link to guidelines

### DIFF
--- a/docs/source/contributing/Guidelines.rst
+++ b/docs/source/contributing/Guidelines.rst
@@ -82,7 +82,7 @@ Rules for Contributors
 ======================
 
 1. [Must] Coding style should conform to what's enforced by black (see ``./avocado-static-checks/check-style``)
-2. [Must] PR commit message is meaningful. Refer to the link on how to write a good commit message
+2. [Must] PR commit message is meaningful. Refer to `this link <https://avocado-framework.readthedocs.io/en/latest/guides/contributor/chapters/styleguides.html>`_ on how to write a good commit message
 3. [Must] Travis CI pass and no conflict
 4. [Must] Provide test results. If no, provide justification. Apply to any PR
   One of below options should be aligned:


### PR DESCRIPTION
A link was mentioned but no target set. The avocado main project's
style guides are a suitable reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines: Rule 2 now replaces a vague reference with a direct hyperlink labeled "this link" to the commit-message/style guide, making guidance on writing good commit messages immediately accessible and clearer for contributors. This improves onboarding and ensures more consistent commit message quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->