### PR TITLE
virttest/utils_netperf: fix spelling errors

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -1164,6 +1164,7 @@ guestmount
 gz
 handlings
 hardcode
+hardcoded
 Hardcode
 harddrives
 Hariharan

--- a/virttest/utils_netperf.py
+++ b/virttest/utils_netperf.py
@@ -190,7 +190,7 @@ class NetperfPackage(remote_old.Remote_Package):
         Modify the value from the source code previous to compilation to the
         desired value.
         """
-        # Obtain host/guest/vm/target netperf running sytem's number of CPUs
+        # Obtain host/guest/vm/target netperf running system's number of CPUs
         try:
             n_cpus = int(
                 self.session.cmd_output('lscpu | grep -oP "^CPU\(s\)\: *\K[0-9]+"')


### PR DESCRIPTION
4ce1c76f3f5ee55d0e038fa957ddc6fc1c722637 included bad spelling.

Fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a comment to correct a typo for improved clarity.
  * Added "hardcoded" to the list of ignored words for spell checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->