### PR TITLE
utils_disk: Add a default mount option

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -1112,7 +1112,12 @@ def configure_empty_linux_disk(
         mount_dst = "/mnt/" + new_partition
         session.cmd("rm -rf %s; mkdir %s" % (mount_dst, mount_dst))
         if not mount(
-            "/dev/%s" % new_partition, mount_dst, fstype=fstype, session=session
+            "/dev/%s" % new_partition,
+            mount_dst,
+            fstype=fstype,
+            session=session,
+            options="rw",
+            verbose=True,
         ):
             err_msg = "Failed to mount partition '%s'"
             raise exceptions.TestError(err_msg % new_partition)


### PR DESCRIPTION
In mount(), if there are no mount option, is_mount() will always return True. So add a default mount option.

Before:
[stdlog] 2025-08-10 11:30:45,881 aexpect.client client           L1412 DEBUG| Sending command (safe): findmnt -J -S /dev/sda1 -M /mnt/sda1 -t ext4 -O
[stdlog] 2025-08-10 11:30:45,986 avocado.virttest.utils_disk utils_disk       L0094 INFO | Output of findmnt: findmnt: option requires an argument -- 'O'
[stdlog] Try 'findmnt --help' for more information.
[stdlog] 2025-08-10 11:30:45,986 avocado.virttest.utils_disk utils_disk       L0100 INFO | /dev/sda1 is mounted
[stdlog] 2025-08-10 11:30:45,986 aexpect.client client           L1412 DEBUG| Sending command (safe): mount -t ext4 -o remount, /dev/sda1 /mnt/sda1
[stdlog] 2025-08-10 11:30:46,091 aexpect.client client           L1412 DEBUG| Sending command (safe): echo $?

After:
[stdlog] 2025-08-10 12:07:27,419 aexpect.client client           L1412 DEBUG| Sending command (safe): findmnt -J -S /dev/sda1 -M /mnt/sda1 -t ext4 -O rw
[stdlog] 2025-08-10 12:07:27,524 avocado.virttest.utils_disk utils_disk       L0094 INFO | Output of findmnt:
[stdlog] 2025-08-10 12:07:27,524 avocado.virttest.utils_disk utils_disk       L0103 INFO | /dev/sda1 is not mounted
[stdlog] 2025-08-10 12:07:27,524 aexpect.client client           L1412 DEBUG| Sending command (safe): mount -t ext4 -o rw /dev/sda1 /mnt/sda1


 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_retain_sparsity.disk_num_1.dest1_qcow2.src1_qcow2.copy_storage_all: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_retain_sparsity.disk_num_1.dest1_qcow2.src1_qcow2.copy_storage_all: PASS (213.17 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved disk mounting process by explicitly setting read-write options and enabling verbose logging for better clarity during operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->