### PR TITLE
unattended_install: Add viosock driver path

### DIFF
--- a/virttest/tests/unattended_install.py
+++ b/virttest/tests/unattended_install.py
@@ -206,6 +206,7 @@ class UnattendedInstallConfig(object):
             "virtio_viofs_path",
             "virtio_fwcfg_path",
             "virtio_viomem_path",
+            "virtio_viosock_path",
             "virtio_oemsetup_id",
             "virtio_network_installer_path",
             "virtio_balloon_installer_path",
@@ -623,6 +624,7 @@ class UnattendedInstallConfig(object):
                 self.virtio_viofs_path,
                 self.virtio_fwcfg_path,
                 self.virtio_viomem_path,
+                self.virtio_viosock_path,
             ]
 
             # XXX: Force to replace the drive letter which loaded the


### PR DESCRIPTION
Add viosock driver path, and replacing the virtio driver path in the autounattend xml.

ID:4050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to specify a virtio viosock driver path for unattended Windows installations.
  - The path is now read from parameters and automatically injected into the generated unattended XML when virtio is enabled, eliminating manual edits.
  - Improves consistency and reduces setup errors by ensuring the correct driver path is applied during unattended Windows setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->