### PR TITLE
Add image mode update boot option support

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -47,6 +47,7 @@ from virttest import (
     utils_misc,
     utils_net,
     utils_package,
+    utils_sys,
     virt_vm,
 )
 
@@ -208,16 +209,25 @@ def update_boot_option(
                     req_remove_args, session=session, remove_args=True
                 )
         else:
-            if not utils_package.package_install("grubby", session=session):
-                raise exceptions.TestError("Failed to install grubby package")
+            image_mode = utils_sys.is_image_mode(session=session)
+            if image_mode:
+                cmd = "rpm-ostree kargs "
+                remove_opt = "--delete-if-present="
+                add_opt = "--append-if-missing="
+            else:
+                if not utils_package.package_install("grubby", session=session):
+                    raise exceptions.TestError("Failed to install grubby package")
+                cmd = "grubby --update-kernel=`grubby --default-kernel` "
+                remove_opt = "--remove-args="
+                add_opt = "--args="
+
             msg = "Update guest kernel option. "
-            cmd = "grubby --update-kernel=`grubby --default-kernel` "
             if req_remove_args:
                 msg += " remove args: %s" % req_remove_args
-                cmd += '--remove-args="%s" ' % req_remove_args
+                cmd += '%s"%s" ' % (remove_opt, req_remove_args)
             if req_args:
                 msg += " add args: %s" % req_args
-                cmd += '--args="%s"' % req_args
+                cmd += '%s"%s"' % (add_opt, req_args)
             if req_remove_args or req_args:
                 __run_cmd_and_handle_error(
                     msg, cmd, session, "Failed to modify guest kernel option"


### PR DESCRIPTION
Add image mode cmd "rpm-ostree kargs" to update boot option.
depends on: https://github.com/avocado-framework/avocado-vt/pull/4215

Test result:
(1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.target_and_address: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.target_and_address: PASS (178.32 s)