### PR TITLE
Update for get non_root disk name in image mode

### DIFF
--- a/virttest/utils_libvirt/libvirt_disk.py
+++ b/virttest/utils_libvirt/libvirt_disk.py
@@ -92,7 +92,7 @@ def get_non_root_disk_names(session, ignore_status=False):
             else:
                 idx = idx - 1
                 continue
-        if mpoint == "/":
+        if mpoint in ("/", "/sysroot"):
             root_mounted = True
             if is_disk:
                 root_disk = line


### PR DESCRIPTION
In image mode, '/sysroot' is where the real root filesystem from the root disk is mounted.

Before:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_with_vhostvdpa.copy_storage_all.non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_with_vhostvdpa.copy_storage_all.non_p2p: ERROR: list index out of range (177.18 s)

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_with_vhostvdpa.copy_storage_all.non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_with_vhostvdpa.copy_storage_all.non_p2p: PASS (404.94 s)


In package mode:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_with_vhostvdpa.copy_storage_all.non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_with_vhostvdpa.copy_storage_all.non_p2p: PASS (366.31 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected root mount detection to also recognize “/sysroot” as the root, preventing root disks from appearing in the non-root disk list on affected systems. This improves reliability of disk selection and avoids unintended actions on the root filesystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->