### PR TITLE
utils_disk: Fix findmnt error

### DIFF
--- a/virttest/utils_disk.py
+++ b/virttest/utils_disk.py
@@ -78,7 +78,7 @@ def is_mount(src, dst=None, fstype=None, options=None, verbose=False, session=No
     """
     mount_options = [("-S", src), ("-M", dst), ("-t", fstype), ("-O", options)]
     mount_opts = " ".join(
-        f"{opt} {val}" for opt, val in mount_options if val is not None
+        f"{opt} {val}" for opt, val in mount_options if val is not None and val != ""
     )
     if mount_opts == "":
         raise exceptions.TestError("Mount options is empty, it is meaningless")
@@ -95,7 +95,7 @@ def is_mount(src, dst=None, fstype=None, options=None, verbose=False, session=No
     except process.CmdError:
         pass
 
-    if mount_result:
+    if mount_result is not None and mount_result != "":
         if verbose:
             LOG.info("%s is mounted", src)
         return True


### PR DESCRIPTION
Before the fix, findmnt will succeed even if the device is not mounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount detection reliability by explicitly handling empty and None responses.
  * Prevented empty mount options from being generated, avoiding invalid command flags and potential errors.
  * Reduces false negatives when checking whether a path is mounted.
  * More stable behavior in environments with missing or empty configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->