### PR TITLE
chore: drop netifaces dependency

### DIFF
--- a/avocado-plugins-vt.spec
+++ b/avocado-plugins-vt.spec
@@ -69,7 +69,6 @@ Xunit output, among others.
 %package -n python3-%{name}
 Summary: %{summary}
 Requires: python3, python3-avocado >= 51.0, python3-aexpect
-Requires: python3-netifaces
 %{?python_provide:%python_provide python3-%{srcname}}
 %description -n python3-%{name}
 Avocado Virt Test is a plugin that lets you execute virt-tests

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -3,7 +3,6 @@ Sphinx==1.3b1
 pylint==3.0.0
 inspektor==0.5.3
 aexpect>=1.6.4
-netifaces==0.11.0
 pyenchant==3.2.2
 black==24.3.0
 isort==5.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ autotest>=0.16.2; python_version < '3.0'
 aexpect>=1.6.4;python_version >= '3.0'
 aexpect>1.5.0; python_version < '3.0'
 zipp<=1.2.0; python_version < '3.0'
-netifaces>=0.10.5

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ if __name__ == "__main__":
             ],
         },
         install_requires=[
-            "netifaces",
             "packaging",
             "six",
             "aexpect",

--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -1137,7 +1137,7 @@ class AvocadoGuest(object):
             if self.session.cmd_status(cmd, timeout=self.timeout) != 0:
                 LOG.error("Failed to restart libvirtd inside guest")
                 return False
-            pip_pack = ["setuptools", "netifaces", "aexpect"]
+            pip_pack = ["setuptools", "aexpect"]
             cmd = ""
             for each in pip_pack:
                 cmd = "%s install %s --upgrade" % (self.pip_bin, each)


### PR DESCRIPTION
Remove netifaces package dependency, replace with native implementation.
- Remove netifaces from requirements.txt and setup.py
- Replace netifaces.ifaddresses() with get_net_if_addrs() in utils_net.py
- Maintain same functionality while reducing external dependencies

Ref: https://pypi.org/project/netifaces/ - netifaces needs a new maintainer and is no longer actively maintained due to work commitments.

ID: 4340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling when no IP address is configured on an interface, reducing unexpected errors.

* **Refactor**
  * Internal networking logic rewritten to remove reliance on an external helper library while preserving behavior.

* **Chores**
  * Removed an optional system-level dependency from install/test requirements and installer metadata, reducing install footprint and improving compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->