### PR TITLE
Drop confusing legacy image_boot parameter with unwanted effects

### DIFF
--- a/selftests/unit/unittest_data/testcfg.huge/guest-hw.cfg
+++ b/selftests/unit/unittest_data/testcfg.huge/guest-hw.cfg
@@ -62,9 +62,6 @@ variants:
         drive_format=scsi
     - virtio_blk:
         drive_format=virtio
-        # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
-        # then kvm_vm will ignore this option.
-        image_boot=yes
     - virtio_scsi:
         # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,
         # scsi-generic

--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -83,9 +83,6 @@ variants:
             cd_format=ide
         q35:
             cd_format=ahci
-        # Add -drive ...boot=yes unless qemu-kvm is 0.12.1.2 or newer
-        # then kvm_vm will ignore this option.
-        image_boot~=yes
     - virtio_scsi:
         no WinXP
         # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,


### PR DESCRIPTION
As argued in

https://github.com/avocado-framework/avocado-vt/issues/4040

the LlazySet operator will set image_boot=yes by default for all VirtIO cases that rely on the legacy -drive options via

qemu_force_use_drive_expression = yes

and used to be commented out before for safety then was uncommented in 68a6450c8dcabe17a35809bfbc35cfb8fae724e4 and converted to lazy set operators in a2cc3a4cc74d99d60b88e5e25e594f8268e3376f. Let's make this behavior optional for VirtIO users that want to change the boot order via "boot_order" and "boot_once" parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted virtio-blk boot behavior to no longer force boot-from-image, aligning with default environment settings and preventing unintended boot selection.

* **Chores**
  * Removed redundant configuration flags and related comments to simplify settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->