### PR TITLE
utils_test: updated check if stress is already installed on host

### DIFF
--- a/virttest/utils_test/__init__.py
+++ b/virttest/utils_test/__init__.py
@@ -35,7 +35,15 @@ import time
 import aexpect
 from aexpect import remote
 from avocado.core import exceptions
-from avocado.utils import archive, aurl, crypto, download, path, process
+from avocado.utils import (
+    archive,
+    aurl,
+    crypto,
+    download,
+    path,
+    process,
+    software_manager,
+)
 from six.moves import xrange
 
 # Import from the top level virttest namespace
@@ -2515,8 +2523,13 @@ class Stress(object):
                     "Installing dependency packages for" " %s failed" % self.stress_type
                 )
         if self.stress_package:
-            mgr = utils_package.package_manager(self.session, self.stress_package)
-            if mgr.is_installed(self.stress_package):
+            if self.session:
+                mgr = utils_package.package_manager(self.session, self.stress_package)
+                stress_installed = mgr.is_installed(self.stress_package)
+            else:
+                mgr = software_manager.manager.SoftwareManager()
+                stress_installed = mgr.check_installed(self.stress_package)
+            if stress_installed:
                 return
             elif self.stress_install_from_repo:
                 # Install the stress package from existing repos


### PR DESCRIPTION
Update: Will be fixed by https://github.com/avocado-framework/avocado-vt/pull/4208 instead.

The current implementation that uses is_installed() does not work on the host, only on the guest (is_installed() is only implemented for RemotePackageMgr(session, pkg), not LocalPackageMgr(pkg)). Therefore, updated the implementation such that, if the session is None, to use check_installed() instead.

Before change:
```
(.libvirt-ci-venv-ci-runtest-tZ4ye3) bash-5.2# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio multi_vms_with_stress --job-timeout 1200 --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: ERROR: 'DnfBackend' object has no attribute 'is_installed' (13.07 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
After change:
```
(.libvirt-ci-venv-ci-runtest-tZ4ye3) bash-5.2# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio multi_vms_with_stress --job-timeout 1200 --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (137.97 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents test failures when no remote session is available by performing host-side package checks.
  * Detects existing stress tools correctly to avoid redundant installations.

* **New Features**
  * Adds automatic fallback to local package verification when session-based checks are unavailable, improving reliability across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->