### PR TITLE
libvirt_disk: add "/sysroot" as root mountpoint (#4161)

### DIFF
--- a/virttest/utils_libvirt/libvirt_disk.py
+++ b/virttest/utils_libvirt/libvirt_disk.py
@@ -92,7 +92,7 @@ def get_non_root_disk_names(session, ignore_status=False):
             else:
                 idx = idx - 1
                 continue
-        if mpoint == "/":
+        if mpoint in ["/", "/sysroot"]:
             root_mounted = True
             if is_disk:
                 root_disk = line


### PR DESCRIPTION
Submit this PR after fixing the author / signed-off check that failed in original submission - https://github.com/avocado-framework/avocado-vt/actions/runs/17374764561/job/49318517347

The original PR https://github.com/avocado-framework/avocado-vt/pull/4161 was already approved and ready for merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root filesystem detection to also recognize systems where the root is mounted at “/sysroot,” ensuring accurate identification of non-root disks.
  * Reduces misclassification and related errors during disk operations on affected systems.
  * Enhances reliability and compatibility across environments without requiring configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->