### PR TITLE
libvirt_service: Fix AttributeError

### DIFF
--- a/virttest/utils_libvirt/libvirt_service.py
+++ b/virttest/utils_libvirt/libvirt_service.py
@@ -76,7 +76,7 @@ def control_service(params):
     if service_operations == "restart":
         control_service.restart()
     elif service_operations == "stop":
-        if service.status():
+        if control_service.status():
             control_service.stop()
 
 


### PR DESCRIPTION
The correct API is control_service.status(), update the code accordingly.

Before:
AttributeError: module 'virttest.staging.service' has no attribute 'status'

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_src_virtqemud.with_precopy.p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_src_virtqemud.with_precopy.p2p: PASS (245.81 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved service stop reliability by checking the specific service instance's status before stopping, reducing cases where a stop might be skipped due to an incorrect status.
- Chores
  - No changes to public interfaces; restart behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->