### PR TITLE
vm_xml: Add the missing slot of hyperv to class VMFeaturesXML

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -3837,6 +3837,7 @@ class VMFeaturesXML(base.LibvirtXMLBase):
         "smm",
         "hpt",
         "htm",
+        "hyperv",
         "smm_tseg_unit",
         "smm_tseg",
         "nested_hv",


### PR DESCRIPTION
We need the slot to setup hyperv-related values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposes a Hyper-V feature on virtual machine feature settings, enabling users to read and configure Hyper-V-related options in VM definitions.
  * Improves interoperability for environments that rely on Hyper-V features, without impacting existing configurations unless the new option is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->