### PR TITLE
env_process: allow creating the dir while it exists

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -182,7 +182,7 @@ def preprocess_fs_source(test, params, fs_name, vm_process_status=None):
                 if os.path.exists(fs_source):
                     shutil.rmtree(fs_source, ignore_errors=True)
                 LOG.info("Create filesystem source %s." % fs_source)
-                os.makedirs(fs_source)
+                os.makedirs(fs_source, exist_ok=True)
     else:
         test.cancel('Unsupport the type of filesystem "%s"' % fs_type)
 


### PR DESCRIPTION
set exist_ok=True for os.makedirs function

ID: 3442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Setup now tolerates pre-existing directories for mounted filesystem sources, preventing unnecessary errors during environment preparation.
  * Avoids failures when the target directory already exists, improving reliability of repeated runs.
  * Reduces manual cleanup and reruns by making directory creation idempotent.
  * Improves stability for repeated and concurrent workflows while preserving existing error handling in other scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->