### PR TITLE
libvirt_xml/../interface: add loadparm attribute

### DIFF
--- a/virttest/libvirt_xml/devices/interface.py
+++ b/virttest/libvirt_xml/devices/interface.py
@@ -24,6 +24,7 @@ class Interface(base.TypedDeviceBase):
         "driver",
         "address",
         "boot",
+        "loadparm",
         "rom",
         "mtu",
         "filterref",
@@ -120,6 +121,14 @@ class Interface(base.TypedDeviceBase):
             parent_xpath="/",
             tag_name="boot",
             attribute="order",
+        )
+        accessors.XMLAttribute(
+            property_name="loadparm",
+            libvirtxml=self,
+            forbidden=None,
+            parent_xpath="/",
+            tag_name="boot",
+            attribute="loadparm",
         )
         accessors.XMLElementNest(
             "bandwidth",


### PR DESCRIPTION
Libvirt supports loadparm attribute on s390x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the loadparm setting on network interface boot configuration.
  * You can now set and read the interface boot load parameter directly via the Interface object.
  * Enhances compatibility with libvirt interface boot options, enabling more precise boot customization.
  * No other behavior changes; existing boot order and interface functionality remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->