### PR TITLE
Fix SEV policy

### DIFF
--- a/virttest/qemu_devices/qcontainer.py
+++ b/virttest/qemu_devices/qcontainer.py
@@ -3983,8 +3983,8 @@ class DevContainer(object):
             sev_common_props = {
                 # FIXME: Set the following two properties from sev capabilities
                 # if they are not set yet
-                "cbitpos": int(params["vm_sev_cbitpos"]),
-                "reduced-phys-bits": int(params["vm_sev_reduced_phys_bits"]),
+                "cbitpos": params["vm_sev_cbitpos"],
+                "reduced-phys-bits": params["vm_sev_reduced_phys_bits"],
             }
 
             if params.get("vm_sev_kernel_hashes"):
@@ -4010,8 +4010,8 @@ class DevContainer(object):
 
             sev_obj_props.update(_gen_sev_common_props(params))
 
-            # Set policy=3 if vm_sev_policy is not set
-            sev_obj_props["policy"] = int(params.get("vm_sev_policy", 3))
+            # Set policy=0x3 if vm_sev_policy is not set
+            sev_obj_props["policy"] = params.get("vm_sev_policy", "0x3")
 
             # FIXME: If these files are host dependent, we have to find
             # another way to set them, because different files are needed

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -1120,9 +1120,9 @@ uuid_dimm = ""
 #
 # Note: In order to keep consistent with the original specific sev params, properties
 #       defined by this param can be overwriten by the original ones, e.g.
-#         vm_sev_policy = 3
-#         vm_secure_guest_object_options = "policy=7"
-#       Finally the sev policy is 3.
+#         vm_sev_policy = 0x3
+#         vm_secure_guest_object_options = "policy=0x7"
+#       Finally the sev policy is 0x3.
 #
 # AMD SEV secure guest params
 #
@@ -1133,11 +1133,11 @@ uuid_dimm = ""
 # Set the sev device, or specify per-vm values  (optional)
 #vm_sev_device[_vm1] = /dev/sev
 # Set the policy, or specify per-vm values (optional)
-#vm_sev_policy[_vm1] = 7
-# Note: VT can set a default value 3 if vm_sev_policy is not set,
+#vm_sev_policy[_vm1] = 0x7
+# Note: VT can set a default value 0x3 if vm_sev_policy is not set,
 #       If SEV-ES is required, please make sure bit 2 is set, e.g.
-#       A SEV guest: vm_sev_policy[_vm1] = 3
-#       A SEV-ES guest: vm_sev_policy[_vm1] = 7
+#       A SEV guest: vm_sev_policy[_vm1] = 0x3
+#       A SEV-ES guest: vm_sev_policy[_vm1] = 0x7
 # Set the kernel-hashes, or specify per-vm values (optional)
 #vm_sev_kernel_hashes[_vm1] = on/off
 # Set the dh-cert file, or specify per-vm values (optional)


### PR DESCRIPTION
ID: 4567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SEV properties now preserve provided values without forced integer casting, improving compatibility with hex-formatted inputs.
  * Default SEV policy updated to "0x3" for consistent hex representation when no policy is specified.

* **Documentation**
  * Configuration comments and examples updated to use hex values for SEV policies (e.g., 0x3 for SEV, 0x7 for SEV-ES).
  * Clarified default policy representations and example settings in configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->