### PR TITLE
virt_vm: Add recreate_serial_console parameter to wait_for_serial_login

### DIFF
--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -1488,6 +1488,7 @@ class BaseVM(object):
         password=None,
         virtio=False,
         status_check=True,
+        recreate_serial_console=False,
     ):
         """
         Make multiple attempts to log into the guest via serial console.
@@ -1499,8 +1500,15 @@ class BaseVM(object):
         :param status_check: Whether to call verify_alive to detect bad
             VM state early. Disable this when VM status might be unreliable,
             eg. during reboot or pause)
+        :param recreate_serial_console: Whether to cleanup and recreate the
+            serial console before attempting login. Useful after VM state
+            changes (reboot, migration, restore, etc.). Default is False
+            for backward compatibility.
         :return: ConsoleSession instance.
         """
+        if recreate_serial_console:
+            self.cleanup_serial_console()
+            self.create_serial_console()
         LOG.debug(
             "Attempting to log into '%s' via serial console " "(timeout %ds)",
             self.name,


### PR DESCRIPTION
Add optional 'recreate_serial_console' parameter (default False) to the wait_for_serial_login() method. When set to True, it will call cleanup_serial_console() and create_serial_console() before attempting to login via serial console.

This eliminates a duplicated code pattern where tests need to manually call cleanup_serial_console() and create_serial_console() before wait_for_serial_login() after VM state changes such as:
- VM reboot or reset
- Migration (when connecting to remote host)
- Restore from save/snapshot
- Suspend/resume operations
- Any operation that invalidates the existing console connection

The parameter name 'recreate_serial_console' clearly describes the action performed (cleanup + create)
**Fully backward compatible** - The parameter defaults to `False`, so all existing code continues to work without modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional flag to recreate the serial console before attempting serial login. This can improve reliability in environments with unstable consoles. Disabled by default; enable as needed.

* **Documentation**
  * Updated parameter documentation to explain the new serial console recreation option and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->