### PR TITLE
utils_net: revert PR#4002 critical regression

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -31,7 +31,6 @@ from virttest import (
     test_setup,
     utils_logfile,
     utils_misc,
-    utils_net,
     utils_package,
     utils_selinux,
     virsh,
@@ -378,17 +377,6 @@ class VM(virt_vm.BaseVM):
                 os.remove(xml_file)
             LOG.error("Failed to backup xml file:\n%s", detail)
             return ""
-
-    def _get_address(self, index=0, ip_version="ipv4", session=None, timeout=60.0):
-        try:
-            return super()._get_address(index, ip_version, session, timeout)
-        except virt_vm.VMIPAddressMissingError:
-            if ip_version == "ipv4":
-                mac = self.get_mac_address(index).lower()
-                ipaddr = utils_net.obtain_guest_ip_from_domifaddr(self.name, mac)
-                self.address_cache[mac] = ipaddr
-                return ipaddr
-            return None
 
     def clone(
         self,

--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -34,7 +34,6 @@ from virttest import (
     utils_misc,
     utils_package,
     utils_selinux,
-    virsh,
 )
 from virttest.remote import RemoteRunner
 from virttest.staging import service, utils_memory
@@ -4928,21 +4927,3 @@ def check_class_rules(ifname, rule_id, bandwidth, expect_none=False):
         stacktrace.log_exc_info(sys.exc_info())
         return False
     return True
-
-
-def obtain_guest_ip_from_domifaddr(vm_name, mac):
-    """
-    Obtaining the guest ip address from virsh domifaddr command
-    :param: Mac address of the guest
-    :return: return ip-address if found for given mac in the
-             virsh domifaddr --full --source arp, else return None
-    """
-    output = virsh.domifaddr(vm_name, "--full --source arp")
-    lines = output.stdout.splitlines()
-    for line in lines:
-        if mac in line:
-            parts = line.split()
-            for part in parts:
-                if "/" in part:
-                    return part.split("/")[0]
-    return None


### PR DESCRIPTION
This reverts commit https://github.com/avocado-framework/avocado-vt/commit/72ad9c074592082afdeea0502241368ed7b4bbe2.

PR https://github.com/avocado-framework/avocado-vt/pull/4002 causes _get_address() to return None instead of raising
VMIPAddressMissingError for non-IPv4 cases. During VM reboot, this
None value is passed to aexpect.remote_login(), which sets
output_prefix=None, causing a TypeError crash in the tail thread.

Reverting restores the original exception-based error handling,
allowing retry logic to work correctly.

Fixes: Issue with reboot_start test case failing with TypeError

Assisted-by: cursor/claude-4-sonnet
Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed the legacy fallback for guest IP discovery; address lookup now relies on primary resolution and will report clearer errors when a VM address is unavailable.

- Chores
  - Eliminated an unused networking utility and its external IP-discovery dependency, simplifying the networking stack and reducing maintenance surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->