### PR TITLE
feat: add IGVM firmware support for confidential VMs

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -2126,3 +2126,4 @@ SME
 Yihuang
 Yu
 yihyu
+igvm

--- a/virttest/qemu_capabilities.py
+++ b/virttest/qemu_capabilities.py
@@ -29,6 +29,7 @@ class Flags(object):
     SEV_GUEST = _auto_value()
     SNP_GUEST = _auto_value()
     TDX_GUEST = _auto_value()
+    IGVM_CFG = _auto_value()
     FLOPPY_DEVICE = _auto_value()
     BLOCKJOB_BACKING_MASK_PROTOCOL = _auto_value()
 

--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -1210,3 +1210,14 @@ uuid_dimm = ""
 #pr_helper_props_helper1 = {"sock_path": "/path/to/qemu-pr-helper.sock",
 #                           "pidfile": "/path/to/qemu-pr-helper.pid"}
 #
+
+# IGVM configuration
+# When enable_igvm is set to "yes", the framework will automatically use IGVM instead of OVMF
+# as the firmware. This is currently only effective on q35 machine type and requires
+# SNP (Secure Nested Paging) to be enabled.
+# TODO: Consider converting this into a firmware variant in guest-hw.cfg for better
+#       organization, especially if ARM CCA and other platforms enable coconut-svsm
+#       support in the future.
+# enable_igvm = no
+# igvm_path = /usr/share/coconut-svsm
+# igvm_filename = coconut-qemu.igvm


### PR DESCRIPTION
Add support for Independent Guest Virtual Machine (IGVM) firmware, which provides embedded EDK2 firmware for confidential computing environments using SVSM (Secure Virtual Service Module).

- Add igvm_handler() function to configure IGVM firmware
- Integrate IGVM support in machine_q35() for q35 machine type
- Add enable_igvm switch to control IGVM usage
- Add configuration options in base.cfg with sensible defaults
- Support fallback to /usr/share/coconut-svsm as default IGVM path
- Use coconut-qemu.igvm as default IGVM filename
- Add file existence validation with helpful error messages

Currently supports AMD SEV-SNP with Intel TDX support planned for the future. IGVM is only effective on q35 machine type with SNP enabled.

ID: 4602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IGVM firmware support with capability detection, conditional enablement, configurable path/filename, and graceful skip when unsupported.
* **Documentation**
  * Added commented IGVM configuration options to the default config for enablement and file settings.
* **Chores**
  * Added IGVM to spell-ignore list and exposed a new IGVM capability flag for integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->