### PR TITLE
Improved the bootloader section to support more functional scenarios

### DIFF
--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -22,6 +22,10 @@ qemu_io_binary = qemu-io
 # qemu_compat = deprecated-input=crash
 # Pass a custom bios path for debugging
 #bios_path = /path/to/coreboot.rom
+# bios_props: define the security and type settings of the bios_path's loader for uefi mode
+#bios_props = {"loader_readonly": "yes", "loader_type": "pflash", "loader_secure": "no"}
+# bios_vars_template_path: UEFI firmware variable storage file, provide for use by the nvram.template parameter in virt-install
+#bios_vars_template_path = /path/to/OVMF_VARS.fd
 
 # List of virtual machine object names (whitespace separated)
 vms = avocado-vt-vm1


### PR DESCRIPTION
1.Improved the bootloader section to support more functional scenarios.
2.There is a project need to migrate tp-qemu cases to tp-libvirt. For tp-qemu users (especially those testing Windows guests), there's a challenge in frequently installing and testing multiple different guest versions. Because tester need to test unsigned ISOs and drivers, even a driver that has just been fixed during developer. Therefore we need avocado-vt provide a unified interface to support this as libvirt method. The current patch mainly implements, if you'd like to know the install process implement please refer to avocado-vt PR 4264.

ID: LIBVIRTAT-22079
Signed-off-by: Lei Yang leiyang@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support per-option UEFI/firmware loader properties plus optional NVRAM template path when the platform tool supports them.

* **Improvements**
  * Clearer user-facing warnings when the loader or specific firmware sub-options (e.g., nvram.template) are not supported.
  * Predictable mapping of known firmware sub-options to loader property names.

* **Documentation**
  * Added inline guidance describing firmware sub-options and NVRAM template usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->