### PR TITLE
Modify the nic's sub_option parameter to be compatible with the new format

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -937,10 +937,10 @@ class VM(virt_vm.BaseVM):
                 if (
                     nettype
                     and nic_queues
-                    and has_sub_option("network", "driver_queues")
+                    and has_sub_option("network", "driver[._]queues")
                 ):
                     result += ",driver_queues=%s" % nic_queues
-                    if nic_driver and has_sub_option("network", "driver_name"):
+                    if nic_driver and has_sub_option("network", "driver[._]name"):
                         result += ",driver_name=%s" % nic_driver
                 elif mac:  # possible to specify --mac w/o --network
                     result += " --mac=%s" % mac


### PR DESCRIPTION
Because of the new version's virt-install --network help sub_option's format already from driver_queues to driver.queues, driver_queues as an alias, is still supportted by virt-install command, so modified sub_option to support both them.

ID: LIBVIRTAT-22112
Signed-off-by: Lei Yang leiyang@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of driver-related network options to recognize variant option name formats (dot or underscore).
  * Deferred compatibility validation to the underlying virtualization provider to avoid spurious errors or warnings for unavailable driver features.
  * Preserved existing behavior for applying driver parameters when network type and NIC conditions are met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->