### PR TITLE
Consolidate static checks to use avocado-static-checks submodule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+# Exclude files or directories from linting
+ignore=avocado-libs,cache_populate.py,example.py,github_issues.py,label_issues.py,pulls_applied.py,stale_pulls.py,unassigned_issues.py
+
+# Add files or directories matching the regex patterns to the blacklist
+ignore-patterns=.git
+
+[MESSAGES CONTROL]
+# Disable specific error codes from pylint command:
+# W (warning), R (refactor), C (convention), and specific codes
+disable=W,R,C,E0203,E0601,E1002,E1101,E1102,E1103,E1120,F0401,I0011,E1003,W605,I1101

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,7 @@ requirements: pip
 	- $(PYTHON) -m pip install -r requirements.txt
 
 check:
-	./avocado-static-checks/check-style
-	./avocado-static-checks/check-import-order
-	inspekt lint --disable W,R,C,E0203,E0601,E1002,E1101,E1102,E1103,E1120,F0401,I0011,E1003,W605,I1101 --exclude avocado-libs,scripts/github
+	./avocado-static-checks/run-static-checks
 	pylint --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
 
 clean:

--- a/avocado-static-checks.conf
+++ b/avocado-static-checks.conf
@@ -1,0 +1,2 @@
+[lint]
+.:.pylintrc

--- a/docs/source/WritingTests/WritingSimpleTests.rst
+++ b/docs/source/WritingTests/WritingSimpleTests.rst
@@ -205,16 +205,13 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
 
 #. Now, I deliberately introduced a bug on this code just to show you
    guys how to use some tools to find and remove trivial bugs on your
-   code. I strongly encourage you guys to check your code with the `inspektor`
-   tool. This tool uses pylint to catch bugs on test code. You can install
-   inspektor by adding the COPR repo https://copr.fedoraproject.org/coprs/lmr/Autotest/
-   and doing ::
+   code. I strongly encourage you guys to check your code with the `avocado-static-checks`
+   tool. This tool uses pylint to catch bugs on test code and other static checks.
+   It is available in the avocado-static-checks submodule. You can run it by running::
 
-    $ yum install inspektor
+        $ git submodule update --init --recursive
+        $ ./avocado-static-checks/run-static-checks
 
-   After you're done, you can run it::
-
-        $ inspekt lint generic/tests/uptime.py
         ************* Module generic.tests.uptime
         E0602: 10,4: run: Undefined variable 'logging'
         Pylint check fail: generic/tests/uptime.py
@@ -241,18 +238,22 @@ to pick up a living guest, connect to it via ssh, and return its uptime.
            logging.info("Guest uptime result is: %s", uptime)
            session.close()
 
-#. Let's re-run ``inspektor`` to see if it's happy with the code
+#. Let's run ``check-lint`` to re-run the lint checks and see if it's happy with the code
    generated::
 
-        $ inspekt lint generic/tests/uptime.py
-        Syntax check PASS
+        $ ./avocado-static-checks/check-lint
+        Found configuration file: ./avocado-static-checks/../avocado-static-checks.conf
+        ** Running pylint on directory '.' with config from '.pylintrc'...
+
+        --------------------------------------------------------------------
+        Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
 
 #. So we're good. Nice! Now, as good indentation does matter to python,
-   `inspekt indent` will fix indentation problems, and cut trailing
+   `black` will fix indentation problems, and cut trailing
    whitespaces on your code. Very nice for tidying up your test before
    submission::
 
-        $ inspekt indent generic/tests/uptime.py
+        $ black generic/tests/uptime.py
 
 #. Now, you can test your code. When listing the qemu tests your new test should
    appear in the list (or shouldn't it?)::

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,7 +1,6 @@
 Sphinx==1.3b1
-# inspektor (static and style checks)
+# (static and style checks)
 pylint==3.0.0
-inspektor==0.5.3
 aexpect>=1.6.4
 pyenchant==3.2.2
 black==24.3.0

--- a/selftests/checkall
+++ b/selftests/checkall
@@ -8,9 +8,7 @@ run_rc() {
     fi
     echo ""
 }
-run_rc 'inspekt lint --exclude=.git'
-run_rc 'inspekt indent --exclude=.git'
-run_rc 'inspekt style --exclude=.git --disable E501,E265,W503,W601,E402,E722'
+run_rc './avocado-static-checks/run-static-checks'
 run_rc 'selftests/run'
 exit ${GR}
 


### PR DESCRIPTION
This commit centralizes the static checks configuration:

- Add .pylintrc with disabled pylint messages and excluded directories from the inspekt lint command (W, R, C, and specific error codes). Also excludes avocado-libs and scripts/github directories.

- Add avocado-static-checks.conf to configure the static checks system

- Simplify Makefile check target to use a single run-static-checks script instead of multiple individual check commands

- Replace inspekt lint usage: inspekt is outdated and no longer in active development, so the configuration has been migrated to use pylint directly via .pylintrc

This refactoring makes the static checks configuration more maintainable and easier to update in a single location.

Assisted-by: Cursor
Reference:
https://github.com/avocado-framework/avocado-static-checks/pull/14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated static code analysis into a unified process, streamlining the development workflow.
  * Updated development dependencies and configuration files.

* **Documentation**
  * Updated contribution guidelines to reflect the new code analysis workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->