### PR TITLE
Disk throttlte filter: add new throttlefilters element and virsh command

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -810,3 +810,5 @@ ulimited
 FO
 LOnly
 SME
+throttlefilters
+throttlefilter

--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -5434,3 +5434,18 @@ def domdirtyrate_calc(name, options="", **dargs):
     """
 
     return command("domdirtyrate-calc %s %s" % (name, options), **dargs)
+
+
+def domthrottlegroupset(name, throttle_group, options="", **dargs):
+    """
+    Add or update a throttle group against specific domain.
+
+    :param name: VM name
+    :param throttle_group: the throttle group
+    :param options: options of this command
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object.
+    """
+
+    cmd = "domthrottlegroupset %s %s %s" % (name, throttle_group, options)
+    return command(cmd, **dargs)


### PR DESCRIPTION
Add throttlefilters element into disk.py and domthrottlegroupset virsh command into virsh.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk configuration now recognizes a throttlefilters container for per-disk throttle entries (serialized as an empty <throttlefilters/> by default).
  * Added a command wrapper to set domain throttle groups for I/O throttling.

* **Chores**
  * Added spell-ignore entries for "throttlefilters" and "throttlefilter".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->