### PR TITLE
Allow for configurable extra vm dump checks for present/absent messages

### DIFF
--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -659,7 +659,7 @@ def postprocess_vm(test, params, env, name):
 
         if kernel_extra_params_add or kernel_extra_params_remove:
             # VM might be brought down after test
-            if vm and not vm.is_alive():
+            if not vm.is_alive():
                 if params.get("vm_type") == "libvirt":
                     vm.start()
                 elif params.get("vm_type") == "qemu":

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -12,6 +12,7 @@ import threading
 import time
 
 import six
+from aexpect import ops_linux as ops
 from aexpect import remote
 from avocado.core import exceptions
 from avocado.utils import archive
@@ -671,6 +672,61 @@ def postprocess_vm(test, params, env, name):
                     serial_login=serial_login,
                 )
 
+    if params.get("vm_extra_dump_paths") is not None:
+        # even if there is previously existing session we cannot guarantee its state
+        # is viable, e.g. it may be in python .env or SMTP sub-session, etc.
+        if not vm.is_alive():
+            LOG.warning("VM is not alive so we cannot download extra dump paths")
+        else:
+            session = vm.wait_for_login(timeout=vm.LOGIN_WAIT_TIMEOUT)
+            vm_extra_dumps = os.path.join(test.outputdir, "vm_extra_dumps", vm.name)
+            if not os.path.exists(vm_extra_dumps):
+                os.makedirs(vm_extra_dumps)
+            for i, dump_path in enumerate(
+                params.get_list("vm_extra_dump_paths", delimiter=";")
+            ):
+                errors = []
+                if params.get_boolean(f"verify_vm_extra_dump_{i}"):
+                    if vm.params["os_type"] == "windows":
+                        LOG.warning(
+                            "Extra dump file validation is not supported on Windows"
+                        )
+                    else:
+                        LOG.info(f"Checking for expected messages in {dump_path}")
+                        for message in params.get_list(
+                            f"expected_vm_extra_dump_{i}", delimiter=";"
+                        ):
+                            if not ops.grep(
+                                session, message, dump_path, check=True, flags="-aP"
+                            ):
+                                errors.append(
+                                    f"Missing expected message '{message}' "
+                                    f"in {vm.name} extra dump {dump_path}"
+                                )
+                        for message in params.get_list(
+                            f"unexpected_vm_extra_dump_{i}", delimiter=";"
+                        ):
+                            if ops.grep(
+                                session, message, dump_path, check=True, flags="-aP"
+                            ):
+                                errors.append(
+                                    f"Redundant unexpected message '{message}' "
+                                    f"in {vm.name} extra dump {dump_path}"
+                                )
+                try:
+                    vm.copy_files_from(dump_path, vm_extra_dumps)
+                except:
+                    LOG.error(
+                        "Could not copy the extra dump '%s' from the vm '%s'",
+                        dump_path,
+                        vm.name,
+                    )
+                if errors:
+                    raise exceptions.TestFail(
+                        f"Errors during validation of log messages dumped "
+                        f"from {vm.name}:\n" + "\n".join(errors)
+                    )
+
     # Close all SSH sessions that might be active to this VM
     for s in vm.remote_sessions[:]:
         try:
@@ -680,20 +736,6 @@ def postprocess_vm(test, params, env, name):
             pass
 
     utils_logfile.close_log_file()
-
-    if params.get("vm_extra_dump_paths") is not None:
-        vm_extra_dumps = os.path.join(test.outputdir, "vm_extra_dumps")
-        if not os.path.exists(vm_extra_dumps):
-            os.makedirs(vm_extra_dumps)
-        for dump_path in params.get("vm_extra_dump_paths").split(";"):
-            try:
-                vm.copy_files_from(dump_path, vm_extra_dumps)
-            except:
-                LOG.error(
-                    "Could not copy the extra dump '%s' from the vm '%s'",
-                    dump_path,
-                    vm.name,
-                )
 
     if params.get("kill_vm") == "yes":
         kill_vm_timeout = float(params.get("kill_vm_timeout", 0))


### PR DESCRIPTION
The typical use for this is when dumping extra logs and wanting to make sure certain information is always present (e.g. startup, etc.) and certain information is always absent (e.g. segfaults, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-dump processing now opens a fresh VM session for each extra-dump, performs individual copy and verification steps, and removes the previous unconditional end-of-run dump copy.

* **Bug Fixes**
  * Skip extra-dump retrieval with a warning when the VM is not alive.
  * Simplified alive/not-alive check before starting/creating and applying boot options.
  * Failures to copy or missing/extra verification messages are now detected and reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->