### PR TITLE
Adding support for SLES16 guest-os name and qcow2 image naming convention

### DIFF
--- a/virttest/shared/cfg/guest-os/Linux/SLES/16.0.ppc64le.cfg
+++ b/virttest/shared/cfg/guest-os/Linux/SLES/16.0.ppc64le.cfg
@@ -1,0 +1,5 @@
+- 16.0.ppc64le:
+    image_name = images/sles-16.0.ppc64le
+    vm_arch_name = ppc64le
+    os_variant = sles16
+    shell_prompt = "^[a-zA-Z0-9._-]+:~\s+#\s*$"


### PR DESCRIPTION
Creating a cfg file for Sles16, tested basic scenario as importing guest, running one test from memory test bucket and removing guest using --guest-os SLES.16.0.ppc64le Please find the test results below.

```
localhost:/home/tests # python3 avocado-setup.py --run-suite guest_memory-bck --guest-os SLES.16.0.ppc64le --only-filter 'virtio_scsi virtio_net qcow2' --no-download
08:06:52 INFO    : Env Config: /home/tests/config/wrapper/env.conf
08:06:52 INFO    : No Run Config: /home/tests/config/wrapper/no_run_tests.conf
08:06:52 WARNING : Overriding user setting and enabling kvm bootstrap as guest tests are requested
08:06:52 INFO    : Check for environment
08:06:54 INFO    : Creating temporary mux dir
08:06:54 INFO    :
08:06:54 INFO    : Running Guest Tests Suite memory-bck
08:06:54 INFO    : Running: /usr/local/bin/avocado run --vt-type libvirt --vt-config /home/tests/data/avocado-vt/backends/libvirt/cfg/memory-bck.cfg                 --force-job-id 14971e4f81a76104a1dbe1dc70ce9a1f5ea7187f                 --job-results-dir /home/tests/results  --vt-only-filter                                             "virtio_scsi virtio_net qcow2 SLES.16.0.ppc64le"
JOB ID     : 14971e4f81a76104a1dbe1dc70ce9a1f5ea7187f
JOB LOG    : /home/tests/results/job-2025-11-21T08.06-14971e4/job.log
 (1/3) io-github-autotest-qemu.unattended_install.import.import.default_install.aio_native: STARTED
 (1/3) io-github-autotest-qemu.unattended_install.import.import.default_install.aio_native: PASS (87.24 s)
 (2/3) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.mem_basic.default: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.mem_basic.default: PASS (76.49 s)
 (3/3) io-github-autotest-libvirt.remove_guest.without_disk: STARTED
 (3/3) io-github-autotest-libvirt.remove_guest.without_disk: PASS (5.38 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/tests/results/job-2025-11-21T08.06-14971e4/results.html
JOB TIME   : 178.29 s
08:09:57 INFO    :
08:09:57 INFO    : Summary of test results can be found below:
TestSuite                                                                                TestRun    Summary

guest_memory-bck                                                                         Run        Successfully executed
/home/tests/results/job-2025-11-21T08.06-14971e4/job.log
| PASS 3 || CANCEL 0 || ERRORS 0 || FAILURES 0 || SKIP 0 || WARN 0 || INTERRUPT 0 |
```

