### PR TITLE
utils_sys: check bootc available

### DIFF
--- a/virttest/utils_sys.py
+++ b/virttest/utils_sys.py
@@ -97,6 +97,9 @@ def is_image_mode(session=None):
         )
         return result
 
+    status, _ = cmd_status_output("which bootc", shell=True, session=session)
+    if status:
+        return False
     if session:
         status, output = session.cmd_status_output(check_command)
         return _check_output(status, output)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to gracefully manage missing dependencies, ensuring the system properly defaults to package mode when the bootc command is unavailable instead of failing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->