### PR TITLE
virttest/staging/lv_utils: ignore warnings

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -56,6 +56,8 @@ bool
 backend
 hotplug
 PCI
+PFree
+PSize
 numa
 tuple
 NIC


### PR DESCRIPTION
The current implementation filters the data through grep. However, in some cases a warning message might be displayed, such as

"""
File descriptor 3 (/dev/z90crypt) leaked on pvs invocation. Parent PID 5118: -bash """

While this is a valuable piece of information, the test case shouldn't break on it if the command succeeds and the necessary information is found in the output; the function focuses on identifying the blk target.

So, instead, read the pvs output and identify error conditions (command failure, empty output). If these are not given, identify the relevant parts as before from those output lines, that is the code does the filtering, not grep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving volume-group mappings by handling command failures, empty responses, and varied output formatting to avoid errors.
  * More robust parsing via line-by-line scanning, skipping headers/non-data lines and validating entries to prevent incorrect matches and parsing failures.
* **Chores**
  * Updated spell-ignore list with two additional tokens to reduce false positives in spell checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->