### PR TITLE
Perform vm alive checks in the right order

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -291,11 +291,6 @@ class VM(virt_vm.BaseVM):
         :raise VMDeadError: If the VM is dead
         :raise: Various monitor exceptions if the monitor is unresponsive
         """
-        self.verify_disk_image_bootable()
-        self.verify_userspace_crash()
-        self.verify_kernel_crash()
-        self.verify_illegal_instruction()
-        self.verify_kvm_internal_error()
         try:
             virt_vm.BaseVM.verify_alive(self)
             if self.monitor:
@@ -304,6 +299,11 @@ class VM(virt_vm.BaseVM):
             raise virt_vm.VMDeadError(
                 self.process.get_status(), self.process.get_output()
             )
+        self.verify_disk_image_bootable()
+        self.verify_userspace_crash()
+        self.verify_kernel_crash()
+        self.verify_illegal_instruction()
+        self.verify_kvm_internal_error()
 
     def is_alive(self):
         """


### PR DESCRIPTION
Some of the subchecks rely on pre-existing vm process which is only validated and established during the base class check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified the order of VM health verification checks to execute after initial connection attempts, refining error detection timing during VM status verification processes without altering overall functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->