### PR TITLE
Improve package installation for network utilities

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4664,7 +4664,9 @@ def create_ovs_bridge(
                 "No network interfaces in UP state found for bridge creation"
             )
         iface_name = up_ifaces[0]
-    if not utils_package.package_install(["tmux", "dhcp-client"], session):
+    if not utils_package.package_install(
+        ["tmux"], session
+    ) or not utils_package.package_install_any(["dhcp-client", "dhcpcd"], session):
         raise exceptions.TestError("Failed to install the required packages.")
 
     res = utils_misc.cmd_status_output(
@@ -4721,7 +4723,9 @@ def delete_ovs_bridge(
                 "No network interfaces in UP state found for bridge deletion"
             )
         iface_name = up_ifaces[0]
-    if not utils_package.package_install(["tmux", "dhcp-client"], session):
+    if not utils_package.package_install(
+        ["tmux"], session
+    ) or not utils_package.package_install_any(["dhcp-client", "dhcpcd"], session):
         raise exceptions.TestError("Failed to install the required packages.")
 
     res = utils_misc.cmd_status_output(
@@ -4830,7 +4834,9 @@ def create_linux_bridge_tmux(
     """
     # Create bridge
     br_path = "/sys/class/net/%s" % linux_bridge_name
-    if not utils_package.package_install(["tmux", "dhcp-client", "net-tools"], session):
+    if not utils_package.package_install(
+        ["tmux", "net-tools"], session
+    ) or not utils_package.package_install_any(["dhcp-client", "dhcpcd"], session):
         raise exceptions.TestError("Failed to install the required packages.")
     if session:
         bridge_exists = session.cmd_status("ip link show %s" % linux_bridge_name) == 0

--- a/virttest/utils_package.py
+++ b/virttest/utils_package.py
@@ -259,6 +259,22 @@ def package_install(pkg, session=None, timeout=PKG_MGR_TIMEOUT):
     return utils_misc.wait_for(mgr.install, timeout)
 
 
+def package_install_any(candidates, session=None, timeout=PKG_MGR_TIMEOUT):
+    """
+    Try to install the first available package from candidates.
+
+    :param candidates: iterable of package names to try in order
+    :param session: session Object
+    :param timeout: timeout for each install session
+    :return: True if any candidate installed successfully, else False
+    """
+    for pkg in candidates:
+        mgr = package_manager(session, pkg)
+        if utils_misc.wait_for(mgr.install, timeout):
+            return True
+    return False
+
+
 def package_remove(pkg, session=None, timeout=PKG_MGR_TIMEOUT):
     """
     Try to remove packages on system with package manager.


### PR DESCRIPTION
utils_package: add package_install_any to try multiple candidates
utils_net: update package install to support multiple dhcp clients

ID: LIBVIRTAT-22185
Signed-off-by: Wenli Quan <wquan@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility that tries multiple package candidates and returns success on the first available installer.

* **Improvements**
  * Installation sequence now installs terminal tooling first, then ensures a DHCP client from available options.
  * Network bridge setup is more flexible across distributions.

* **Bug Fixes**
  * Reduced false failures by splitting installation checks and adjusting error handling for independent steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->