### PR TITLE
docs: Add Codeowners section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,3 +48,19 @@ AI-Generated code policy
 ========================
 The Avocado-vt project allows the use of AI-generated code, but it has to follow
 the guidelines and requirements outlined in the `Policy for AI-Generated Code <https://avocado-framework.readthedocs.io/en/latest/guides/contributor/chapters/ai_policy.html>`__
+
+Codeowners
+==========
+
+Contributors can request reviews from the following codeowners based on the area
+of their changes:
+
+* **Libvirt**: @smitterl, @cliping, @nanli1, @Yingshun, @dzhengfy, @chloerh
+
+* **Qemu**: @YongxueHong, @zhencliu, @nickzhq
+
+* **Avocado-vt core**: @smitterl, @richtja, @nickzhq, @YongxueHong, @zhencliu, @cliping, @nanli1, @Yingshun, @dzhengfy, @chloerh, @PaulYuuu
+
+* **Documentation**: @smitterl, @richtja, @clebergnu
+
+* **Avocado-vt CI**: @richtja, @clebergnu, @PaulYuuu


### PR DESCRIPTION
Add a new Codeowners section to README.rst that lists codeowners by area Libvirt, Qemu, Avocado-vt core, Documentation, CI to help contributors identify the appropriate reviewers for their changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Codeowners section under the AI-generated code policy to define per-area reviewers for Libvirt, Qemu, Avocado‑vt core, Documentation, and CI (no individual usernames included).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->