### PR TITLE
utils_net: enable host interface setting for ovs bridge

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -4634,7 +4634,12 @@ def create_ovs_bridge(
     if session:
         runner = session.cmd
     if not iface_name:
-        iface_name = get_net_if(runner=runner, state="UP", ip_options=ip_options)[0]
+        up_ifaces = get_net_if(runner=runner, state="UP", ip_options=ip_options)
+        if not up_ifaces:
+            raise exceptions.TestError(
+                "No network interfaces in UP state found for bridge creation"
+            )
+        iface_name = up_ifaces[0]
     if not utils_package.package_install(["tmux", "dhcp-client"], session):
         raise exceptions.TestError("Failed to install the required packages.")
 
@@ -4684,7 +4689,12 @@ def delete_ovs_bridge(
     if session:
         runner = session.cmd
     if not iface_name:
-        iface_name = get_net_if(runner=runner, state="UP", ip_options=ip_options)[0]
+        up_ifaces = get_net_if(runner=runner, state="UP", ip_options=ip_options)
+        if not up_ifaces:
+            raise exceptions.TestError(
+                "No network interfaces in UP state found for bridge deletion"
+            )
+        iface_name = up_ifaces[0]
     if not utils_package.package_install(["tmux", "dhcp-client"], session):
         raise exceptions.TestError("Failed to install the required packages.")
 


### PR DESCRIPTION
Tested via https://github.com/autotest/tp-libvirt/pull/6717

ovs bridge handling discovers the network interface to use. However, in our environments we need to select a specific interface that has DHCP. Make this parameter configurable but default to previous behavior to not change anything for existing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bridge create/delete operations accept an optional interface parameter; if omitted, the system auto-selects the first active network interface.
* **Bug Fixes**
  * Operations now raise a clear error when no active network interface is available.
* **Documentation**
  * Inline docs updated to reflect the optional interface behavior and usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->