### PR TITLE
migration: Retrieve QEMU logs after migration failure

### DIFF
--- a/virttest/migration_template.py
+++ b/virttest/migration_template.py
@@ -510,7 +510,7 @@ class MigrationTemplate(object):
         )
 
         LOG.info("Check migration result: succeed or fail with expected error")
-        self.obj_migration.check_result(self.obj_migration.ret, self.params)
+        self.obj_migration.check_result(self.obj_migration.ret, self.params, self.vms)
 
         # Check "suspended post-copy" event after postcopy migration
         if self.migrate_flags & VIR_MIGRATE_POSTCOPY:
@@ -563,7 +563,7 @@ class MigrationTemplate(object):
         )
 
         LOG.info("Check migration result: succeed or fail with expected error")
-        self.obj_migration.check_result(self.obj_migration.ret, self.params)
+        self.obj_migration.check_result(self.obj_migration.ret, self.params, self.vms)
 
         # Set vm connect_uri to self.src_uri if migration back succeeds
         if self.obj_migration.ret.exit_status == 0:


### PR DESCRIPTION
## Summary

Add functionality to capture QEMU logs from both source and destination hosts when migration fails unexpectedly. This helps with debugging migration failures.

## Changes

- Add `get_local_qemu_log()` in `utils_sys.py` to retrieve QEMU log from local host
- Add `get_remote_qemu_log()` in `utils_sys.py` to retrieve QEMU log from remote host via SSH
- Update `check_result()` in `migration.py` to call these functions when migration fails unexpectedly (status_error=no but migration failed)
- Add test parameter to `do_migration()` to pass test object

## Details

The functions retrieve the last 10 lines of QEMU logs by default, which is configurable via the `log_lines` parameter.

When migration fails unexpectedly:
- Local QEMU log is read from `test.debugdir/vm.name.log`
- Remote QEMU log is read from `/var/log/libvirt/qemu/vm.name.log` via SSH

This provides valuable debugging information in the test logs when investigating migration failures.

Signed-off-by: Dan Zheng <dzheng@redhat.com>

🤖 Assisted by [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collect QEMU logs from local and remote hosts (configurable) to capture diagnostics during migrations.
  * Migration flow now includes VM context in result validation for richer diagnostics.

* **Bug Fixes**
  * Improved error handling on migration failures to gather relevant logs before reporting errors, aiding faster debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->