### PR TITLE
fix migration cannot customize source uri issue

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -206,7 +206,8 @@ class VM(virt_vm.BaseVM):
         self.root_dir = root_dir
         self.address_cache = address_cache
         self.vnclisten = "0.0.0.0"
-        self.connect_uri = normalize_connect_uri(params.get("connect_uri", "default"))
+        self.connect_uri = params.get("customized_uri") if params.get("customized_uri") is not None \
+            else normalize_connect_uri(params.get("connect_uri", "default"))
         self.driver_type = virsh.driver(uri=self.connect_uri)
         self.params["driver_type_" + self.name] = self.driver_type
         self.monitor = Monitor(self.name)

--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -630,7 +630,14 @@ class MigrationTest(object):
                 self.RET_LOCK.release()
 
         for vm in vms:
-            vm.connect_uri = args.get("virsh_uri", "qemu:///system")
+            # Handle source URI setting with proper fallback logic, the last logic would cover the uri:
+            # 1. If explicit srcuri provided, use it (normal migration tests)
+            # 2. If vm has no connect_uri or it's default, use fallback (new VMs)
+            # 3. Or preserve existing vm.connect_uri (customized_uri cases)
+            if srcuri:
+                vm.connect_uri = srcuri
+            elif not hasattr(vm, 'connect_uri') or vm.connect_uri in [None, "default"]:
+                vm.connect_uri = args.get("virsh_uri", "qemu:///system")
         if migration_type == "orderly":
             for vm in vms:
                 if func and multi_funcs:


### PR DESCRIPTION
   We need to support customize source uri for migration, especially when unprivileged
user is trying to use "/bin/virsh -c 'qemu+ssh://test_user@ip/session' migrate **"

The migration cmd is always use 'qemu:///system' and cannot be modifized in the migration structure, Detail invoking process is showing in libvirt task :xxxx-22126 comment

For https://github.com/autotest/tp-libvirt/pull/6625/files
Signed-off-by: nanli <nanli@redhat.com>


