### PR TITLE
libvirt.py: Add wait time for mk_label check

### DIFF
--- a/virttest/utils_test/libvirt.py
+++ b/virttest/utils_test/libvirt.py
@@ -1074,7 +1074,19 @@ class PoolVolumeTest(object):
             disk_label = source_format
             if disk_label == "dos":
                 disk_label = "msdos"
-            mk_label(device_name, disk_label)
+
+            def mk_label_wait():
+                try:
+                    mk_label(device_name, disk_label)
+                except process.CmdError:
+                    return False
+                return True
+
+            result = utils_misc.wait_for(
+                mk_label_wait,
+                10,
+                text="Label not created as device is unavailable. Retrying...",
+            )
             # Disk pool does not allow to create volume by virsh command,
             # so introduce parameter 'pre_disk_vol' to create partition(s)
             # by 'parted' command, the parameter is a list of partition size,


### PR DESCRIPTION
When the script tries to label a newly created partition, it might fail saying the partition is not available, as there is a slight delay between defining the partition and it being available in the block devices list. This PR helps to fix that by adding a wait statement with a 10 second timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved disk label creation during pool setup: the test now retries label application with a timed wait and feedback, reducing race-condition flakiness and improving error recovery during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->