### PR TITLE
fix: skip no-commit-to-branch hook in CI workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      SKIP: no-commit-to-branch
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
The no-commit-to-branch hook should not run in CI environments as it prevents the workflow from functioning correctly on protected branches. Added SKIP environment variable to disable this hook during pre-commit CI runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance pre-commit job handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->