### PR TITLE
utils_libvirt/libvirt_service: wait for service to terminate on kill

### DIFF
--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -864,6 +864,10 @@ libvirtd_debug_file = ""
 # libvirtd_log_permission = "0600"
 libvirtd_log_cleanup = "yes"
 
+# Timeout determining how long to wait for a libvirt service to be terminated
+# after killing it
+libvirt_kill_service_timeout = 30
+
 #Define one flexbit whether enable split daemons feature, default is disable
 enable_split_libvirtd_feature = "no"
 


### PR DESCRIPTION
The function only issued the kill command but didn't wait for it to become effective. This lead to timing issues with test steps afterwards, possibly requiring invocation of `sleep` with absolute times.

Instead, now wait for a set timeout for the process to terminate. If it doesn't, log this for better debugging later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service termination operations now verify the process has fully stopped before continuing, rather than returning immediately after the kill command.
  * Added configurable timeout for termination verification (default 30 seconds).
  * Enhanced reliability for both local and remote service management scenarios with improved logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->