### PR TITLE
utils_sys: Fix 'server_session' referenced before assignment

### DIFF
--- a/virttest/utils_sys.py
+++ b/virttest/utils_sys.py
@@ -147,6 +147,7 @@ def get_qemu_log(vms, type="local", params=None, log_lines=10):
     :return: list, like [{"vm_name": "vm1", "local": xxx, "remote": xxx}, {"vm_name": "vm2", "local": xxx}]
     """
     logs = []
+    server_session = None
     if params is not None and type != "local":
         server_ip = params.get("migrate_dest_host", params.get("remote_ip"))
         server_user = params.get("server_user", params.get("remote_user"))


### PR DESCRIPTION
Before:
local variable 'server_session' referenced before assignment

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_dst_virtqemud.with_precopy.p2p: PASS (420.27 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-12-26T05.33-e87beda/results.html
JOB TIME   : 422.58 s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code reliability by ensuring proper variable initialization in session handling logic, preventing potential undefined variable issues in certain execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->