### PR TITLE
guest-os: Align Windows os_variant names with osinfo-query output

### DIFF
--- a/virttest/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win2008/x86_64.cfg
@@ -66,6 +66,7 @@
                     cdrom_unattended = "images/win2008-sp2-64/autounattend.iso"
 
         - r2:
+            os_variant = win2k8r2
             image_name += -r2-64
             unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation:
                 cdrom_cd1 = isos/windows/en_windows_server_2008_r2_standard_enterprise_datacenter_and_web_x64_dvd_x15-59754.iso

--- a/virttest/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win2012/x86_64.cfg
@@ -27,6 +27,7 @@
     variants:
         - @r1:
         - r2:
+            os_variant = win2k12r2
             image_name += r2
             unattended_install.cdrom, whql.support_vm_install, svirt_install, with_installation, check_block_size..extra_cdrom_ks:
                 cdrom_cd1 = isos/windows/en_windows_server_2012_r2_x64_dvd_2707946.iso

--- a/virttest/shared/cfg/guest-os/Windows/Win2016.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win2016.cfg
@@ -1,3 +1,3 @@
 - Win2016:
-    os_variant = win2016
+    os_variant = win2k16
     image_name = images/win2016

--- a/virttest/shared/cfg/guest-os/Windows/Win2019.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win2019.cfg
@@ -1,3 +1,3 @@
 - Win2019:
-    os_variant = win2019
+    os_variant = win2k19
     image_name = images/win2019

--- a/virttest/shared/cfg/guest-os/Windows/Win2022.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win2022.cfg
@@ -1,3 +1,3 @@
 - Win2022:
-    os_variant = win2022
+    os_variant = win2k22
     image_name = images/win2022

--- a/virttest/shared/cfg/guest-os/Windows/Win2025.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/Win2025.cfg
@@ -1,3 +1,3 @@
 - Win2025:
-    os_variant = win2025
+    os_variant = win2k25
     image_name = images/win2025

--- a/virttest/shared/cfg/guest-os/Windows/WinLegacy.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/WinLegacy.cfg
@@ -1,3 +1,3 @@
 - WinLegacy:
-    os_variant = winlegacy
+    os_variant = win11
     image_name = images/winlegacy

--- a/virttest/shared/cfg/guest-os/Windows/WinNext.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/WinNext.cfg
@@ -1,3 +1,3 @@
 - WinNext:
-    os_variant = winnext
+    os_variant = win11
     image_name = images/winnext

--- a/virttest/shared/cfg/guest-os/Windows/WinVista.cfg
+++ b/virttest/shared/cfg/guest-os/Windows/WinVista.cfg
@@ -1,5 +1,5 @@
 - WinVista:
-    os_variant = vista
+    os_variant = winvista
     image_name = images/winvista
     whql.submission:
         desc_path_desc1 = $\WDK\Logo Type\Device Logo\Vista Client\Device Premium


### PR DESCRIPTION
Update os_variant values for Windows guests to match the short IDs returned by osinfo-query, ensuring compatibility with libosinfo:
- win2016 -> win2k16
- win2019 -> win2k19
- win2022 -> win2k22
- win2025 -> win2k25
- winnext -> win11
- winlegacy -> win11
- vista -> winvista
- Add win2k8r2 for Windows Server 2008 R2
- Add win2k12r2 for Windows Server 2012 R2

ID: 4923

Signed-off-by: Yanan Fu <yfu@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Windows OS variant identifiers for Vista, 2016, 2019, 2022, and 2025.
  * Added explicit variant mappings for Windows 2008 R2 and Windows 2012 R2 to improve variant recognition.
  * Updated legacy/next Windows entries to map to the Windows 11 variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->