### PR TITLE
MInor fix utils_sys: Fix UnboundLocalError for server_session variable

### DIFF
--- a/virttest/utils_sys.py
+++ b/virttest/utils_sys.py
@@ -147,6 +147,7 @@ def get_qemu_log(vms, type="local", params=None, log_lines=10):
     :return: list, like [{"vm_name": "vm1", "local": xxx, "remote": xxx}, {"vm_name": "vm2", "local": xxx}]
     """
     logs = []
+    server_session = None
     if params is not None and type != "local":
         server_ip = params.get("migrate_dest_host", params.get("remote_ip"))
         server_user = params.get("server_user", params.get("remote_user"))


### PR DESCRIPTION
Initialize server_session to None at function start to prevent UnboundLocalError when referenced in finally block. The variable was previously only defined within a conditional block, causing an error when the condition was not met.

AI assisted code and commit. Human reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced reliability of QEMU logging operations to prevent potential runtime failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->