### PR TITLE
utils_nbd.py: add shared option for qemu-nbd

### DIFF
--- a/virttest/utils_nbd.py
+++ b/virttest/utils_nbd.py
@@ -44,6 +44,7 @@ class NbdExport(object):
         deleteExisted=True,
         private_key_encrypt_passphrase=None,
         secret_uuid=None,
+        shared_num=None,
     ):
         """Create a new NbdExport instance
 
@@ -70,6 +71,7 @@ class NbdExport(object):
             self.private_key_encrypt_passphrase = private_key_encrypt_passphrase
             self.secret_uuid = secret_uuid
         self.deleteExisted = deleteExisted
+        self.shared_num = shared_num
 
     def _create_img(self):
         """Create a image file with specified format"""
@@ -226,6 +228,8 @@ class NbdExport(object):
             )
             if self.export_name:
                 qemu_nbd_cmd += "-x %s " % self.export_name
+            if self.shared_num:
+                qemu_nbd_cmd += "--shared=%s" % self.shared_num
             qemu_nbd_cmd += "&"
             process.run(
                 qemu_nbd_cmd,


### PR DESCRIPTION
In some cases, we may need to use --shared option to share device by clients. So add this option into the utils_nbd.py function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration to control the number of shared NBD export connections, enabling administrators to limit concurrent connections for better resource management and availability control.

* **Chores**
  * Exposed the new setting as a public, optional attribute for easier configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->