### PR TITLE
Spell.ignore: remove unnecessary fileds because the usage of codespell

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -13,5 +13,3 @@ ulimited
 FO
 LOnly
 SME
-throttlefilters
-throttlefilter


### PR DESCRIPTION
Avocado-vt uses codespell now. So we don't need to add some special test fileds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up spell checker configuration by removing obsolete entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->