### PR TITLE
migration: fix missing server_ip

### DIFF
--- a/virttest/migration.py
+++ b/virttest/migration.py
@@ -830,6 +830,15 @@ class MigrationTest(object):
 
         extra_args.update({"status_error": params.get("status_error", "no")})
         extra_args.update({"err_msg": params.get("err_msg")})
+        extra_args.update(
+            {"server_ip": params.get("migrate_dest_host", params.get("remote_ip"))}
+        )
+        extra_args.update(
+            {"server_user": params.get("server_user", params.get("remote_user"))}
+        )
+        extra_args.update(
+            {"server_pwd": params.get("server_pwd", params.get("remote_pwd"))}
+        )
         return extra_args
 
     def check_result(self, result, params, vms):


### PR DESCRIPTION
This is to fix https://github.com/avocado-framework/avocado-vt/pull/4285

The problem is that the warning is reported for remote host IP missing when migration fails.
```
2026-01-12 06:52:09,491 avocado.virttest.migration migration        L0851 INFO | Migration error: Migration: [ 0.19 %]Migration: [13.18 %]Migration: [15.59 %]Migration: [17.28 %]Migration: [54.56 %]Migration: [73.24 %]Migration: [78.43 %]Migration: [85.87 %]Migration: [88.08 %]Migration: [90.27 %]Migration: [93.06 %]Migration: [94.82 %]Migration: [96.54 %]Migration: [91.73 %]Migration: [93.20 %]Migration: [94.67 %]Migration: [99.04 %]Migration: [93.09 %]Migration: [95.03 %]Migration: [97.00 %]Migration: [97.93 %]Migration: [99.14 %]error: operation failed: job 'migration out' failed: Unable to read from socket: Connection reset by peer
2026-01-12 06:52:09,491 avocado.virttest.utils_sys utils_sys        L0160 WARNI| **Remote host IP not found in params**
```

Signed-off-by: Dan Zheng <dzheng@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration now includes explicit remote server login fields (server IP, username, and password) so migration operations can pass and use destination host connection details alongside existing migration status and event info.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->