### PR TITLE
libvirt_vfio: Add get_pci_driver() and refactor check_vfio_pci()

### DIFF
--- a/virttest/utils_libvirt/libvirt_vfio.py
+++ b/virttest/utils_libvirt/libvirt_vfio.py
@@ -5,11 +5,23 @@ Libvirt vfio related utilities.
 """
 
 import logging
+import os
 
 from avocado.core import exceptions
-from avocado.utils import process
 
 LOG = logging.getLogger("avocado." + __name__)
+
+
+def get_pci_driver(pci_id):
+    """
+    Get the driver name for a PCI device
+
+    :param pci_id: The id of pci device
+    :return: The driver name
+    """
+    driver_path = f"/sys/bus/pci/devices/{pci_id}/driver"
+    resolved_path = os.readlink(driver_path)
+    return os.path.basename(resolved_path)
 
 
 def check_vfio_pci(pci_id, status_error=False, ignore_error=False, exp_driver=None):
@@ -24,11 +36,7 @@ def check_vfio_pci(pci_id, status_error=False, ignore_error=False, exp_driver=No
     :return: True if got the expected driver;
         False otherwise when ignore_error is set to True
     """
-    cmd = (
-        "readlink -f /sys/bus/pci/devices/%s/driver "
-        "| awk -F '/' '{print $NF}'" % pci_id
-    )
-    output = process.run(cmd, shell=True, verbose=True).stdout_text.strip()
+    output = get_pci_driver(pci_id)
     res = (
         exp_driver == output
         if exp_driver


### PR DESCRIPTION
- Add new get_pci_driver() function to get PCI driver name using os.readlink
- Refactor check_vfio_pci() to use get_pci_driver() instead of subprocess
- Replace shell command with native Python implementation
- Add os import, remove unused process import from avocado.utils
- Improves code efficiency and maintainability

AI assisted code and commit. Human reviewed.
Signed-off-by: hholoubk <hholoubk@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new utility function to resolve PCI driver names for VFIO devices.

* **Refactor**
  * Simplified VFIO PCI driver validation logic by replacing shell commands with direct implementation, improving reliability and reducing external dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->