### PR TITLE
Add AAutils pylint configuration for virttest utils migration

### DIFF
--- a/.pylintrc_utils
+++ b/.pylintrc_utils
@@ -1,0 +1,566 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=netifaces
+
+# =============================================================================
+# BLACKLIST - All files to ignore (by basename)
+# =============================================================================
+# This uses 'ignore=' which works on basenames even when files are passed
+# explicitly to pylint. To migrate a utility file to AAutils standards:
+# 1. Remove its basename from this list
+# 2. Run pre-commit (pylint will check the file)
+# 3. Fix all reported issues
+#
+# -----------------------------------------------------------------------------
+# CAN BE MIGRATED (remove from blacklist when ready):
+# -----------------------------------------------------------------------------
+# utils_*.py (root level):
+#   utils_backup.py, utils_config.py, utils_conn.py, utils_disk.py,
+#   utils_gdb.py, utils_hotplug.py, utils_ids.py, utils_iptables.py,
+#   utils_kernel_module.py, utils_libguestfs.py, utils_libvirtd.py,
+#   utils_linux_modules.py, utils_misc.py, utils_nbd.py, utils_net.py,
+#   utils_netperf.py, utils_npiv.py, utils_numeric.py, utils_package.py,
+#   utils_pyvmomi.py, utils_qemu.py, utils_selinux.py, utils_split_daemons.py,
+#   utils_sriov.py, utils_switchdev.py, utils_sys.py, utils_time.py,
+#   utils_version.py, utils_vsock.py, utils_zchannels.py, utils_zcrypt.py
+#
+# utils_libvirt/*.py:
+#   libvirt_disk.py, libvirt_embedded_qemu.py, libvirt_keywrap.py,
+#   libvirt_memory.py, libvirt_misc.py, libvirt_nested.py, libvirt_network.py,
+#   libvirt_nwfilter.py, libvirt_secret.py, libvirt_service.py,
+#   libvirt_usb.py, libvirt_vfio.py
+#
+# utils_windows/*.py:
+#   wmic.py
+#
+# vt_utils/*.py (already refactored):
+#   __init__.py, block.py, cpu.py, filesystem.py, interrupted_thread.py,
+#   memory.py, pci_utils.py, qemu_utils.py, sys_time.py, tool.py
+#
+# vt_utils/net/*.py (already refactored):
+#   __init__.py, interface.py, ip.py, mac.py, tap.py
+#
+# vt_utils/net/drivers/*.py (already refactored):
+#   __init__.py, bridge.py, macvtap.py, ovs.py
+#
+# -----------------------------------------------------------------------------
+# CAN'T BE MIGRATED (permanent - VM-specific or has virttest dependencies):
+# -----------------------------------------------------------------------------
+# utils_*.py:
+#   utils_env.py, utils_logfile.py, utils_params.py, utils_sasl.py,
+#   utils_spice.py, utils_stress.py, utils_v2v.py, utils_vdpa.py,
+#   utils_virtio_port.py
+#
+# utils_test/*.py:
+#   __init__.py, libguestfs.py, libvirt.py, libvirt_device_utils.py,
+#   libvirt_domjobinfo.py, qemu/__init__.py, qemu/migration.py
+#
+# utils_windows/*.py (guest functions):
+#   __init__.py, drive.py, system.py, virtio_win.py
+#
+# utils_libvirt/*.py:
+#   __init__.py, libvirt_bios.py, libvirt_ceph_utils.py, libvirt_config.py,
+#   libvirt_cpu.py, libvirt_filesystem.py, libvirt_monitor.py, libvirt_numa.py,
+#   libvirt_pcicontr.py, libvirt_unprivileged.py, libvirt_virtio.py,
+#   libvirt_vmxml.py
+#
+# TO BE REMOVED:
+#   utils_scheduling.py (will be deleted from codebase)
+#
+ignore=CVS,accessors.py,address.py,aexpect.py,ah_ipv6.py,ah.py,all_ipv6.py,all.py,arch.py,arp.py,asset.py,audio.py,backup_xml.py,base_installer.py,base.py,block.py,block_volume.py,bootstrap.py,boottool.py,bridge.py,build_helper.py,capability_xml.py,cartesian_config.py,cb.py,ceph.py,channel.py,character.py,check_cpu_flag.py,checkpoint_xml.py,cmd_runner.py,compat.py,console.py,controller.py,core.py,cpu.py,curl.py,data_dir.py,dd.py,defaults.py,dir_pool.py,dir_volume.py,disk.py,domcapability_xml.py,drive.py,duplicate_pages.py,emulator.py,env_process.py,error_context.py,error_event.py,esp_ipv6.py,esp.py,filesystem.py,file_volume.py,filterref.py,funcatexit.py,gcov.py,gluster.py,graphical_console.py,graphics.py,guest_agent.py,hostdev.py,http_server.py,hub.py,icmp.py,icmpv6.py,idmap_xml.py,igmp.py,__init__.py,input.py,installer.py,interface.py,interrupted_thread.py,iommu.py,ip.py,ip_sniffing.py,ipv6.py,iscsi.py,kernelinstall.py,kernel_interface.py,kernel.py,key_event_form.py,ksm_overcommit_guest.py,lease.py,libguestfs.py,librarian.py,libvirt_bios.py,libvirt_ceph_utils.py,libvirt_cgroup.py,libvirt_config.py,libvirt_cpu.py,libvirtd_decorator.py,libvirt_device_utils.py,libvirt_disk.py,libvirt_domjobinfo.py,libvirt_embedded_qemu.py,libvirt_filesystem.py,libvirt_installer.py,libvirt_keywrap.py,libvirt_memory.py,libvirt_misc.py,libvirt_monitor.py,libvirt_nested.py,libvirt_network.py,libvirt_numa.py,libvirt_nwfilter.py,libvirt_pcicontr.py,libvirt.py,libvirt_remote.py,libvirt_secret.py,libvirt_service.py,libvirt_setup.py,libvirt_storage.py,libvirt_unprivileged.py,libvirt_usb.py,libvirt_version.py,libvirt_vfio.py,libvirt_virtio.py,libvirt_vm.py,libvirt_vmxml.py,logger.py,logging_manager.py,lvm.py,lvsb_base.py,lvsb.py,lvsbs.py,lv_utils.py,mac.py,macvtap.py,memballoon.py,memory.py,messenger.py,migration.py,migration_template.py,mock.py,multicast_guest.py,nbd.py,netperf_agent.py,net_volume.py,networking.py,network_xml.py,nfs_pool.py,nfs.py,nfs_volume.py,nodedev_xml.py,node_properties.py,node.py,nvme.py,nvram.py,nwfilter_binding.py,nwfilter_xml.py,openvswitch.py,os_posix.py,ovirt.py,ovs.py,ovs_utils.py,panic.py,parallel.py,pci_utils.py,pmsocat36.py,png_utils.py,pool.py,pool_selector.py,pool_xml.py,port_resource.py,postprocess_iozone.py,ppc.py,ppm_utils.py,propcan.py,proxy.py,pstore.py,qcontainer.py,qdevice_format.py,qdevices.py,qemu_capabilities.py,qemu_installer.py,qemu_io.py,qemu_migration.py,qemu_monitor.py,qemu_qtree.py,qemu_storage.py,qemu_utils.py,qemu_virtio_port.py,qemu_vm.py,rarp.py,redirdev.py,redirfilter.py,remote_build.py,remote_interface.py,remote_master.py,remote.py,remote_runner.py,requirement_checks.py,resource_manager.py,resource.py,RFBDes.py,rng_egd.py,rng.py,scan_autotest_results.py,scheduler.py,sctp_ipv6.py,sctp.py,seclabel.py,secret_xml.py,selector.py,serial_host_send_receive.py,serial.py,service.py,set_win_promisc.py,sev.py,shmem.py,smartcard.py,snapshot_xml.py,sound.py,ssh_key.py,standalone_test.py,step_editor.py,storage.py,storage_ssh.py,stp.py,syslog_server.py,system.py,sys_time.py,tap_network.py,tap_port.py,tap.py,tcp_ipv6.py,tcp.py,telnet.py,test_controller_xml.py,test_interface_xml.py,test_memory_xml.py,test_network_xml.py,test_utils_kernel_module.py,test_utils_misc.py,test_utils_test__init__.py,test_utils_zchannels.py,test_utils_zcrypt.py,test_vm_xml.py,tool.py,tpm.py,udp_ipv6.py,udplite_ipv6.py,udplite.py,udp.py,unattended_install.py,utils_backup.py,utils_cgroup.py,utils_config.py,utils_conn.py,utils_cpi.py,utils_disk.py,utils_env.py,utils_gdb.py,utils_hotplug.py,utils_ids.py,utils_iptables.py,utils_kernel_module.py,utils_koji.py,utils_libguestfs.py,utils_libvirtd.py,utils_linux_modules.py,utils_logfile.py,utils_memory.py,utils_misc.py,utils_nbd.py,utils_netperf.py,utils_net.py,utils_npiv.py,utils_numeric.py,utils_package.py,utils_params.py,utils.py,utils_pyvmomi.py,utils_qemu.py,utils_sasl.py,utils_scheduling.py,utils_selinux.py,utils_spice.py,utils_split_daemons.py,utils_sriov.py,utils_stress.py,utils_switchdev.py,utils_sys.py,utils_time.py,utils_v2v.py,utils_vdpa.py,utils_version.py,utils_virtio_port.py,utils_vsock.py,utils_zchannels.py,utils_zcrypt.py,vdpa_blk.py,verify.py,versionable_class.py,version.py,vhost_user_blk.py,video_maker.py,video.py,virsh.py,virt_admin.py,VirtIoChannel_guest_send_receive.py,virtio_console_guest.py,virtio_win.py,virt_vm.py,vlan.py,vms.py,vm_xml.py,volume.py,vol_xml.py,vsock.py,vt_console.py,vt_iothread.py,wait_for_quit.py,watchdog.py,windows_support.py,wmic.py,_wrappers.py,xcepts.py,xml_utils.py,yumrepo.py
+
+# regex matches against base names, not paths.
+ignore-patterns=.git
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=pylint.extensions.no_self_use,pylint.extensions.docparams,pylint.extensions.docstyle
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=all
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=line-too-long,
+  locally-disabled,
+  suppressed-message,
+  useless-suppression,
+  use-symbolic-message-instead,
+  too-few-public-methods,
+  fixme
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: en_ZM (myspell), en_ZW
+# (myspell), en_US (myspell), en_PH (myspell), en_IN (myspell), en_BW
+# (myspell), en_TT (myspell), en_GB (myspell), en_SG (myspell), en_AG
+# (myspell), en_NG (myspell), en_CA (myspell), en_BS (myspell), en_AU
+# (myspell), en_JM (myspell), en_ZA (myspell), en_HK (myspell), en_BZ
+# (myspell), en_IE (myspell), en_NZ (myspell), en_DK (myspell), en_MW
+# (myspell), en_NA (myspell), en_GH (myspell)..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
+
+[tool.pylint.parameter_documentation]
+accept-no-param-doc = false
+
+accept-no-raise-doc = false
+
+accept-no-return-doc = false
+
+accept-no-yields-doc = false
+
+# Possible choices: ['sphinx', 'epytext', 'google', 'numpy', 'default']
+default-docstring-type = sphinx

--- a/avocado-static-checks.conf
+++ b/avocado-static-checks.conf
@@ -1,2 +1,3 @@
 [lint]
+virttest:.pylintrc_utils
 .:.pylintrc


### PR DESCRIPTION
This adds the AAutils pylint configuration for avocado-vt utilities, following the same approach as avocado's utils migration setup.

Changes:
Add .pylintrc_utils with strict AAutils checks (docparams, docstyle, sphinx format)
Update avocado-static-checks.conf to apply AAutils config to virttest directory
Blacklist all 96 utility files by basename (64 can be migrated, 32 can't be migrated)
Ignore all non-utility virttest files (directories and root-level files)