### PR TITLE
Doc build fixes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: false
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,18 +64,7 @@ VERSION = open(version_file, "r").read().strip()
 version = VERSION
 release = VERSION
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from
-# docs.readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-    except ImportError:
-        html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 htmlhelp_basename = "avocadodoc"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,8 +102,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "http://docs.python.org/": None,
-    "http://avocado-framework.readthedocs.org/en/latest/": None,
+    "python": ("https://docs.python.org", None),
+    "avocado": ("http://avocado-framework.readthedocs.org/en/latest/", None),
 }
 
 autoclass_content = "both"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Read the Docs v2 configuration to enable automated Sphinx documentation builds on Ubuntu 22.04 with Python 3.11 and pip-managed dependencies.
  * Standardized the documentation theme and improved inter-document cross-reference mappings to make docs rendering and navigation more consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->