### PR TITLE
hostdev: add acpi element

### DIFF
--- a/virttest/libvirt_xml/devices/hostdev.py
+++ b/virttest/libvirt_xml/devices/hostdev.py
@@ -26,6 +26,7 @@ class Hostdev(base.TypedDeviceBase):
         "rom",
         "address",
         "driver",
+        "acpi",
     )
 
     def __init__(self, type_name="hostdev", virsh_instance=base.base.virsh):
@@ -83,6 +84,7 @@ class Hostdev(base.TypedDeviceBase):
             subclass=self.Driver,
             subclass_dargs={"virsh_instance": virsh_instance},
         )
+        accessors.XMLElementDict("acpi", self, parent_xpath="/", tag_name="acpi")
         super(self.__class__, self).__init__(
             device_tag="hostdev", type_name=type_name, virsh_instance=virsh_instance
         )


### PR DESCRIPTION
This is to support new element <acpi nodeset='1-9'/> in hostdev device.

    <hostdev mode='subsystem' type='pci' managed='no'>
      <driver iommufd='yes'/>
      <source>
        <address domain='0x0009' bus='0x01' slot='0x00' function='0x0'/>
      </source>
      <acpi nodeset='1-9'/>
    </hostdev>

Signed-off-by: Dan Zheng <dzheng@redhat.com>