### PR TITLE
add support for displaying log on remote host

### DIFF
--- a/virttest/utils_sys.py
+++ b/virttest/utils_sys.py
@@ -191,3 +191,23 @@ def get_qemu_log(vms, type="local", params=None, log_lines=10):
         if server_session:
             server_session.close()
     return logs
+
+
+def display_remote_log(params, test):
+    """
+    Display remote log content.
+
+    :param params: dict, test parameters.
+    :param test: test object.
+    """
+    log_path = params.get("libvirtd_debug_file")
+    remote_session = params.get("remote_session")
+    remote_file_type = params.get("remote_file_type", "virtqemud")
+    log_lines = params.get("log_lines", 50)
+    try:
+        cmd = f"tail -n {log_lines} {log_path}"
+        remote_output = remote_session.cmd_output(cmd, timeout=10).strip()
+        test.log.debug(f"=== Print {remote_file_type} log ===\n{remote_output}")
+
+    except Exception as e:
+        test.log.debug(f"Failed to get log: {str(e)} \n")


### PR DESCRIPTION
there is one function set_remote_log() in base_step.py, we need to we need to display this log after migration



for https://github.com/autotest/tp-libvirt/pull/6784 
 Signed-off-by: nanli <nanli@redhat.com>



```
]# avocado run --vt-type libvirt --vt-machine-type q35 virtual_network.migrate.migrate_with_bridge_type_interface.start_with_interface.precopy_migration.linux_bridge
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.migrate.migrate_with_bridge_type_interface.start_with_interface.precopy_migration.linux_bridge: PASS (296.41 s)
```

 Task from : xxxx-21435

Set in cfg
```
    set_remote_libvirtd_log = "yes"
    libvirtd_debug_level = 1
    libvirtd_debug_file = "/var/log/libvirt/virtqemud.log"
```


LOG

```
[stdlog] 2026-01-31 23:34:12,046 avocado.test utils_sys        L0210 DEBUG| === Print virtqemud log ===
[stdlog] 2026-02-01 04:34:11.921+0000: 184563: debug : virEventGLibTimeoutRemove:466 : Remove timeout data=0x7f2acc001150 timer=8
[stdlog] 2026-02-01 04:34:11.921+0000: 184563: info : virObjectRef:400 : OBJECT_REF: obj=0x564da2f34ce0
[stdlog] 2026-02-01 04:34:11.921+0000: 184563: info : virObjectUnref:378 : OBJECT_UNREF: obj=0x564da2f35060
[stdlog] 2026-02-01 04:34:11.921+0000: 184563: info : virObjectUnref:378 : OBJECT_UNREF: obj=0x564da2f34ce0
[stdlog] 2026-02-01 04:34:11.921+0000: 184563: info : virObjectRef:400 : OBJECT_REF: obj=0x564da2f34ce0
[stdlog] 2026-02-01 04:34:11.921+0000: 184563: debug : daemonRemoveAllClientStreams:518 : stream=(nil)
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virObjectUnref:378 : OBJECT_UNREF: obj=0x564da2f34ce0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virEventGLibHandleRemove:263 : EVENT_GLIB_REMOVE_HANDLE: watch=8
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virEventGLibHandleRemove:274 : Remove handle data=0x564da2f27900 watch=8 fd=18
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virNetMessageQueueServe:122 : queue serve start queue=0x564da2f34d88 *queue=0x564da2f35820
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virNetMessageQueueServe:128 : queue serve end queue=0x564da2f34d88 *queue=(nil)
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virNetMessageFree:93 : msg=0x564da2f35820 nfds=0 cb=(nil)
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virObjectUnref:378 : OBJECT_UNREF: obj=0x564da2f34ae0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virNetServerCheckLimits:269 : Checking client-related limits to re-enable or temporarily suspend services: nclients=0 nclients_max=5000 nclients_unauth=0 nclients_unauth_max=20
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virNetServerCheckLimits:292 : Re-enabling services
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virEventGLibHandleUpdate:194 : EVENT_GLIB_UPDATE_HANDLE: watch=2 events=1
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virEventGLibHandleUpdate:205 : Update handle data=0x564da2f2d020 watch=2 fd=4 events=1
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virEventGLibHandleUpdate:194 : EVENT_GLIB_UPDATE_HANDLE: watch=3 events=1
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virEventGLibHandleUpdate:205 : Update handle data=0x564da2f2d380 watch=3 fd=3 events=1
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virObjectUnref:378 : OBJECT_UNREF: obj=0x564da2f34ce0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virNetDaemonShutdownTimerUpdate:498 : Activating shutdown timer 1
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virEventGLibTimeoutUpdate:396 : EVENT_GLIB_UPDATE_TIMEOUT: timer=1 interval=120000
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virEventGLibTimeoutUpdate:407 : Update timeout data=0x564da2f307c0 timer=1 interval=120000 ms
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virEventRunDefaultImpl:359 : running default event implementation
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virEventGLibHandleRemoveIdle:244 : EVENT_GLIB_REMOVE_HANDLE_IDLE: watch=8 ff=0x7f2af1ffc330 opaque=0x564da2f34ae0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virObjectUnref:378 : OBJECT_UNREF: obj=0x564da2f34ce0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : vir_object_finalize:319 : OBJECT_DISPOSE: obj=0x564da2f34ae0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virNetSocketDispose:1285 : RPC_SOCKET_DISPOSE: sock=0x564da2f34ae0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virObjectUnref:378 : OBJECT_UNREF: obj=0x564da2f34ae0
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: debug : virEventRunDefaultImpl:359 : running default event implementation
[stdlog] 2026-02-01 04:34:11.922+0000: 184563: info : virEventGLibTimeoutRemoveIdle:435 : EVENT_GLIB_REMOVE_TIMEOUT_IDLE: timer=8 ff=0x7f2af1f23050 opaque=0x564da2f35060


```