### PR TITLE
libvirt_vm: Skip vm startup when --noreboot is specified

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2264,16 +2264,20 @@ class VM(virt_vm.BaseVM):
                         )
                 # some other problem happened, raise normally
                 raise
-            # Wait for the domain to be created
-            utils_misc.wait_for(
-                func=self.is_alive,
-                timeout=60,
-                text=("waiting for domain %s to start" % self.name),
-            )
-            result = virsh.domuuid(self.name, uri=self.connect_uri)
-            self.uuid = result.stdout_text.strip()
-            # Create isa serial ports.
-            self.create_serial_console()
+            # Don't start VM and create console when user add --noreboot flag
+            if params.get("use_no_reboot") == "yes":
+                LOG.info("VM created with --noreboot, skipping start up")
+            else:
+                # Wait for the domain to be created
+                utils_misc.wait_for(
+                    func=self.is_alive,
+                    timeout=60,
+                    text=("waiting for domain %s to start" % self.name),
+                )
+                result = virsh.domuuid(self.name, uri=self.connect_uri)
+                self.uuid = result.stdout_text.strip()
+                # Create isa serial ports.
+                self.create_serial_console()
         finally:
             fcntl.lockf(lockfile, fcntl.LOCK_UN)
             lockfile.close()


### PR DESCRIPTION
Skip vm startup and session created when user add --noreboot flag

ID:LIBVIRTAT-22305
Signed-off-by: Lei Yang leiyang@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `use_no_reboot` parameter option to VM creation. When enabled, post-creation initialization steps are skipped for faster VM provisioning in scenarios where full setup is not immediately required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->