### PR TITLE
virttest: Fix UnboundLocalError in restart_guest_network()

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1758,7 +1758,7 @@ def restart_guest_network(
             else:
                 restart_cmd += "%s %s" % (dhcp_cmd, nic_ifname)
         else:
-            restart_cmd += "%s %s; " % (dhcp_cmd, release_flag)
+            restart_cmd = "%s %s; " % (dhcp_cmd, release_flag)
             if ip_version == "ipv6":
                 restart_cmd += "%s -6" % dhcp_cmd
             else:


### PR DESCRIPTION
Fix a bug in restart_guest_network() where restart_cmd variable was used before initialization when mac_addr parameter is None.

Error occurred at line 1761:
    restart_cmd += "%s %s; " % (dhcp_cmd, release_flag)

The += operator attempted to append to restart_cmd, but the variable was never initialized in the else branch (when mac_addr is None).

The variable restart_cmd is only initialized in the if mac_addr block (line 1754), so when execution reaches the else block, restart_cmd does not exist, causing:
    UnboundLocalError: local variable 'restart_cmd' referenced before assignment

Fix: Change line 1761 from += to = to properly initialize the variable:
    restart_cmd = "%s %s; " % (dhcp_cmd, release_flag)

Committer: Bolatbek Issakh <bissakh@redhat.com>