### PR TITLE
utils_net: Fix uninitialized variable 'restart_cmd'

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1758,7 +1758,7 @@ def restart_guest_network(
             else:
                 restart_cmd += "%s %s" % (dhcp_cmd, nic_ifname)
         else:
-            restart_cmd += "%s %s; " % (dhcp_cmd, release_flag)
+            restart_cmd = "%s %s; " % (dhcp_cmd, release_flag)
             if ip_version == "ipv6":
                 restart_cmd += "%s -6" % dhcp_cmd
             else:


### PR DESCRIPTION
The variable 'restart_cmd' is not initialized in the else branch. It will cause the error like:
cannot access local variable 'restart_cmd' where it is not associated with a value

Fixes: 785a92daa (utils_net: fix guest net restart)