### PR TITLE
utils_sys:Fix dmesg cmd output

### DIFF
--- a/virttest/utils_sys.py
+++ b/virttest/utils_sys.py
@@ -27,7 +27,7 @@ def check_dmesg_output(pattern, expect=True, session=None):
     :return: True if result met expectation, False if not met
     """
     dmesg_cmd = "dmesg"
-    func_get_dmesg = session.cmd if session else process.run
+    func_get_dmesg = session.cmd if session else process.getoutput
     dmesg = func_get_dmesg(dmesg_cmd)
 
     prefix = "" if expect else "Not "


### PR DESCRIPTION
Since process.run returns a CmdResult object instead of a string, prefer process.getoutput for string.