### PR TITLE
utils_kernel_module: filter out not applicable module parameters

### DIFF
--- a/virttest/shared/cfg/base.cfg
+++ b/virttest/shared/cfg/base.cfg
@@ -1225,3 +1225,18 @@ uuid_dimm = ""
 # enable_igvm = no
 # igvm_path = /usr/share/coconut-svsm
 # igvm_filename = coconut-qemu.igvm
+
+# KVM Module Reload/Restore Settings for Test Pre-processing and Post-processing
+# ---------------------------------------------------------
+# Force reload KVM module
+#kvm_module_force_load = yes
+# Force reload vendor-specific module (kvm_intel/kvm_amd)
+#kvm_probe_module_force_load = yes
+# Parameters for KVM module (e.g., "nested=1")
+#kvm_module_parameters = "nested=1"
+# Parameters for vendor-specific module (e.g., "tdx=1")
+#kvm_probe_module_parameters = "tdx=1"
+# Parameters to ignore when restoring KVM module which split by semicolon
+#kvm_module_ignored_parameters = vmentry_l1d_flush=not required;key=value
+# Parameters to ignore when restoring vendor-specific module (kvm_intel/kvm_amd) which split by semicolon
+#kvm_probe_module_ignored_parameters = vmentry_l1d_flush=not required;key=value

--- a/virttest/test_setup/kernel.py
+++ b/virttest/test_setup/kernel.py
@@ -1,3 +1,5 @@
+import re
+
 from virttest import arch, test_setup, utils_kernel_module
 from virttest.test_setup.core import Setuper
 
@@ -7,10 +9,14 @@ class ReloadKVMModules(Setuper):
         super().__init__(test, params, env)
         self.kvm_module_handlers = []
 
+    def _get_param_prefix(self, module_name):
+        """Determine parameter prefix based on module name."""
+        return "kvm" if module_name == "kvm" else "kvm_probe"
+
     def setup(self):
         kvm_modules = arch.get_kvm_module_list()
         for module in reversed(kvm_modules):
-            param_prefix = module if module == "kvm" else "kvm_probe"
+            param_prefix = self._get_param_prefix(module)
             module_force_load = self.params.get_boolean(
                 "%s_module_force_load" % param_prefix
             )
@@ -25,7 +31,11 @@ class ReloadKVMModules(Setuper):
 
     def cleanup(self):
         for kvm_module in self.kvm_module_handlers:
-            kvm_module.restore()
+            param_prefix = self._get_param_prefix(kvm_module.module_name)
+            ignored_dict = self.params.get_dict(
+                "%s_module_ignored_parameters" % param_prefix, delimiter=";"
+            )
+            kvm_module.restore(ignored_dict)
 
 
 class KSMSetup(Setuper):

--- a/virttest/utils_kernel_module.py
+++ b/virttest/utils_kernel_module.py
@@ -22,6 +22,7 @@ import os
 from avocado.utils import process
 
 LOG = logging.getLogger("avocado." + __name__)
+INVALID_MODULE_PARAM_PAIRS = {"vmentry_l1d_flush": "not required"}
 
 
 class KernelModuleError(Exception):
@@ -132,8 +133,9 @@ class KernelModuleHandler(object):
         current_config = self.current_config
         if not force:
             do_not_load = False
+            params_dict = dict(item.split("=", 1) for item in params.split())
             if current_config and all(
-                x in current_config.split() for x in params.split()
+                (k, v) in current_config.items() for k, v in params_dict.items()
             ):
                 LOG.debug(
                     "Not reloading module. Current module configuration"
@@ -141,7 +143,7 @@ class KernelModuleHandler(object):
                     " Requested: '%s'. Current: '%s'. Use force=True to"
                     " force loading.",
                     self._module_name,
-                    params,
+                    params_dict,
                     current_config,
                 )
                 do_not_load = True
@@ -164,9 +166,31 @@ class KernelModuleHandler(object):
         for holder in self._module_holders:
             holder.restore()
 
-    def restore(self):
+    def _separate_dict(self, source_dict, ref_dict):
+        """
+        Split source_dict into two dictionaries by exact key-value matches in ref_dict.
+
+        :param source_dict: Source dictionary to filter
+        :param ref_dict: Reference dictionary to compare
+        :return: A tuple containing two dictionaries:
+            - unique_dict: dict of unique key-value pairs in source_dict
+            - common_dict: dict of common key-value pairs in source_dict and ref_dict
+        """
+        unique_dict = {}
+        common_dict = {}
+        ref_set = set(ref_dict.items())
+        for k, v in source_dict.items():
+            if (k, v) in ref_set:
+                common_dict[k] = v
+            else:
+                unique_dict[k] = v
+        return unique_dict, common_dict
+
+    def restore(self, ignored_params=None):
         """
         Restore previous module state.
+
+        :param ignored_params: params dict to be ignored for module restore
 
         The state will only be restored if the original state
         was altered.
@@ -188,9 +212,22 @@ class KernelModuleHandler(object):
             # TODO: Handle cases were module cannot be removed
             self.unload_module()
             if self._was_loaded:
+                restore_dict = self._config_backup
+                if ignored_params:
+                    restore_dict, ignored_dict = self._separate_dict(
+                        self._config_backup,
+                        ignored_params,
+                    )
+                    if ignored_dict:
+                        LOG.debug(
+                            "Module restore ignores parameter pairs '%s'.", ignored_dict
+                        )
+                restore_string = " ".join(
+                    "%s=%s" % (k, v) for k, v in restore_dict.items()
+                )
                 restore_cmd = "modprobe %s %s" % (
                     self._module_name,
-                    self._config_backup,
+                    restore_string,
                 )
                 LOG.debug("Restoring module state: %s", restore_cmd)
                 status, output = process.getstatusoutput(restore_cmd)
@@ -218,6 +255,12 @@ class KernelModuleHandler(object):
         )
 
     @property
+    def module_name(self):
+        """Read-only property"""
+
+        return self._module_name
+
+    @property
     def was_loaded(self):
         """Read-only property"""
 
@@ -239,7 +282,7 @@ class KernelModuleHandler(object):
         """
         Get current module parameters if found
 
-        :return: String holding module config 'param1=value1 param2=value2 ...', None if
+        :return: Dict holding module config parameter and value pairs, None if
          module not loaded
         """
 
@@ -248,14 +291,23 @@ class KernelModuleHandler(object):
             return
         # Some modules do not have parameters
         elif not os.path.exists(self._module_params_path):
-            return ""
+            return {}
 
         mod_params = {}
         params = os.listdir(self._module_params_path)
         for param in params:
             with open(os.path.join(self._module_params_path, param), "r") as param_file:
-                mod_params[param] = param_file.read().strip()
-        return " ".join("%s=%s" % _ for _ in mod_params.items())
+                value = param_file.read().strip()
+                # Automatically filter out known invalid param pairs
+                if (param, value) in INVALID_MODULE_PARAM_PAIRS.items():
+                    LOG.debug(
+                        "Module parameter '%s' has invalid value '%s', skipping",
+                        param,
+                        value,
+                    )
+                    continue
+                mod_params[param] = value
+        return mod_params
 
     @property
     def module_holders(self):


### PR DESCRIPTION
When reading kernel module parameters from sysfs, some parameters may
return the string "not required" if they are not applicable, for
example module kvm_intel parameter vmentry_l1d_flush. Previously,
these values were included in the parameter string passed to
modprobe when restoring the module, which leads to module
loading failure.
This change introduces new parameters "kvm_module_ignored_parameters"
and "kvm_probe_module_ignored_parameters", (e.g., "vmentry_l1d_flush=not required")
to skip the parameters.

Below is the test result related with the fix:
 (1/1) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.intel_tdx: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.intel_tdx: PASS (32.30 s)