### PR TITLE
libvirt_vm: use sendline for reboot and force serial console recreation

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2778,7 +2778,7 @@ class VM(virt_vm.BaseVM):
         def _execute_shell_reboot(session):
             """Execute reboot command via shell session."""
             reboot_cmd = self.params.get("reboot_command")
-            session.cmd(reboot_cmd, ignore_all_errors=True)
+            session.sendline(reboot_cmd)
 
         def _check_system_event_reboot(timeout):
             """Check if system is reboot via libvirt events."""
@@ -2811,10 +2811,14 @@ class VM(virt_vm.BaseVM):
                 if not serial:
                     session = self.wait_for_login(nic_index=nic_index, timeout=timeout)
                 else:
-                    session = self.wait_for_serial_login(timeout=timeout)
+                    session = self.wait_for_serial_login(
+                        timeout=timeout, recreate_serial_console=True
+                    )
 
             if isinstance(session, remote.RemoteSession):
-                serial_console = self.wait_for_serial_login(timeout=timeout)
+                serial_console = self.wait_for_serial_login(
+                    timeout=timeout, recreate_serial_console=True
+                )
 
             _reboot = partial(_execute_shell_reboot, session)
             _check_go_down = partial(


### PR DESCRIPTION
This commit addresses two critical issues in the VM reboot logic:
1. Avoid timeout during reboot via serial console:
   Previously, 'session.cmd()' was used to execute the reboot command.
   Since the OS shuts down immediately when receiving this command, the
   session may not get an exit status. This caused the test to hang
   waiting for a response until the timeout, potentially leading to
   failure in subsequent reboot verification checks.
   Replaced 'session.cmd()' with 'session.sendline()' allowing the logic
   to proceed immediately to shutdown detection phase without waiting for
   a non-existent response.

2. Ensure stable serial console connection:
   Forced the re-creation of the serial console connection before
   attempting to login by passing 'recreate_serial_console=True' to
   'wait_for_serial_login()'. This ensures a fresh connection is
   established, preventing connection errors during the reboot process.

Related test result:
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.4k: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.4k: PASS (143.30 s)