### PR TITLE
virttest: fix qemu version parsing

### DIFF
--- a/selftests/unit/test_env_process.py
+++ b/selftests/unit/test_env_process.py
@@ -30,6 +30,7 @@ class QEMUVersion(unittest.TestCase):
                 "0.12.1",
                 "qemu-kvm-0.12.1.2-2.503.el6_9.3",
             ),
+            "QEMU emulator version 10.1.3": ("10.1.3", None),
         }
         for version, expected in list(versions_expected.items()):
             match = re.match(QEMU_VERSION_RE, version)

--- a/virttest/env_process.py
+++ b/virttest/env_process.py
@@ -107,9 +107,8 @@ preprocess_vm_on_hook = None
 postprocess_vm_on_hook = None
 postprocess_vm_off_hook = None
 
-#: QEMU version regex.  Attempts to extract the simple and extended version
-#: information from the output produced by `qemu -version`
-QEMU_VERSION_RE = r"QEMU (?:PC )?emulator version\s([0-9]+\.[0-9]+\.[0-9]+)\s?\((.*?)\)"
+#: QEMU version regex (same compiled pattern as `utils_qemu.QEMU_VERSION_RE`).
+QEMU_VERSION_RE = utils_qemu.QEMU_VERSION_RE
 
 THREAD_ERROR = False
 

--- a/virttest/test_setup/requirement_checks.py
+++ b/virttest/test_setup/requirement_checks.py
@@ -89,9 +89,11 @@ class CheckQEMUVersion(Setuper):
         version_line = version_output.split("\n")[0]
         matches = re.match(env_process.QEMU_VERSION_RE, version_line)
         if matches:
-            return "%s (%s)" % matches.groups()
-        else:
-            return "Unknown"
+            ver, extra = matches.groups()
+            if extra:
+                return "%s (%s)" % (ver, extra)
+            return ver
+        return "Unknown"
 
     def setup(self):
         # Get the KVM userspace version

--- a/virttest/utils_qemu.py
+++ b/virttest/utils_qemu.py
@@ -8,7 +8,7 @@ import re
 from avocado.utils import process
 
 QEMU_VERSION_RE = re.compile(
-    r"QEMU (?:PC )?emulator version\s" r"([0-9]+\.[0-9]+\.[0-9]+)" r"(?:\s\((.*?)\))?"
+    r"QEMU (?:PC )?emulator version\s" r"([0-9]+\.[0-9]+\.[0-9]+)" r"(?:\s*\((.*?)\))?"
 )
 DEVICE_CATEGORY_RE = re.compile(r"([A-Z]\S+) devices:")
 


### PR DESCRIPTION
Current QEMU_VERSION_RE required parenthetical,
but on custom qemu builds prints only “QEMU emulator version X.Y.Z” on the first line so requirement_checks could not read the version and canceled tests.

This commit fixes it and also adds unittest for the same