### PR TITLE
utils_net: strip ANSI escape codes before parsing JSON output

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -3929,6 +3929,7 @@ def get_linux_iface_info(iface="", mac=None, session=None):
 
     try:
         ip_output_str = run_func(ip_cmd).strip()
+        ip_output_str = re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', '', ip_output_str)
         LOG.debug(f"Interface info {iface}:\n{ip_output_str}")
         ip_info = json.loads(ip_output_str)
     except Exception as why:
@@ -4117,6 +4118,7 @@ def get_default_gateway_json(
 
     try:
         ip_output_str = run_func(cmd).strip()
+        ip_output_str = re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', '', ip_output_str)
         LOG.debug(f"ip route output:\n{ip_output_str}")
         ip_route = json.loads(ip_output_str)
     except Exception as why:


### PR DESCRIPTION
This PR fixes a JSON parsing issue in `virttest/utils_net.py` where ANSI escape sequences (like bracketed paste mode codes `^[[?2004l`) in `ip -json` output would cause `json.loads` to fail.

The fix involves stripping all ANSI escape sequences from the command output string before attempting to parse it as JSON.

Signed-off-by: Dan Zheng <dzheng@redhat.com>