### PR TITLE
update ovmf firmware path

### DIFF
--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -462,7 +462,7 @@ variants:
         no i386 ppc64 ppc64le s390x
         no Win2003 WinXP WinVista
         # Please update this based on your test env
-        ovmf_path = /usr/share/OVMF
+        ovmf_path = /usr/share/edk2/ovmf
         ovmf_code_filename = OVMF_CODE.secboot.fd
         ovmf_vars_filename = OVMF_VARS.fd
         unattended_install:

--- a/virttest/shared/cfg/guest-hw.cfg
+++ b/virttest/shared/cfg/guest-hw.cfg
@@ -463,8 +463,8 @@ variants:
         no Win2003 WinXP WinVista
         # Please update this based on your test env
         ovmf_path = /usr/share/edk2/ovmf
-        ovmf_code_filename = OVMF_CODE.secboot.fd
-        ovmf_vars_filename = OVMF_VARS.fd
+        ovmf_code_filename ~= OVMF_CODE.secboot.fd
+        ovmf_vars_filename ~= OVMF_VARS.fd
         unattended_install:
             restore_ovmf_vars = yes
             Windows:


### PR DESCRIPTION
The firmware images are in /usr/share/edk2/ovmf these days, the old
locaation in /usr/share/OVMF has only some backward compatibility
symlinks only.  Update the configuration accordingly.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

Also (second commit added later):

set ovmf filenames only if not present
This allows test variants override the firmware filenames.