### PR TITLE
Undefine persistent VM before virt-install in create()

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2116,6 +2116,9 @@ class VM(virt_vm.BaseVM):
         """
         error_context.context("creating '%s'" % self.name)
         self.destroy(free_mac_addresses=False)
+        if self.is_persistent():
+            if not self.undefine():
+                raise virt_vm.VMError(f"Failed to undefine persistent VM {self.name}")
         if name is not None:
             self.name = name
         if params is not None:


### PR DESCRIPTION
When create_vm_libvirt=yes triggers vm.create(), the method only calls self.destroy() before running virt-install. If a previous test left the VM defined (e.g. via bk_xml.sync() in its cleanup), the VM is still persistent and virt-install fails with:

  "Disk ... is already in use by other guests ['avocado-vt-vm1']"

Add self.undefine() after destroy so that any stale VM definition is removed before virt-install attempts to create the VM fresh.