### PR TITLE
Update  support Python 3.14

### DIFF
--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -112,6 +112,12 @@ class VirtTest(test.VirtTest):
                 self.queue.put(messages.FinishedMessage.get(status, fail_reason))
 
 
+def _vt_test_subprocess_main(queue, runnable):
+    """Run a VirtTest in a child process (forkserver/spawn-safe)."""
+    vt_test = VirtTest(queue, runnable)
+    vt_test.runTest()
+
+
 class VTTestRunner(BaseRunner):
     """
     Runner for Avocado-VT (aka VirtTest) tests
@@ -155,8 +161,10 @@ class VTTestRunner(BaseRunner):
         else:
             try:
                 queue = multiprocessing.SimpleQueue()
-                vt_test = VirtTest(queue, self.runnable)
-                process = multiprocessing.Process(target=vt_test.runTest)
+                process = multiprocessing.Process(
+                    target=_vt_test_subprocess_main,
+                    args=(queue, self.runnable),
+                )
                 process.start()
                 while True:
                     time.sleep(RUNNER_RUN_CHECK_INTERVAL)

--- a/virttest/vt_iothread.py
+++ b/virttest/vt_iothread.py
@@ -1,7 +1,5 @@
 """AUTOtest implementation of iothread manager classes for QEMU."""
 
-import itertools
-
 from virttest.qemu_devices.qdevices import QIOThread
 
 
@@ -20,7 +18,7 @@ class IOThreadManagerBase(object):
         self._iothread_finder = {}
         for iothread in iothreads or []:
             self._iothread_finder[iothread.get_aid()] = iothread
-        self._index = itertools.count(len(iothreads))
+        self._next_iothread_index = len(iothreads or [])
 
     def find_iothread(self, iothread_id):
         """Find iothread with the id specified."""
@@ -28,7 +26,9 @@ class IOThreadManagerBase(object):
 
     def _create_iothread(self):
         """Create and return new iothread object."""
-        return QIOThread(self.ID_PATTERN % next(self._index))
+        idx = self._next_iothread_index
+        self._next_iothread_index += 1
+        return QIOThread(self.ID_PATTERN % idx)
 
     def request_iothread(self, iothread):
         """


### PR DESCRIPTION
Changed two files to fix issue with pickling changes in 3.14

Add a proxy function for calling tests with multiprocessing to avoid pickling the entire VirtTest class

'multiprocessing' must pickle the 'target' and 'args' when using the 'forkserver' (default on Python 3.14+) or 'spawn' start methods. A bound method like 'VirtTest.runTest' would pickle the whole test instance, which includes unpicklable thread locks from Avocado's base test class. Building :class:`VirtTest` inside the child keeps the parent-to-child payload to 'SimpleQueue' and :class:`Runnable` only.

Remove self._index from IOThreadManagerBase as itertools count is not pickleable to address #4266

Can now run hello world in Python 3.14

Assisted-by: Claude