### PR TITLE
libvirt_vm: undefine stale domain before virt-install --import

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2116,6 +2116,17 @@ class VM(virt_vm.BaseVM):
         """
         error_context.context("creating '%s'" % self.name)
         self.destroy(free_mac_addresses=False)
+        # Undefine any persistent definition with our name so that the
+        # virt-install --import below does not fail with
+        # "Disk ... is already in use by other guests ['<name>']"
+        # on its default --check path_in_use=on.
+        try:
+            if virsh.domain_exists(self.name, uri=self.connect_uri):
+                virsh.undefine(self.name, options="--nvram",
+                               uri=self.connect_uri, ignore_status=True)
+        except Exception as _e:
+            LOG.debug("Pre-create undefine of %s skipped: %s",
+                      self.name, _e)
         if name is not None:
             self.name = name
         if params is not None:


### PR DESCRIPTION
VM.create() builds a virt-install --import command that runs with the default --check path_in_use=on. If a persistent domain with the same name still owns the target image -- a common state when a CI runner pre-installs the VM during bootstrap and then a test asks env_process to recreate it -- virt-install refuses with:

    ERROR    Disk /path/to/image.qcow2 is already in use by other
             guests ['<vm_name>']. (Use --check path_in_use=off or
             --check all=off to override)

The cascade then fails every test in the suite that hits the re-install path. self.destroy() already kills the qemu process for our name, but it does not undefine the persistent libvirt domain, so the disk-lock view from virt-install's perspective stays. Add an explicit virsh undefine right after destroy, gated on domain_exists, so the lock is released before virt-install runs. The qcow2 file is untouched; virt-install --import re-uses it.

Verified on connecttech-boson22-01 (RHEL-10.3 aarch64, libvirt-12.2.0-1.el10, virt-install-5.1.0-2.el10): the failing test virtual_network.iface_bridge.update_with_diff_type. shared_physical_network used to ERROR in 13.91s with the "Disk ... already in use" message; with the patch applied it reaches the guest-setup stage (66.11s) and fails on an unrelated "No dhcp client found on the system" issue in the test image.

Committer: Bolatbek Issakh <bissakh@redhat.com>