### PR TITLE
Fix TypeError when updating NUMA cells with existing config!

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -1058,7 +1058,7 @@ class VMXML(VMXMLBase):
                         nodexml_list = []
                         for node in range(no_numa_cell):
                             if vmxml.cpu.numa_cell:
-                                nodexml = vmcpu_xml.numa_cell[node]
+                                nodexml = vmcpu_xml.numa_cell[node].fetch_attrs()
                             else:
                                 nodexml = {}
                             if vcpus_num > 1:


### PR DESCRIPTION
When updating NUMA cell configuration for VMs with existing cells, the code was passing NumaCellXML objects containing LibvirtXMLProperty attributes to dicts_to_cells(), which expects only str/int values.

Fix by using fetch_attrs() to convert NumaCellXML to plain dict before updating attributes. This ensures type validation passes.

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>