### PR TITLE
test_setup: log meminfo and buddyinfo on hugepage allocation failure

### DIFF
--- a/virttest/test_setup/__init__.py
+++ b/virttest/test_setup/__init__.py
@@ -554,9 +554,20 @@ class HugePageConfig(object):
         obj = kernel_interface.SysFS(pgfile, session=self.session)
         obj.sys_fs_value = pagenum
         if obj.sys_fs_value < int(pagenum):
+            if self.session:
+                meminfo = self.session.cmd_output(
+                    "grep -E 'MemTotal|MemFree|HugePages_|Hugepagesize' /proc/meminfo"
+                )
+                buddyinfo = self.session.cmd_output("cat /proc/buddyinfo")
+            else:
+                meminfo = process.getoutput(
+                    "grep -E 'MemTotal|MemFree|HugePages_|Hugepagesize' /proc/meminfo"
+                )
+                buddyinfo = process.getoutput("cat /proc/buddyinfo")
             error_msg = (
                 "Only allocated %d pages %skiB huge pages, "
-                "but required %s" % (obj.sys_fs_value, pagesize, pagenum)
+                "but required %s\nmeminfo:\n%s\nbuddyinfo:\n%s"
+                % (obj.sys_fs_value, pagesize, pagenum, meminfo, buddyinfo)
             )
             if not ignore_error:
                 raise exceptions.TestSetupFail(error_msg)


### PR DESCRIPTION
When set_kernel_hugepages fails to allocate the requested number of hugepages, append /proc/meminfo and /proc/buddyinfo to the error message to help diagnose whether the failure is due to memory pressure or fragmentation.

Signed-off-by: Mohammadfaiz Bawa <mbawa@redhat.com>