### PR TITLE
libvirt_vm: undefine stale domain before virt-install --import

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2116,6 +2116,38 @@ class VM(virt_vm.BaseVM):
         """
         error_context.context("creating '%s'" % self.name)
         self.destroy(free_mac_addresses=False)
+        # A persistent domain with our name -- left by a previous test
+        # (env_cleanup=no) or pre-installed during CI bootstrap -- makes the
+        # "virt-install --import" below fail under its default
+        # "--check path_in_use=on":
+        #     Disk ... is already in use by other guests ['<name>']
+        # destroy() only kills the qemu process, it does not drop the
+        # persistent definition, so the disk/name stays locked. Undefine it
+        # here. Detect nvram from the domain XML so this also works on
+        # UEFI-only arches (e.g. aarch64), where "virsh undefine" fails
+        # without --nvram. Only the definition is removed; the qcow2 image is
+        # left intact for --import to reuse.
+        if virsh.domain_exists(self.name, uri=self.connect_uri):
+            undefine_opts = "--managed-save"
+            try:
+                domxml = virsh.dumpxml(
+                    self.name, extra="--inactive", uri=self.connect_uri
+                ).stdout_text
+            except process.CmdError as detail:
+                domxml = ""
+                LOG.debug(
+                    "Could not dump XML of %s before undefine: %s",
+                    self.name,
+                    detail,
+                )
+            if "<nvram" in domxml:
+                undefine_opts += " --nvram"
+            virsh.undefine(
+                self.name,
+                options=undefine_opts,
+                uri=self.connect_uri,
+                ignore_status=True,
+            )
         if name is not None:
             self.name = name
         if params is not None:


### PR DESCRIPTION
VM.create() builds a "virt-install --import" command that runs with the default "--check path_in_use=on". If a persistent domain with the same name still owns the target image -- a common state when a previous test leaves the guest defined (env_cleanup=no) or a CI runner pre-installs the VM during bootstrap -- virt-install refuses with:

    ERROR    Disk /path/to/image.qcow2 is already in use by other
             guests ['<vm_name>']. (Use --check path_in_use=off or
             --check all=off to override)

env_process preprocess then errors for every test that hits the re-install path, cascading across the whole suite. self.destroy() kills the qemu process for our name but does not drop the persistent libvirt definition, so the disk/name stays locked from virt-install's view.

Undefine the stale domain right after destroy(), gated on domain_exists. Detect nvram from the inactive domain XML and add --nvram when present so the undefine also succeeds on UEFI-only arches such as aarch64, where "virsh undefine" otherwise fails with "cannot delete inactive domain with nvram". Only the definition is removed; the qcow2 image is left intact and reused by --import.

Verified on aarch64 (RHEL-9.9, libvirt-11.10.0): the virtual_network.mtu and iface_options groups used to ERROR in env setup with the "Disk ... already in use" message on every test; with the patch they reach guest setup and pass (remaining failures are unrelated test image issues, e.g. "No dhcp client found on the system").

Author:    Bolatbek Issakh <bissakh@redhat.com>