### PR TITLE
utils_net: Use dhcpcd for OVS bridge setup on RHEL 10

### DIFF
--- a/virttest/utils_net.py
+++ b/virttest/utils_net.py
@@ -1710,6 +1710,47 @@ def _deactivate_ipv4ll_dhcpcd(session):
         raise exceptions.TestError("Couldn't deactivate IPv4 local link setting.")
 
 
+def _get_rhel_major_version(session=None):
+    """
+    Return the RHEL major version for the target host.
+
+    :param session: guest/remote session, or None for local host
+    :return: major version int, or None if not RHEL/unknown
+    """
+    if session is None:
+        if distro.detect().name == "rhel":
+            return int(distro.detect().version_parts()[0])
+        return None
+
+    status, output = utils_misc.cmd_status_output(
+        "rpm -E '%{rhel}' 2>/dev/null", shell=True,
+        ignore_status=True, session=session)
+    if status == 0 and output.strip().isdigit():
+        return int(output.strip())
+    return None
+
+
+def _get_dhcp_client_packages(session=None):
+    """
+    Return DHCP-related packages required on the target host.
+
+    RHEL 10+ uses dhcpcd; older RHEL releases use dhcp-client (dhclient).
+    """
+    rhel_ver = _get_rhel_major_version(session)
+    if rhel_ver is not None and rhel_ver >= 10:
+        return ["tmux", "dhcpcd"]
+    return ["tmux", "dhcp-client"]
+
+
+def _format_dhcp_acquire_cmd(dhcp_cmd, iface):
+    """
+    Build a one-shot DHCP acquire command for the given interface.
+    """
+    if dhcp_cmd == "dhcpcd":
+        return "dhcpcd -n %s" % iface
+    return "%s %s" % (dhcp_cmd, iface)
+
+
 def get_dhcp_client(session):
     """
     Return the available dhcp client command and its release argument.
@@ -1718,11 +1759,14 @@ def get_dhcp_client(session):
     :return: tuple of dhcp command and its release argument, raises TestError if none found
     """
     dhcp_clients = [("dhclient", "-r"), ("dhcpcd", "-k")]
-    if distro.detect().name == "rhel" and int(distro.detect().version) >= 10:
-        dhcp_clients = [dhcp_clients[1]]
+    rhel_ver = _get_rhel_major_version(session)
+    if rhel_ver is not None and rhel_ver >= 10:
+        clients_order = [dhcp_clients[1]]
+    elif rhel_ver is not None:
+        clients_order = [dhcp_clients[0]]
     else:
-        dhcp_clients = [dhcp_clients[0]]
-    for cmd, release_flag in dhcp_clients:
+        clients_order = dhcp_clients
+    for cmd, release_flag in clients_order:
         status, _ = utils_misc.cmd_status_output(
             "which %s" % cmd, shell=True, ignore_status=True, session=session
         )
@@ -4664,7 +4708,7 @@ def create_ovs_bridge(
                 "No network interfaces in UP state found for bridge creation"
             )
         iface_name = up_ifaces[0]
-    if not utils_package.package_install(["tmux", "dhcp-client"], session):
+    if not utils_package.package_install(_get_dhcp_client_packages(session), session):
         raise exceptions.TestError("Failed to install the required packages.")
 
     res = utils_misc.cmd_status_output(
@@ -4676,15 +4720,14 @@ def create_ovs_bridge(
             "sure the openvswitch or openvswitch2 pkg "
             "is installed."
         )
-    # <TODO> Find a more stable dhcpcd cmd to get ip on RHEL10.
-    dhcp_cmd, release_flag = "dhclient", "-r"
+    dhcp_cmd, release_flag = get_dhcp_client(session)
 
     cmd = (
         f"ovs-vsctl add-br {ovs_bridge_name};"
         f"ovs-vsctl add-port {ovs_bridge_name} {iface_name};"
         f"{dhcp_cmd} {release_flag};"
         "sleep 5;"
-        f"{dhcp_cmd} {ovs_bridge_name}"
+        f"{_format_dhcp_acquire_cmd(dhcp_cmd, ovs_bridge_name)}"
     )
     tmux_cmd = 'tmux -c "{}"'.format(cmd)
     return utils_misc.cmd_status_output(
@@ -4721,7 +4764,7 @@ def delete_ovs_bridge(
                 "No network interfaces in UP state found for bridge deletion"
             )
         iface_name = up_ifaces[0]
-    if not utils_package.package_install(["tmux", "dhcp-client"], session):
+    if not utils_package.package_install(_get_dhcp_client_packages(session), session):
         raise exceptions.TestError("Failed to install the required packages.")
 
     res = utils_misc.cmd_status_output(
@@ -4733,13 +4776,13 @@ def delete_ovs_bridge(
             "sure the openvswitch or openvswitch2 pkg "
             "is installed."
         )
-    dhcp_cmd, release_flag = "dhclient", "-r"
+    dhcp_cmd, release_flag = get_dhcp_client(session)
     cmd = (
         f"ovs-vsctl del-port {ovs_bridge_name} {iface_name};"
         f"ovs-vsctl del-br {ovs_bridge_name};"
         f"{dhcp_cmd} {release_flag};"
         "sleep 5;"
-        f"{dhcp_cmd} {iface_name}"
+        f"{_format_dhcp_acquire_cmd(dhcp_cmd, iface_name)}"
     )
     tmux_cmd = 'tmux -c "{}"'.format(cmd)
     return utils_misc.cmd_status_output(
@@ -4830,7 +4873,8 @@ def create_linux_bridge_tmux(
     """
     # Create bridge
     br_path = "/sys/class/net/%s" % linux_bridge_name
-    if not utils_package.package_install(["tmux", "dhcp-client", "net-tools"], session):
+    if not utils_package.package_install(
+            _get_dhcp_client_packages(session) + ["net-tools"], session):
         raise exceptions.TestError("Failed to install the required packages.")
     if session:
         bridge_exists = session.cmd_status("ip link show %s" % linux_bridge_name) == 0
@@ -4854,7 +4898,7 @@ def create_linux_bridge_tmux(
             f"ifconfig {iface_name} 0; "
             f"pkill {dhcp_cmd}; "
             "sleep 6; "
-            f"{dhcp_cmd} {linux_bridge_name};"
+            f"{_format_dhcp_acquire_cmd(dhcp_cmd, linux_bridge_name)};"
         )
         if remove_addr_on_dev:
             shell_cmd = "%s ifconfig %s 0" % (shell_cmd, iface_name)


### PR DESCRIPTION
## Summary
- Fix `create_ovs_bridge()` / `delete_ovs_bridge()` hardcoding `dhcp-client`/`dhclient`, which fails on RHEL 10 where only `dhcpcd` is available
- Detect RHEL major version per target host (local or remote SSH session) via `rpm -E '%{rhel}'`
- Reuse and fix `get_dhcp_client()` to choose the DHCP client based on the **session host**, not the local runner (fixes 9.9 worker → 10.3 resource cross-migration)
- Use `dhcpcd -n <iface>` for one-shot lease acquisition on OVS bridges

## Problem
`virsh.migrate_network.ovs_br.without_postcopy` fails on aarch64 cross-migration (RHEL 9.9 ↔ 10.3) when creating the OVS bridge on the RHEL 10 resource host:

```
yum install -y dhcp-client
No match for argument: dhcp-client
```

## Test plan
- [ ] RHEL 9.9 host: `create_ovs_bridge()` still uses `dhclient` (unchanged)
- [ ] RHEL 10.3 host: `create_ovs_bridge()` installs/uses `dhcpcd`
- [ ] Cross-migration: `virsh.migrate_network.ovs_br.without_postcopy` (9.9 worker → 10.3 resource)
- [ ] Regression: single-host OVS bridge tests on x86_64 / RHEL 9