### PR TITLE
libvirt_vm: recreate serial console in reboot() to fix stale handle timeout

### DIFF
--- a/virttest/libvirt_vm.py
+++ b/virttest/libvirt_vm.py
@@ -2814,7 +2814,11 @@ class VM(virt_vm.BaseVM):
                     session = self.wait_for_serial_login(timeout=timeout)
 
             if isinstance(session, remote.RemoteSession):
-                serial_console = self.wait_for_serial_login(timeout=timeout)
+                serial_console = self.wait_for_serial_login(
+                    timeout=timeout,
+                    recreate_serial_console=True,
+                    status_check=False,
+                )
 
             _reboot = partial(_execute_shell_reboot, session)
             _check_go_down = partial(
@@ -2838,10 +2842,15 @@ class VM(virt_vm.BaseVM):
                 session.close()
             if serial_console:
                 serial_console.close()
+            self.cleanup_serial_console()
 
         error_context.context("logging in after reboot", LOG.info)
         if serial:
-            return self.wait_for_serial_login(timeout=timeout)
+            return self.wait_for_serial_login(
+                timeout=timeout,
+                recreate_serial_console=True,
+                status_check=False,
+            )
         return self.wait_for_login(nic_index, timeout=timeout)
 
     def screendump(self, filename, debug=False):


### PR DESCRIPTION

1.When reboot() is invoked with an active SSH session (RemoteSession), it opens a second serial console via wait_for_serial_login() to monitor guest shutdown. After VM lifecycle events such as destroy/start or a prior reboot in preprocess, the existing self.serial_console handle can remain referenced while the underlying virsh console connection is dead. _create_serial_console() only recreates the console when the object is None or marked closed, so wait_for_serial_login() may reuse a stale pipe and spin until the login timeout (360s).

2.Fix by passing recreate_serial_console=True to wait_for_serial_login() in reboot() wherever a serial session is opened around a reboot. Also call cleanup_serial_console() in the finally block after closing the local serial_console reference, so self.serial_console is cleared and cannot be reused on the next wait. Use status_check=False during these waits because guest state is unreliable while shutting down or booting, consistent with the parameter documentation.

3.Changes in LibvirtVM.reboot():
- Pre-reboot serial monitor (RemoteSession path): recreate console
- Post-reboot serial login (serial=True path): recreate console
- finally block: cleanup_serial_console() after close This uses the existing recreate_serial_console API added to wait_for_serial_login() in virt_vm.py

Test Results:
(1/2) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.strict: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.strict: PASS (272.79 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.interleave: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.interleave: PASS (245.02 s)



ID:5295