### PR TITLE
virttest: add ipv6 portal check for iscsi

### DIFF
--- a/virttest/iscsi.py
+++ b/virttest/iscsi.py
@@ -726,10 +726,15 @@ class IscsiLIO(_IscsiComm):
 
             check_portal = "targetcli /iscsi/%s/tpg1/portals ls" % self.target
             portal_info = process.run(check_portal).stdout_text
-            if "0.0.0.0:3260" not in portal_info:
+            # Check for both IPv4 (0.0.0.0:3260) and IPv6 ([::]:3260 or [::0]:3260) default portals
+            if not any(
+                portal in portal_info
+                for portal in ("0.0.0.0:3260", "[::]:3260", "[::0]:3260")
+            ):
                 # Create portal
-                # 0.0.0.0 means binding to INADDR_ANY
-                # and using default IP port 3260
+                # 0.0.0.0 means binding to INADDR_ANY (IPv4)
+                # [::] or [::0] means binding to in6addr_any (IPv6)
+                # using default IP port 3260
                 portal_cmd = "targetcli /iscsi/%s/tpg1/portals/ create %s" % (
                     self.target,
                     "0.0.0.0",


### PR DESCRIPTION
The portal check only looked for IPv4 format (0.0.0.0:3260) and failed to detect IPv6 default portals ([::]:3260 or [::0]:3260), causing unnecessary portal creation attempts in IPv6 environments.

Now checks for both IPv4 and IPv6 default portal formats before attempting to create a new portal.