### PR TITLE
libvirt_xml: add VMOSXML support for uefi-vars varstore element

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -826,8 +826,12 @@ class VMXML(VMXMLBase):
     def undefine(self, options=None, virsh_instance=base.virsh):
         """Undefine this VM with libvirt retaining XML in instance"""
         os_attrs = self.os.fetch_attrs()
-        nvram = any([os_attrs.get("os_firmware") == "efi", os_attrs.get("nvram")])
-        if nvram:
+        has_uefi_vars = any([
+            os_attrs.get("os_firmware") == "efi",
+            os_attrs.get("nvram"),
+            os_attrs.get("varstore_attrs"),
+        ])
+        if has_uefi_vars:
             nvram_option = "--keep-nvram"
             if options is None:
                 options = nvram_option
@@ -3528,7 +3532,7 @@ class VMOSXML(base.LibvirtXMLBase):
     Elements:
         os:           list attributes - firmware
         type:         text attributes - arch, machine
-        loader:       path
+        loader:       path  attributes - readonly, type, format, stateless, secure
         boots:        list attributes - dev
         bootmenu:          attributes - enable, timeout
         smbios:            attributes - mode
@@ -3540,6 +3544,8 @@ class VMOSXML(base.LibvirtXMLBase):
         initrd:       text
         cmdline:      text
         dtb:          text
+        nvram:        text  attributes - template, type, format
+        varstore:           attributes - template, path
         firmware:     list attribute - feature
         acpi:         list attribute - table
     TODO:
@@ -3566,9 +3572,11 @@ class VMOSXML(base.LibvirtXMLBase):
         "initargs",
         "loader_readonly",
         "loader_type",
+        "loader_format",
         "nvram",
         "nvram_attrs",
         "nvram_source",
+        "varstore_attrs",
         "secure",
         "bootmenu_timeout",
         "os_firmware",
@@ -3579,7 +3587,6 @@ class VMOSXML(base.LibvirtXMLBase):
 
     def __init__(self, virsh_instance=base.virsh):
         accessors.XMLElementText("type", self, parent_xpath="/", tag_name="type")
-        accessors.XMLElementText("loader", self, parent_xpath="/", tag_name="loader")
         accessors.XMLAttribute(
             "arch", self, parent_xpath="/", tag_name="type", attribute="arch"
         )
@@ -3635,12 +3642,16 @@ class VMOSXML(base.LibvirtXMLBase):
         accessors.XMLElementText("cmdline", self, parent_xpath="/", tag_name="cmdline")
         accessors.XMLElementText("dtb", self, parent_xpath="/", tag_name="dtb")
         accessors.XMLElementText("init", self, parent_xpath="/", tag_name="init")
+        accessors.XMLElementText("loader", self, parent_xpath="/", tag_name="loader")
         accessors.XMLAttribute(
             "loader_readonly",
             self,
             parent_xpath="/",
             tag_name="loader",
             attribute="readonly",
+        )
+        accessors.XMLAttribute(
+            "secure", self, parent_xpath="/", tag_name="loader", attribute="secure"
         )
         accessors.XMLAttribute(
             "loader_type", self, parent_xpath="/", tag_name="loader", attribute="type"
@@ -3651,6 +3662,13 @@ class VMOSXML(base.LibvirtXMLBase):
             parent_xpath="/",
             tag_name="loader",
             attribute="stateless",
+        )
+        accessors.XMLAttribute(
+            "loader_format",
+            self,
+            parent_xpath="/",
+            tag_name="loader",
+            attribute="format",
         )
         accessors.XMLElementText("nvram", self, parent_xpath="/", tag_name="nvram")
         accessors.XMLElementDict(
@@ -3664,8 +3682,8 @@ class VMOSXML(base.LibvirtXMLBase):
             subclass=self.NvramSourceXML,
             subclass_dargs={"virsh_instance": virsh_instance},
         )
-        accessors.XMLAttribute(
-            "secure", self, parent_xpath="/", tag_name="loader", attribute="secure"
+        accessors.XMLElementDict(
+            "varstore_attrs", self, parent_xpath="/", tag_name="varstore"
         )
         accessors.XMLAttribute(
             "os_firmware", self, parent_xpath="/", tag_name="os", attribute="firmware"

--- a/virttest/utils_libvirt/libvirt_bios.py
+++ b/virttest/utils_libvirt/libvirt_bios.py
@@ -11,12 +11,12 @@ LOG = logging.getLogger("avocado." + __name__)
 
 def remove_bootconfig_items_from_vmos(osxml):
     """
-    Remove efi firmware attribute and loader/nvram elements
+    Remove efi firmware attribute and loader/nvram/varstore elements
 
     :param osxml: VMOSXML object
     :return: VMOSXML, the updated object
     """
-    # Remove efi firmware attribute and loader/nvram elements
+    # Remove efi firmware attribute and loader/nvram/varstore elements
     # if they exist which may affect newly added same elements
     os_attrs = osxml.fetch_attrs()
     LOG.debug("<os> configuration:%s", os_attrs)
@@ -24,6 +24,8 @@ def remove_bootconfig_items_from_vmos(osxml):
         osxml.del_os_firmware()
     if os_attrs.get("nvram"):
         osxml.del_nvram()
+    if os_attrs.get("varstore_attrs"):
+        osxml.del_varstore_attrs()
     if os_attrs.get("loader"):
         osxml.del_loader()
     if os_attrs.get("firmware"):


### PR DESCRIPTION
## Summary

Libvirt 12.1+ enlarged the domain `<os>` XML for the new uefi-vars firmware
model on aarch64 (and optionally x86): besides `<loader>` and `<nvram>`,
guests can now use a `<varstore template="..." path="..."/>` element for
UEFI variable storage (e.g. Secure Boot with `vars.secboot.json`).

This PR extends avocado-vt's `VMOSXML` bindings so tests can build and
verify that XML via `setup_attrs()` / `varstore_attrs`, matching the
existing `nvram_attrs` pattern.

Changes:
- Add `varstore_attrs` accessor for `<varstore template="..." path="..."/>`
- Add `loader_format` accessor for the loader `format` attribute
- Update `VMXML.undefine()` to pass `--keep-nvram` when varstore is present
- Update `remove_bootconfig_items_from_vmos()` to remove stale `<varstore>`
  before applying new firmware XML
- Document enlarged `<os>` elements in `VMOSXML` docstring

## Test plan

- [ ] Used locally with tp-libvirt `guest_os_booting.ovmf_firmware_feature`
      aarch64 secure-boot / custom varstore template variants
- [ ] `varstore_attrs` round-trip: `setup_attrs(os={...})` produces
      `<varstore template='...'/>` in dumpxml
- [ ] Existing nvram-based OVMF tests unaffected