### PR TITLE
Add support for Python 3.14 this time with integration test coverage (separate PR)

### DIFF
--- a/avocado_vt/plugins/vt_runner.py
+++ b/avocado_vt/plugins/vt_runner.py
@@ -154,9 +154,13 @@ class VTTestRunner(BaseRunner):
             )
         else:
             try:
-                queue = multiprocessing.SimpleQueue()
+                if "fork" in multiprocessing.get_all_start_methods():
+                    context = multiprocessing.get_context("fork")
+                else:
+                    context = multiprocessing
+                queue = context.SimpleQueue()
                 vt_test = VirtTest(queue, self.runnable)
-                process = multiprocessing.Process(target=vt_test.runTest)
+                process = context.Process(target=vt_test.runTest)
                 process.start()
                 while True:
                     time.sleep(RUNNER_RUN_CHECK_INTERVAL)

--- a/virttest/error_event.py
+++ b/virttest/error_event.py
@@ -17,6 +17,17 @@ class EventBus(object):
         """Create the error event bus with queue.Queue."""
         self.error_events = queue.Queue()
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # do not pickle the Queue as it is not needed in the child
+        del state["error_events"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # reconstruct a fresh queue if needed
+        self.error_events = queue.Queue()
+
     def put(self, event, block=True, timeout=None):
         """Put an event into the event bus."""
         self.error_events.put(event, block, timeout)

--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -4393,7 +4393,9 @@ class VM(virt_vm.BaseVM):
         else:
             vcpus_info = self.monitor.info("cpus", debug=debug).splitlines()
             vcpu_pids = [
-                int(vcpu_info.split("thread_id=")[1]) for vcpu_info in vcpus_info
+                int(re.search(r"thread_id=\s*(\d+)", vcpu_info).group(1))
+                for vcpu_info in vcpus_info
+                if vcpu_info is not None
             ]
 
         return vcpu_pids
@@ -5715,7 +5717,7 @@ class VM(virt_vm.BaseVM):
             if not utils_misc.wait_for(
                 # no monitor.migrate-status method
                 lambda: re.search(
-                    "(status.*completed)", str(self.monitor.info("migrate")), re.M
+                    "([Ss]tatus.*completed)", str(self.monitor.info("migrate")), re.M
                 ),
                 self.MIGRATE_TIMEOUT,
                 2,

--- a/virttest/vt_iothread.py
+++ b/virttest/vt_iothread.py
@@ -22,6 +22,17 @@ class IOThreadManagerBase(object):
             self._iothread_finder[iothread.get_aid()] = iothread
         self._index = itertools.count(len(iothreads))
 
+    def __getstate__(self):
+        """Return a pickle-safe state for the iothread manager."""
+        state = self.__dict__.copy()
+        state.pop("_index", None)
+        return state
+
+    def __setstate__(self, state):
+        """Restore the manager state and rebuild the internal counter."""
+        self.__dict__.update(state)
+        self._index = itertools.count(len(self._iothread_finder))
+
     def find_iothread(self, iothread_id):
         """Find iothread with the id specified."""
         return self._iothread_finder.get(iothread_id)


### PR DESCRIPTION
The default CI only checked superficial things and didn't truly test compatibility with Python 3.14 which needs:

1) adaptations to new `multiprocessing` module importing and picking behavior
2) adaptations to newer qemu outputs on some python 3.14 inclusive distros