### PR TITLE
virttest: add wrapper for await in virsh.py

### DIFF
--- a/virttest/virsh.py
+++ b/virttest/virsh.py
@@ -5451,3 +5451,21 @@ def domthrottlegroupset(name, throttle_group, options="", **dargs):
 
     cmd = "domthrottlegroupset %s %s %s" % (name, throttle_group, options)
     return command(cmd, **dargs)
+
+
+def await_condition(name, condition, timeout=None, **dargs):
+    """
+    Wait for a domain condition to be met (virsh await).
+
+    :param name: domain name, id, or uuid
+    :param condition: condition string ('domain-inactive',
+                      'guest-agent-available')
+    :param timeout: optional --timeout value in seconds; omitted if None
+    :param dargs: standardized virsh function API keywords
+    :return: CmdResult object
+    """
+    cmd = "await %s --condition %s" % (name, condition)
+    if timeout is not None:
+        cmd += " --timeout %s" % timeout
+        dargs.setdefault("timeout", int(timeout) + 10)
+    return command(cmd, **dargs)


### PR DESCRIPTION
await is a feature added in libvirt 11.7.0, as a way to pause scripts until a certain state change is achieved by the VM. It currently supports only two states, domain-inactive and guest-agent-available.