### PR TITLE
cpu: remove vnmi from EPYC-Genoa CPU_TYPES_RE

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -108,12 +108,12 @@ CPU_TYPES = {
 }
 CPU_TYPES_RE = {
     "EPYC-Genoa-v1": (
-        "la57,vnmi,avx512f,avx512dq,avx512ifma,avx512cd,"
+        "la57,avx512f,avx512dq,avx512ifma,avx512cd,"
         "avx512bw,avx512vl,avx512vbmi,avx512_vbmi2|avx512vbmi2,gfni,"
         "avx512_vnni,avx512_bitalg,avx512_vpopcntdq,avx512_bf16"
     ),
     "EPYC-Genoa": (
-        "la57,vnmi,avx512f,avx512dq,avx512ifma,avx512cd,"
+        "la57,avx512f,avx512dq,avx512ifma,avx512cd,"
         "avx512bw,avx512vl,avx512vbmi,avx512_vbmi2|avx512vbmi2,gfni,"
         "avx512_vnni,avx512_bitalg,avx512_vpopcntdq,avx512_bf16"
     ),


### PR DESCRIPTION
## Summary
- `vnmi` (SVM Virtual NMI) is not part of QEMU's EPYC-Genoa or EPYC-Genoa-v1 model definitions
- `query-cpu-model-expansion type=full` reports `vnmi=False` for both models
- tp-qemu's `cpu_info_check` test verifies CPU_TYPES_RE flags against QEMU's query-cpu-model-expansion output; it fails on Genoa/Turin hosts with "Check cpu model props failed, vnmi is not True"

## Verification
- Checked QEMU 10.1.0 `query-cpu-model-expansion type=static` for EPYC-Genoa-v1 and v2: `vnmi=False` in both
- Ran tp-qemu cpu_info_check test on Turin after fix: PASS