### PR TITLE
cpu: remove vnmi from EPYC-Genoa CPU_TYPES_RE

### DIFF
--- a/virttest/cpu.py
+++ b/virttest/cpu.py
@@ -108,12 +108,12 @@ CPU_TYPES = {
 }
 CPU_TYPES_RE = {
     "EPYC-Genoa-v1": (
-        "la57,vnmi,avx512f,avx512dq,avx512ifma,avx512cd,"
+        "la57,avx512f,avx512dq,avx512ifma,avx512cd,"
         "avx512bw,avx512vl,avx512vbmi,avx512_vbmi2|avx512vbmi2,gfni,"
         "avx512_vnni,avx512_bitalg,avx512_vpopcntdq,avx512_bf16"
     ),
     "EPYC-Genoa": (
-        "la57,vnmi,avx512f,avx512dq,avx512ifma,avx512cd,"
+        "la57,avx512f,avx512dq,avx512ifma,avx512cd,"
         "avx512bw,avx512vl,avx512vbmi,avx512_vbmi2|avx512vbmi2,gfni,"
         "avx512_vnni,avx512_bitalg,avx512_vpopcntdq,avx512_bf16"
     ),


### PR DESCRIPTION
EPYC-Genoa does not include vnmi in its QEMU CPU model definition.
Remove it from CPU_TYPES_RE so cpu_info_check doesn't fail trying
to match a nonexistent property.

Signed-off-by: Igor Mammedov <imammedo@redhat.com>