### PR TITLE
Handle syntax warnings detectable in the newest Python 3.14

### DIFF
--- a/selftests/unit/test_utils_misc.py
+++ b/selftests/unit/test_utils_misc.py
@@ -4,6 +4,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock as unittest_mock
 
 from avocado.utils import process
 
@@ -17,6 +18,66 @@ from virttest.unittest_utils import mock
 
 
 class TestUtilsMisc(unittest.TestCase):
+    def test_get_distro_from_session(self):
+        session = unittest_mock.Mock()
+        session.cmd_status_output.return_value = (0, "ID=fedora")
+
+        self.assertEqual(utils_misc.get_distro(session), "fedora")
+
+    def test_get_distro_returns_empty_string_on_session_error(self):
+        session = unittest_mock.Mock()
+        session.cmd_status_output.side_effect = RuntimeError("session error")
+
+        self.assertEqual(utils_misc.get_distro(session), "")
+
+    @unittest_mock.patch("aexpect.remote.copy_files_from")
+    @unittest_mock.patch("virttest.utils_package.package_install", return_value=True)
+    @unittest_mock.patch("virttest.utils_misc.get_distro", return_value="fedora")
+    def test_get_sosreport_returns_path_and_closes_session(
+        self, _get_distro, _package_install, copy_files_from
+    ):
+        session = unittest_mock.Mock()
+        session.cmd_status_output.return_value = (0, "sosreport complete")
+
+        result = utils_misc.get_sosreport(
+            path="/host/sosreport",
+            session=session,
+            remote_ip="192.0.2.1",
+            remote_pwd="password",
+        )
+
+        self.assertEqual(result, "/host/sosreport")
+        copy_files_from.assert_called_once()
+        session.close.assert_called_once_with()
+
+    @unittest_mock.patch("virttest.utils_package.package_install", return_value=True)
+    @unittest_mock.patch("virttest.utils_misc.get_distro", return_value="fedora")
+    def test_get_sosreport_returns_none_on_ignored_exception(
+        self, _get_distro, _package_install
+    ):
+        session = unittest_mock.Mock()
+        session.cmd_status_output.side_effect = RuntimeError("sosreport failed")
+
+        result = utils_misc.get_sosreport(path="/host/sosreport", session=session)
+
+        self.assertIsNone(result)
+        session.close.assert_called_once_with()
+
+    @unittest_mock.patch("virttest.utils_package.package_install", return_value=True)
+    @unittest_mock.patch("virttest.utils_misc.get_distro", return_value="fedora")
+    def test_get_sosreport_raises_and_closes_session(
+        self, _get_distro, _package_install
+    ):
+        session = unittest_mock.Mock()
+        session.cmd_status_output.side_effect = RuntimeError("sosreport failed")
+
+        with self.assertRaises(utils_misc.exceptions.TestError):
+            utils_misc.get_sosreport(
+                path="/host/sosreport", session=session, ignore_status=False
+            )
+
+        session.close.assert_called_once_with()
+
     def test_get_archive_tarball_name(self):
         tarball_name = utils_misc.get_archive_tarball_name("/tmp", "tmp-archive", "bz2")
         self.assertEqual(tarball_name, "tmp-archive.tar.bz2")

--- a/virttest/utils_misc.py
+++ b/virttest/utils_misc.py
@@ -198,8 +198,7 @@ def cmd_status_output(
     except Exception as info:
         status = 1
         stdout = to_text(info)
-    finally:
-        return status, stdout
+    return status, stdout
 
 
 def write_keyval(path, dictionary, type_tag=None, tap_report=None):
@@ -4460,17 +4459,18 @@ def get_distro(session=None):
     """
     if not session:
         return distro.detect().name
+    distro_name = ""
+    cmd = "cat /etc/os-release | grep '^ID='"
+    try:
+        status, output = session.cmd_status_output(cmd, timeout=300)
+    except Exception as info:
+        LOG.debug("Unable to get the distro name: %s", info)
+        return distro_name
+    if status:
+        LOG.debug("Unable to get the distro name: %s" % output)
     else:
-        distro_name = ""
-        cmd = "cat /etc/os-release | grep '^ID='"
-        try:
-            status, output = session.cmd_status_output(cmd, timeout=300)
-            if status:
-                LOG.debug("Unable to get the distro name: %s" % output)
-            else:
-                distro_name = output.split("=")[1].strip()
-        finally:
-            return distro_name
+        distro_name = output.split("=")[1].strip()
+    return distro_name
 
 
 def get_guest_distro_info(vm, serial=False):
@@ -4662,12 +4662,13 @@ def get_sosreport(
     except Exception as info:
         if ignore_status:
             LOG.error(info)
+            return None
         else:
             raise exceptions.TestError(info)
     finally:
         if session:
             session.close()
-        return host_path
+    return host_path
 
 
 def asterisk_passwd(passwd):

--- a/virttest/virt_vm.py
+++ b/virttest/virt_vm.py
@@ -741,27 +741,23 @@ class BaseVM(object):
         :return: host path where guest sosrepost saved, default to logdir
                  None if vm is not linux or sosreport fails.
         """
-        log_path = None
         if not self.params["os_type"] == "linux":
             LOG.warning("sosreport not applicable for %s", self.params["os_type"])
             return None
-        try:
-            pkg = "sos"
-            if "ubuntu" in self.get_distro().lower():
-                pkg = "sosreport"
-            guest_ip = self.get_address(session=self.session)
-            guest_user = self.params["username"]
-            guest_pwd = self.params["password"]
-            log_path = utils_misc.get_sosreport(
-                session=self.session,
-                remote_ip=guest_ip,
-                remote_pwd=guest_pwd,
-                remote_user=guest_user,
-                sosreport_name=self.name,
-                sosreport_pkg=pkg,
-            )
-        finally:
-            return log_path
+        pkg = "sos"
+        if "ubuntu" in self.get_distro().lower():
+            pkg = "sosreport"
+        guest_ip = self.get_address(session=self.session)
+        guest_user = self.params["username"]
+        guest_pwd = self.params["password"]
+        return utils_misc.get_sosreport(
+            session=self.session,
+            remote_ip=guest_ip,
+            remote_pwd=guest_pwd,
+            remote_user=guest_user,
+            sosreport_name=self.name,
+            sosreport_pkg=pkg,
+        )
 
     def get_mac_address(self, nic_index=0):
         """


### PR DESCRIPTION
Add some isolation (unit) tests to verify the misc util functions affected return correct results on different exceptions.