### PR TITLE
Use the avocado framework for VT's own selftests

### DIFF
--- a/selftests/doc/test_doc_build.py
+++ b/selftests/doc/test_doc_build.py
@@ -7,6 +7,7 @@ This is geared towards documentation build regression testing.
 import os
 import unittest
 
+from avocado import Test, skip
 from avocado.utils import process
 
 basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
@@ -17,7 +18,8 @@ class DocBuildError(Exception):
     pass
 
 
-class DocBuildTest(unittest.TestCase):
+class DocBuildTest(Test):
+    @skip("Documentation built goes beyond unit tests")
     @unittest.skip("Documentation built goes beyond unit tests")
     def test_build_docs(self):
         """

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 
+from avocado import Test
 from avocado.utils import process, script
 
 BASE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
@@ -70,7 +71,7 @@ verify_host_dmesg = no
 """
 
 
-class BasicTests(unittest.TestCase):
+class BasicTests(Test):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="avocado_" + __name__)
         self.rm_files = []

--- a/selftests/unit/test_cartesian_config.py
+++ b/selftests/unit/test_cartesian_config.py
@@ -10,13 +10,15 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest import cartesian_config
 
 mydir = os.path.dirname(__file__)
 testdatadir = os.path.join(mydir, "unittest_data")
 
 
-class CartesianConfigTest(unittest.TestCase):
+class CartesianConfigTest(Test):
     def _checkDictionaries(self, parser, reference):
         result = list(parser.get_dicts())
         # as the dictionary list is very large, test each item individually:

--- a/selftests/unit/test_cartesian_config_lint.py
+++ b/selftests/unit/test_cartesian_config_lint.py
@@ -8,6 +8,8 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
+from avocado import Test, skipIf
+
 from virttest import cartesian_config
 
 BASEDIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -15,7 +17,7 @@ RHELDIR = os.path.join(BASEDIR, "shared", "cfg", "guest-os", "Linux", "RHEL")
 UNATTENDEDDIR = os.path.join(BASEDIR, "shared", "unattended")
 
 
-class CartesianCfgLint(unittest.TestCase):
+class CartesianCfgLint(Test):
     @staticmethod
     def get_cfg_as_dict(path, drop_only=True, drop_conditional_assigment=True):
         """
@@ -48,6 +50,7 @@ class CartesianCfgLint(unittest.TestCase):
         assert len_dicts == 1
         return dicts[0]
 
+    @skipIf(not os.path.isdir(RHELDIR), "Could not find RHEL configuration dir")
     @unittest.skipIf(
         not os.path.isdir(RHELDIR), "Could not find RHEL configuration dir"
     )
@@ -104,6 +107,9 @@ class CartesianCfgLint(unittest.TestCase):
                             "isos/linux/RHEL-%s.%s-%s-DVD.iso" % (major, minor, arch),
                         )
 
+    @skipIf(
+        not os.path.isdir(UNATTENDEDDIR), "Could not find unattended configuration dir"
+    )
     @unittest.skipIf(
         not os.path.isdir(UNATTENDEDDIR), "Could not find unattended configuration dir"
     )

--- a/selftests/unit/test_env_process.py
+++ b/selftests/unit/test_env_process.py
@@ -6,10 +6,12 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
+from avocado import Test
+
 from virttest.env_process import QEMU_VERSION_RE
 
 
-class QEMUVersion(unittest.TestCase):
+class QEMUVersion(Test):
     def test_regex(self):
         versions_expected = {
             "QEMU emulator version 2.9.0(qemu-kvm-rhev-2.9.0-16.el7_4.8)": (

--- a/selftests/unit/test_installer.py
+++ b/selftests/unit/test_installer.py
@@ -9,10 +9,12 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest import cartesian_config, installer
 
 
-class installer_test(unittest.TestCase):
+class installer_test(Test):
     def setUp(self):
         self.registry = installer.InstallerRegistry()
 

--- a/selftests/unit/test_iscsi.py
+++ b/selftests/unit/test_iscsi.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest
 
+from avocado import Test
 from avocado.utils import path, process
 from avocado.utils.process import CmdResult
 
@@ -15,7 +16,7 @@ from virttest import iscsi, utils_package, utils_selinux
 from virttest.unittest_utils import mock
 
 
-class iscsi_test(unittest.TestCase):
+class iscsi_test(Test):
     def setup_stubs_init(self):
         pass
 

--- a/selftests/unit/test_libvirt_network.py
+++ b/selftests/unit/test_libvirt_network.py
@@ -7,6 +7,7 @@ import os
 import sys
 import unittest
 
+from avocado import Test
 from avocado.utils.process import CmdResult
 
 # simple magic for using scripts within a source tree
@@ -30,7 +31,7 @@ global _net_state
 _net_state = {"active": False, "autostart": False, "persistent": False}
 
 
-class NetworkTestBase(unittest.TestCase):
+class NetworkTestBase(Test):
     """
     Base class for NetworkXML test providing fake virsh commands.
     """

--- a/selftests/unit/test_libvirt_storage.py
+++ b/selftests/unit/test_libvirt_storage.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest
 
+from avocado import Test
 from avocado.utils.process import CmdResult
 
 # simple magic for using scripts within a source tree
@@ -26,7 +27,7 @@ global _pools_output
 _pools_output = _DEFAULT_POOL
 
 
-class PoolTestBase(unittest.TestCase):
+class PoolTestBase(Test):
     @staticmethod
     def _pool_list(option="--all", **dargs):
         # Bogus output of virsh commands

--- a/selftests/unit/test_libvirt_xml.py
+++ b/selftests/unit/test_libvirt_xml.py
@@ -7,6 +7,7 @@ import sys
 import unittest
 
 import six
+from avocado import Test
 from avocado.utils import process
 
 try:
@@ -55,7 +56,7 @@ toggle='no'/></features></guest></capabilities>"""
 CAPABILITIES = _CAPABILITIES % UUID
 
 
-class LibvirtXMLTestBase(unittest.TestCase):
+class LibvirtXMLTestBase(Test):
 
     # Override instance methods needed for testing
 

--- a/selftests/unit/test_libvirt_xml.py
+++ b/selftests/unit/test_libvirt_xml.py
@@ -23,7 +23,7 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
 
 from test_virsh import FakeVirshFactory
 
-from virttest import data_dir, utils_misc, xml_utils
+from virttest import utils_misc, xml_utils
 from virttest.libvirt_xml import (
     accessors,
     base,
@@ -210,13 +210,11 @@ class LibvirtXMLTestBase(Test):
         return process.CmdResult("virsh nodedev-dumpxml pci_0000_00_00_0", xml, "", 0)
 
     def setUp(self):
+        super().setUp()
         self.dummy_virsh = FakeVirshFactory()
         # make a tmp_dir to store information.
-        LibvirtXMLTestBase.__doms_dir__ = os.path.join(
-            data_dir.get_tmp_dir(), "domains"
-        )
-        if not os.path.isdir(LibvirtXMLTestBase.__doms_dir__):
-            os.makedirs(LibvirtXMLTestBase.__doms_dir__)
+        LibvirtXMLTestBase.__doms_dir__ = os.path.join(self.workdir, "domains")
+        os.makedirs(LibvirtXMLTestBase.__doms_dir__)
 
         # Normally not kosher to call super_set, but required here for testing
         self.dummy_virsh.__super_set__("capabilities", self._capabilities)
@@ -227,8 +225,10 @@ class LibvirtXMLTestBase(Test):
 
     def tearDown(self):
         librarian.DEVICE_TYPES = list(ORIGINAL_DEVICE_TYPES)
-        if os.path.isdir(self.__doms_dir__):
-            shutil.rmtree(self.__doms_dir__)
+        if os.path.isdir(LibvirtXMLTestBase.__doms_dir__):
+            shutil.rmtree(LibvirtXMLTestBase.__doms_dir__)
+        LibvirtXMLTestBase.__doms_dir__ = None
+        super().tearDown()
 
 
 # AccessorsTest.test_XMLElementNest is namespace sensitive

--- a/selftests/unit/test_nfs.py
+++ b/selftests/unit/test_nfs.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest
 
+from avocado import Test
 from avocado.utils import path, process
 
 # simple magic for using scripts within a source tree
@@ -35,7 +36,7 @@ class FakeService(object):
         return self.get_stdout("restart")
 
 
-class nfs_test(unittest.TestCase):
+class nfs_test(Test):
     def setup_stubs_init(self):
         path.find_command.expect_call("mount")
         path.find_command.expect_call("service")

--- a/selftests/unit/test_propcan.py
+++ b/selftests/unit/test_propcan.py
@@ -9,10 +9,12 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest import propcan
 
 
-class TestPropCanBase(unittest.TestCase):
+class TestPropCanBase(Test):
     def test_empty_init(self):
         self.assertRaises(NotImplementedError, propcan.PropCanBase)
 
@@ -197,7 +199,7 @@ class TestPropCanBase(unittest.TestCase):
         self.assertEqual(testdict, kwargs)
 
 
-class TestPropCan(unittest.TestCase):
+class TestPropCan(Test):
     def setUp(self):
         logging.disable(logging.INFO)
 

--- a/selftests/unit/test_qemu_devices.py
+++ b/selftests/unit/test_qemu_devices.py
@@ -18,6 +18,7 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
 import six
+from avocado import Test, skip
 from avocado.utils.process import CmdResult
 from six.moves import xrange
 
@@ -67,7 +68,7 @@ class MockHMPMonitor(qemu_monitor.HumanMonitor):
         pass
 
 
-class Devices(unittest.TestCase):
+class Devices(Test):
     """set of qemu devices tests"""
 
     def test_q_base_device(self):
@@ -149,7 +150,7 @@ class Devices(unittest.TestCase):
         self.assertEqual(out, exp, "QMP command corrupted:\n%s\n%s" % (out, exp))
 
 
-class Buses(unittest.TestCase):
+class Buses(Test):
     """Set of bus-representation tests"""
 
     def test_q_sparse_bus(self):
@@ -668,7 +669,7 @@ Slots:
         self.assertEqual("usb1.0(uhci): {1:a'usb-kbd',2:a'usb-kbd'}", hub3.str_short())
 
 
-class Container(unittest.TestCase):
+class Container(Test):
     """Tests related to the abstract representation of qemu machine"""
 
     def setUp(self):
@@ -952,11 +953,10 @@ fdc
         out = qdev.str_bus_short()
         assert out == exp, "Bus representation is corrupted:\n%s\n%s" % (out, exp)
 
+    @skip("Current hotplug state handling diverges from this legacy workflow")
+    @unittest.skip("Current hotplug state handling diverges from this legacy workflow")
     def test_qdev_hotplug(self):
         """Test the hotplug/unplug functionality"""
-        self.skipTest(
-            "Current hotplug state handling diverges from this legacy workflow"
-        )
         qdev = self.create_qdev("vm1", False, True)
         devs = qdev.machine_by_params(ParamsDict({"machine_type": "pc"}))
         for dev in devs:
@@ -1252,8 +1252,9 @@ fdc
             qdev2.str_long(),
         )
 
+    @skip("Current PCIe parent-bus matching rejects this legacy topology")
+    @unittest.skip("Current PCIe parent-bus matching rejects this legacy topology")
     def test_pci(self):
-        self.skipTest("Current PCIe parent-bus matching rejects this legacy topology")
         qdev = self.create_qdev("vm1")
         devs = qdev.machine_by_params(ParamsDict({"machine_type": "pc"}))
         for dev in devs:

--- a/selftests/unit/test_qemu_monitor.py
+++ b/selftests/unit/test_qemu_monitor.py
@@ -10,6 +10,7 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
 import six
+from avocado import Test
 
 from virttest import qemu_monitor
 
@@ -24,7 +25,7 @@ class MockMonitor(qemu_monitor.Monitor):
         pass
 
 
-class InfoNumaTests(unittest.TestCase):
+class InfoNumaTests(Test):
     def testZeroNodes(self):
         d = "0 nodes\n"
         r = qemu_monitor.Monitor.parse_info_numa(d)
@@ -42,7 +43,7 @@ class InfoNumaTests(unittest.TestCase):
         self.assertEqual(r, [(12, set([0, 2, 4])), (34, set([1, 3, 5]))])
 
 
-class InfoBlocks(unittest.TestCase):
+class InfoBlocks(Test):
     def testParseBlocks(self):
         info_1_4 = """ide0-hd0: removable=0 io-status=ok file=c.qcow2 backing_file=b.qcow2 backing_file_depth=2 ro=0 drv=qcow2 encrypted=0 bps=0 bps_rd=0 bps_wr=0 iops=0 iops_rd=0 iops_wr=0
 scsi0-hd0: removable=0 io-status=ok file=a.qcow ro=1 drv=raw encrypted=0 bps=0 bps_rd=0 bps_wr=0 iops=0 iops_rd=0 iops_wr=0

--- a/selftests/unit/test_qemu_qtree.py
+++ b/selftests/unit/test_qemu_qtree.py
@@ -17,6 +17,7 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
 import six
+from avocado import Test
 from six.moves import xrange
 
 from virttest import qemu_qtree
@@ -189,7 +190,7 @@ params = ParamsDict(
 )
 
 
-class QtreeContainerTest(unittest.TestCase):
+class QtreeContainerTest(Test):
     """QtreeContainer tests"""
 
     def test_qtree(self):
@@ -256,7 +257,7 @@ class QtreeContainerTest(unittest.TestCase):
         self.assertRaises(ValueError, qtree.parse_info_qtree, info)
 
 
-class QtreeDiskContainerTest(unittest.TestCase):
+class QtreeDiskContainerTest(Test):
     """QtreeDiskContainer tests"""
 
     def setUp(self):
@@ -326,7 +327,7 @@ Host: scsi1 Channel: 00 Id: 00 Lun: 00
         self.assertEqual(disks.check_guests_proc_scsi(_guest_proc_scsi), (0, 1, 1, 0))
 
 
-class KvmQtreeClassTest(unittest.TestCase):
+class KvmQtreeClassTest(Test):
     """Additional tests for qemu_qtree classes"""
 
     def test_qtree_bus_bus(self):

--- a/selftests/unit/test_remote.py
+++ b/selftests/unit/test_remote.py
@@ -9,10 +9,12 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest import data_dir, remote
 
 
-class RemoteFileTest(unittest.TestCase):
+class RemoteFileTest(Test):
     tmp_dir = data_dir.get_tmp_dir()
     test_file_path = os.path.join(tmp_dir, "remote_file")
     default_data = ["RemoteFile Test.\n", "Pattern Line."]

--- a/selftests/unit/test_setup_networking.py
+++ b/selftests/unit/test_setup_networking.py
@@ -1,11 +1,13 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from avocado import Test
+
 from virttest.test_setup.networking import BridgeConfig, NetworkProxies
 from virttest.utils_params import Params
 
 
-class TestProxySetuper(unittest.TestCase):
+class TestProxySetuper(Test):
     def setUp(self):
         self._test_mock = Mock()
         self._env_mock = Mock()
@@ -108,7 +110,7 @@ class TestProxySetuper(unittest.TestCase):
             np.setup()
 
 
-class TestBridgeSetuper(unittest.TestCase):
+class TestBridgeSetuper(Test):
     def setUp(self):
         self._test_mock = Mock()
         self._env_mock = Mock()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -14,6 +14,8 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from avocado_vt import test as vt_test
 
 
@@ -26,7 +28,7 @@ class FakeJob(object):
 FAKE_PARAMS = {"shortname": "fake", "vm_type": "fake"}
 
 
-class VirtTestTest(unittest.TestCase):
+class VirtTestTest(Test):
     def setUp(self):
         self.test = vt_test.VirtTest(job=FakeJob(), vt_params=FAKE_PARAMS)
 

--- a/selftests/unit/test_utils_cgroup.py
+++ b/selftests/unit/test_utils_cgroup.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 
+from avocado import Test
 from avocado.core import exceptions
 
 # simple magic for using scripts within a source tree
@@ -134,7 +135,7 @@ mount_cases = [
 ]
 
 
-class CgroupTest(unittest.TestCase):
+class CgroupTest(Test):
     def test_get_cgroup_mountpoint(self):
         for case in mount_cases:
             # Let's work around the fact that NamedTemporaryFile

--- a/selftests/unit/test_utils_config.py
+++ b/selftests/unit/test_utils_config.py
@@ -18,6 +18,8 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test, skipIf
+
 from virttest import utils_config
 
 # Test conf file content
@@ -41,7 +43,7 @@ f = test
 """
 
 
-class SectionlessConfigTest(unittest.TestCase):
+class SectionlessConfigTest(Test):
     def test_accessers(self):
         config_file = tempfile.NamedTemporaryFile()
         config_path = config_file.name
@@ -192,6 +194,7 @@ class SectionlessConfigTest(unittest.TestCase):
         finally:
             os.remove(config_path)
 
+    @skipIf(PYTHON_26, "Unreliable in python 2.6")
     @unittest.skipIf(PYTHON_26, "Unreliable in python 2.6")
     def test_restore(self):
         config_file = tempfile.NamedTemporaryFile()
@@ -240,6 +243,7 @@ class SectionlessConfigTest(unittest.TestCase):
                 final_file.close()
             os.remove(config_path)
 
+    @skipIf(PYTHON_26, "Unreliable in python 2.6")
     @unittest.skipIf(PYTHON_26, "Unreliable in python 2.6")
     def test_sync_file(self):
         config_file = tempfile.NamedTemporaryFile()
@@ -270,7 +274,7 @@ class SectionlessConfigTest(unittest.TestCase):
             os.remove(config_path)
 
 
-class LibvirtConfigCommonTest(unittest.TestCase):
+class LibvirtConfigCommonTest(Test):
     class UnimplementedConfig(utils_config.LibvirtConfigCommon):
         pass
 
@@ -366,7 +370,7 @@ class LibvirtConfigCommonTest(unittest.TestCase):
             os.remove("/tmp/config_unittest.conf")
 
 
-class LibvirtConfigTest(unittest.TestCase):
+class LibvirtConfigTest(Test):
     def test_accessers(self):
         config_file = tempfile.NamedTemporaryFile()
         config_path = config_file.name

--- a/selftests/unit/test_utils_env.py
+++ b/selftests/unit/test_utils_env.py
@@ -11,6 +11,8 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest import utils_env, utils_misc, utils_params
 
 
@@ -44,7 +46,7 @@ class FakeSyncListenServer(object):
         logging.info("Closing sync server (instance %s)", self.instance)
 
 
-class TestEnv(unittest.TestCase):
+class TestEnv(Test):
     def setUp(self):
         self.envfilename = "/dev/shm/EnvUnittest" + self.id()
 

--- a/selftests/unit/test_utils_libguestfs.py
+++ b/selftests/unit/test_utils_libguestfs.py
@@ -5,6 +5,7 @@ import sys
 import unittest
 from unittest import mock
 
+from avocado import Test
 from avocado.utils import path, process
 
 # simple magic for using scripts within a source tree
@@ -15,7 +16,7 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
 from virttest import utils_libguestfs as lgf
 
 
-class LibguestfsTest(unittest.TestCase):
+class LibguestfsTest(Test):
     def test_lgf_cmd_check(self):
         cmds = ["virt-ls", "virt-cat"]
         for cmd in cmds:
@@ -45,7 +46,7 @@ class LibguestfsTest(unittest.TestCase):
         )
 
 
-class SlotsCheckTest(unittest.TestCase):
+class SlotsCheckTest(Test):
     def test_LibguestfsBase_default_slots(self):
         """Default slots' value check"""
         lfb = lgf.LibguestfsBase()

--- a/selftests/unit/test_utils_misc.py
+++ b/selftests/unit/test_utils_misc.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from unittest import mock as unittest_mock
 
+from avocado import Test
 from avocado.utils import process
 
 # simple magic for using scripts within a source tree
@@ -17,7 +18,7 @@ from virttest import build_helper, cartesian_config, utils_misc, utils_package
 from virttest.unittest_utils import mock
 
 
-class TestUtilsMisc(unittest.TestCase):
+class TestUtilsMisc(Test):
     def test_get_distro_from_session(self):
         session = unittest_mock.Mock()
         session.cmd_status_output.return_value = (0, "ID=fedora")
@@ -184,7 +185,7 @@ all_nodes_contents = "0\n"
 online_nodes_contents = "0\n"
 
 
-class TestNumaNode(unittest.TestCase):
+class TestNumaNode(Test):
     def setUp(self):
         self.god = mock.mock_god(ut=self)
         self.god.stub_with(process, "run", utils_run)

--- a/selftests/unit/test_utils_net.py
+++ b/selftests/unit/test_utils_net.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 import unittest
 
+from avocado import Test
 from avocado.utils import process
 from six.moves import xrange
 
@@ -44,7 +45,7 @@ class FakeVm(object):
         logging.info("Fake VM %s (instance %s)", self.name, self.instance)
 
 
-class TestBridge(unittest.TestCase):
+class TestBridge(Test):
     class FakeCmd(object):
         iter = 0
 
@@ -137,7 +138,7 @@ virbr2        8000.525400c0b080    yes        em1
         os.rmdir(self.sysfs_net_dir)
 
 
-class TestVirtIface(unittest.TestCase):
+class TestVirtIface(Test):
 
     VirtIface = utils_net.VirtIface
 
@@ -240,7 +241,7 @@ class TestLibvirtIface(TestVirtIface):
         self.VirtIface = utils_net.LibvirtIface
 
 
-class TestVmNetStyle(unittest.TestCase):
+class TestVmNetStyle(Test):
     def setUp(self):
         logging.disable(logging.INFO)
         logging.disable(logging.WARNING)
@@ -262,7 +263,7 @@ class TestVmNetStyle(unittest.TestCase):
         self.assertTrue(issubclass(style["container_class"], utils_net.VirtIface))
 
 
-class TestVmNet(unittest.TestCase):
+class TestVmNet(Test):
     def setUp(self):
         logging.disable(logging.INFO)
         logging.disable(logging.WARNING)
@@ -296,7 +297,7 @@ class TestVmNet(unittest.TestCase):
         self.assertEqual(test_data[2]["mac"], vmnet[2]["mac"])
 
 
-class TestVmNetSubclasses(unittest.TestCase):
+class TestVmNetSubclasses(Test):
 
     nettests_cartesian = """
     variants:

--- a/selftests/unit/test_utils_net.py
+++ b/selftests/unit/test_utils_net.py
@@ -370,16 +370,17 @@ class TestVmNetSubclasses(Test):
     """
 
     mac_prefix = "01:02:03:04:05:"
-    db_filename = "/dev/shm/UnitTest_AddressPool"
-    db_item_count = 0
     counter = 0  # for printing dots
 
     def setUp(self):
         """
         Runs before every test
         """
+        super().setUp()
         logging.disable(logging.INFO)
         logging.disable(logging.WARNING)
+        self.db_filename = os.path.join(self.workdir, "UnitTest_AddressPool")
+        self.db_item_count = 0
         # MAC generator produces from incrementing byte list
         # at random starting point (class property).
         # make sure it starts counting at zero before every test
@@ -397,6 +398,69 @@ class TestVmNetSubclasses(Test):
                 nics = vm.get("nics")
                 if nics and len(nics.split()) > 0:
                     self.db_item_count += 1
+
+    def _populate_cartesian_db(self):
+        """Populate a fresh address pool from the Cartesian test data."""
+        try:
+            os.unlink(self.db_filename)
+        except OSError:
+            pass
+        self.zero_counter()
+        for fakevm in self.fakevm_generator():
+            test_params = fakevm.get_params()
+            virtnet = utils_net.DbNet(
+                test_params, fakevm.name, self.db_filename, fakevm.instance
+            )
+            self.assertTrue(hasattr(virtnet, "container_class"))
+            self.assertTrue(hasattr(virtnet, "mac_prefix"))
+            self.assertTrue(not hasattr(virtnet, "lock"))
+            self.assertTrue(not hasattr(virtnet, "db"))
+            vm_name_params = test_params.object_params(fakevm.name)
+            nic_name_list = vm_name_params.objects("nics")
+            for nic_name in nic_name_list:
+                nic_dict = {"nic_name": nic_name}
+                nic_params = test_params.object_params(nic_name)
+                proplist = list(virtnet.container_class().__all_slots__)
+                del proplist[proplist.index("nic_name")]
+                for propertea in proplist:
+                    nic_dict[propertea] = nic_params.get(propertea)
+                virtnet.append(nic_dict)
+            virtnet.update_db()
+            self.print_and_inc()
+
+    def _populate_mac_pool(self, include_last=False):
+        """Populate a fresh address pool with deterministic MAC addresses."""
+        try:
+            os.unlink(self.db_filename)
+        except OSError:
+            pass
+        self.zero_counter(25)
+        for lastbyte in xrange(0, 0xFF):
+            vm_name = "vm%d" % lastbyte
+            if lastbyte < 16:
+                mac = "%s0%x" % (self.mac_prefix, lastbyte)
+            else:
+                mac = "%s%x" % (self.mac_prefix, lastbyte)
+            params = utils_params.Params(
+                {"nics": "nic1", "vms": vm_name, "mac_nic1": mac}
+            )
+            virtnet = utils_net.VirtNet(params, vm_name, vm_name, self.db_filename)
+            virtnet.mac_prefix = self.mac_prefix
+            self.assertEqual(virtnet["nic1"].mac, mac)
+            self.assertEqual(virtnet.get_mac_address(0), mac)
+            self.assertEqual(
+                virtnet.get_mac_address(0).lower(), virtnet.get_mac_address(0)
+            )
+            self.assertEqual(virtnet.mac_list(), [mac])
+            self.print_and_inc()
+
+        if include_last:
+            params = utils_params.Params({"nics": "nic1 nic2", "vms": "vm255"})
+            virtnet = utils_net.VirtNet(params, "vm255", "vm255", self.db_filename)
+            virtnet.mac_prefix = self.mac_prefix
+            self.assertEqual(
+                virtnet.generate_mac_address(0, 300), "%sff" % self.mac_prefix
+            )
 
     def fakevm_generator(self):
         for params in self.CartesianResult:
@@ -521,41 +585,13 @@ class TestVmNetSubclasses(Test):
         """
         Load Cartesian combinatorial result from params into database
         """
-        try:
-            os.unlink(self.db_filename)
-        except OSError:
-            pass
-        self.zero_counter()
-        for fakevm in self.fakevm_generator():
-            test_params = fakevm.get_params()
-            virtnet = utils_net.DbNet(
-                test_params, fakevm.name, self.db_filename, fakevm.instance
-            )
-            self.assertTrue(hasattr(virtnet, "container_class"))
-            self.assertTrue(hasattr(virtnet, "mac_prefix"))
-            self.assertTrue(not hasattr(virtnet, "lock"))
-            self.assertTrue(not hasattr(virtnet, "db"))
-            vm_name_params = test_params.object_params(fakevm.name)
-            nic_name_list = vm_name_params.objects("nics")
-            for nic_name in nic_name_list:
-                # nic name is only in params scope
-                nic_dict = {"nic_name": nic_name}
-                nic_params = test_params.object_params(nic_name)
-                # avoid processing unsupported properties
-                proplist = list(virtnet.container_class().__all_slots__)
-                # name was already set, remove from __slots__ list copy
-                del proplist[proplist.index("nic_name")]
-                for propertea in proplist:
-                    nic_dict[propertea] = nic_params.get(propertea)
-                virtnet.append(nic_dict)
-            virtnet.update_db()
-            # db shouldn't store empty items
-            self.print_and_inc()
+        self._populate_cartesian_db()
 
     def test_03_db(self):
         """
-        Load from database created in test_02_db, verify data against params
+        Populate a database and verify its data against the parameters.
         """
+        self._populate_cartesian_db()
         # Verify on-disk data matches dummy data just written
         self.zero_counter()
         db = shelve.open(self.db_filename)
@@ -578,43 +614,13 @@ class TestVmNetSubclasses(Test):
         """
         Populate database with max - 1 mac addresses
         """
-        try:
-            os.unlink(self.db_filename)
-        except OSError:
-            pass
-        self.zero_counter(25)
-        # setup() method already set LASTBYTE to '-1'
-        for lastbyte in xrange(0, 0xFF):
-            # test_07_VirtNet demands last byte in name and mac match
-            vm_name = "vm%d" % lastbyte
-            if lastbyte < 16:
-                mac = "%s0%x" % (self.mac_prefix, lastbyte)
-            else:
-                mac = "%s%x" % (self.mac_prefix, lastbyte)
-            params = utils_params.Params(
-                {
-                    "nics": "nic1",
-                    "vms": vm_name,
-                    "mac_nic1": mac,
-                }
-            )
-            virtnet = utils_net.VirtNet(params, vm_name, vm_name, self.db_filename)
-            virtnet.mac_prefix = self.mac_prefix
-            self.assertEqual(virtnet["nic1"].mac, mac)
-            self.assertEqual(virtnet.get_mac_address(0), mac)
-            # Confirm only lower-case macs are stored
-            self.assertEqual(
-                virtnet.get_mac_address(0).lower(), virtnet.get_mac_address(0)
-            )
-            self.assertEqual(virtnet.mac_list(), [mac])
-            self.print_and_inc()
+        self._populate_mac_pool()
 
     def test_05_VirtNet(self):
         """
-        Load max - 1 entries from db, overriding params.
-
-        DEPENDS ON test_04_VirtNet running first
+        Populate and load max - 1 entries from db, overriding params.
         """
+        self._populate_mac_pool()
         self.zero_counter(25)
         # second loop forces db load from disk
         # also confirming params merge with db data
@@ -632,10 +638,9 @@ class TestVmNetSubclasses(Test):
 
     def test_06_VirtNet(self):
         """
-        Generate last possibly mac and verify value.
-
-        DEPENDS ON test_05_VirtNet running first
+        Populate the pool, generate the last possible MAC, and verify it.
         """
+        self._populate_mac_pool()
         self.zero_counter(25)
         # test two nics, second mac generation should fail (pool exhausted)
         params = utils_params.Params({"nics": "nic1 nic2", "vms": "vm255"})
@@ -653,6 +658,7 @@ class TestVmNetSubclasses(Test):
         """
         Release mac from beginning, middle, and end, re-generate + verify value
         """
+        self._populate_mac_pool(include_last=True)
         self.zero_counter(1)
         beginning_params = utils_params.Params({"nics": "nic1 nic2", "vms": "vm0"})
         middle_params = utils_params.Params({"nics": "nic1 nic2", "vms": "vm127"})

--- a/selftests/unit/test_utils_params.py
+++ b/selftests/unit/test_utils_params.py
@@ -73,20 +73,21 @@ CORRECT_RESULT_MAPPING = {
 
 class TestParams(Test):
     def setUp(self):
-        self.params = utils_params.Params(BASE_DICT)
+        super().setUp()
+        self.vt_params = utils_params.Params(BASE_DICT)
 
     def testObjects(self):
-        self.assertEqual(self.params.objects("images"), ["image1", "stg"])
+        self.assertEqual(self.vt_params.objects("images"), ["image1", "stg"])
 
     def testObjectsParams(self):
         for key in list(CORRECT_RESULT_MAPPING.keys()):
             self.assertEqual(
-                self.params.object_params(key), CORRECT_RESULT_MAPPING[key]
+                self.vt_params.object_params(key), CORRECT_RESULT_MAPPING[key]
             )
 
     def testGetItemMissing(self):
         try:
-            self.params["bogus"]
+            self.vt_params["bogus"]
             raise ValueError(
                 "Did not get a ParamNotFound error when trying "
                 "to access a non-existing param"
@@ -96,64 +97,72 @@ class TestParams(Test):
             pass
 
     def testGetItem(self):
-        self.assertEqual(self.params["image_size"], "10G")
+        self.assertEqual(self.vt_params["image_size"], "10G")
 
     def testGetBoolean(self):
-        self.params["foo1"] = "yes"
-        self.params["foo2"] = "no"
-        self.params["foo3"] = "on"
-        self.params["foo4"] = "off"
-        self.params["foo5"] = "true"
-        self.params["foo6"] = "false"
-        self.assertEqual(True, self.params.get_boolean("foo1"))
-        self.assertEqual(False, self.params.get_boolean("foo2"))
-        self.assertEqual(True, self.params.get_boolean("foo3"))
-        self.assertEqual(False, self.params.get_boolean("foo4"))
-        self.assertEqual(True, self.params.get_boolean("foo5"))
-        self.assertEqual(False, self.params.get_boolean("foo6"))
-        self.assertEqual(False, self.params.get_boolean("notgiven"))
+        self.vt_params["foo1"] = "yes"
+        self.vt_params["foo2"] = "no"
+        self.vt_params["foo3"] = "on"
+        self.vt_params["foo4"] = "off"
+        self.vt_params["foo5"] = "true"
+        self.vt_params["foo6"] = "false"
+        self.assertEqual(True, self.vt_params.get_boolean("foo1"))
+        self.assertEqual(False, self.vt_params.get_boolean("foo2"))
+        self.assertEqual(True, self.vt_params.get_boolean("foo3"))
+        self.assertEqual(False, self.vt_params.get_boolean("foo4"))
+        self.assertEqual(True, self.vt_params.get_boolean("foo5"))
+        self.assertEqual(False, self.vt_params.get_boolean("foo6"))
+        self.assertEqual(False, self.vt_params.get_boolean("notgiven"))
 
     def testGetNumeric(self):
-        self.params["something"] = "7"
-        self.params["foobar"] = 11
-        self.params["barsome"] = 13.17
-        self.params["hex_val"] = "0xff"
-        self.params["oct_val"] = "0o755"
-        self.params["bin_val"] = "0b11111111"
-        self.assertEqual(7, self.params.get_numeric("something"))
-        self.assertEqual(7, self.params.get_numeric("something", target_type=int))
-        self.assertEqual(7.0, self.params.get_numeric("something", target_type=float))
-        self.assertEqual(11, self.params.get_numeric("foobar"))
-        self.assertEqual(11, self.params.get_numeric("foobar", target_type=int))
-        self.assertEqual(11.0, self.params.get_numeric("foobar", target_type=float))
-        self.assertEqual(13, self.params.get_numeric("barsome"))
-        self.assertEqual(13, self.params.get_numeric("barsome", target_type=int))
-        self.assertEqual(13.17, self.params.get_numeric("barsome", target_type=float))
-        self.assertEqual(17, self.params.get_numeric("joke", 17))
+        self.vt_params["something"] = "7"
+        self.vt_params["foobar"] = 11
+        self.vt_params["barsome"] = 13.17
+        self.vt_params["hex_val"] = "0xff"
+        self.vt_params["oct_val"] = "0o755"
+        self.vt_params["bin_val"] = "0b11111111"
+        self.assertEqual(7, self.vt_params.get_numeric("something"))
+        self.assertEqual(7, self.vt_params.get_numeric("something", target_type=int))
         self.assertEqual(
-            17.13, self.params.get_numeric("joke", 17.13, target_type=float)
+            7.0, self.vt_params.get_numeric("something", target_type=float)
+        )
+        self.assertEqual(11, self.vt_params.get_numeric("foobar"))
+        self.assertEqual(11, self.vt_params.get_numeric("foobar", target_type=int))
+        self.assertEqual(11.0, self.vt_params.get_numeric("foobar", target_type=float))
+        self.assertEqual(13, self.vt_params.get_numeric("barsome"))
+        self.assertEqual(13, self.vt_params.get_numeric("barsome", target_type=int))
+        self.assertEqual(
+            13.17, self.vt_params.get_numeric("barsome", target_type=float)
+        )
+        self.assertEqual(17, self.vt_params.get_numeric("joke", 17))
+        self.assertEqual(
+            17.13, self.vt_params.get_numeric("joke", 17.13, target_type=float)
         )
         # Test automatic base detection (0x/0o/0b prefixes)
-        self.assertEqual(255, self.params.get_numeric("hex_val"))
-        self.assertEqual(493, self.params.get_numeric("oct_val"))
-        self.assertEqual(255, self.params.get_numeric("bin_val"))
+        self.assertEqual(255, self.vt_params.get_numeric("hex_val"))
+        self.assertEqual(493, self.vt_params.get_numeric("oct_val"))
+        self.assertEqual(255, self.vt_params.get_numeric("bin_val"))
 
     def testGetList(self):
-        self.params["primes"] = "7 11 13 17"
-        self.params["dashed"] = "7-11-13"
-        self.assertEqual(["7", "11", "13", "17"], self.params.get_list("primes"))
+        self.vt_params["primes"] = "7 11 13 17"
+        self.vt_params["dashed"] = "7-11-13"
+        self.assertEqual(["7", "11", "13", "17"], self.vt_params.get_list("primes"))
         self.assertEqual(
-            [7, 11, 13, 17], self.params.get_list("primes", "1 2 3", " ", int)
+            [7, 11, 13, 17], self.vt_params.get_list("primes", "1 2 3", " ", int)
         )
-        self.assertEqual([1, 2, 3], self.params.get_list("missing", "1 2 3", " ", int))
-        self.assertEqual([7, 11, 13], self.params.get_list("dashed", "1 2 3", "-", int))
+        self.assertEqual(
+            [1, 2, 3], self.vt_params.get_list("missing", "1 2 3", " ", int)
+        )
+        self.assertEqual(
+            [7, 11, 13], self.vt_params.get_list("dashed", "1 2 3", "-", int)
+        )
 
     def testGetDict(self):
-        self.params["dummy"] = "name1=value1 name2=value2"
+        self.vt_params["dummy"] = "name1=value1 name2=value2"
         self.assertEqual(
-            {"name1": "value1", "name2": "value2"}, self.params.get_dict("dummy")
+            {"name1": "value1", "name2": "value2"}, self.vt_params.get_dict("dummy")
         )
-        result_dict = self.params.get_dict("dummy", need_order=True)
+        result_dict = self.vt_params.get_dict("dummy", need_order=True)
         right_dict, wrong_dict = OrderedDict(), OrderedDict()
         right_dict["name1"] = "value1"
         right_dict["name2"] = "value2"
@@ -163,14 +172,14 @@ class TestParams(Test):
         self.assertNotEqual(wrong_dict, result_dict)
 
     def dropDictInternals(self):
-        self.params["a"] = "7"
-        self.params["b"] = "11"
-        self.params["_b"] = "13"
-        pruned = self.params.drop_dict_internals()
+        self.vt_params["a"] = "7"
+        self.vt_params["b"] = "11"
+        self.vt_params["_b"] = "13"
+        pruned = self.vt_params.drop_dict_internals()
         self.assertIn("a", pruned.keys())
-        self.assertEqual(pruned["a"], self.params["a"])
+        self.assertEqual(pruned["a"], self.vt_params["a"])
         self.assertIn("b", pruned.keys())
-        self.assertEqual(pruned["b"], self.params["b"])
+        self.assertEqual(pruned["b"], self.vt_params["b"])
         self.assertNotIn("_b", pruned.keys())
 
 

--- a/selftests/unit/test_utils_params.py
+++ b/selftests/unit/test_utils_params.py
@@ -10,6 +10,8 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest import utils_params
 
 BASE_DICT = {
@@ -69,7 +71,7 @@ CORRECT_RESULT_MAPPING = {
 }
 
 
-class TestParams(unittest.TestCase):
+class TestParams(Test):
     def setUp(self):
         self.params = utils_params.Params(BASE_DICT)
 

--- a/selftests/unit/test_versionable_class.py
+++ b/selftests/unit/test_versionable_class.py
@@ -19,7 +19,9 @@ from avocado import Test
 from virttest.unittest_utils import mock
 from virttest.versionable_class import Manager, VersionableClass, factory
 
-man = Manager(__name__)
+# manager replaces this module in sys.modules with a ModuleWrapper so delay that
+# until after avocado's loader has inspected and instantiated the test class
+man = None
 
 # pylint: disable=E1003
 
@@ -270,11 +272,18 @@ class AA(Sys_Container, BB, System_Container):
 
 class TestVersionableClass(Test):
     def setUp(self):
+        global man
+        super().setUp()
+        man = Manager(__name__)
         self.god = mock.mock_god(ut=self)
         self.version = 1
 
     def tearDown(self):
-        self.god.unstub_all()
+        try:
+            self.god.unstub_all()
+        finally:
+            sys.modules[__name__] = man.wrapper.wrapped
+            super().tearDown()
 
     def test_simple_versioning(self):
         self.god.stub_function(VM, "func1")

--- a/selftests/unit/test_versionable_class.py
+++ b/selftests/unit/test_versionable_class.py
@@ -14,6 +14,8 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest.unittest_utils import mock
 from virttest.versionable_class import Manager, VersionableClass, factory
 
@@ -266,7 +268,7 @@ class AA(Sys_Container, BB, System_Container):
         return super(man[cls, AA], cls).__new__(cls, *args, **kargs)
 
 
-class TestVersionableClass(unittest.TestCase):
+class TestVersionableClass(Test):
     def setUp(self):
         self.god = mock.mock_god(ut=self)
         self.version = 1

--- a/selftests/unit/test_virsh.py
+++ b/selftests/unit/test_virsh.py
@@ -5,6 +5,7 @@ import os
 import sys
 import unittest
 
+from avocado import Test
 from avocado.utils import process
 
 # simple magic for using scripts within a source tree
@@ -72,7 +73,7 @@ def FakeVirshFactory(preserve=None):
     return fake_virsh
 
 
-class ModuleLoad(unittest.TestCase):
+class ModuleLoad(Test):
     from virttest import virsh
 
 
@@ -222,7 +223,7 @@ class ConstructorsTest(ModuleLoad):
 
 
 # Ensure the following tests ONLY run if a valid virsh command exists #####
-class ModuleLoadCheckVirsh(unittest.TestCase):
+class ModuleLoadCheckVirsh(Test):
     from virttest import virsh
 
     def run(self, result=None):

--- a/selftests/unit/test_virsh.py
+++ b/selftests/unit/test_virsh.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python
 
+import gc
 import logging
 import os
 import sys
 import unittest
 
-from avocado import Test
-from avocado.utils import process
+from aexpect.exceptions import ShellProcessTerminatedError, ShellStatusError
+from avocado import Test, skipUnless
 
 # simple magic for using scripts within a source tree
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -14,21 +15,28 @@ if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
 
-def process_is_alive(name_pattern):
-    """
-    'pgrep name' misses all python processes and also long process names.
-    'pgrep -f name' gets all shell commands with name in args.
-    So look only for command whose initial pathname ends with name.
-    Name itself is an egrep pattern, so it can use | etc for variations.
-    """
-    return (
-        process.system(
-            "pgrep -f '^([^ /]*/)*(%s)([ ]|$)'" % name_pattern,
-            ignore_status=True,
-            shell=True,
-        )
-        == 0
-    )
+def virsh_session_is_alive(session_id):
+    """Return whether one particular aexpect-backed virsh session is alive."""
+    from virttest import virsh
+
+    try:
+        session = virsh.VirshSession(a_id=session_id, check_libvirtd=False)
+        return session.is_alive()
+    except (
+        ShellStatusError,
+        ShellProcessTerminatedError,
+    ):  # The session no longer exists or cannot be attached.
+        return False
+
+
+def virsh_is_available():
+    """Check whether the test environment provides a real virsh executable."""
+    from virttest import virsh
+
+    return virsh.Virsh()["virsh_exec"] != "/bin/true"
+
+
+VIRSH_AVAILABLE = virsh_is_available()
 
 
 class bogusVirshFailureException(unittest.TestCase.failureException):
@@ -226,21 +234,9 @@ class ConstructorsTest(ModuleLoad):
 class ModuleLoadCheckVirsh(Test):
     from virttest import virsh
 
-    def run(self, result=None):
-        test_virsh = self.virsh.Virsh()
-        if test_virsh["virsh_exec"] == "/bin/true":
-            if result is None:
-                result = self.defaultTestResult()
-            result.startTest(self)
-            try:
-                result.addSkip(self, "no virsh executable was found")
-            finally:
-                result.stopTest(self)
-            return result
-        else:
-            return super(ModuleLoadCheckVirsh, self).run(result)
 
-
+@skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
+@unittest.skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
 class SessionManagerTest(ModuleLoadCheckVirsh):
     def test_del_VirshPersistent(self):
         """
@@ -250,10 +246,11 @@ class SessionManagerTest(ModuleLoadCheckVirsh):
         well in `del vp_instance`.
         """
         vp = self.virsh.VirshPersistent()
-        virsh_exec = vp.virsh_exec
-        self.assertTrue(process_is_alive(virsh_exec))
+        session_id = vp.session_id
+        self.assertTrue(virsh_session_is_alive(session_id))
         del vp
-        self.assertFalse(process_is_alive(virsh_exec))
+        gc.collect()
+        self.assertFalse(virsh_session_is_alive(session_id))
 
     def test_VirshSession(self):
         """
@@ -264,17 +261,19 @@ class SessionManagerTest(ModuleLoadCheckVirsh):
         virsh_exec = self.virsh.Virsh()["virsh_exec"]
         # Build a VirshSession object.
         session_1 = self.virsh.VirshSession(virsh_exec, auto_close=True)
-        self.assertTrue(process_is_alive(virsh_exec))
+        session_id = session_1.get_id()
+        self.assertTrue(session_1.is_alive())
         del session_1
-        self.assertFalse(process_is_alive(virsh_exec))
+        gc.collect()
+        self.assertFalse(virsh_session_is_alive(session_id))
 
     def test_VirshPersistent(self):
         """
         Unittest for session manager of VirshPersistent.
         """
-        virsh_exec = self.virsh.Virsh()["virsh_exec"]
         vp_1 = self.virsh.VirshPersistent()
-        self.assertTrue(process_is_alive(virsh_exec))
+        session_id = vp_1.session_id
+        self.assertTrue(virsh_session_is_alive(session_id))
         # Init the vp_2 with same params of vp_1.
         vp_2 = self.virsh.VirshPersistent(**vp_1)
         # Make sure vp_1 and vp_2 are refer to the same session.
@@ -282,12 +281,15 @@ class SessionManagerTest(ModuleLoadCheckVirsh):
 
         del vp_1
         # Make sure the session is not closed when vp_2 still refer to it.
-        self.assertTrue(process_is_alive(virsh_exec))
+        self.assertTrue(virsh_session_is_alive(session_id))
         del vp_2
+        gc.collect()
         # Session was closed since no other VirshPersistent refer to it.
-        self.assertFalse(process_is_alive(virsh_exec))
+        self.assertFalse(virsh_session_is_alive(session_id))
 
 
+@skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
+@unittest.skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
 class VirshHasHelpCommandTest(ModuleLoadCheckVirsh):
     def setUp(self):
         # subclasses override self.virsh
@@ -333,6 +335,8 @@ class VirshHasHelpCommandTest(ModuleLoadCheckVirsh):
         self.assertTrue(len(grp_cmd_set), len(commands_set) + len(groups_set))
 
 
+@skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
+@unittest.skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
 class VirshHelpCommandTest(ModuleLoadCheckVirsh):
     def test_cache_command(self):
         l1 = self.virsh.help_command(cache=True)
@@ -350,13 +354,15 @@ class VirshClassHasHelpCommandTest(VirshHasHelpCommandTest):
         self.virsh = self.virsh.Virsh(debug=False)
 
 
+@skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
+@unittest.skipUnless(VIRSH_AVAILABLE, "no virsh executable was found")
 class VirshPersistentClassHasHelpCommandTest(VirshHasHelpCommandTest):
     def setUp(self):
         logging.disable(logging.INFO)
         super(VirshPersistentClassHasHelpCommandTest, self).setUp()
         self.VirshPersistent = self.virsh.VirshPersistent
         self.virsh = self.VirshPersistent(debug=False)
-        self.assertTrue(process_is_alive(self.virsh.virsh_exec))
+        self.assertTrue(virsh_session_is_alive(self.virsh.session_id))
 
     def test_recycle_session(self):
         # virsh can be used as a dict of it's properties
@@ -364,9 +370,14 @@ class VirshPersistentClassHasHelpCommandTest(VirshHasHelpCommandTest):
         self.assertEqual(self.virsh.session_id, another.session_id)
 
     def tearDown(self):
-        self.assertTrue(process_is_alive(self.virsh.virsh_exec))
-        self.virsh.close_session()
-        self.assertFalse(process_is_alive(self.virsh.virsh_exec))
+        try:
+            if hasattr(self.virsh, "session_id"):
+                session_id = self.virsh.session_id
+                self.assertTrue(virsh_session_is_alive(session_id))
+                self.virsh.close_session()
+                self.assertFalse(virsh_session_is_alive(session_id))
+        finally:
+            super(VirshPersistentClassHasHelpCommandTest, self).tearDown()
 
 
 if __name__ == "__main__":

--- a/selftests/unit/test_vt_init.py
+++ b/selftests/unit/test_vt_init.py
@@ -3,10 +3,12 @@ import os
 import tempfile
 import unittest
 
+from avocado import Test
+
 from selftests import BASEDIR
 
 
-class VtInitTest(unittest.TestCase):
+class VtInitTest(Test):
     @staticmethod
     def _swap():
         data_dir = os.path.join(BASEDIR, "selftests", ".data")

--- a/selftests/unit/test_wrappers.py
+++ b/selftests/unit/test_wrappers.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 from string import ascii_lowercase as ascii_lc
 from time import sleep
 
+from avocado import Test
+
 from virttest import _wrappers
 
 
@@ -111,7 +113,7 @@ class baseImportTests(ABC):
         self.assertEqual(pre_sys_path, sys.path)
 
 
-class ImportModuleTest(baseImportTests, unittest.TestCase):
+class ImportModuleTest(baseImportTests, Test):
     def _check_import(self, name, value, path=""):
         """Wraps the import checking workflow used in some tests"""
         module = _wrappers.import_module(name, path)
@@ -179,7 +181,7 @@ class ImportModuleTest(baseImportTests, unittest.TestCase):
             check(res.result(), mod_data)
 
 
-class LoadSourceTest(baseImportTests, unittest.TestCase):
+class LoadSourceTest(baseImportTests, Test):
     def _check_import(self, name, value, path=""):
         path = os.path.join(path, f"{name}.py")
         module = _wrappers.load_source(name, path)

--- a/selftests/unit/test_wrappers.py
+++ b/selftests/unit/test_wrappers.py
@@ -1,12 +1,11 @@
+import importlib
 import os
 import random
 import sys
-import unittest
 from abc import ABC
 from concurrent.futures import ThreadPoolExecutor, wait
 from copy import deepcopy
 from string import ascii_lowercase as ascii_lc
-from time import sleep
 
 from avocado import Test
 
@@ -52,35 +51,27 @@ class baseImportTests(ABC):
     _subdir_inner_val = 1
     _indir_inner_val = 0
 
-    @classmethod
-    def setUpClass(cls):
-        create_module(cls._tmp_in_module_name, cls._indir_inner_val)
-        create_module(
-            cls._tmp_sub_module_name, cls._subdir_inner_val, cls._tmp_sub_module_dir
+    def setUp(self):
+        super().setUp()
+        self._tmp_root = self.workdir
+        self._tmp_sub_module_dir = os.path.join(
+            self._tmp_root, self._tmp_sub_module_dir
         )
-        os.makedirs(cls._aux_sub_mod_dir, exist_ok=True)
-        # Wait a bit so the import mechanism cache can be refreshed
-        sleep(2)
+        self._aux_sub_mod_dir = os.path.join(self._tmp_root, self._aux_sub_mod_dir)
+        create_module(self._tmp_in_module_name, self._indir_inner_val, self._tmp_root)
+        create_module(
+            self._tmp_sub_module_name,
+            self._subdir_inner_val,
+            self._tmp_sub_module_dir,
+        )
+        os.makedirs(self._aux_sub_mod_dir, exist_ok=True)
+        importlib.invalidate_caches()
 
-    @classmethod
-    def tearDownClass(cls):
-        def rm_subdir(subdir):
-            # Remove inner __pycache__
-            sub_pycache_dir = os.path.join(subdir, "__pycache__")
-            if os.path.exists(sub_pycache_dir):
-                for pycache_file in os.listdir(sub_pycache_dir):
-                    os.remove(os.path.join(sub_pycache_dir, pycache_file))
-                os.rmdir(sub_pycache_dir)
-            # Remove sub-module files
-            for tmp_sub_mod in os.listdir(subdir):
-                os.remove(os.path.join(subdir, tmp_sub_mod))
-            # Finally delete created directory
-            os.rmdir(subdir)
-
-        rm_subdir(cls._tmp_sub_module_dir)
-        rm_subdir(cls._aux_sub_mod_dir)
-        # And the file created in the exec dir
-        os.remove(f"{cls._tmp_in_module_name}.py")
+    def tearDown(self):
+        sys.modules.pop(self._tmp_in_module_name, None)
+        sys.modules.pop(self._tmp_sub_module_name, None)
+        sys.modules.pop("name", None)
+        super().tearDown()
 
     def _compare_mods(self, one, other):
         self.assertEqual(one.__name__, other.__name__)
@@ -109,7 +100,9 @@ class baseImportTests(ABC):
     def test_import_from_dir(self):
         """Imports a module that's in the same directory"""
         pre_sys_path = deepcopy(sys.path)
-        self._check_import(self._tmp_in_module_name, self._indir_inner_val)
+        self._check_import(
+            self._tmp_in_module_name, self._indir_inner_val, self._tmp_root
+        )
         self.assertEqual(pre_sys_path, sys.path)
 
 
@@ -189,7 +182,9 @@ class LoadSourceTest(baseImportTests, Test):
 
     def test_mismatching_names(self):
         # test that importing a module mismatching the file name works good
-        module = _wrappers.load_source("name", f"{self._tmp_in_module_name}.py")
+        module = _wrappers.load_source(
+            "name", os.path.join(self._tmp_root, f"{self._tmp_in_module_name}.py")
+        )
         check_imported_module(self, "name", module, self._indir_inner_val)
 
     def test_no_existing_file(self):

--- a/selftests/unit/test_xml_utils.py
+++ b/selftests/unit/test_xml_utils.py
@@ -13,10 +13,12 @@ basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isdir(os.path.join(basedir, "virttest")):
     sys.path.append(basedir)
 
+from avocado import Test
+
 from virttest import xml_utils
 
 
-class xml_test_data(unittest.TestCase):
+class xml_test_data(Test):
     def get_tmp_files(self, prefix, suffix):
         path_string = os.path.join("/tmp", "%s*%s" % (prefix, suffix))
         return glob.glob(path_string)

--- a/virttest/unittests/libvirt_xml/device_xml/test_controller_xml.py
+++ b/virttest/unittests/libvirt_xml/device_xml/test_controller_xml.py
@@ -1,5 +1,7 @@
 import unittest
 
+from avocado import Test
+
 from virttest.libvirt_xml.devices import controller
 
 XM_PCI = """
@@ -30,7 +32,7 @@ pci_controller_attrs = {
 }
 
 
-class TestcontrollerXML(unittest.TestCase):
+class TestcontrollerXML(Test):
     def test_setup_controller_pci(self):
         pci_ctrlr = controller.Controller()
         pci_ctrlr.setup_attrs(**pci_controller_attrs)

--- a/virttest/unittests/libvirt_xml/device_xml/test_interface_xml.py
+++ b/virttest/unittests/libvirt_xml/device_xml/test_interface_xml.py
@@ -1,5 +1,7 @@
 import unittest
 
+from avocado import Test
+
 from virttest.libvirt_xml.devices import interface
 
 XML = """
@@ -34,7 +36,7 @@ iface_attrs = {
 }
 
 
-class TestcontrollerXML(unittest.TestCase):
+class TestcontrollerXML(Test):
     def test_setup_iface_default(self):
         iface = interface.Interface()
         iface.setup_attrs(**iface_attrs)

--- a/virttest/unittests/libvirt_xml/device_xml/test_memory_xml.py
+++ b/virttest/unittests/libvirt_xml/device_xml/test_memory_xml.py
@@ -1,5 +1,7 @@
 import unittest
 
+from avocado import Test
+
 from virttest.libvirt_xml.devices import memory
 
 test_xml_pairs = []
@@ -202,7 +204,7 @@ attrs_6 = {
 groups = len([x for x in locals() if x.startswith("TESTXML_")])
 
 
-class TestMemoryXML(unittest.TestCase):
+class TestMemoryXML(Test):
     def test_setup_memory_default(self):
         for i in range(groups):
             print(i)

--- a/virttest/unittests/libvirt_xml/test_network_xml.py
+++ b/virttest/unittests/libvirt_xml/test_network_xml.py
@@ -1,5 +1,7 @@
 import unittest
 
+from avocado import Test
+
 from virttest.libvirt_xml import network_xml
 
 # TODO: The current test doesn't cover all attributes of a network xml.
@@ -102,7 +104,7 @@ network_attrs = {
 }
 
 
-class TestNetworkXML(unittest.TestCase):
+class TestNetworkXML(Test):
     def test_setup_network_default(self):
         network = network_xml.NetworkXML()
         network.setup_attrs(**network_attrs)

--- a/virttest/unittests/libvirt_xml/test_vm_xml.py
+++ b/virttest/unittests/libvirt_xml/test_vm_xml.py
@@ -1,5 +1,7 @@
 import unittest
 
+from avocado import Test
+
 from virttest.libvirt_xml import vm_xml, xcepts
 
 XML = """
@@ -17,7 +19,7 @@ def get_vmxml():
     return vmxml
 
 
-class TestVMXMLDelSeclabel(unittest.TestCase):
+class TestVMXMLDelSeclabel(Test):
     def test_del_seclabel_default(self):
         vmxml = get_vmxml()
         self.assertEqual(2, len(vmxml.get_seclabel()))

--- a/virttest/unittests/test_utils_kernel_module.py
+++ b/virttest/unittests/test_utils_kernel_module.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     import mock
 
+from avocado import Test
+
 from virttest import utils_kernel_module
 
 # Test values
@@ -23,7 +25,7 @@ getstatusoutput_ok = mock.Mock(return_value=(0, ""))
     utils_kernel_module, "open", mock.mock_open(read_data=some_module_val + "\n")
 )
 @mock.patch.object(utils_kernel_module.process, "getstatusoutput", getstatusoutput_ok)
-class TestUnloadModule(unittest.TestCase):
+class TestUnloadModule(Test):
     """
     Tests the reload_module method
     """
@@ -55,7 +57,7 @@ class TestUnloadModule(unittest.TestCase):
     utils_kernel_module, "open", mock.mock_open(read_data=some_module_val + "\n")
 )
 @mock.patch.object(utils_kernel_module.process, "getstatusoutput", getstatusoutput_ok)
-class TestReloadModule(unittest.TestCase):
+class TestReloadModule(Test):
     """
     Tests the reload_module method
     """
@@ -137,7 +139,7 @@ class TestReloadModule(unittest.TestCase):
 @mock.patch.object(
     utils_kernel_module, "open", mock.mock_open(read_data=some_module_val + "\n")
 )
-class TestInit(unittest.TestCase):
+class TestInit(Test):
     """
     Tests if module status is backed up correctly
     """
@@ -163,7 +165,7 @@ class TestInit(unittest.TestCase):
     utils_kernel_module, "open", mock.mock_open(read_data=some_module_val + "\n")
 )
 @mock.patch.object(utils_kernel_module.process, "getstatusoutput", getstatusoutput_ok)
-class TestRestore(unittest.TestCase):
+class TestRestore(Test):
     """
     Tests the restore method
     """
@@ -226,7 +228,7 @@ class TestRestore(unittest.TestCase):
 @mock.patch.object(
     utils_kernel_module.KernelModuleHandler, "reload_module", return_value=None
 )
-class TestReload(unittest.TestCase):
+class TestReload(Test):
     """
     Tests the module global reload method
     """

--- a/virttest/unittests/test_utils_misc.py
+++ b/virttest/unittests/test_utils_misc.py
@@ -1,12 +1,14 @@
 import logging
 import unittest
 
+from avocado import Test
+
 from virttest import utils_misc
 
 LOG = logging.getLogger("avocado." + __name__)
 
 
-class TestDmesgFilter(unittest.TestCase):
+class TestDmesgFilter(Test):
     def test__remove_dmesg_matches(self):
         messages = "msg_1\nmsg_2\nmsg_3\nmsg_4"
         expected_dmesg = "'^msg_1$', '^msg_4$'"

--- a/virttest/unittests/test_utils_test__init__.py
+++ b/virttest/unittests/test_utils_test__init__.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     import mock
 
+from avocado import Test
 from avocado.core import exceptions
 
 from virttest import utils_test
@@ -18,7 +19,7 @@ LOG = logging.getLogger("avocado." + __name__)
 
 @mock.patch("virttest.utils_package.package_install")
 @mock.patch.object(utils_test, "check_kernel_cmdline", check_kernel_cmdline_mock)
-class TestUpdateBootOptionZipl(unittest.TestCase):
+class TestUpdateBootOptionZipl(Test):
     vm = mock.MagicMock()
     session = mock.MagicMock()
 

--- a/virttest/unittests/test_utils_zchannels.py
+++ b/virttest/unittests/test_utils_zchannels.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     import mock
 
+from avocado import Test
+
 import virttest
 from virttest.utils_zchannels import ChannelPaths, SubchannelPaths
 
@@ -33,7 +35,7 @@ OUT_OK = [
 ]
 
 
-class TestSubchannelPaths(unittest.TestCase):
+class TestSubchannelPaths(Test):
     def test_get_info(self):
         virttest.utils_zchannels.cmd_status_output = mock.Mock(
             return_value=(0, "\n".join(OUT_OK))
@@ -76,7 +78,7 @@ class TestSubchannelPaths(unittest.TestCase):
         self.assertEqual("0.0.26ab", device[1])
 
 
-class TestChannelPaths(unittest.TestCase):
+class TestChannelPaths(Test):
     def test__split(self):
         chpids = "12345678"
         ids = ChannelPaths._split(chpids)

--- a/virttest/unittests/test_utils_zcrypt.py
+++ b/virttest/unittests/test_utils_zcrypt.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     import mock
 
+from avocado import Test
+
 import virttest
 from virttest.utils_zcrypt import CryptoDeviceInfoBuilder
 
@@ -29,7 +31,7 @@ OUT_OK = (
 virttest.utils_zcrypt.cmd_status_output = mock.Mock(return_value=(0, OUT_OK))
 
 
-class LszcryptCmd(unittest.TestCase):
+class LszcryptCmd(Test):
     def setUp(self):
         self.info = CryptoDeviceInfoBuilder.get()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated test suites to a unified Avocado-based test framework.
  * Improved test setup, cleanup, and isolation using managed working directories.
  * Added clearer conditional skipping for unavailable or legacy scenarios.
  * Strengthened virsh session lifecycle and cleanup verification.
  * Preserved existing test coverage and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->