### PR TITLE
Provide minimal documentation for running VT tests in parallel

### DIFF
--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -170,3 +170,11 @@ options:
 * Send an e-mail to `the avocado mailing list <https://www.redhat.com/mailman/listinfo/avocado-devel>`__.
 * Open an issue on `the avocado-vt github area <https://github.com/avocado-framework/avocado-vt/issues/new>`__.
 * We also hang out on `IRC (irc.oftc.net, #avocado) <irc://irc.oftc.net/#avocado>`__.
+
+Further steps
+=============
+
+You can now build upon the first step depending on different needs:
+
+* If you want to run in parallel simply check `the parallel jobs guide <https://avocado-vt.readthedocs.io/en/latest/ParallelJobs.html>`__.
+* There are various other guides on the side bar for more specialized topics.

--- a/docs/source/ParallelJobs.rst
+++ b/docs/source/ParallelJobs.rst
@@ -1,7 +1,7 @@
 .. _parallel_jobs:
 
-Parallel Jobs
-=============
+Running tests in parallel without isolation
+===========================================
 
 Avocado-VT ships with a plugin that creates a lock file in a known
 public location (``/tmp`` by default, but configurable) to prevent
@@ -72,3 +72,36 @@ Then verify with::
 
 Do the same thing for other users and their jobs will not be locked by
 one another.
+
+Running tests in parallel using LXC
+===================================
+
+Avocado itself has supported running tests in parallel for a long time, but due
+to the nature of VT tests, proper parallelism requires at least an LXC container
+level isolation. Assuming you have created two LXC containers c101 and c102 and
+have performed the `vt-bootstrap` step in each, you can run in parallel like
+
+    $ avocado run --spawner lxc --max-parallel-tasks 2 --vt-type qemu "only boot" "only reboot" --status-server-disable-auto --config lxc-slots.conf
+
+Here the `--status-server-disable-auto` option can also be added in a config which
+needs::
+
+    # lxc-slots.conf
+    [spawner.lxc]
+    slots = ['c101', 'c102']
+
+if e.g. there are at least two LXC containers available (slots corresponding
+to the container IDs). A command line such as the above produces the output::
+
+    JOB ID     : 07d217fbe04c17f3c045517a580f024249aeeec7
+    JOB LOG    : /mnt/local/results/job-2026-08-17T22.28-07d217f/job.log
+    (1/2) io-github-autotest-qemu.boot: STARTED
+    (2/2) io-github-autotest-qemu.reboot: STARTED
+    (1/2) io-github-autotest-qemu.boot: PASS (131.72 s)
+    (2/2) io-github-autotest-qemu.reboot: PASS (326.27 s)
+    RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
+    JOB HTML   : /mnt/local/results/job-2026-08-17T22.28-07d217f/results.html
+    JOB TIME   : 331.12 s
+
+The LXC containers can be easily created via the ``contrib/create_lxc_container.sh``
+bash script that can be found within the code base or used as a reference.


### PR DESCRIPTION
The minimal requirement for a reliable parallel run is LXC containers which have their own pointer bash script for help with setup. The documented example was fully locally tested at the time of writing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for running Avocado-VT tests in parallel with LXC container isolation.
  - Included command-line examples, optional container-slot configuration, sample output, and container creation instructions.
  - Added a “Further steps” section to the getting started guide, linking to parallel jobs and other specialized guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->