### PR TITLE
vm_xml: support domain-level iommufd element

### DIFF
--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -161,6 +161,12 @@ class VMXMLBase(LibvirtXMLBase):
             get: return VMMemTuneXML instance for the domain.
             set: Define memtune tag from a VMCPUTuneXML instance.
             del: remove memtune tag
+        iommufd: IOMMUFDXML
+            get: return IOMMUFDXML instance for the domain-level <iommufd>
+            set: define iommufd tag from an IOMMUFDXML instance
+            del: remove iommufd tag
+            Attributes (enabled, fdgroup, ...) are on IOMMUFDXML.iommufd_attr,
+            not a nested child element.
     """
 
     # Additional names of attributes and dictionary-keys instances may contain
@@ -208,6 +214,7 @@ class VMXMLBase(LibvirtXMLBase):
         "clock",
         "description",
         "genid",
+        "iommufd",
     )
 
     __uncompareable__ = base.LibvirtXMLBase.__uncompareable__
@@ -519,6 +526,14 @@ class VMXMLBase(LibvirtXMLBase):
             parent_xpath="/",
             tag_name="idmap",
             subclass=VMIDMapXML,
+            subclass_dargs={"virsh_instance": virsh_instance},
+        )
+        accessors.XMLElementNest(
+            property_name="iommufd",
+            libvirtxml=self,
+            parent_xpath="/",
+            tag_name="iommufd",
+            subclass=IOMMUFDXML,
             subclass_dargs={"virsh_instance": virsh_instance},
         )
         super(VMXMLBase, self).__init__(virsh_instance=virsh_instance)
@@ -2080,6 +2095,29 @@ class VMXML(VMXMLBase):
             raise xcepts.LibvirtXMLError(
                 "Invalid feature tag or attribute: %s" % detail
             )
+
+
+class IOMMUFDXML(base.LibvirtXMLBase):
+    """
+    VM IOMMUFD xml class for domain-level <iommufd/>.
+
+    Properties:
+
+    iommufd_attr:
+        dict. Attributes of the <iommufd> element itself
+        (e.g. enabled='yes', fdgroup='iommu'). XMLElementDict with
+        tag_name matching the class root is intentional: element_by_parent
+        applies attributes on <iommufd>, not a nested child.
+    """
+
+    __slots__ = ("iommufd_attr",)
+
+    def __init__(self, virsh_instance=base.virsh):
+        accessors.XMLElementDict(
+            "iommufd_attr", self, parent_xpath="/", tag_name="iommufd"
+        )
+        super(IOMMUFDXML, self).__init__(virsh_instance=virsh_instance)
+        self.xml = "<iommufd/>"
 
 
 class VMCPUXML(base.LibvirtXMLBase):

--- a/virttest/unittests/libvirt_xml/test_vm_xml.py
+++ b/virttest/unittests/libvirt_xml/test_vm_xml.py
@@ -45,5 +45,43 @@ class TestVMXMLDelSeclabel(Test):
         self.assertEqual(2, len(seclabels))
 
 
+IOMMUFD_XML = "<iommufd enabled='yes' fdgroup='iommu'/>"
+
+iommufd_attrs = {
+    "iommufd_attr": {"enabled": "yes", "fdgroup": "iommu"},
+}
+
+
+class TestVMXMLIommufd(Test):
+    def test_setup_iommufd(self):
+        iommufd = vm_xml.IOMMUFDXML()
+        iommufd.setup_attrs(**iommufd_attrs)
+
+        cmp_xml = vm_xml.IOMMUFDXML()
+        cmp_xml.xml = IOMMUFD_XML
+        self.assertEqual(iommufd, cmp_xml)
+        self.assertNotIn("<attrs", str(iommufd))
+
+    def test_fetch_attrs_iommufd(self):
+        iommufd = vm_xml.IOMMUFDXML()
+        iommufd.xml = IOMMUFD_XML
+        self.assertEqual(iommufd_attrs, iommufd.fetch_attrs())
+
+    def test_vmxml_iommufd_element(self):
+        vmxml = vm_xml.VMXML()
+        vmxml.xml = "<domain type='kvm'><name>test</name></domain>"
+        iommufd = vm_xml.IOMMUFDXML()
+        iommufd.setup_attrs(**iommufd_attrs)
+        vmxml.iommufd = iommufd
+
+        self.assertEqual(iommufd_attrs["iommufd_attr"], vmxml.iommufd.iommufd_attr)
+        self.assertIn("<iommufd", str(vmxml))
+        self.assertNotIn("<attrs", str(vmxml))
+
+        del vmxml.iommufd
+        with self.assertRaises(xcepts.LibvirtXMLError):
+            _ = vmxml.iommufd
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Carry forward closed avocado-vt#4348 (Dan Zheng) so tests can set domain-level `<iommufd enabled='yes'/>`.
- Document `iommufd` as an `IOMMUFDXML` instance; `iommufd_attr` holds attributes on `<iommufd>` itself (same `XMLElementDict` pattern as `Hostdev.Driver`). Do not introduce a nested `<attrs>` child — that would be invalid libvirt XML.

## Test plan
- [ ] Confirm generated XML is `<iommufd enabled='yes' fdgroup='iommu'/>` (not a nested child).
- [ ] This helper is for the 12.2 whole-VM element; per-device `<driver iommufd='yes'/>` already works via existing `driver_attr` and does not depend on this PR.
- [ ] Follow-up: tp-libvirt cases that need domain-level iommufd (LIBVIRTAT-22459).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the domain-level `<iommufd>` element in virtual machine XML.
  * Added access to IOMMUFD attributes through the VM configuration interface.
  * Added documentation describing the new configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->